### PR TITLE
Added Missing TestEngine tests

### DIFF
--- a/RetailCoder.VBE/UnitTesting/NewUnitTestModuleCommand.cs
+++ b/RetailCoder.VBE/UnitTesting/NewUnitTestModuleCommand.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Vbe.Interop;
 using Rubberduck.VBEditor.Extensions;
 
@@ -9,28 +7,6 @@ namespace Rubberduck.UnitTesting
 {
     public static class NewUnitTestModuleCommand
     {
-        public static void EnsureReferenceToAddInLibrary(this VBProject project)
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-
-            var name = assembly.GetName().Name.Replace('.', '_');
-            var referencePath = Path.ChangeExtension(assembly.Location, ".tlb");
-
-            var references = project.References.Cast<Reference>().ToList();
-
-            var reference = references.SingleOrDefault(r => r.Name == name);
-            if (reference != null)
-            {
-                references.Remove(reference);
-                project.References.Remove(reference);
-            }
-
-            if (references.All(r => r.FullPath != referencePath))
-            {
-                project.References.AddFromFile(referencePath);
-            }
-        }
-
         private static readonly string TestModuleEmptyTemplate = String.Concat(
                  "'@TestModule\n"
                 , "'' uncomment for late-binding:\n"
@@ -82,6 +58,7 @@ namespace Rubberduck.UnitTesting
             }
             catch (Exception exception)
             {
+                //can we please comment when we swallow every possible exception?
             }
         }
 

--- a/RetailCoder.VBE/UnitTesting/ProjectTestExtensions.cs
+++ b/RetailCoder.VBE/UnitTesting/ProjectTestExtensions.cs
@@ -6,7 +6,8 @@ using Rubberduck.Parsing;
 using Rubberduck.Parsing.Reflection;
 using Rubberduck.Reflection;
 using Rubberduck.VBEditor.Extensions;
-using Rubberduck.VBEditor.VBEHost;
+using System.Reflection;
+using System.IO;
 
 namespace Rubberduck.UnitTesting
 {
@@ -86,6 +87,28 @@ namespace Rubberduck.UnitTesting
                  && member.MemberVisibility == MemberVisibility.Public;
 
             return result;
+        }
+
+        public static void EnsureReferenceToAddInLibrary(this VBProject project)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+
+            var name = assembly.GetName().Name.Replace('.', '_');
+            var referencePath = Path.ChangeExtension(assembly.Location, ".tlb");
+
+            var references = project.References.Cast<Reference>().ToList();
+
+            var reference = references.SingleOrDefault(r => r.Name == name);
+            if (reference != null)
+            {
+                references.Remove(reference);
+                project.References.Remove(reference);
+            }
+
+            if (references.All(r => r.FullPath != referencePath))
+            {
+                project.References.AddFromFile(referencePath);
+            }
         }
     }
 }

--- a/RetailCoder.VBE/UnitTesting/TestEngine.cs
+++ b/RetailCoder.VBE/UnitTesting/TestEngine.cs
@@ -84,6 +84,9 @@ namespace Rubberduck.UnitTesting
 
         public void Run(IEnumerable<TestMethod> tests, VBProject project)
         {
+            //todo: move this to the "UI" layer. This code doesn't have to run for COM clients.
+            //  COM clients will have to either already have a good reference, or be late bound.
+            //  This is problematic for late bound code, because now we've *forced* them into early binding.
             project.EnsureReferenceToAddInLibrary();
 
             var testMethods = tests as IList<TestMethod> ?? tests.ToList();


### PR DESCRIPTION
Expanded code coverage for issue #611; closes #623;
Moved `EnsureReference` extension method from `NewUnitTestModule` to `ProjectTestExtensions`. It seemed to fit better there now that the behavior has changed.