### PR TITLE
ExtractMethodRefactoring test harness

### DIFF
--- a/RetailCoder.VBE/Refactorings/ExtractMethod/ExtractMethodPresenter.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractMethod/ExtractMethodPresenter.cs
@@ -6,7 +6,12 @@ using Rubberduck.Parsing.Grammar;
 
 namespace Rubberduck.Refactorings.ExtractMethod
 {
-    public class ExtractMethodPresenter
+    public interface IExtractMethodPresenter
+    {
+        ExtractMethodModel Show();
+    }
+
+    public class ExtractMethodPresenter : IExtractMethodPresenter
     {
         private readonly IExtractMethodDialog _view;
         private readonly ExtractMethodModel _model;

--- a/RetailCoder.VBE/Refactorings/ExtractMethod/ExtractMethodPresenterFactory.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractMethod/ExtractMethodPresenterFactory.cs
@@ -5,7 +5,7 @@ using Rubberduck.VBEditor;
 
 namespace Rubberduck.Refactorings.ExtractMethod
 {
-    public class ExtractMethodPresenterFactory : IRefactoringPresenterFactory<ExtractMethodPresenter>
+    public class ExtractMethodPresenterFactory : IRefactoringPresenterFactory<IExtractMethodPresenter>
     {
         private readonly IActiveCodePaneEditor _editor;
         private readonly Declarations _declarations;
@@ -16,7 +16,7 @@ namespace Rubberduck.Refactorings.ExtractMethod
             _declarations = declarations;
         }
 
-        public ExtractMethodPresenter Create()
+        public IExtractMethodPresenter Create()
         {
             var selection = _editor.GetSelection();
             if (selection == null)

--- a/RetailCoder.VBE/Refactorings/ExtractMethod/ExtractMethodRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractMethod/ExtractMethodRefactoring.cs
@@ -15,9 +15,9 @@ namespace Rubberduck.Refactorings.ExtractMethod
     public class ExtractMethodRefactoring : IRefactoring
     {
         private readonly IActiveCodePaneEditor _editor;
-        private readonly IRefactoringPresenterFactory<ExtractMethodPresenter> _factory;
+        private readonly IRefactoringPresenterFactory<IExtractMethodPresenter> _factory;
 
-        public ExtractMethodRefactoring(IRefactoringPresenterFactory<ExtractMethodPresenter> factory, IActiveCodePaneEditor editor)
+        public ExtractMethodRefactoring(IRefactoringPresenterFactory<IExtractMethodPresenter> factory, IActiveCodePaneEditor editor)
         {
             _factory = factory;
             _editor = editor;

--- a/RetailCoder.VBE/UI/CodeExplorer/CodeExplorerWindow.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/CodeExplorerWindow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Forms;
 using Microsoft.Vbe.Interop;
 using Rubberduck.Parsing.Symbols;
@@ -6,6 +7,7 @@ using Rubberduck.Properties;
 
 namespace Rubberduck.UI.CodeExplorer
 {
+    [ExcludeFromCodeCoverage]
     public partial class CodeExplorerWindow : UserControl, IDockableUserControl
     {
         private const string ClassId = "C5318B59-172F-417C-88E3-B377CDA2D809";

--- a/RubberduckTests/Mocks/MockFactory.cs
+++ b/RubberduckTests/Mocks/MockFactory.cs
@@ -103,10 +103,10 @@ namespace RubberduckTests.Mocks
         /// <returns></returns>
         internal static Mock<CodeModule> CreateCodeModuleMock(string code)
         {
-            var lines = code.Split(new [] { Environment.NewLine }, StringSplitOptions.None);
+            var lines = code.Split(new[] {Environment.NewLine}, StringSplitOptions.None).ToList();
 
             var codeModule = new Mock<CodeModule>();
-            codeModule.SetupGet(c => c.CountOfLines).Returns(lines.Length);
+            codeModule.SetupGet(c => c.CountOfLines).Returns(lines.Count);
 
             // ReSharper disable once UseIndexedProperty
             // No R#, the indexed property breaks the expression. I tried that first.
@@ -115,6 +115,12 @@ namespace RubberduckTests.Mocks
 
             codeModule.Setup(m => m.ReplaceLine(It.IsAny<int>(), It.IsAny<string>()))
                 .Callback<int, string>((index, str) => lines[index - 1] = str);
+
+            codeModule.Setup(m => m.DeleteLines(It.IsAny<int>(), It.IsAny<int>()))
+                .Callback<int, int>((index, count) => lines.RemoveRange(index - 1, count));
+
+            codeModule.Setup(m => m.InsertLines(It.IsAny<int>(), It.IsAny<string>()))
+                .Callback<int, string>((index, newLine) => lines.Insert(index - 1, newLine));
                 
             return codeModule;
         }

--- a/RubberduckTests/Refactoring/ExtractMethodTests.cs
+++ b/RubberduckTests/Refactoring/ExtractMethodTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.ExtractMethod;
+using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.Extensions;
+
+namespace RubberduckTests.Refactoring
+{
+    [TestClass]
+    public class ExtractMethodTests : RefactoringTestBase
+    {
+        [TestMethod]
+        public void ExtractMethod_PrivateFunction()
+        {
+            const string inputCode = @"
+Private Sub Foo()
+    Dim x As Integer
+    x = 1 + 2
+End Sub";
+
+            const string expectedCode = @"
+Private Sub Foo()
+    x = Bar()
+End Sub
+
+Private Function Bar() As Integer
+    Dim x As Integer
+    x = 1 + 2
+    Bar = x
+End Function
+
+";
+
+            SetupProject(inputCode);
+
+            var qualifiedSelection = GetQualifiedSelection(new Selection(4,1,4,20));
+
+            var parseResult = new RubberduckParser().Parse(Project.Object);
+            
+            var editor = new ActiveCodePaneEditor(IDE.Object);
+
+            var model = new ExtractMethodModel(editor, parseResult.Declarations, qualifiedSelection);
+            model.Method.Accessibility = Accessibility.Private;
+            model.Method.MethodName = "Bar";
+            model.Method.ReturnValue = new ExtractedParameter("Integer", ExtractedParameter.PassedBy.ByVal, "x");
+            model.Method.Parameters = new List<ExtractedParameter>();
+
+            var factory = SetupFactory(model);
+            
+            //act
+            var refactoring = new ExtractMethodRefactoring(factory.Object, editor);
+            refactoring.Refactor(qualifiedSelection);
+
+            //assert
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
+        }
+
+        private static Mock<IRefactoringPresenterFactory<IExtractMethodPresenter>> SetupFactory(ExtractMethodModel model)
+        {
+            var presenter = new Mock<IExtractMethodPresenter>();
+            presenter.Setup(p => p.Show()).Returns(model);
+
+            var factory = new Mock<IRefactoringPresenterFactory<IExtractMethodPresenter>>();
+            factory.Setup(f => f.Create()).Returns(presenter.Object);
+            return factory;
+        }
+    }
+}

--- a/RubberduckTests/Refactoring/RefactoringTestBase.cs
+++ b/RubberduckTests/Refactoring/RefactoringTestBase.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using Microsoft.Vbe.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Rubberduck.VBEditor;
+using RubberduckTests.Mocks;
+using MockFactory = RubberduckTests.Mocks.MockFactory;
+
+namespace RubberduckTests.Refactoring
+{
+    public abstract class RefactoringTestBase
+    {
+        protected Mock<VBProject> Project;
+        protected Mock<VBComponent> Component;
+        protected Mock<CodeModule> Module;
+        protected Mock<VBE> IDE;
+
+        [TestCleanup]
+        public void CleanUp()
+        {
+            Project = null;
+            Component = null;
+            Module = null;
+        }
+
+        protected QualifiedSelection GetQualifiedSelection(Selection selection)
+        {
+            return new QualifiedSelection(new QualifiedModuleName(Component.Object), selection);
+        }
+
+        protected void SetupProject(string inputCode)
+        {
+            var window = MockFactory.CreateWindowMock(string.Empty);
+            var windows = new MockWindowsCollection(window.Object);
+
+            IDE = MockFactory.CreateVbeMock(windows);
+
+            var codePane = MockFactory.CreateCodePaneMock(IDE, window);
+
+            IDE.SetupGet(vbe => vbe.ActiveCodePane).Returns(codePane.Object);
+
+            Module = MockFactory.CreateCodeModuleMock(inputCode, codePane.Object);
+
+            codePane.SetupGet(p => p.CodeModule).Returns(Module.Object);
+
+            Project = MockFactory.CreateProjectMock("VBAProject", vbext_ProjectProtection.vbext_pp_none);
+
+            Component = MockFactory.CreateComponentMock("Module1", Module.Object, vbext_ComponentType.vbext_ct_StdModule);
+
+            var components = MockFactory.CreateComponentsMock(new List<VBComponent>() { Component.Object });
+            components.SetupGet(c => c.Parent).Returns(Project.Object);
+
+            Project.SetupGet(p => p.VBComponents).Returns(components.Object);
+            Component.SetupGet(c => c.Collection).Returns(components.Object);
+        }
+    }
+}

--- a/RubberduckTests/Refactoring/RemoveParametersTests.cs
+++ b/RubberduckTests/Refactoring/RemoveParametersTests.cs
@@ -1,33 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Vbe.Interop;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings;
 using Rubberduck.Refactorings.RemoveParameters;
 using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.Extensions;
-using MockFactory = RubberduckTests.Mocks.MockFactory;
 
 namespace RubberduckTests.Refactoring
 {
     [TestClass]
-    public class RemoveParametersTests
+    public class RemoveParametersTests : RefactoringTestBase
     {
-        private Mock<VBProject> _project;
-        private Mock<VBComponent> _component;
-        private Mock<CodeModule> _module;
-
-        [TestCleanup]
-        private void CleanUp()
-        {
-            _project = null;
-            _component = null;
-            _module = null;
-        }
-
         [TestMethod]
         public void RemoveParamatersRefactoring_RemoveBothParams()
         {
@@ -44,7 +27,7 @@ End Sub";
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -60,7 +43,7 @@ End Sub";
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -79,7 +62,7 @@ End Sub";
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -95,7 +78,7 @@ End Sub";
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -114,7 +97,7 @@ End Sub"; //note: The IDE strips out the extra whitespace
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -130,7 +113,7 @@ End Sub"; //note: The IDE strips out the extra whitespace
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -149,7 +132,7 @@ End Sub"; //note: The IDE strips out the extra whitespace
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -165,7 +148,7 @@ End Sub"; //note: The IDE strips out the extra whitespace
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -184,7 +167,7 @@ End Function"; //note: The IDE strips out the extra whitespace
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -200,7 +183,7 @@ End Function"; //note: The IDE strips out the extra whitespace
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -219,7 +202,7 @@ End Property"; //note: The IDE strips out the extra whitespace
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -235,7 +218,7 @@ End Property"; //note: The IDE strips out the extra whitespace
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         //bug: We shouldn't allow the only param in a setter to be removed, it will break the VBA code.
@@ -255,7 +238,7 @@ End Property"; //note: The IDE strips out the extra whitespace
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -271,7 +254,7 @@ End Property"; //note: The IDE strips out the extra whitespace
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         //note: removing other params from setters is fine (In fact, we may want to create an inspection for this).
@@ -291,7 +274,7 @@ End Property"; //note: The IDE strips out the extra whitespace
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -307,7 +290,7 @@ End Property"; //note: The IDE strips out the extra whitespace
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -336,7 +319,7 @@ End Sub
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -352,13 +335,7 @@ End Sub
             refactoring.Refactor(qualifiedSelection);
 
             //Assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
-        }
-
-        #region setup
-        private QualifiedSelection GetQualifiedSelection(Selection selection)
-        {
-            return new QualifiedSelection(new QualifiedModuleName(_component.Object), selection);
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         private static Mock<IRefactoringPresenterFactory<IRemoveParametersPresenter>> SetupFactory(RemoveParametersModel model)
@@ -370,29 +347,5 @@ End Sub
             factory.Setup(f => f.Create()).Returns(presenter.Object);
             return factory;
         }
-
-        private void SetupProject(string inputCode)
-        {
-            var window = MockFactory.CreateWindowMock(string.Empty);
-            var windows = new Mocks.MockWindowsCollection(window.Object);
-
-            var vbe = MockFactory.CreateVbeMock(windows);
-
-            var codePane = MockFactory.CreateCodePaneMock(vbe, window);
-
-            _module = MockFactory.CreateCodeModuleMock(inputCode, codePane.Object);
-           
-            _project = MockFactory.CreateProjectMock("VBAProject", vbext_ProjectProtection.vbext_pp_none);
-
-            _component = MockFactory.CreateComponentMock("Module1", _module.Object, vbext_ComponentType.vbext_ct_StdModule);
-
-            var components = MockFactory.CreateComponentsMock(new List<VBComponent>() {_component.Object});
-            components.SetupGet(c => c.Parent).Returns(_project.Object);
-
-            _project.SetupGet(p => p.VBComponents).Returns(components.Object);
-            _component.SetupGet(c => c.Collection).Returns(components.Object);
-        }
-
-        #endregion
     }
 }

--- a/RubberduckTests/Refactoring/ReorderParametersTests.cs
+++ b/RubberduckTests/Refactoring/ReorderParametersTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Vbe.Interop;
+﻿using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Rubberduck.Parsing.VBA;
@@ -9,25 +6,12 @@ using Rubberduck.Refactorings;
 using Rubberduck.Refactorings.ReorderParameters;
 using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.Extensions;
-using MockFactory = RubberduckTests.Mocks.MockFactory;
 
 namespace RubberduckTests.Refactoring
 {
     [TestClass]
-    public class ReorderParametersTests
+    public class ReorderParametersTests : RefactoringTestBase
     {
-        private Mock<VBProject> _project;
-        private Mock<VBComponent> _component;
-        private Mock<CodeModule> _module;
-
-        [TestCleanup]
-        private void CleanUp()
-        {
-            _project = null;
-            _component = null;
-            _module = null;
-        }
-
         [TestMethod]
         public void ReorderParams_SwapPositions()
         {
@@ -44,7 +28,7 @@ End Sub";
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -59,7 +43,7 @@ End Sub";
             refactoring.Refactor(qualifiedSelection);
 
             //assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -78,7 +62,7 @@ End Sub";
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -100,7 +84,7 @@ End Sub";
             refactoring.Refactor(qualifiedSelection);
 
             //assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         [TestMethod]
@@ -129,7 +113,7 @@ End Sub
 
             //Arrange
             SetupProject(inputCode);
-            var parseResult = new RubberduckParser().Parse(_project.Object);
+            var parseResult = new RubberduckParser().Parse(Project.Object);
 
             var qualifiedSelection = GetQualifiedSelection(selection);
 
@@ -144,7 +128,7 @@ End Sub
             refactoring.Refactor(qualifiedSelection);
 
             //assert
-            Assert.AreEqual(expectedCode, _module.Object.Lines());
+            Assert.AreEqual(expectedCode, Module.Object.Lines());
         }
 
         private static Mock<IRefactoringPresenterFactory<IReorderParametersPresenter>> SetupFactory(ReorderParametersModel model)
@@ -155,33 +139,6 @@ End Sub
             var factory = new Mock<IRefactoringPresenterFactory<IReorderParametersPresenter>>();
             factory.Setup(f => f.Create()).Returns(presenter.Object);
             return factory;
-        }
-
-        private QualifiedSelection GetQualifiedSelection(Selection selection)
-        {
-            return new QualifiedSelection(new QualifiedModuleName(_component.Object), selection);
-        }
-
-        private void SetupProject(string inputCode)
-        {
-            var window = MockFactory.CreateWindowMock(string.Empty);
-            var windows = new Mocks.MockWindowsCollection(window.Object);
-
-            var vbe = MockFactory.CreateVbeMock(windows);
-
-            var codePane = MockFactory.CreateCodePaneMock(vbe, window);
-
-            _module = MockFactory.CreateCodeModuleMock(inputCode, codePane.Object);
-
-            _project = MockFactory.CreateProjectMock("VBAProject", vbext_ProjectProtection.vbext_pp_none);
-
-            _component = MockFactory.CreateComponentMock("Module1", _module.Object, vbext_ComponentType.vbext_ct_StdModule);
-
-            var components = MockFactory.CreateComponentsMock(new List<VBComponent>() { _component.Object });
-            components.SetupGet(c => c.Parent).Returns(_project.Object);
-
-            _project.SetupGet(p => p.VBComponents).Returns(components.Object);
-            _component.SetupGet(c => c.Collection).Returns(components.Object);
         }
     }
 }

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -182,8 +182,10 @@
   <ItemGroup>
     <Compile Include="Mocks\MockFactory.cs" />
     <Compile Include="Mocks\MockWindowsCollection.cs" />
+    <Compile Include="Refactoring\RefactoringTestBase.cs" />
     <Compile Include="Refactoring\RemoveParametersTests.cs" />
     <Compile Include="Refactoring\ReorderParametersTests.cs" />
+    <Compile Include="Refactoring\ExtractMethodTests.cs" />
     <Compile Include="SourceControl\ChangesPresenterTests.cs" />
     <Compile Include="SourceControl\BranchesPresenterTests.cs" />
     <Compile Include="SourceControl\SCPresenterTests.cs" />


### PR DESCRIPTION
Also extracted common setup code for the different refactorings into a common base class.
This brings us up to 20% coverage excluding the parser. 
The parser itself is 15% covered through indirect tests.