### PR TITLE
Fix for ParameterCanBeByValInspectionResult quickfix

### DIFF
--- a/RetailCoder.VBE/Inspections/ParameterCanBeByValInspectionResult.cs
+++ b/RetailCoder.VBE/Inspections/ParameterCanBeByValInspectionResult.cs
@@ -25,7 +25,7 @@ namespace Rubberduck.Inspections
 
         private void PassParameterByValue()
         {
-            var parameter = Context.GetText();
+            var parameter = Context.Parent.GetText();
             var newContent = string.Concat(Tokens.ByVal, " ", parameter.Replace(Tokens.ByRef, string.Empty).Trim());
             var selection = QualifiedSelection.Selection;
 

--- a/RetailCoder.VBE/Properties/AssemblyInfo.cs
+++ b/RetailCoder.VBE/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.1.*")]
-[assembly: AssemblyFileVersion("1.4.1.0")]
+[assembly: AssemblyVersion("1.4.2.*")]
+[assembly: AssemblyFileVersion("1.4.2.0")]


### PR DESCRIPTION
Fixes a bug where the quickfix would not remove an existing `ByRef` when changing a parameter to `ByVal`.

Repro:

    Public Sub DoSomething(ByRef value)
    End Sub

The quickfix would result in this broken code:

    Public Sub DoSomething(ByRef ByVal value)
    End Sub
