### PR TITLE
Remove extra initialialization of ParseErrorsPresenter

### DIFF
--- a/RetailCoder.VBE/App.cs
+++ b/RetailCoder.VBE/App.cs
@@ -39,7 +39,6 @@ namespace Rubberduck
             _addIn = addIn;
             _factory = new RubberduckCodePaneFactory();
 
-            _parserErrorsPresenter = new ParserErrorsPresenter(vbe, addIn);
             _configService.SettingsChanged += _configService_SettingsChanged;
 
             _editor = new ActiveCodePaneEditor(vbe, _factory);


### PR DESCRIPTION
This should just be initialized in Setup.

This one line change was all that's necessary, it was thoroughly discussed in chat.