### PR TITLE
Architecture changes (IoC)

### DIFF
--- a/RetailCoder.VBE/Inspections/CodeInspectionQuickFix.cs
+++ b/RetailCoder.VBE/Inspections/CodeInspectionQuickFix.cs
@@ -1,0 +1,16 @@
+﻿namespace Rubberduck.Inspections
+{
+    public abstract class CodeInspectionQuickFix
+    {
+        private readonly string _description;
+
+        public CodeInspectionQuickFix(string description)
+        {
+            _description = description;
+        }
+
+        public string Description { get { return _description; } }
+
+        public abstract void Fix();
+    }
+}

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -251,6 +251,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppMenu.cs" />
+    <Compile Include="Inspections\CodeInspectionQuickFix.cs" />
     <Compile Include="Navigation\NavigateAllReferences.cs" />
     <Compile Include="Navigation\NavigateAllImplementations.cs" />
     <Compile Include="Navigation\IDeclarationNavigator.cs" />
@@ -308,6 +309,10 @@
     <Compile Include="Inspections\IdentifierNotUsedInspectionResult.cs" />
     <Compile Include="Inspections\VariableNotAssignedInspection.cs" />
     <Compile Include="Inspections\IdentifierNotAssignedInspectionResult.cs" />
+    <Compile Include="UI\CodeInspections\InspectionResultsControl.xaml.cs">
+      <DependentUpon>InspectionResultsControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UI\CodeInspections\InspectionResultsViewModel.cs" />
     <Compile Include="UI\Command\AboutCommand.cs" />
     <Compile Include="UI\Command\AddTestMethodExpectedErrorCommand.cs" />
     <Compile Include="UI\Command\AddTestMethodCommand.cs" />
@@ -643,6 +648,7 @@
     <Compile Include="UI\Settings\TodoSettingPresenter.cs" />
     <Compile Include="UI\ToDoItems\ToDoExplorerDockablePresenter.cs" />
     <Compile Include="UI\ToDoItems\ToDoItemClickEventArgs.cs" />
+    <Compile Include="UI\BindableSelectedItemBehavior.cs" />
     <Compile Include="UI\UnitTesting\StandardModuleTestExplorerModel.cs" />
     <Compile Include="UI\UnitTesting\TestExplorerControl.xaml.cs">
       <DependentUpon>TestExplorerControl.xaml</DependentUpon>
@@ -1167,6 +1173,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="UI\CodeInspections\InspectionResultsControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="UI\FindSymbol\FindSymbolControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/RetailCoder.VBE/UI/BindableSelectedItemBehavior.cs
+++ b/RetailCoder.VBE/UI/BindableSelectedItemBehavior.cs
@@ -1,0 +1,53 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interactivity;
+
+namespace Rubberduck.UI
+{
+    /// <summary>
+    /// http://stackoverflow.com/a/5118406/1188513
+    /// </summary>
+    public class BindableSelectedItemBehavior : Behavior<TreeView>
+    {
+        public object SelectedItem
+        {
+            get { return (object) GetValue(SelectedItemProperty); }
+            set { SetValue(SelectedItemProperty, value); }
+        }
+
+        public static readonly DependencyProperty SelectedItemProperty =
+            DependencyProperty.Register("SelectedItem", typeof (object), typeof (BindableSelectedItemBehavior),
+                new UIPropertyMetadata(null, OnSelectedItemChanged));
+
+        private static void OnSelectedItemChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            var item = e.NewValue as TreeViewItem;
+            if (item != null)
+            {
+                item.SetValue(TreeViewItem.IsSelectedProperty, true);
+            }
+        }
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            this.AssociatedObject.SelectedItemChanged += OnTreeViewSelectedItemChanged;
+        }
+
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+
+            if (this.AssociatedObject != null)
+            {
+                this.AssociatedObject.SelectedItemChanged -= OnTreeViewSelectedItemChanged;
+            }
+        }
+
+        private void OnTreeViewSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            this.SelectedItem = e.NewValue;
+        }
+    }
+}

--- a/RetailCoder.VBE/UI/CodeInspections/CodeInspectionsDockablePresenter.cs
+++ b/RetailCoder.VBE/UI/CodeInspections/CodeInspectionsDockablePresenter.cs
@@ -26,10 +26,6 @@ namespace Rubberduck.UI.CodeInspections
         /// <summary>
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when <see cref="_inspector_Reset"/> is <c>null</c>.</exception>
-        /// <param name="inspector"></param>
-        /// <param name="vbe"></param>
-        /// <param name="addin"></param>
-        /// <param name="window"></param>
         public CodeInspectionsDockablePresenter(IInspector inspector, VBE vbe, AddIn addin, CodeInspectionsWindow window, ICodePaneWrapperFactory wrapperFactory)
             :base(vbe, addin, window)
         {

--- a/RetailCoder.VBE/UI/CodeInspections/CodeInspectionsMenu.cs
+++ b/RetailCoder.VBE/UI/CodeInspections/CodeInspectionsMenu.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.UI.CodeInspections
 
         public void Initialize(CommandBarPopup parentMenu)
         {
-            _codeInspectionsButton = AddButton(parentMenu, RubberduckUI.RubberduckMenu_CodeInspections, false, new CommandBarButtonClickEvent(OnCodeInspectionsButtonClick));
+            _codeInspectionsButton = AddButton(parentMenu, RubberduckUI.RubberduckMenu_CodeInspections, false, OnCodeInspectionsButtonClick);
         }
 
         public void Inspect()

--- a/RetailCoder.VBE/UI/CodeInspections/InspectionResultsControl.xaml
+++ b/RetailCoder.VBE/UI/CodeInspections/InspectionResultsControl.xaml
@@ -1,0 +1,78 @@
+﻿<UserControl x:Class="Rubberduck.UI.CodeInspections.InspectionResultsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:inspections="clr-namespace:Rubberduck.Inspections"
+             xmlns:resx="clr-namespace:Rubberduck.UI"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <UserControl.Resources>
+
+        <Style x:Key="IconStyle" TargetType="Image">
+            <Setter Property="Height" Value="16" />
+            <Setter Property="Width" Value="16" />
+            <Setter Property="Margin" Value="4" />
+        </Style>
+
+        <CollectionViewSource x:Key="InspectionTypeGroupViewSource" Source="{Binding}">
+            <CollectionViewSource.GroupDescriptions>
+                <PropertyGroupDescription PropertyName="" />
+            </CollectionViewSource.GroupDescriptions>
+        </CollectionViewSource>
+
+        <DataTemplate x:Key="InspectionResultTemplate" DataType="{x:Type inspections:CodeInspectionResultBase}">
+            <StackPanel Orientation="Horizontal">
+                <Image Style="{StaticResource IconStyle}" 
+                       Source="{Binding Severity}"
+                       VerticalAlignment="Center" />
+                <TextBlock Margin="4" 
+                           VerticalAlignment="Center" 
+                           Text="{Binding Name}" 
+                           TextWrapping="NoWrap"/>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="QuickFixItemTemplate" DataType="{x:Type inspections:CodeInspectionResultBase}">
+            
+        </DataTemplate>
+
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="16"/>
+            <RowDefinition Height="*" MinHeight="64" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Grid.RowSpan="3" Background="#FFEEF5FD" />
+
+        <ToolBar Grid.Row="0">
+
+            <Button Command="{Binding RefreshCommand}">
+                <Image Height="16" Source="../../Resources/arrow-circle-double.png" />
+            </Button>
+
+            <Separator />
+
+            <Button Command="{Binding CopyResultsCommand}">
+                <Image Height="16" Source="../../Resources/document-copy.png" />
+            </Button>
+
+            <Button Command="{Binding ExportResultsCommand}">
+                <Image Height="16" Source="../../Resources/disk.png" />
+            </Button>
+
+        </ToolBar>
+
+        <TreeView Grid.Row="2" x:Name="TestMethodTree"
+                  ItemsSource="{Binding Source={StaticResource InspectionTypeGroupViewSource}, Path=Groups}"
+                  ItemTemplate="{StaticResource InspectionResultTemplate}">
+            <i:Interaction.Behaviors>
+                <resx:BindableSelectedItemBehavior SelectedItem="{Binding SelectedItem, Mode=TwoWay}" />
+            </i:Interaction.Behaviors>
+        </TreeView>
+    </Grid>
+</UserControl>

--- a/RetailCoder.VBE/UI/CodeInspections/InspectionResultsControl.xaml.cs
+++ b/RetailCoder.VBE/UI/CodeInspections/InspectionResultsControl.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Rubberduck.UI.CodeInspections
+{
+    /// <summary>
+    /// Interaction logic for InspectionResultsControl.xaml
+    /// </summary>
+    public partial class InspectionResultsControl : UserControl
+    {
+        public InspectionResultsControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/RetailCoder.VBE/UI/CodeInspections/InspectionResultsViewModel.cs
+++ b/RetailCoder.VBE/UI/CodeInspections/InspectionResultsViewModel.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Rubberduck.Inspections;
+using Rubberduck.UI.Command;
+using Rubberduck.VBEditor.VBEInterfaces.RubberduckCodePane;
+
+namespace Rubberduck.UI.CodeInspections
+{
+    public class InspectionResultsViewModel : ViewModelBase
+    {
+        private readonly IInspector _inspector;
+        private readonly ICodePaneWrapperFactory _wrapperFactory;
+
+        public InspectionResultsViewModel(IInspector inspector, ICodePaneWrapperFactory wrapperFactory)
+        {
+            _inspector = inspector;
+            _wrapperFactory = wrapperFactory;
+        }
+
+        private readonly ICommand _runAllInspections;
+    }
+}

--- a/RetailCoder.VBE/UI/Command/RunCodeInspectionsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/RunCodeInspectionsCommand.cs
@@ -1,5 +1,9 @@
 ﻿using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows.Input;
+using Microsoft.Vbe.Interop;
+using Rubberduck.Inspections;
+using Rubberduck.Parsing;
 using Rubberduck.UI.Command.MenuItems;
 using Rubberduck.UI.Command.MenuItems.ParentMenus;
 
@@ -11,9 +15,30 @@ namespace Rubberduck.UI.Command
     [ComVisible(false)]
     public class RunCodeInspectionsCommand : CommandBase
     {
-        public override void Execute(object parameter)
+        private readonly VBE _vbe;
+        private readonly IInspector _inspector;
+        private readonly IRubberduckParser _parser;
+
+        public RunCodeInspectionsCommand(VBE vbe, IInspector inspector, IRubberduckParser parser)
         {
-            throw new System.NotImplementedException();
+            _vbe = vbe;
+            _inspector = inspector;
+            _parser = parser;
+        }
+
+        /// <summary>
+        /// Runs code inspections 
+        /// </summary>
+        /// <param name="parameter"></param>
+        public override async void Execute(object parameter)
+        {
+            // todo: find a way to run this from UI
+            //var project = parameter as VBProject;
+            //var parseResult = project == null 
+            //    ? _parser.Parse(_vbe.ActiveVBProject)
+            //    : _parser.Parse(project);
+
+            //var results = _inspector.FindIssuesAsync(parseResult, CancellationToken.None);
         }
     }
 

--- a/RetailCoder.VBE/UI/UnitTesting/TestExplorerControl.xaml
+++ b/RetailCoder.VBE/UI/UnitTesting/TestExplorerControl.xaml
@@ -167,7 +167,7 @@
                   ItemsSource="{Binding Source={StaticResource OutcomeGroupViewSource}, Path=Groups}"
                   ItemTemplate="{StaticResource OutcomeTemplate}">
             <i:Interaction.Behaviors>
-                <local:BindableSelectedItemBehavior SelectedItem="{Binding SelectedItem, Mode=TwoWay}" />
+                <resx:BindableSelectedItemBehavior SelectedItem="{Binding SelectedItem, Mode=TwoWay}" />
             </i:Interaction.Behaviors>
             <TreeView.ContextMenu>
                 <ContextMenu>

--- a/RetailCoder.VBE/UI/UnitTesting/TestExplorerControl.xaml.cs
+++ b/RetailCoder.VBE/UI/UnitTesting/TestExplorerControl.xaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Interactivity;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -69,53 +68,6 @@ namespace Rubberduck.UI.UnitTesting
             }
 
             Context.NavigateCommand.Execute(selection.GetNavigationArgs());
-        }
-    }
-
-    /// <summary>
-    /// http://stackoverflow.com/a/5118406/1188513
-    /// </summary>
-    public class BindableSelectedItemBehavior : Behavior<TreeView>
-    {
-        public object SelectedItem
-        {
-            get { return (object) GetValue(SelectedItemProperty); }
-            set { SetValue(SelectedItemProperty, value); }
-        }
-
-        public static readonly DependencyProperty SelectedItemProperty =
-            DependencyProperty.Register("SelectedItem", typeof (object), typeof (BindableSelectedItemBehavior),
-                new UIPropertyMetadata(null, OnSelectedItemChanged));
-
-        private static void OnSelectedItemChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
-        {
-            var item = e.NewValue as TreeViewItem;
-            if (item != null)
-            {
-                item.SetValue(TreeViewItem.IsSelectedProperty, true);
-            }
-        }
-
-        protected override void OnAttached()
-        {
-            base.OnAttached();
-
-            this.AssociatedObject.SelectedItemChanged += OnTreeViewSelectedItemChanged;
-        }
-
-        protected override void OnDetaching()
-        {
-            base.OnDetaching();
-
-            if (this.AssociatedObject != null)
-            {
-                this.AssociatedObject.SelectedItemChanged -= OnTreeViewSelectedItemChanged;
-            }
-        }
-
-        private void OnTreeViewSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
-        {
-            this.SelectedItem = e.NewValue;
         }
     }
 }


### PR DESCRIPTION
This is a work-in-progress, merges work done by @Hosch250 on PR #721 and implements a proper composition root; most notable changes include: Rubberduck menu completely handled by IoC; all (most) components are now decoupled and sitting there, waiting to be "reconnected" - at this point only Unit Testing functionality works.

Other functionalities (code inspections, refactorings, etc.) are still "disconnected" - to "reconnect" them all that needs to happen is to implement the `ICommand` for them; this can be collaboratively worked on, hence I'm merging what I have at this point, because "reconnecting" all the components is quite a bit of work.

In the process, I've decided to re-implement the UI in WPF/XAML. Test Explorer is done, Inspection Results is in progress; rest of the UI hasn't been touched.

`ICommand` implementations that are constructor-injected, can be wired up and reused anywhere (context menus, etc.) - `DelegateCommand` used in ViewModels are ViewModel-specific.

Anyway, so this PR is all about architectural changes, and leaves a TON of work to be done... and a bunch of unit tests were broken in the process - but the new, more decoupled architecture should make unit testing even easier.