### PR TITLE
Ran TranslationHelper locale file normalization

### DIFF
--- a/RetailCoder.VBE/UI/RubberduckUI.de.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -1113,5 +1113,11 @@ Warnung: Alle eigenen Einstellungen gehen dabei verloren.</value>
   </data>
   <data name="RubberduckMenu_Navigate" xml:space="preserve">
     <value>Na&amp;vigieren</value>
+  </data>
+  <data name="Language_JP">
+    <value />
+  </data>
+  <data name="Inspections_MultilineParameter">
+    <value />
   </data>
 </root>

--- a/RetailCoder.VBE/UI/RubberduckUI.fr.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.fr.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -933,9 +933,6 @@ Attention: les valeurs personnalisées seront perdues.    Le fichier original se
   <data name="SourceControl_CommitSync" xml:space="preserve">
     <value>Consigner et synchroniser</value>
   </data>
-  <data name="SourceControl_CreateNewBranch" xml:space="preserve">
-    <value>Rubberduck - Nouvelle Branche</value>
-  </data>
   <data name="SourceControl_CurrentBranchLabel" xml:space="preserve">
     <value>Branche:</value>
   </data>
@@ -1119,5 +1116,14 @@ Attention: les valeurs personnalisées seront perdues.    Le fichier original se
   </data>
   <data name="RubberduckMenu_Navigate" xml:space="preserve">
     <value>Na&amp;viguer</value>
+  </data>
+  <data name="Language_JP">
+    <value />
+  </data>
+  <data name="Ducky">
+    <value />
+  </data>
+  <data name="Inspections_MultilineParameter">
+    <value />
   </data>
 </root>

--- a/RetailCoder.VBE/UI/RubberduckUI.jp.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.jp.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -1112,5 +1112,8 @@
   </data>
   <data name="RubberduckMenu_Navigate" xml:space="preserve">
     <value>&amp;vナビゲート</value>
+  </data>
+  <data name="Language_DE">
+    <value />
   </data>
 </root>

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>

--- a/RetailCoder.VBE/UI/RubberduckUI.sv.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.sv.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -1104,5 +1104,23 @@ Varning: Alla anpassade inställningar kommer att försvinna.    Din gamla fil k
   </data>
   <data name="RubberduckMenu_Navigate" xml:space="preserve">
     <value>Na&amp;vigera</value>
+  </data>
+  <data name="Language_JP">
+    <value />
+  </data>
+  <data name="Run">
+    <value />
+  </data>
+  <data name="Rename_DeclarationType">
+    <value />
+  </data>
+  <data name="Ducky">
+    <value />
+  </data>
+  <data name="Inspections_MultilineParameter">
+    <value />
+  </data>
+  <data name="RenamePresenter_TargetIsInterfaceMemberImplementation">
+    <value />
   </data>
 </root>


### PR DESCRIPTION
 removed unused keys and added new keys to de, fr, jp and sv translations