### PR TITLE
Resolver picks up references to built-in type functions (e.g. Chr$)

### DIFF
--- a/RetailCoder.VBE/Inspections/UntypedFunctionUsageInspection.cs
+++ b/RetailCoder.VBE/Inspections/UntypedFunctionUsageInspection.cs
@@ -1,12 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
-using Antlr4.Runtime;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Nodes;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.UI;
-using Rubberduck.VBEditor;
 
 namespace Rubberduck.Inspections
 {
@@ -22,8 +20,7 @@ namespace Rubberduck.Inspections
         public CodeInspectionType InspectionType { get { return CodeInspectionType.LanguageOpportunities; } }
         public CodeInspectionSeverity Severity { get; set; }
 
-        private readonly string[] _tokens = new string[]
-        {
+        private readonly string[] _tokens = {
             Tokens.Error,
             Tokens.Hex,
             Tokens.Oct,
@@ -55,16 +52,5 @@ namespace Rubberduck.Inspections
             return declarations.SelectMany(declaration => declaration.References
                 .Select(item => new UntypedFunctionUsageInspectionResult(this, string.Format(Description, declaration.IdentifierName), item.QualifiedModuleName, item.Context)));
         }
-    }
-
-    public class UntypedFunctionUsageInspectionResult : CodeInspectionResultBase
-    {
-        public UntypedFunctionUsageInspectionResult(IInspection inspection, string result, QualifiedModuleName qualifiedName, ParserRuleContext context) 
-            : base(inspection, result, qualifiedName, context)
-        {
-        }
-
-        //todo: override QuickFixes getter
-        //public override IEnumerable<CodeInspectionQuickFix> QuickFixes { get; private set; }
     }
 }

--- a/RetailCoder.VBE/Inspections/UntypedFunctionUsageInspectionResult.cs
+++ b/RetailCoder.VBE/Inspections/UntypedFunctionUsageInspectionResult.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Antlr4.Runtime;
+using Rubberduck.UI;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Inspections
+{
+    public class UntypedFunctionUsageInspectionResult : CodeInspectionResultBase
+    {
+        private readonly IEnumerable<CodeInspectionQuickFix> _quickFixes;
+
+        public UntypedFunctionUsageInspectionResult(IInspection inspection, string result, QualifiedModuleName qualifiedName, ParserRuleContext context) 
+            : base(inspection, result, qualifiedName, context)
+        {
+            _quickFixes = new[]
+            {
+                new UntypedFunctionUsageQuickFix(Context, QualifiedSelection), 
+            };
+        }
+
+        public override IEnumerable<CodeInspectionQuickFix> QuickFixes { get { return _quickFixes; } }
+    }
+
+    public class UntypedFunctionUsageQuickFix : CodeInspectionQuickFix
+    {
+        public UntypedFunctionUsageQuickFix(ParserRuleContext context, QualifiedSelection selection) 
+            : base(context, selection, string.Format(RubberduckUI.QuickFixUseTypedFunction_, context.GetText()))
+        {
+        }
+
+        public override void Fix()
+        {
+            var originalInstruction = Context.GetText();
+            var newInstruction = originalInstruction + "$";
+            var selection = Selection.Selection;
+
+            var module = Selection.QualifiedName.Component.CodeModule;
+            var lines = module.get_Lines(selection.StartLine, selection.LineCount);
+
+            var result = lines.Replace(originalInstruction, newInstruction);
+            module.ReplaceLine(selection.StartLine, result);
+        }
+    }
+}

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -270,6 +270,7 @@
     <Compile Include="AppMenu.cs" />
     <Compile Include="Common\ClipboardWriter.cs" />
     <Compile Include="Inspections\CodeInspectionQuickFix.cs" />
+    <Compile Include="Inspections\UntypedFunctionUsageInspectionResult.cs" />
     <Compile Include="Inspections\WriteOnlyPropertyInspection.cs" />
     <Compile Include="Inspections\UntypedFunctionUsageInspection.cs" />
     <Compile Include="Navigation\NavigateAllReferences.cs" />

--- a/RetailCoder.VBE/UI/CodeInspections/InspectionResultsControl.xaml
+++ b/RetailCoder.VBE/UI/CodeInspections/InspectionResultsControl.xaml
@@ -123,11 +123,11 @@
                 <TextBlock Margin="4" 
                            VerticalAlignment="Center" 
                            Text="{Binding Name, Converter={StaticResource InspectionDescriptionConverter}}"
-                           TextWrapping="NoWrap"/>
+                           TextWrapping="Wrap"/>
                 <TextBlock Margin="0,4,4,4" 
                            VerticalAlignment="Center" 
                            Text="{Binding ItemCount, StringFormat=({0})}" 
-                           TextWrapping="NoWrap"/>
+                           TextWrapping="Wrap"/>
             </StackPanel>
         </HierarchicalDataTemplate>
 
@@ -139,11 +139,11 @@
                 <TextBlock VerticalAlignment="Center" 
                            Text="{Binding Name}"
                            FontWeight="Bold"
-                           TextWrapping="NoWrap"/>
+                           TextWrapping="Wrap"/>
                 <TextBlock Margin="4,0,4,0" 
                            VerticalAlignment="Center" 
                            Text="{Binding ItemCount, StringFormat=({0})}" 
-                           TextWrapping="NoWrap"/>
+                           TextWrapping="Wrap"/>
             </StackPanel>
         </HierarchicalDataTemplate>
 
@@ -157,11 +157,11 @@
                 <TextBlock VerticalAlignment="Center" 
                            Text="{Binding Name}"
                            FontWeight="Bold"
-                           TextWrapping="NoWrap"/>
+                           TextWrapping="Wrap"/>
                 <TextBlock Margin="4,0,4,0" 
                            VerticalAlignment="Center" 
                            Text="{Binding ItemCount, StringFormat=({0})}" 
-                           TextWrapping="NoWrap"/>
+                           TextWrapping="Wrap"/>
             </StackPanel>
         </HierarchicalDataTemplate>
         

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -886,7 +886,7 @@ namespace Rubberduck.UI {
         /// </summary>
         public static System.Drawing.Icon Ducky {
             get {
-                object obj = ResourceManager.GetObject("Ducky");
+                object obj = ResourceManager.GetObject("Ducky", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }
         }
@@ -1713,6 +1713,15 @@ namespace Rubberduck.UI {
         public static string QuickFix_ThisProject {
             get {
                 return ResourceManager.GetString("QuickFix_ThisProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;{0}$&apos; instead of &apos;{0}&apos;..
+        /// </summary>
+        public static string QuickFixUseTypedFunction_ {
+            get {
+                return ResourceManager.GetString("QuickFixUseTypedFunction_", resourceCulture);
             }
         }
         

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -1185,4 +1185,7 @@ Are you sure you want to proceed with this rename?</value>
   <data name="UntypedFunctionUsage_" xml:space="preserve">
     <value>Use of untyped function '{0}'. String-returning version '{0}$' is available.</value>
   </data>
+  <data name="QuickFixUseTypedFunction_" xml:space="preserve">
+    <value>Use '{0}$' instead of '{0}'.</value>
+  </data>
 </root>


### PR DESCRIPTION
also fixes #806