### PR TITLE
Fixed SourceControl factory IoC bindings

### DIFF
--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -95,7 +95,7 @@ namespace Rubberduck.Root
         {
             _kernel.Bind(t => t.From(assemblies)
                 .SelectAllInterfaces()
-                .Where(type => type.Name.EndsWith("Factory"))
+                .Where(type => type.Name.EndsWith("Factory")) 
                 .BindToFactory()
                 .Configure(binding => binding.InSingletonScope()));
         }

--- a/RetailCoder.VBE/UI/SourceControl/SourceControlBindings.cs
+++ b/RetailCoder.VBE/UI/SourceControl/SourceControlBindings.cs
@@ -2,6 +2,7 @@
 using Ninject;
 using Ninject.Modules;
 using Rubberduck.Settings;
+using Rubberduck.SourceControl;
 
 namespace Rubberduck.UI.SourceControl
 {
@@ -31,12 +32,11 @@ namespace Rubberduck.UI.SourceControl
             Bind<IMergeView>().To<MergeForm>();
 
             //factories 
-            // todo: check on note below
-            // ninject is complaining about also having a SourceControlProviderFactoryProxy and a FolderBrowserFactoryProxy
-            // I'm unsure about commenting these out. I have a feeling that it's not the "right thing", but everything seems to work.
 
-            //Bind<ISourceControlProviderFactory>().To<SourceControlProviderFactory>();
-            //Bind<IFolderBrowserFactory>().To<DialogFactory>();
+            // note: RubberduckModule sets up factory proxies by convention. 
+            // Replace these factory proxies with our existing concrete implementations.
+            Rebind<ISourceControlProviderFactory>().To<SourceControlProviderFactory>();
+            Rebind<IFolderBrowserFactory>().To<DialogFactory>();
         }
     }
 }


### PR DESCRIPTION
The UI isn't working, but the factories it relies on are being correctly bound to the IoC container now.
I can start debugging the *actual* issues next weekend.