### PR TITLE
fix visual studio 2015 invalidcastexception for built-in declarations

### DIFF
--- a/Rubberduck.Parsing/Symbols/AdodbObjectModel.cs
+++ b/Rubberduck.Parsing/Symbols/AdodbObjectModel.cs
@@ -2,9 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Rubberduck.VBEditor;
+using System.Runtime.CompilerServices;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -19,7 +18,7 @@ namespace Rubberduck.Parsing.Symbols
             {
                 if (_adodbDeclarations == null)
                 {
-                    var nestedTypes = typeof(AdodbObjectModel).GetNestedTypes(BindingFlags.NonPublic);
+                    var nestedTypes = typeof(AdodbObjectModel).GetNestedTypes(BindingFlags.NonPublic).Where(t => Attribute.GetCustomAttribute(t, typeof(CompilerGeneratedAttribute)) == null);
                     var fields = nestedTypes.SelectMany(t => t.GetFields());
                     var values = fields.Select(f => f.GetValue(null));
                     _adodbDeclarations = values.Cast<Declaration>();

--- a/Rubberduck.Parsing/Symbols/ExcelObjectModel.cs
+++ b/Rubberduck.Parsing/Symbols/ExcelObjectModel.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Rubberduck.VBEditor;
+using System.Runtime.CompilerServices;
+using System;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -21,7 +23,7 @@ namespace Rubberduck.Parsing.Symbols
             {
                 if (_excelDeclarations == null)
                 {
-                    var nestedTypes = typeof(ExcelObjectModel).GetNestedTypes(BindingFlags.NonPublic);
+                    var nestedTypes = typeof(ExcelObjectModel).GetNestedTypes(BindingFlags.NonPublic).Where(t => Attribute.GetCustomAttribute(t, typeof(CompilerGeneratedAttribute)) == null);
                     var fields = nestedTypes.SelectMany(t => t.GetFields());
                     var values = fields.Select(f => f.GetValue(null));
                     _excelDeclarations = values.Cast<Declaration>();

--- a/Rubberduck.Parsing/Symbols/VbaStandardLib.cs
+++ b/Rubberduck.Parsing/Symbols/VbaStandardLib.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Rubberduck.VBEditor;
+using System.Runtime.CompilerServices;
+using System;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -19,7 +21,7 @@ namespace Rubberduck.Parsing.Symbols
             {
                 if (_standardLibDeclarations == null)
                 {
-                    var nestedTypes = typeof(VbaStandardLib).GetNestedTypes(BindingFlags.NonPublic);
+                    var nestedTypes = typeof(VbaStandardLib).GetNestedTypes(BindingFlags.NonPublic).Where(t => Attribute.GetCustomAttribute(t, typeof(CompilerGeneratedAttribute)) == null);
                     var fields = nestedTypes.SelectMany(t => t.GetFields());
                     var values = fields.Select(f => f.GetValue(null));
                     _standardLibDeclarations = values.Cast<Declaration>();


### PR DESCRIPTION
Apparently Visual Studio 2015 uses a new compiler which generates different code that in turn affects what GetNestedTypes() returns. See: http://stackoverflow.com/questions/31542076/behavior-of-assembly-gettypes-changed-in-visual-studio-2015.

This change resulted in a compiler generated class being returned for the built-in declarations which lead to an invalid cast exception. The fix simply ignores the compiler generated types.

Hosch250 tested the fix in Visual Studio 2013 and it seemed to work. I'm not sure if it'll work on Vista as well though.
