### PR TITLE
fix The "Function return value not used" inspection doesn't work with…

### DIFF
--- a/RetailCoder.VBE/Inspections/CodeInspectionQuickFix.cs
+++ b/RetailCoder.VBE/Inspections/CodeInspectionQuickFix.cs
@@ -17,7 +17,7 @@ namespace Rubberduck.Inspections
         }
 
         public string Description { get { return _description; } }
-        protected ParserRuleContext Context { get { return _context; } }
+        public ParserRuleContext Context { get { return _context; } }
         public QualifiedSelection Selection { get { return _selection; } }
 
         public abstract void Fix();

--- a/RetailCoder.VBE/Inspections/CompositeCodeInspectionFix.cs
+++ b/RetailCoder.VBE/Inspections/CompositeCodeInspectionFix.cs
@@ -1,0 +1,34 @@
+﻿using Antlr4.Runtime;
+using Rubberduck.VBEditor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rubberduck.Inspections
+{
+    public sealed class CompositeCodeInspectionFix : CodeInspectionQuickFix
+    {
+        private readonly CodeInspectionQuickFix _root;
+        private readonly List<CodeInspectionQuickFix> _children;
+
+        public CompositeCodeInspectionFix(CodeInspectionQuickFix root)
+            : base(root.Context, root.Selection, root.Description)
+        {
+            _root = root;
+            _children = new List<CodeInspectionQuickFix>();
+        }
+
+        public void AddChild(CodeInspectionQuickFix quickFix)
+        {
+            _children.Add(quickFix);
+        }
+
+        public override void Fix()
+        {
+            _root.Fix();
+            _children.ForEach(child => child.Fix());
+        }
+    }
+}

--- a/RetailCoder.VBE/Inspections/FunctionReturnValueNotUsedInspection.cs
+++ b/RetailCoder.VBE/Inspections/FunctionReturnValueNotUsedInspection.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.Grammar;
 using Antlr4.Runtime;
 using Rubberduck.UI;
+using Rubberduck.Common;
+using Rubberduck.VBEditor;
 
 namespace Rubberduck.Inspections
 {
@@ -21,20 +24,70 @@ namespace Rubberduck.Inspections
 
         public override IEnumerable<CodeInspectionResultBase> GetInspectionResults()
         {
+            // Note: This inspection does not find dictionary calls (e.g. foo!bar) since we do not know what the
+            // default member is of a class.
+            var interfaceMembers = UserDeclarations.FindInterfaceMembers();
+            var interfaceImplementationMembers = UserDeclarations.FindInterfaceImplementationMembers();
             var functions = UserDeclarations.Where(function => function.DeclarationType == DeclarationType.Function).ToList();
-            var returnValueNotUsedFunctions = functions.Where(function =>
-                    function.References.All(usage =>
-                            IsReturnStatement(function, usage) || IsAddressOfCall(usage) || IsCallWithoutAssignment(usage)));
+            var interfaceMemberIssues = GetInterfaceMemberIssues(interfaceMembers);
+            var nonInterfaceFunctions = functions.Except(interfaceMembers.Union(interfaceImplementationMembers));
+            var nonInterfaceIssues = GetNonInterfaceIssues(nonInterfaceFunctions);
+            return interfaceMemberIssues.Union(nonInterfaceIssues);
+        }
 
-            var issues = returnValueNotUsedFunctions
+        private IEnumerable<FunctionReturnValueNotUsedInspectionResult> GetInterfaceMemberIssues(IEnumerable<Declaration> interfaceMembers)
+        {
+            var interfaceIssues = new List<FunctionReturnValueNotUsedInspectionResult>();
+            foreach (var interfaceMember in interfaceMembers)
+            {
+                var implementationMembers = UserDeclarations.FindInterfaceImplementationMembers(interfaceMember.IdentifierName);
+                if (!IsReturnValueUsed(interfaceMember) && implementationMembers.All(member => !IsReturnValueUsed(member)))
+                {
+                    var implementationMemberIssues = implementationMembers
+                        .Select(implementationMember =>
+                            Tuple.Create(
+                                implementationMember.Context,
+                                new QualifiedSelection(
+                                    implementationMember.QualifiedName.QualifiedModuleName,
+                                    implementationMember.Selection),
+                                GetReturnStatements(implementationMember)));
+
+                    interfaceIssues.Add(new FunctionReturnValueNotUsedInspectionResult(
+                            this,
+                            interfaceMember.Context,
+                            interfaceMember.QualifiedName,
+                            GetReturnStatements(interfaceMember),
+                            implementationMemberIssues));
+                }
+            }
+            return interfaceIssues;
+        }
+
+        private IEnumerable<FunctionReturnValueNotUsedInspectionResult> GetNonInterfaceIssues(IEnumerable<Declaration> nonInterfaceFunctions)
+        {
+            var returnValueNotUsedFunctions = nonInterfaceFunctions.Where(function => !IsReturnValueUsed(function));
+            var nonInterfaceIssues = returnValueNotUsedFunctions
                 .Select(function =>
                         new FunctionReturnValueNotUsedInspectionResult(
                             this,
-                            function.Context, 
+                            function.Context,
                             function.QualifiedName,
-                            function.References.Where(usage => IsReturnStatement(function, usage)).Select(usage => usage.Context.Parent.Parent.Parent.GetText())));
+                            GetReturnStatements(function)));
+            return nonInterfaceIssues;
+        }
 
-            return issues;
+        private IEnumerable<string> GetReturnStatements(Declaration function)
+        {
+            return function.References
+                .Where(usage => IsReturnStatement(function, usage))
+                .Select(usage => usage.Context.Parent.Parent.Parent.GetText());
+        }
+
+        private bool IsReturnValueUsed(Declaration function)
+        {
+            return function.References.Count() > 0
+                && function.References.Any(usage =>
+                            !IsReturnStatement(function, usage) && !IsAddressOfCall(usage) && !IsCallWithoutAssignment(usage));
         }
 
         private bool IsAddressOfCall(IdentifierReference usage)
@@ -51,7 +104,7 @@ namespace Rubberduck.Inspections
 
         private bool IsCallWithoutAssignment(IdentifierReference usage)
         {
-            return usage.Context.Parent != null && usage.Context.Parent is VBAParser.ICS_B_ProcedureCallContext;
+            return usage.Context.Parent != null && usage.Context.Parent.Parent is VBAParser.ImplicitCallStmt_InBlockContext;
         }
     }
 }

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -302,6 +302,7 @@
       <DependentUpon>GroupingGrid.xaml</DependentUpon>
     </Compile>
     <Compile Include="Inspections\CodeInspectionQuickFix.cs" />
+    <Compile Include="Inspections\CompositeCodeInspectionFix.cs" />
     <Compile Include="Inspections\ConvertToProcedureQuickFix.cs" />
     <Compile Include="Inspections\FunctionReturnValueNotUsedInspection.cs" />
     <Compile Include="Inspections\FunctionReturnValueNotUsedInspectionResult.cs" />


### PR DESCRIPTION
… interfaces. (#1041)

The `CompositeCodeInspectionFix` is meant to allow one quick fix to be composed of many other ones  but still allow the entire quick fix to presented to the user as one "atomic quickfix".

With this change interface functions whose return values are not used are now flagged as such. An interface function is considered not used if the interface function as well as all implementation functions are not used anywhere. The quick fix automatically converts the interface function including all implementation functions to procedures.