### PR TITLE
some small typo fixes

### DIFF
--- a/RetailCoder.VBE/Inspections/InspectionsUI.Designer.cs
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.Designer.cs
@@ -317,43 +317,51 @@ namespace Rubberduck.Inspections {
                 return ResourceManager.GetString("ImplicitVariantReturnTypeInspectionName", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Move &apos;{0}&apos; closer to usage.
-        /// </summary>
-        internal static string MoveFieldCloseToUsageInspection {
-            get {
-                return ResourceManager.GetString("MoveFieldCloseToUsageInspection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A field that is only used in one method should be a local variable..
-        /// </summary>
-        internal static string MoveFieldCloseToUsageInspectionMeta {
-            get {
-                return ResourceManager.GetString("MoveFieldCloseToUsageInspectionMeta", resourceCulture);
-            }
-        }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Move field closer to usage.
         /// </summary>
-        internal static string MoveFieldCloseToUsageInspectionName {
-            get {
-                return ResourceManager.GetString("MoveFieldCloseToUsageInspectionName", resourceCulture);
+        internal static string MoveFieldCloserToUsageInspection
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveFieldCloserToUsageInspection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to A field that is only used in one method should be a local variable..
+        /// </summary>
+        internal static string MoveFieldCloserToUsageInspectionMeta
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveFieldCloserToUsageInspectionMeta", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Move field closer to usage.
+        /// </summary>
+        internal static string MoveFieldCloserToUsageInspectionName
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveFieldCloserToUsageInspectionName", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Move field &apos;{0}&apos; closer to usage.
         /// </summary>
-        internal static string MoveFieldCloseToUsageInspectionQuickFix {
-            get {
-                return ResourceManager.GetString("MoveFieldCloseToUsageInspectionQuickFix", resourceCulture);
+        internal static string MoveFieldCloserToUsageInspectionQuickFix
+        {
+            get
+            {
+                return ResourceManager.GetString("MoveFieldCloserToUsageInspectionQuickFix", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Consider continuing long signatures between parameters. Splitting a parameter declaration across multiple lines arguably hurts readability..
         /// </summary>

--- a/RetailCoder.VBE/Inspections/InspectionsUI.resx
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.resx
@@ -195,16 +195,16 @@
   <data name="ImplicitVariantReturnTypeInspectionName" xml:space="preserve">
     <value>Return type is implicitly 'Variant'</value>
   </data>
-  <data name="MoveFieldCloseToUsageInspection" xml:space="preserve">
+  <data name="MoveFieldCloserToUsageInspection" xml:space="preserve">
     <value>Move field closer to usage</value>
   </data>
-  <data name="MoveFieldCloseToUsageInspectionMeta" xml:space="preserve">
+  <data name="MoveFieldCloserToUsageInspectionMeta" xml:space="preserve">
     <value>A field that is only used in one method should be a local variable.</value>
   </data>
-  <data name="MoveFieldCloseToUsageInspectionName" xml:space="preserve">
+  <data name="MoveFieldCloserToUsageInspectionName" xml:space="preserve">
     <value>Move field closer to usage</value>
   </data>
-  <data name="MoveFieldCloseToUsageInspectionQuickFix" xml:space="preserve">
+  <data name="MoveFieldCloserToUsageInspectionQuickFix" xml:space="preserve">
     <value>Move field '{0}' closer to usage</value>
   </data>
   <data name="LanguageOpportunities" xml:space="preserve">

--- a/RetailCoder.VBE/Inspections/MoveFieldCloserToUsageInspection.cs
+++ b/RetailCoder.VBE/Inspections/MoveFieldCloserToUsageInspection.cs
@@ -18,7 +18,7 @@ namespace Rubberduck.Inspections
             Severity = CodeInspectionSeverity.Suggestion;
         }
 
-        public override string Description { get { return InspectionsUI.MoveFieldCloseToUsageInspectionName; } }
+        public override string Description { get { return InspectionsUI.MoveFieldCloserToUsageInspectionName; } }
         public override CodeInspectionType InspectionType { get { return CodeInspectionType.MaintainabilityAndReadabilityIssues; } }
 
         public override IEnumerable<CodeInspectionResultBase> GetInspectionResults()

--- a/RetailCoder.VBE/Inspections/MoveFieldCloserToUsageInspectionResult.cs
+++ b/RetailCoder.VBE/Inspections/MoveFieldCloserToUsageInspectionResult.cs
@@ -36,7 +36,7 @@ namespace Rubberduck.Inspections
         private readonly IMessageBox _messageBox;
 
         public MoveFieldCloserToUsageQuickFix(ParserRuleContext context, QualifiedSelection selection, Declaration target, RubberduckParserState parseResult, ICodePaneWrapperFactory wrapperFactory, IMessageBox messageBox)
-            : base(context, selection, string.Format(InspectionsUI.MoveFieldCloseToUsageInspectionQuickFix, target.IdentifierName))
+            : base(context, selection, string.Format(InspectionsUI.MoveFieldCloserToUsageInspectionQuickFix, target.IdentifierName))
         {
             _target = target;
             _parseResult = parseResult;

--- a/RetailCoder.VBE/UI/RubberduckUI.de.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.de.resx
@@ -392,7 +392,7 @@
     <value>Unbenutzte Variable entfernen</value>
   </data>
   <data name="Inspections_RemoveUnusedDeclaration" xml:space="preserve">
-    <value>Unbenutzte Deklaration entforenen</value>
+    <value>Unbenutzte Deklaration entfernen</value>
   </data>
   <data name="Inspections_RemoveUnusedParameter" xml:space="preserve">
     <value>Unbenutzten Parameter entfernen</value>


### PR DESCRIPTION
- MoveFieldCloseToUsageInspection -> MoveFieldCloserToUsageInspection (the inspection result was shown without name)
- German translation typo fix