### PR TITLE
Partial fix for project name sorting in Code Explorer

### DIFF
--- a/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -88,8 +88,8 @@ namespace Rubberduck.Navigation.CodeExplorer
                 .GroupBy(declaration => declaration.Project)
                 .ToList();
 
-            Projects = new ObservableCollection<CodeExplorerProjectViewModel>(userDeclarations.Select(grouping => 
-                new CodeExplorerProjectViewModel(grouping.Single(declaration => declaration.DeclarationType == DeclarationType.Project), grouping)));
+            Projects = new ObservableCollection<CodeExplorerProjectViewModel>(userDeclarations.Select(grouping =>
+                new CodeExplorerProjectViewModel(grouping.First(declaration => declaration.DeclarationType == DeclarationType.Project), grouping)));
         }
 
         private void ParserState_ModuleStateChanged(object sender, Parsing.ParseProgressEventArgs e)


### PR DESCRIPTION
avoids unhandled exception of the Single method (because more than one
item returned by linq), and instead uses the First method.