### PR TITLE
ImplicitPublicMemberInspection

### DIFF
--- a/RetailCoder.VBE/Inspections/ImplicitPublicMemberInspectionResult.cs
+++ b/RetailCoder.VBE/Inspections/ImplicitPublicMemberInspectionResult.cs
@@ -42,16 +42,16 @@ namespace Rubberduck.Inspections
 
         public override void Fix()
         {
-            var oldContent = Context.GetText();
+            var selection = Context.GetSelection();
+            var module = Selection.QualifiedName.Component.CodeModule;
+
+            var signatureLine = selection.StartLine;
+
+            var oldContent = module.get_Lines(signatureLine, 1);
             var newContent = Tokens.Public + ' ' + oldContent;
 
-            var selection = Context.GetSelection();
-
-            var module = Selection.QualifiedName.Component.CodeModule;
-            var lines = module.get_Lines(selection.StartLine, selection.LineCount);
-
-            module.DeleteLines(selection.StartLine, selection.LineCount);
-            module.InsertLines(selection.StartLine, newContent);
+            module.DeleteLines(signatureLine);
+            module.InsertLines(signatureLine, newContent);
         }
     }
 }

--- a/RubberduckTests/Inspections/ImplicitPublicMemberInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitPublicMemberInspectionTests.cs
@@ -145,13 +145,13 @@ End Sub";
         {
             const string inputCode =
 @"Sub Foo(ByVal arg1 as Integer)
-
+'Just an inoffensive little comment
 
 End Sub";
 
             const string expectedCode =
 @"Public Sub Foo(ByVal arg1 as Integer)
-
+'Just an inoffensive little comment
 
 End Sub";
 


### PR DESCRIPTION
Fixed to no longer rewrite entire procedure; quickfix simply adds access modifier to existing line and restores it as-is.