### PR TITLE
updates for missing typedeclaration for LongLong

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBA.g4
+++ b/Rubberduck.Parsing/Grammar/VBA.g4
@@ -562,7 +562,7 @@ literal : HEXLITERAL | OCTLITERAL | DATELITERAL | DOUBLELITERAL | INTEGERLITERAL
 
 type : (baseType | complexType) (WS? LPAREN WS? RPAREN)?;
 
-typeHint : '&' | '%' | '#' | '!' | '@' | '$';
+typeHint : '%' | '&' | '^' | '!' | '#' | '@' | '$';
 
 visibility : PRIVATE | PUBLIC | FRIEND | GLOBAL;
 


### PR DESCRIPTION
also reordered them according to their size, because why not?
Integer | Long | LongLong | Single | Double | Currency | String