### PR TITLE
closes #1246

### DIFF
--- a/RetailCoder.VBE/App.cs
+++ b/RetailCoder.VBE/App.cs
@@ -47,7 +47,7 @@ namespace Rubberduck
             IGeneralConfigService configService,
             IAppMenu appMenus,
             RubberduckCommandBar stateBar,
-            IIndenter indenter/*,
+            IIndenter indenter/*
             IRubberduckHooks hooks*/)
         {
             _vbe = vbe;

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -346,6 +346,8 @@
     <Compile Include="UI\About\AboutDialog.Designer.cs">
       <DependentUpon>AboutDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="UI\Command\ShowParserErrorsCommand.cs" />
+    <Compile Include="UI\Command\SyntaxErrorExtensions.cs" />
     <Compile Include="UI\Controls\DeclarationTypeToStringConverter.cs" />
     <Compile Include="UI\Controls\SearchResultPresenterInstanceManager.cs" />
     <Compile Include="UI\Controls\ISearchResultsWindowViewModel.cs" />

--- a/RetailCoder.VBE/UI/Command/MenuItems/RubberduckCommandBar.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/RubberduckCommandBar.cs
@@ -12,16 +12,26 @@ namespace Rubberduck.UI.Command.MenuItems
     {
         private readonly RubberduckParserState _state;
         private readonly VBE _vbe;
+        private readonly IShowParserErrorsCommand _command;
 
         private CommandBarButton _refreshButton;
         private CommandBarButton _statusButton;
 
-        public RubberduckCommandBar(RubberduckParserState state, VBE vbe)
+        public RubberduckCommandBar(RubberduckParserState state, VBE vbe, IShowParserErrorsCommand command)
         {
             _state = state;
             _vbe = vbe;
+            _command = command;
             _state.StateChanged += State_StateChanged;
             Initialize();
+        }
+
+        private void _statusButton_Click(CommandBarButton Ctrl, ref bool CancelDefault)
+        {
+            if (_state.Status == ParserState.Error)
+            {
+                _command.Execute(null);
+            }
         }
 
         public void SetStatusText(string value = null)
@@ -60,6 +70,7 @@ namespace Rubberduck.UI.Command.MenuItems
             _statusButton = (CommandBarButton)commandbar.Controls.Add(MsoControlType.msoControlButton);
             _statusButton.Style = MsoButtonStyle.msoButtonCaption;
             _statusButton.Tag = "Status";
+            _statusButton.Click += _statusButton_Click;
 
             commandbar.Visible = true;
         }

--- a/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows.Input;
+using Microsoft.Vbe.Interop;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.UI.Controls;
+
+namespace Rubberduck.UI.Command
+{
+    public interface IShowParserErrorsCommand : ICommand { }
+
+    [ComVisible(false)]
+    public class ShowParserErrorsCommand : CommandBase, IShowParserErrorsCommand
+    {
+        private readonly INavigateCommand _navigateCommand;
+        private readonly RubberduckParserState _state;
+        private readonly ISearchResultsWindowViewModel _viewModel;
+        private readonly SearchResultPresenterInstanceManager _presenterService;
+
+        public ShowParserErrorsCommand(INavigateCommand navigateCommand, RubberduckParserState state, ISearchResultsWindowViewModel viewModel, SearchResultPresenterInstanceManager presenterService)
+        {
+            _navigateCommand = navigateCommand;
+            _state = state;
+            _viewModel = viewModel;
+            _presenterService = presenterService;
+        }
+
+        public override void Execute(object parameter)
+        {
+            if (_state.Status != ParserState.Error)
+            {
+                return;
+            }
+
+            var viewModel = CreateViewModel();
+            _viewModel.AddTab(viewModel);
+            _viewModel.SelectedTab = viewModel;
+
+            try
+            {
+                var presenter = _presenterService.Presenter(_viewModel);
+                presenter.Show();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+
+        private SearchResultsViewModel CreateViewModel()
+        {
+            var errors = from error in _state.ModuleExceptions
+                let declaration = FindModuleDeclaration(error.Item1)
+                select new SearchResultItem(declaration, error.Item2.GetNavigateCodeEventArgs(declaration), error.Item2.Message);
+
+            var viewModel = new SearchResultsViewModel(_navigateCommand, "Parser Errors", null, errors.ToList());
+            return viewModel;
+        }
+
+        private Declaration FindModuleDeclaration(VBComponent component)
+        {
+            return _state.AllUserDeclarations.Single(item => item.Project == component.Collection.Parent
+                                                             && item.QualifiedName.QualifiedModuleName.Component == component 
+                                                             && (item.DeclarationType == DeclarationType.Class || item.DeclarationType == DeclarationType.Module));
+        }
+    }
+}

--- a/RetailCoder.VBE/UI/Command/SyntaxErrorExtensions.cs
+++ b/RetailCoder.VBE/UI/Command/SyntaxErrorExtensions.cs
@@ -1,0 +1,14 @@
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.UI.Command
+{
+    public static class SyntaxErrorExtensions
+    {
+        public static NavigateCodeEventArgs GetNavigateCodeEventArgs(this SyntaxErrorException exception, Declaration declaration)
+        {
+            var selection = new Selection(exception.LineNumber, exception.Position, exception.LineNumber, exception.Position);
+            return new NavigateCodeEventArgs(declaration.QualifiedName.QualifiedModuleName, selection);
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -71,7 +71,7 @@ namespace Rubberduck.Parsing.VBA
 
         public IReadOnlyList<Tuple<VBComponent, SyntaxErrorException>> ModuleExceptions
         {
-            get { return _moduleExceptions.Select(kvp => Tuple.Create(kvp.Key, kvp.Value)).ToList(); }
+            get { return _moduleExceptions.Select(kvp => Tuple.Create(kvp.Key, kvp.Value)).Where(item => item.Item2 != null).ToList(); }
         }
 
         public event EventHandler<ParseProgressEventArgs> ModuleStateChanged;

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -69,6 +69,11 @@ namespace Rubberduck.Parsing.VBA
         private readonly ConcurrentDictionary<VBComponent, SyntaxErrorException> _moduleExceptions =
             new ConcurrentDictionary<VBComponent, SyntaxErrorException>();
 
+        public IReadOnlyList<Tuple<VBComponent, SyntaxErrorException>> ModuleExceptions
+        {
+            get { return _moduleExceptions.Select(kvp => Tuple.Create(kvp.Key, kvp.Value)).ToList(); }
+        }
+
         public event EventHandler<ParseProgressEventArgs> ModuleStateChanged;
 
         private void OnModuleStateChanged(VBComponent component, ParserState state)


### PR DESCRIPTION
Clicking the RubberduckCommandBar status label/button when parser state is `ParseError` will now bring up the "Search Results" toolwindow with a new tab showing parser errors.