### PR TITLE
Small parser/resolver performance improvements

### DIFF
--- a/RetailCoder.VBE/Inspections/InspectionBase.cs
+++ b/RetailCoder.VBE/Inspections/InspectionBase.cs
@@ -10,12 +10,14 @@ namespace Rubberduck.Inspections
     {
         protected readonly RubberduckParserState State;
         private readonly CodeInspectionSeverity _defaultSeverity;
+        private readonly string _name;
 
         protected InspectionBase(RubberduckParserState state, CodeInspectionSeverity defaultSeverity = CodeInspectionSeverity.Warning)
         {
             State = state;
             _defaultSeverity = defaultSeverity;
             Severity = _defaultSeverity;
+            _name = GetType().Name;
         }
 
         /// <summary>
@@ -42,7 +44,7 @@ namespace Rubberduck.Inspections
         /// <summary>
         /// The inspection type name, obtained by reflection.
         /// </summary>
-        public string Name { get { return GetType().Name; } }
+        public string Name { get { return _name; } }
 
         /// <summary>
         /// Inspection severity level. Can control whether an inspection is enabled.

--- a/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -80,7 +80,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         {
             Debug.WriteLine("CodeExplorerViewModel handles StateChanged...");
             IsBusy = _state.Status == ParserState.Parsing;
-            if (_state.Status != ParserState.Parsed)
+            if (_state.Status != ParserState.Ready)
             {
                 return;
             }

--- a/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -51,7 +51,7 @@ namespace Rubberduck.UI.ToDoItems
         private async void _state_StateChanged(object sender, EventArgs e)
         {
             Debug.WriteLine("ToDoExplorerViewModel handles StateChanged...");
-            if (_state.Status != ParserState.Parsed)
+            if (_state.Status != ParserState.Ready)
             {
                 return;
             }

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -1,5 +1,4 @@
 ﻿using Antlr4.Runtime;
-using Microsoft.CSharp.RuntimeBinder;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.VBEditor;
 using System.Linq;
@@ -116,8 +115,7 @@ namespace Rubberduck.Parsing.Symbols
                 _hasTypeHint = false;
                 return false;
             }
-            System.Reflection.MethodInfo method = null;
-            method = Context.Parent.GetType().GetMethods().FirstOrDefault(m => m.Name == "typeHint");
+            var method = Context.Parent.GetType().GetMethods().FirstOrDefault(m => m.Name == "typeHint");
             if (method == null)
             {
                 token = null;

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -2,6 +2,7 @@
 using Microsoft.CSharp.RuntimeBinder;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.VBEditor;
+using System.Linq;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -115,8 +116,8 @@ namespace Rubberduck.Parsing.Symbols
                 _hasTypeHint = false;
                 return false;
             }
-
-            var method = Context.Parent.GetType().GetMethod("typeHint");
+            System.Reflection.MethodInfo method = null;
+            method = Context.Parent.GetType().GetMethods().FirstOrDefault(m => m.Name == "typeHint");
             if (method == null)
             {
                 token = null;

--- a/Rubberduck.VBEEditor/QualifiedModuleName.cs
+++ b/Rubberduck.VBEEditor/QualifiedModuleName.cs
@@ -24,6 +24,7 @@ namespace Rubberduck.VBEditor
 
             _component = component;
             _componentName = component == null ? string.Empty : component.Name;
+            _project = component == null ? null : component.Collection.Parent;
             _projectName = component == null ? string.Empty : component.Collection.Parent.Name;
             _projectHashCode = component == null ? 0 : component.Collection.Parent.GetHashCode();
 
@@ -47,7 +48,6 @@ namespace Rubberduck.VBEditor
         public QualifiedModuleName(string projectName, string componentName)
         {
             _project = null; // field is only assigned when the instance refers to a VBProject.
-
             _projectName = projectName;
             _componentName = componentName;
             _component = null;
@@ -64,7 +64,7 @@ namespace Rubberduck.VBEditor
         public VBComponent Component { get { return _component; } }
 
         private readonly VBProject _project;
-        public VBProject Project { get { return _project ?? (_component == null ? null : _component.Collection.Parent); } }
+        public VBProject Project { get { return _project; } }
 
         private readonly int _projectHashCode;
         public int ProjectHashCode { get { return _projectHashCode; } }


### PR DESCRIPTION
1. The "for next statement" can now have more than one type hint which caused an exception. Not quite sure why it's checking the parent for the type hint though since in the case of a "for next statement" the declaration of the variable including type hint could have happened somewhere else?
2. The other cases are mostly just switching the check from ParserState.Parsed to ParserState.Ready. The ToDoExplorerViewModel previously reloaded the configuration once per module which made everything slow down.