### PR TITLE
associate project references correctly and in the correct order (#1340, #1347)

### DIFF
--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
@@ -44,7 +44,7 @@ namespace Rubberduck.UI.Command.Refactorings
                 item.QualifiedName.QualifiedModuleName.Equals(selection.QualifiedName)
                 && item.IdentifierName == selection.QualifiedName.ComponentName
                 && (item.DeclarationType == DeclarationType.Class || item.DeclarationType == DeclarationType.Document || item.DeclarationType == DeclarationType.UserForm));
-            var hasMembers = _state.AllUserDeclarations.Any(item => item.DeclarationType.HasFlag(DeclarationType.Member) && item.ParentDeclaration.Equals(target));
+            var hasMembers = _state.AllUserDeclarations.Any(item => item.DeclarationType.HasFlag(DeclarationType.Member) && item.ParentDeclaration != null && item.ParentDeclaration.Equals(target));
 
             // true if active code pane is for a class/document/form module
             var canExecute = ModuleTypes.Contains(Vbe.ActiveCodePane.CodeModule.Parent.Type) && target != null && hasMembers;

--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -183,6 +183,8 @@
     <Compile Include="Symbols\IdentifierReferenceResolver.cs" />
     <Compile Include="Symbols\MemberProcessedEventArgs.cs" />
     <Compile Include="Symbols\ParameterDeclaration.cs" />
+    <Compile Include="Symbols\ProjectDeclaration.cs" />
+    <Compile Include="Symbols\ProjectReference.cs" />
     <Compile Include="Symbols\ReferencedDeclarationsCollector.cs" />
     <Compile Include="Symbols\SyntaxErrorException.cs" />
     <Compile Include="Nodes\CommentNode.cs" />

--- a/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
@@ -1,0 +1,43 @@
+﻿using Rubberduck.VBEditor;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rubberduck.Parsing.Symbols
+{
+    public sealed class ProjectDeclaration : Declaration
+    {
+        private readonly List<ProjectReference> _projectReferences;
+
+        public ProjectDeclaration(
+            QualifiedMemberName qualifiedName,
+            string name)
+            : base(
+                  qualifiedName,
+                  null,
+                  (Declaration)null, 
+                  name, 
+                  false, 
+                  false, 
+                  Accessibility.Implicit, 
+                  DeclarationType.Project,
+                  null,
+                  Selection.Home,
+                  false)
+        {
+            _projectReferences = new List<ProjectReference>();
+        }
+
+        public IEnumerable<ProjectReference> ProjectReferences
+        {
+            get
+            {
+                return _projectReferences.OrderBy(reference => reference.Priority);
+            }
+        }
+
+        public void AddProjectReference(string referencedProjectId, int priority)
+        {
+            _projectReferences.Add(new ProjectReference(referencedProjectId, priority));
+        }
+    }
+}

--- a/Rubberduck.Parsing/Symbols/ProjectReference.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectReference.cs
@@ -1,0 +1,30 @@
+﻿namespace Rubberduck.Parsing.Symbols
+{
+    public sealed class ProjectReference
+    {
+        private readonly string _referencedProjectId;
+        private readonly int _priority;
+
+        public ProjectReference(string referencedProjectId, int priority)
+        {
+            _priority = priority;
+            _referencedProjectId = referencedProjectId;
+        }
+
+        public string ReferencedProjectId
+        {
+            get
+            {
+                return _referencedProjectId;
+            }
+        }
+
+        public int Priority
+        {
+            get
+            {
+                return _priority;
+            }
+        }
+    }
+}

--- a/Rubberduck.Parsing/Symbols/ReferencedDeclarationsCollector.cs
+++ b/Rubberduck.Parsing/Symbols/ReferencedDeclarationsCollector.cs
@@ -90,11 +90,10 @@ namespace Rubberduck.Parsing.Symbols
         {
             var projectName = reference.Name;
             var path = reference.FullPath;
-
-            var projectQualifiedModuleName = new QualifiedModuleName(projectName, projectName);
+            var projectQualifiedModuleName = new QualifiedModuleName(projectName, path, projectName);
             var projectQualifiedMemberName = new QualifiedMemberName(projectQualifiedModuleName, projectName);
 
-            var projectDeclaration = new Declaration(projectQualifiedMemberName, null, null, projectName, false, false, Accessibility.Global, DeclarationType.Project);
+            var projectDeclaration = new ProjectDeclaration(projectQualifiedMemberName, projectName);
             yield return projectDeclaration;
 
             ITypeLib typeLibrary;
@@ -134,7 +133,7 @@ namespace Rubberduck.Parsing.Symbols
                 }
                 else
                 {
-                    typeQualifiedModuleName = new QualifiedModuleName(projectName, typeName);
+                    typeQualifiedModuleName = new QualifiedModuleName(projectName, path, typeName);
                     typeQualifiedMemberName = new QualifiedMemberName(typeQualifiedModuleName, typeName);
                 }
 

--- a/Rubberduck.Parsing/VBA/ReferencePriorityMap.cs
+++ b/Rubberduck.Parsing/VBA/ReferencePriorityMap.cs
@@ -8,16 +8,16 @@ namespace Rubberduck.Parsing.VBA
     /// </summary>
     public class ReferencePriorityMap : Dictionary<string, int>
     {
-        private readonly string _referenceId;
+        private readonly string _referencedProjectId;
 
-        public ReferencePriorityMap(string referenceId)
+        public ReferencePriorityMap(string referencedProjectId)
         {
-            _referenceId = referenceId;
+            _referencedProjectId = referencedProjectId;
         }
 
-        public string ReferenceId
+        public string ReferencedProjectId
         {
-            get { return _referenceId; }
+            get { return _referencedProjectId; }
         }
 
         public bool IsLoaded { get; set; }
@@ -27,12 +27,12 @@ namespace Rubberduck.Parsing.VBA
             var other = obj as ReferencePriorityMap;
             if (other == null) return false;
 
-            return other.ReferenceId == ReferenceId;
+            return other.ReferencedProjectId == ReferencedProjectId;
         }
 
         public override int GetHashCode()
         {
-            return _referenceId.GetHashCode();
+            return _referencedProjectId.GetHashCode();
         }
     }
 }

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -99,7 +99,7 @@ namespace Rubberduck.Parsing.VBA
 
         public void RemoveProject(VBProject project)
         {
-            RemoveProject(project.ProjectId());
+            RemoveProject(QualifiedModuleName.GetProjectId(project));
         }
 
         public IEnumerable<VBProject> Projects
@@ -567,12 +567,12 @@ namespace Rubberduck.Parsing.VBA
         public void RemoveBuiltInDeclarations(Reference reference)
         {
             var projectName = reference.Name;
-            var key = new QualifiedModuleName(projectName, projectName);
-
+            var path = reference.FullPath;
+            var key = new QualifiedModuleName(projectName, path, projectName);
             ConcurrentDictionary<Declaration, byte> items;
             if (!_declarations.TryRemove(key, out items))
             {
-                Debug.WriteLine("Could not remove declarations for removed reference '{0}' ({1}).", reference.Name, reference.ReferenceId());
+                Debug.WriteLine("Could not remove declarations for removed reference '{0}' ({1}).", reference.Name, QualifiedModuleName.GetProjectId(reference));
             }
         }
     }

--- a/Rubberduck.VBEEditor/Extensions/VbProjectExtensions.cs
+++ b/Rubberduck.VBEEditor/Extensions/VbProjectExtensions.cs
@@ -1,27 +1,12 @@
-﻿using System;
+﻿using Microsoft.Vbe.Interop;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using Microsoft.Vbe.Interop;
 
 namespace Rubberduck.VBEditor.Extensions
 {
     public static class ProjectExtensions
     {
-        public static string ProjectId(this VBProject project)
-        {
-            return project.HelpFile;
-        }
-
-        public static string ReferenceId(this Reference reference)
-        {
-            return string.IsNullOrEmpty(reference.Guid)
-                ? reference.FullPath
-                : reference.Guid;
-        }
-
         public static IEnumerable<string> ComponentNames(this VBProject project)
         {
             return project.VBComponents.Cast<VBComponent>().Select(component => component.Name);

--- a/Rubberduck.VBEEditor/QualifiedModuleName.cs
+++ b/Rubberduck.VBEEditor/QualifiedModuleName.cs
@@ -9,13 +9,20 @@ namespace Rubberduck.VBEditor
     /// </summary>
     public struct QualifiedModuleName
     {
-        private static string GetProjectId(VBProject project)
+        public static string GetProjectId(VBProject project)
         {
             if (project == null)
             {
                 return string.Empty;
             }
             return string.IsNullOrEmpty(project.HelpFile) ? project.GetHashCode().ToString() : project.HelpFile;
+        }
+
+        public static string GetProjectId(Reference reference)
+        {
+            var projectName = reference.Name;
+            var path = reference.FullPath;
+            return new QualifiedModuleName(projectName, path, projectName).ProjectId;
         }
 
         public QualifiedModuleName(VBProject project)
@@ -55,11 +62,11 @@ namespace Rubberduck.VBEditor
         /// Creates a QualifiedModuleName for a built-in declaration.
         /// Do not use this overload for user declarations.
         /// </summary>
-        public QualifiedModuleName(string projectName, string componentName)
+        public QualifiedModuleName(string projectName, string projectPath, string componentName)
         {
             _project = null;
-            _projectName = projectName;
-            _projectId = projectName.GetHashCode().ToString();
+            _projectName = projectName + ";" + projectPath;
+            _projectId = _projectName.GetHashCode().ToString();
             _componentName = componentName;
             _component = null;
             _contentHashCode = 0;
@@ -80,7 +87,7 @@ namespace Rubberduck.VBEditor
         public int ContentHashCode { get { return _contentHashCode; } }
 
         private readonly string _projectId;
-        public string ProjectId { get { return _projectId;} }
+        public string ProjectId { get { return _projectId; } }
 
         private readonly string _componentName;
         public string ComponentName { get { return _componentName ?? string.Empty; } }
@@ -98,8 +105,8 @@ namespace Rubberduck.VBEditor
             unchecked
             {
                 var hash = 17;
-                hash = hash*23 + _projectId.GetHashCode();
-                hash = hash*23 + (_componentName ?? string.Empty).GetHashCode();
+                hash = hash * 23 + _projectId.GetHashCode();
+                hash = hash * 23 + (_componentName ?? string.Empty).GetHashCode();
                 return hash;
             }
         }


### PR DESCRIPTION
There's a new class ProjectDeclaration that contains the references to other projects with the priorities. Because this happens in the declaration gathering phase we can't add ProjectDeclarations as other references.

I changed the Reference.ReferenceId to ProjectId and also switched from using the ProjectName as ProjectId for references to using a combination of the name + path. Otherwise could not differentiate between two libraries with the same name. Not sure if this will always work though, there might be some cases I don't know about. Not so sure whether it's possible to reference two libraries with the same name in the same DLL either.