### PR TITLE
fix wrong declaration type instantiated

### DIFF
--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -191,8 +191,8 @@ namespace Rubberduck.Parsing.VBA
 
             var qualifiedName = new QualifiedModuleName(vba.IdentifierName, vba.IdentifierName, errObject.IdentifierName);
             var err = new Declaration(new QualifiedMemberName(qualifiedName, Tokens.Err), vba, "Global", errObject.IdentifierName, true, false, Accessibility.Global, DeclarationType.Variable);
-            var debugClassName = new QualifiedModuleName(vba.IdentifierName, vba.IdentifierName, "DebugClass");
-            var debugClass = new Declaration(new QualifiedMemberName(debugClassName, "DebugClass"), vba, "Global", "DebugClass", false, false, Accessibility.Global, DeclarationType.ClassModule);
+            var debugClassName = new QualifiedModuleName(vba.QualifiedName.QualifiedModuleName.ProjectName, vba.QualifiedName.QualifiedModuleName.ProjectPath, "DebugClass");
+            var debugClass = new ClassModuleDeclaration(new QualifiedMemberName(debugClassName, "DebugClass"), vba, "DebugClass", true, new List<IAnnotation>(), new Attributes(), true);
             var debugObject = new Declaration(new QualifiedMemberName(debugClassName, "Debug"), vba, "Global", "DebugClass", true, false, Accessibility.Global, DeclarationType.Variable);
             var debugAssert = new Declaration(new QualifiedMemberName(debugClassName, "Assert"), debugObject, debugObject.Scope, null, false, false, Accessibility.Global, DeclarationType.Procedure);
             var debugPrint = new Declaration(new QualifiedMemberName(debugClassName, "Print"), debugObject, debugObject.Scope, null, false, false, Accessibility.Global, DeclarationType.Procedure);

--- a/Rubberduck.VBEEditor/QualifiedModuleName.cs
+++ b/Rubberduck.VBEEditor/QualifiedModuleName.cs
@@ -96,15 +96,32 @@ namespace Rubberduck.VBEditor
         public string ComponentName { get { return _componentName ?? string.Empty; } }
 
         public string Name { get { return ToString(); } }
+
         private readonly string _projectName;
+
+        public string ProjectName
+        {
+            get
+            {
+                return _projectName;
+            }
+        }
         private readonly string _projectPath;
+
+        public string ProjectPath
+        {
+            get
+            {
+                return _projectPath;
+            }
+        }
 
         public override string ToString()
         {
-            return _component == null && string.IsNullOrEmpty(_projectName)
+            return _component == null && string.IsNullOrEmpty(ProjectName)
                 ? string.Empty
-                : (string.IsNullOrEmpty(_projectPath) ? string.Empty : System.IO.Path.GetFileName(_projectPath) + ";")
-                     + _projectName + "." + _componentName;
+                : (string.IsNullOrEmpty(ProjectPath) ? string.Empty : System.IO.Path.GetFileName(ProjectPath) + ";")
+                     + ProjectName + "." + _componentName;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Class modules have their own declaration class now. Furthermore all built-in class modules have to be instantiated with IsExposed=true otherwise they won't be found as that specifies whether a class module is referenceable from external projects. Also for referenced projects / built-in projects a project path has to be passed to QualifiedModuleName, otherwise an incorrect project id will be created.