### PR TITLE
Translation

### DIFF
--- a/RetailCoder.VBE/Inspections/InspectionsUI.de.resx
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -520,5 +520,44 @@
   </data>
   <data name="ObjectVariableNotSetInspectionName" xml:space="preserve">
     <value>Zuweisung in eine Objektvariable benötigt das 'Set'-Schlüsselwort.</value>
+  </data>
+  <data name="Inspections_Usage" xml:space="preserve">
+    <value>Verwendung</value>
+  </data>
+  <data name="Inspections_Declaration" xml:space="preserve">
+    <value>Deklaration</value>
+  </data>
+  <data name="VariableTypeNotDeclaredInspectionResultFormat" xml:space="preserve">
+    <value>{0} '{1}' ist implizit 'Variant'</value>
+  </data>
+  <data name="ObsoleteCommentSyntaxInspectionResultFormat" xml:space="preserve">
+    <value>Kommentar verwendet die obsolete 'REM' - Markierung</value>
+  </data>
+  <data name="DefaultProjectNameInspectionResultFormat" xml:space="preserve">
+    <value>Projekt '{0}' hat den Standardnamen</value>
+  </data>
+  <data name="ObsoleteCallStatementInspectionResultFormat" xml:space="preserve">
+    <value>Zuweisung verwendet obsolete 'Call' Anweisung</value>
+  </data>
+  <data name="ObsoleteLetStatementInspectionResultFormat" xml:space="preserve">
+    <value>Zuweisung verwendet obsoleten 'Let' Anweisung</value>
+  </data>
+  <data name="ImplicitActiveSheetReferenceInspectionResultFormat" xml:space="preserve">
+    <value>Member '{0}' referenziert implizit auf 'ActiveSheet'</value>
+  </data>
+  <data name="ImplicitActiveWorkbookReferenceInspectionResultFormat" xml:space="preserve">
+    <value>Member '{0}' referenziert implizit auf 'ActiveWorkbook'</value>
+  </data>
+  <data name="UntypedFunctionUsageInspectionResultFormat" xml:space="preserve">
+    <value>Ersetze Funktion {0} mit der existierenden typed function</value>
+  </data>
+  <data name="OptionBaseInspectionResultFormat" xml:space="preserve">
+    <value>Komponente '{0}' verwendet 'Option Base 1'</value>
+  </data>
+  <data name="ObsoleteTypeHintInspectionResultFormat" xml:space="preserve">
+    <value>{0}  von {1} '{2}' verwendet einen obsoleten Typenhinweis</value>
+  </data>
+  <data name="MultipleDeclarationsInspectionResultFormat" xml:space="preserve">
+    <value>Instruktion enthält Mehrfachdeklaration</value>
   </data>
 </root>

--- a/RetailCoder.VBE/Inspections/InspectionsUI.fr.resx
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.fr.resx
@@ -228,7 +228,7 @@
   <data name="MultipleFolderAnnotationsInspectionMeta" xml:space="preserve">
     <value />
   </data>
-  <data name="MultipleFolderAnnotationsInspectionNamer" xml:space="preserve">
+  <data name="MultipleFolderAnnotationsInspectionName" xml:space="preserve">
     <value />
   </data>
   <data name="NonReturningFunctionInspectionMeta" xml:space="preserve">

--- a/RetailCoder.VBE/Inspections/InspectionsUI.ja.resx
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.ja.resx
@@ -228,7 +228,7 @@
   <data name="MultipleFolderAnnotationsInspectionMeta" xml:space="preserve">
     <value />
   </data>
-  <data name="MultipleFolderAnnotationsInspectionNamer" xml:space="preserve">
+  <data name="MultipleFolderAnnotationsInspectionName" xml:space="preserve">
     <value />
   </data>
   <data name="NonReturningFunctionInspectionMeta" xml:space="preserve">

--- a/RetailCoder.VBE/Inspections/InspectionsUI.sv.resx
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.sv.resx
@@ -228,7 +228,7 @@
   <data name="MultipleFolderAnnotationsInspectionMeta" xml:space="preserve">
     <value />
   </data>
-  <data name="MultipleFolderAnnotationsInspectionNamer" xml:space="preserve">
+  <data name="MultipleFolderAnnotationsInspectionName" xml:space="preserve">
     <value />
   </data>
   <data name="NonReturningFunctionInspectionMeta" xml:space="preserve">

--- a/RetailCoder.VBE/UI/RubberduckUI.de.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.de.resx
@@ -1483,4 +1483,10 @@ Allen Sternguckern, Likern &amp; Followern, für das warme Kribbeln
   <data name="DeclarationType_LibraryProcedure" xml:space="preserve">
     <value>Bibliotheksprozedur</value>
   </data>
+  <data name="CodeExplorer_AddClassModuleText" xml:space="preserve">
+    <value>Klassenmodul (.cls)</value>
+  </data>
+  <data name="CodeExplorer_ShowSignaturesToolTip" xml:space="preserve">
+    <value>Wechsele Signatur</value>
+  </data>
 </root>


### PR DESCRIPTION
I added the German translation.
I found the following keys that are seemed to be obsolete:
Inspections_DeclarationOf
Inspections_UsageOf
CodeExplorer_AddClassText  here as been "&" in the text

Can these be removed?

I see that you look at the obsolete Let statement (key: ObsoleteLetStatementInspectionResultFormat).
Should't be there a check about the Set statement as well? 