### PR TITLE
clean up file statements + consider inherited members as belonging to enclosed module + special forms

### DIFF
--- a/Rubberduck.Parsing/Binding/BindingService.cs
+++ b/Rubberduck.Parsing/Binding/BindingService.cs
@@ -37,8 +37,15 @@ namespace Rubberduck.Parsing.Binding
 
         public IBoundExpression ResolveDefault(Declaration module, Declaration parent, string expression, IBoundExpression withBlockVariable, ResolutionStatementContext statementContext)
         {
-            var expr = Parse(expression.Trim());
-            return _defaultBindingContext.Resolve(module, parent, expr, withBlockVariable, statementContext);
+            try
+            {
+                var expr = Parse(expression.Trim());
+                return _defaultBindingContext.Resolve(module, parent, expr, withBlockVariable, statementContext);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         public IBoundExpression ResolveType(Declaration module, Declaration parent, string expression)

--- a/Rubberduck.Parsing/Binding/BindingService.cs
+++ b/Rubberduck.Parsing/Binding/BindingService.cs
@@ -37,15 +37,8 @@ namespace Rubberduck.Parsing.Binding
 
         public IBoundExpression ResolveDefault(Declaration module, Declaration parent, string expression, IBoundExpression withBlockVariable, ResolutionStatementContext statementContext)
         {
-            try
-            {
-                var expr = Parse(expression.Trim());
-                return _defaultBindingContext.Resolve(module, parent, expr, withBlockVariable, statementContext);
-            }
-            catch
-            {
-                return null;
-            }
+            var expr = Parse(expression.Trim());
+            return _defaultBindingContext.Resolve(module, parent, expr, withBlockVariable, statementContext);
         }
 
         public IBoundExpression ResolveType(Declaration module, Declaration parent, string expression)

--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -38,7 +38,9 @@ namespace Rubberduck.Parsing.Binding
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAExpressionParser.StartRuleContext expression, IBoundExpression withBlockVariable, ResolutionStatementContext statementContext)
         {
-            // Call statements always have an argument list
+            // Call statements always have an argument list.
+            // One of the reasons we're doing this is that an empty argument list could represent a call to a default member,
+            // which requires us to use an IndexDefaultBinding.
             if (statementContext == ResolutionStatementContext.CallStatement)
             {
                 if (expression.callStmt() != null)
@@ -113,6 +115,14 @@ namespace Rubberduck.Parsing.Binding
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAExpressionParser.NewExprContext expression, IBoundExpression withBlockVariable, ResolutionStatementContext statementContext)
         {
             return Visit(module, parent, expression.newExpression(), withBlockVariable, ResolutionStatementContext.Undefined);
+        }
+
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAExpressionParser.MarkedFileNumberExprContext expression, IBoundExpression withBlockVariable, ResolutionStatementContext statementContext)
+        {
+            // The MarkedFileNumberExpr doesn't actually exist but for backwards compatibility reasons we support it, ignore the "hash tag" of the file number
+            // and resolve it as a normal expression.
+            // This allows us to support functions such as Input(file1, #file1) which would otherwise not work.
+            return Visit(module, parent, (dynamic)expression.expression(), withBlockVariable, ResolutionStatementContext.Undefined);
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAExpressionParser.NewExpressionContext expression, IBoundExpression withBlockVariable, ResolutionStatementContext statementContext)

--- a/Rubberduck.Parsing/Binding/IndexDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/IndexDefaultBinding.cs
@@ -269,8 +269,7 @@ namespace Rubberduck.Parsing.Binding
              */
             if (lExpression.Classification == ExpressionClassification.Property
                || lExpression.Classification == ExpressionClassification.Function
-               || lExpression.Classification == ExpressionClassification.Subroutine
-               || lExpression.Classification == ExpressionClassification.Type)
+               || lExpression.Classification == ExpressionClassification.Subroutine)
             {
                 return new IndexExpression(lExpression.ReferencedDeclaration, lExpression.Classification, _expression, lExpression, _argumentList);
             }

--- a/Rubberduck.Parsing/Binding/MemberAccessDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/MemberAccessDefaultBinding.cs
@@ -349,7 +349,7 @@ namespace Rubberduck.Parsing.Binding
         {
             if (lExpressionIsEnclosingProject)
             {
-                var foundType = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, _name, memberType);
+                var foundType = _declarationFinder.FindMemberEnclosingModule(_module, _parent, _name, memberType);
                 if (foundType != null)
                 {
                     return new MemberAccessExpression(foundType, classification, _context, _unrestrictedNameContext,  _lExpression);

--- a/Rubberduck.Parsing/Binding/MemberAccessTypeBinding.cs
+++ b/Rubberduck.Parsing/Binding/MemberAccessTypeBinding.cs
@@ -219,7 +219,7 @@ namespace Rubberduck.Parsing.Binding
              */
             if (lExpressionIsEnclosingProject)
             {
-                var foundType = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, memberType);
+                var foundType = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, memberType);
                 if (foundType != null)
                 {
                     return new MemberAccessExpression(foundType, ExpressionClassification.Type, GetExpressionContext(), _unrestrictedNameContext, lExpression);

--- a/Rubberduck.Parsing/Binding/SimpleNameDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/SimpleNameDefaultBinding.cs
@@ -101,37 +101,37 @@ namespace Rubberduck.Parsing.Binding
                 Enclosing Module namespace: A variable, constant, Enum type, Enum member, property, 
                 function or subroutine defined at the module-level in the enclosing module.
             */
-            var moduleVariable = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Variable);
+            var moduleVariable = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Variable);
             if (IsValidMatch(moduleVariable, name))
             {
                 return new SimpleNameExpression(moduleVariable, ExpressionClassification.Variable, _expression);
             }
-            var moduleConstant = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Constant);
+            var moduleConstant = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Constant);
             if (IsValidMatch(moduleConstant, name))
             {
                 return new SimpleNameExpression(moduleConstant, ExpressionClassification.Variable, _expression);
             }
-            var enumType = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Enumeration);
+            var enumType = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Enumeration);
             if (IsValidMatch(enumType, name))
             {
                 return new SimpleNameExpression(enumType, ExpressionClassification.Type, _expression);
             }
-            var enumMember = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.EnumerationMember);
+            var enumMember = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.EnumerationMember);
             if (IsValidMatch(enumMember, name))
             {
                 return new SimpleNameExpression(enumMember, ExpressionClassification.Value, _expression);
             }
-            var property = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, _propertySearchType);
+            var property = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, _propertySearchType);
             if (IsValidMatch(property, name))
             {
                 return new SimpleNameExpression(property, ExpressionClassification.Property, _expression);
             }
-            var function = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Function);
+            var function = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Function);
             if (IsValidMatch(function, name))
             {
                 return new SimpleNameExpression(function, ExpressionClassification.Function, _expression);
             }
-            var subroutine = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Procedure);
+            var subroutine = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Procedure);
             if (IsValidMatch(subroutine, name))
             {
                 return new SimpleNameExpression(subroutine, ExpressionClassification.Subroutine, _expression);

--- a/Rubberduck.Parsing/Binding/SimpleNameProcedurePointerBinding.cs
+++ b/Rubberduck.Parsing/Binding/SimpleNameProcedurePointerBinding.cs
@@ -48,17 +48,17 @@ namespace Rubberduck.Parsing.Binding
                 Enclosing Module namespace: A function, subroutine or property with a Property Get defined 
                 at the module-level in the enclosing module.
             */
-            var function = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Function);
+            var function = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Function);
             if (function != null)
             {
                 return new SimpleNameExpression(function, ExpressionClassification.Function, _expression);
             }
-            var subroutine = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Procedure);
+            var subroutine = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Procedure);
             if (subroutine != null)
             {
                 return new SimpleNameExpression(subroutine, ExpressionClassification.Subroutine, _expression);
             }
-            var propertyGet = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.PropertyGet);
+            var propertyGet = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.PropertyGet);
             if (propertyGet != null)
             {
                 return new SimpleNameExpression(propertyGet, ExpressionClassification.Property, _expression);

--- a/Rubberduck.Parsing/Binding/SimpleNameTypeBinding.cs
+++ b/Rubberduck.Parsing/Binding/SimpleNameTypeBinding.cs
@@ -97,12 +97,12 @@ namespace Rubberduck.Parsing.Binding
                 Enclosing Module namespace: A UDT or Enum type defined at the module-level in the 
                 enclosing module.
             */
-            var udt = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.UserDefinedType);
+            var udt = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.UserDefinedType);
             if (udt != null)
             {
                 return new SimpleNameExpression(udt, ExpressionClassification.Type, _expression);
             }
-            var enumType = _declarationFinder.FindMemberEnclosingModule(_project, _module, _parent, name, DeclarationType.Enumeration);
+            var enumType = _declarationFinder.FindMemberEnclosingModule(_module, _parent, name, DeclarationType.Enumeration);
             if (enumType != null)
             {
                 return new SimpleNameExpression(enumType, ExpressionClassification.Type, _expression);

--- a/Rubberduck.Parsing/Binding/VBAExpressionParser.cs
+++ b/Rubberduck.Parsing/Binding/VBAExpressionParser.cs
@@ -1301,6 +1301,26 @@ public partial class VBAExpressionParser : Parser {
 			else return visitor.VisitChildren(this);
 		}
 	}
+	public partial class MarkedFileNumberExprContext : ExpressionContext {
+		public ExpressionContext expression() {
+			return GetRuleContext<ExpressionContext>(0);
+		}
+		public ITerminalNode HASH() { return GetToken(VBAExpressionParser.HASH, 0); }
+		public MarkedFileNumberExprContext(ExpressionContext context) { CopyFrom(context); }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAExpressionParserListener typedListener = listener as IVBAExpressionParserListener;
+			if (typedListener != null) typedListener.EnterMarkedFileNumberExpr(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAExpressionParserListener typedListener = listener as IVBAExpressionParserListener;
+			if (typedListener != null) typedListener.ExitMarkedFileNumberExpr(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAExpressionParserVisitor<TResult> typedVisitor = visitor as IVBAExpressionParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitMarkedFileNumberExpr(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
 	public partial class ModOpContext : ExpressionContext {
 		public WhiteSpaceContext whiteSpace(int i) {
 			return GetRuleContext<WhiteSpaceContext>(i);
@@ -1618,7 +1638,7 @@ public partial class VBAExpressionParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 219;
+			State = 221;
 			switch (_input.La(1)) {
 			case MINUS:
 				{
@@ -1635,7 +1655,7 @@ public partial class VBAExpressionParser : Parser {
 					}
 				}
 
-				State = 199; expression(14);
+				State = 199; expression(15);
 				}
 				break;
 			case NOT:
@@ -1652,7 +1672,16 @@ public partial class VBAExpressionParser : Parser {
 					}
 				}
 
-				State = 204; expression(7);
+				State = 204; expression(8);
+				}
+				break;
+			case HASH:
+				{
+				_localctx = new MarkedFileNumberExprContext(_localctx);
+				_ctx = _localctx;
+				_prevctx = _localctx;
+				State = 205; Match(HASH);
+				State = 206; expression(1);
 				}
 				break;
 			case ABS:
@@ -1702,6 +1731,7 @@ public partial class VBAExpressionParser : Parser {
 			case BOOLEAN:
 			case BYTE:
 			case CLASS:
+			case CLOSE:
 			case DATABASE:
 			case DATE:
 			case DOUBLE:
@@ -1714,8 +1744,10 @@ public partial class VBAExpressionParser : Parser {
 			case EXIT_FUNCTION:
 			case EXIT_PROPERTY:
 			case EXIT_SUB:
+			case GET:
 			case INPUT:
 			case INTEGER:
+			case LOCK:
 			case LONG:
 			case LIB:
 			case LINE_INPUT:
@@ -1726,17 +1758,21 @@ public partial class VBAExpressionParser : Parser {
 			case MID:
 			case ON:
 			case ON_ERROR:
+			case OPEN:
 			case OUTPUT:
+			case PUT:
 			case RANDOM:
 			case READ:
 			case READ_WRITE:
 			case RESET:
+			case SEEK:
 			case SHARED:
 			case SINGLE:
 			case STEP:
 			case STRING:
 			case TAB:
 			case TEXT:
+			case UNLOCK:
 			case VARIANT:
 			case VERSION:
 			case WIDTH:
@@ -1749,7 +1785,7 @@ public partial class VBAExpressionParser : Parser {
 				_localctx = new LExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 205; lExpression(0);
+				State = 207; lExpression(0);
 				}
 				break;
 			case LPAREN:
@@ -1757,25 +1793,25 @@ public partial class VBAExpressionParser : Parser {
 				_localctx = new ParenthesizedExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 206; Match(LPAREN);
-				State = 208;
+				State = 208; Match(LPAREN);
+				State = 210;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 207; whiteSpace();
+					State = 209; whiteSpace();
 					}
 				}
 
-				State = 210; expression(0);
-				State = 212;
+				State = 212; expression(0);
+				State = 214;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 211; whiteSpace();
+					State = 213; whiteSpace();
 					}
 				}
 
-				State = 214; Match(RPAREN);
+				State = 216; Match(RPAREN);
 				}
 				break;
 			case TYPEOF:
@@ -1783,7 +1819,7 @@ public partial class VBAExpressionParser : Parser {
 				_localctx = new TypeOfIsExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 216; typeOfIsExpression();
+				State = 218; typeOfIsExpression();
 				}
 				break;
 			case NEW:
@@ -1791,7 +1827,7 @@ public partial class VBAExpressionParser : Parser {
 				_localctx = new NewExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 217; newExpression();
+				State = 219; newExpression();
 				}
 				break;
 			case EMPTY:
@@ -1809,14 +1845,14 @@ public partial class VBAExpressionParser : Parser {
 				_localctx = new LiteralExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 218; literalExpression();
+				State = 220; literalExpression();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
 			_ctx.stop = _input.Lt(-1);
-			State = 331;
+			State = 333;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,43,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
@@ -1824,32 +1860,32 @@ public partial class VBAExpressionParser : Parser {
 					if ( _parseListeners!=null ) TriggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					State = 329;
+					State = 331;
 					switch ( Interpreter.AdaptivePredict(_input,42,_ctx) ) {
 					case 1:
 						{
 						_localctx = new PowOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 221;
-						if (!(Precpred(_ctx, 15))) throw new FailedPredicateException(this, "Precpred(_ctx, 15)");
 						State = 223;
+						if (!(Precpred(_ctx, 16))) throw new FailedPredicateException(this, "Precpred(_ctx, 16)");
+						State = 225;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 222; whiteSpace();
+							State = 224; whiteSpace();
 							}
 						}
 
-						State = 225; Match(POW);
-						State = 227;
+						State = 227; Match(POW);
+						State = 229;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 226; whiteSpace();
+							State = 228; whiteSpace();
 							}
 						}
 
-						State = 229; expression(16);
+						State = 231; expression(17);
 						}
 						break;
 
@@ -1857,31 +1893,31 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new MultOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 230;
-						if (!(Precpred(_ctx, 13))) throw new FailedPredicateException(this, "Precpred(_ctx, 13)");
 						State = 232;
+						if (!(Precpred(_ctx, 14))) throw new FailedPredicateException(this, "Precpred(_ctx, 14)");
+						State = 234;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 231; whiteSpace();
+							State = 233; whiteSpace();
 							}
 						}
 
-						State = 234;
+						State = 236;
 						_la = _input.La(1);
 						if ( !(_la==DIV || _la==MULT) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 236;
+						State = 238;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 235; whiteSpace();
+							State = 237; whiteSpace();
 							}
 						}
 
-						State = 238; expression(14);
+						State = 240; expression(15);
 						}
 						break;
 
@@ -1889,26 +1925,26 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new IntDivOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 239;
-						if (!(Precpred(_ctx, 12))) throw new FailedPredicateException(this, "Precpred(_ctx, 12)");
 						State = 241;
+						if (!(Precpred(_ctx, 13))) throw new FailedPredicateException(this, "Precpred(_ctx, 13)");
+						State = 243;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 240; whiteSpace();
+							State = 242; whiteSpace();
 							}
 						}
 
-						State = 243; Match(INTDIV);
-						State = 245;
+						State = 245; Match(INTDIV);
+						State = 247;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 244; whiteSpace();
+							State = 246; whiteSpace();
 							}
 						}
 
-						State = 247; expression(13);
+						State = 249; expression(14);
 						}
 						break;
 
@@ -1916,26 +1952,26 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new ModOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 248;
-						if (!(Precpred(_ctx, 11))) throw new FailedPredicateException(this, "Precpred(_ctx, 11)");
 						State = 250;
+						if (!(Precpred(_ctx, 12))) throw new FailedPredicateException(this, "Precpred(_ctx, 12)");
+						State = 252;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 249; whiteSpace();
+							State = 251; whiteSpace();
 							}
 						}
 
-						State = 252; Match(MOD);
-						State = 254;
+						State = 254; Match(MOD);
+						State = 256;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 253; whiteSpace();
+							State = 255; whiteSpace();
 							}
 						}
 
-						State = 256; expression(12);
+						State = 258; expression(13);
 						}
 						break;
 
@@ -1943,31 +1979,31 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new AddOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 257;
-						if (!(Precpred(_ctx, 10))) throw new FailedPredicateException(this, "Precpred(_ctx, 10)");
 						State = 259;
+						if (!(Precpred(_ctx, 11))) throw new FailedPredicateException(this, "Precpred(_ctx, 11)");
+						State = 261;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 258; whiteSpace();
+							State = 260; whiteSpace();
 							}
 						}
 
-						State = 261;
+						State = 263;
 						_la = _input.La(1);
 						if ( !(_la==MINUS || _la==PLUS) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 263;
+						State = 265;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 262; whiteSpace();
+							State = 264; whiteSpace();
 							}
 						}
 
-						State = 265; expression(11);
+						State = 267; expression(12);
 						}
 						break;
 
@@ -1975,26 +2011,26 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new ConcatOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 266;
-						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
 						State = 268;
+						if (!(Precpred(_ctx, 10))) throw new FailedPredicateException(this, "Precpred(_ctx, 10)");
+						State = 270;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 267; whiteSpace();
+							State = 269; whiteSpace();
 							}
 						}
 
-						State = 270; Match(AMPERSAND);
-						State = 272;
+						State = 272; Match(AMPERSAND);
+						State = 274;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 271; whiteSpace();
+							State = 273; whiteSpace();
 							}
 						}
 
-						State = 274; expression(10);
+						State = 276; expression(11);
 						}
 						break;
 
@@ -2002,31 +2038,31 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new RelationalOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 275;
-						if (!(Precpred(_ctx, 8))) throw new FailedPredicateException(this, "Precpred(_ctx, 8)");
 						State = 277;
+						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
+						State = 279;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 276; whiteSpace();
+							State = 278; whiteSpace();
 							}
 						}
 
-						State = 279;
+						State = 281;
 						_la = _input.La(1);
 						if ( !(_la==IS || _la==LIKE || ((((_la - 206)) & ~0x3f) == 0 && ((1L << (_la - 206)) & ((1L << (EQ - 206)) | (1L << (GEQ - 206)) | (1L << (GT - 206)) | (1L << (LEQ - 206)) | (1L << (LT - 206)) | (1L << (NEQ - 206)))) != 0)) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 281;
+						State = 283;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 280; whiteSpace();
+							State = 282; whiteSpace();
 							}
 						}
 
-						State = 283; expression(9);
+						State = 285; expression(10);
 						}
 						break;
 
@@ -2034,26 +2070,26 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new LogicalAndOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 284;
-						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
 						State = 286;
+						if (!(Precpred(_ctx, 7))) throw new FailedPredicateException(this, "Precpred(_ctx, 7)");
+						State = 288;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 285; whiteSpace();
+							State = 287; whiteSpace();
 							}
 						}
 
-						State = 288; Match(AND);
-						State = 290;
+						State = 290; Match(AND);
+						State = 292;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 289; whiteSpace();
+							State = 291; whiteSpace();
 							}
 						}
 
-						State = 292; expression(7);
+						State = 294; expression(8);
 						}
 						break;
 
@@ -2061,26 +2097,26 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new LogicalOrOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 293;
-						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
 						State = 295;
+						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
+						State = 297;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 294; whiteSpace();
+							State = 296; whiteSpace();
 							}
 						}
 
-						State = 297; Match(OR);
-						State = 299;
+						State = 299; Match(OR);
+						State = 301;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 298; whiteSpace();
+							State = 300; whiteSpace();
 							}
 						}
 
-						State = 301; expression(6);
+						State = 303; expression(7);
 						}
 						break;
 
@@ -2088,26 +2124,26 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new LogicalXorOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 302;
-						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
 						State = 304;
+						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
+						State = 306;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 303; whiteSpace();
+							State = 305; whiteSpace();
 							}
 						}
 
-						State = 306; Match(XOR);
-						State = 308;
+						State = 308; Match(XOR);
+						State = 310;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 307; whiteSpace();
+							State = 309; whiteSpace();
 							}
 						}
 
-						State = 310; expression(5);
+						State = 312; expression(6);
 						}
 						break;
 
@@ -2115,26 +2151,26 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new LogicalEqvOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 311;
-						if (!(Precpred(_ctx, 3))) throw new FailedPredicateException(this, "Precpred(_ctx, 3)");
 						State = 313;
+						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
+						State = 315;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 312; whiteSpace();
+							State = 314; whiteSpace();
 							}
 						}
 
-						State = 315; Match(EQV);
-						State = 317;
+						State = 317; Match(EQV);
+						State = 319;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 316; whiteSpace();
+							State = 318; whiteSpace();
 							}
 						}
 
-						State = 319; expression(4);
+						State = 321; expression(5);
 						}
 						break;
 
@@ -2142,32 +2178,32 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new LogicalImpOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 320;
-						if (!(Precpred(_ctx, 2))) throw new FailedPredicateException(this, "Precpred(_ctx, 2)");
 						State = 322;
+						if (!(Precpred(_ctx, 3))) throw new FailedPredicateException(this, "Precpred(_ctx, 3)");
+						State = 324;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 321; whiteSpace();
+							State = 323; whiteSpace();
 							}
 						}
 
-						State = 324; Match(IMP);
-						State = 326;
+						State = 326; Match(IMP);
+						State = 328;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 325; whiteSpace();
+							State = 327; whiteSpace();
 							}
 						}
 
-						State = 328; expression(3);
+						State = 330; expression(4);
 						}
 						break;
 					}
 					} 
 				}
-				State = 333;
+				State = 335;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,43,_ctx);
 			}
@@ -2221,7 +2257,7 @@ public partial class VBAExpressionParser : Parser {
 		LiteralExpressionContext _localctx = new LiteralExpressionContext(_ctx, State);
 		EnterRule(_localctx, 28, RULE_literalExpression);
 		try {
-			State = 341;
+			State = 343;
 			switch (_input.La(1)) {
 			case OCTLITERAL:
 			case HEXLITERAL:
@@ -2229,19 +2265,19 @@ public partial class VBAExpressionParser : Parser {
 			case INTEGERLITERAL:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 334; numberLiteral();
+				State = 336; numberLiteral();
 				}
 				break;
 			case DATELITERAL:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 335; Match(DATELITERAL);
+				State = 337; Match(DATELITERAL);
 				}
 				break;
 			case STRINGLITERAL:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 336; Match(STRINGLITERAL);
+				State = 338; Match(STRINGLITERAL);
 				}
 				break;
 			case EMPTY:
@@ -2251,12 +2287,12 @@ public partial class VBAExpressionParser : Parser {
 			case TRUE:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 337; literalIdentifier();
-				State = 339;
+				State = 339; literalIdentifier();
+				State = 341;
 				switch ( Interpreter.AdaptivePredict(_input,44,_ctx) ) {
 				case 1:
 					{
-					State = 338; typeSuffix();
+					State = 340; typeSuffix();
 					}
 					break;
 				}
@@ -2310,7 +2346,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 343;
+			State = 345;
 			_la = _input.La(1);
 			if ( !(((((_la - 226)) & ~0x3f) == 0 && ((1L << (_la - 226)) & ((1L << (OCTLITERAL - 226)) | (1L << (HEXLITERAL - 226)) | (1L << (FLOATLITERAL - 226)) | (1L << (INTEGERLITERAL - 226)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2369,25 +2405,25 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 345; Match(LPAREN);
-			State = 347;
+			State = 347; Match(LPAREN);
+			State = 349;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 346; whiteSpace();
+				State = 348; whiteSpace();
 				}
 			}
 
-			State = 349; expression(0);
-			State = 351;
+			State = 351; expression(0);
+			State = 353;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 350; whiteSpace();
+				State = 352; whiteSpace();
 				}
 			}
 
-			State = 353; Match(RPAREN);
+			State = 355; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2443,13 +2479,13 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 355; Match(TYPEOF);
-			State = 356; whiteSpace();
-			State = 357; expression(0);
+			State = 357; Match(TYPEOF);
 			State = 358; whiteSpace();
-			State = 359; Match(IS);
+			State = 359; expression(0);
 			State = 360; whiteSpace();
-			State = 361; typeExpression();
+			State = 361; Match(IS);
+			State = 362; whiteSpace();
+			State = 363; typeExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2498,9 +2534,9 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 363; Match(NEW);
-			State = 364; whiteSpace();
-			State = 365; typeExpression();
+			State = 365; Match(NEW);
+			State = 366; whiteSpace();
+			State = 367; typeExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2685,7 +2721,7 @@ public partial class VBAExpressionParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 371;
+			State = 373;
 			switch (_input.La(1)) {
 			case ME:
 				{
@@ -2693,7 +2729,7 @@ public partial class VBAExpressionParser : Parser {
 				_ctx = _localctx;
 				_prevctx = _localctx;
 
-				State = 368; instanceExpression();
+				State = 370; instanceExpression();
 				}
 				break;
 			case ABS:
@@ -2741,6 +2777,7 @@ public partial class VBAExpressionParser : Parser {
 			case BOOLEAN:
 			case BYTE:
 			case CLASS:
+			case CLOSE:
 			case DATABASE:
 			case DATE:
 			case DOUBLE:
@@ -2753,8 +2790,10 @@ public partial class VBAExpressionParser : Parser {
 			case EXIT_FUNCTION:
 			case EXIT_PROPERTY:
 			case EXIT_SUB:
+			case GET:
 			case INPUT:
 			case INTEGER:
+			case LOCK:
 			case LONG:
 			case LIB:
 			case LINE_INPUT:
@@ -2764,17 +2803,21 @@ public partial class VBAExpressionParser : Parser {
 			case MID:
 			case ON:
 			case ON_ERROR:
+			case OPEN:
 			case OUTPUT:
+			case PUT:
 			case RANDOM:
 			case READ:
 			case READ_WRITE:
 			case RESET:
+			case SEEK:
 			case SHARED:
 			case SINGLE:
 			case STEP:
 			case STRING:
 			case TAB:
 			case TEXT:
+			case UNLOCK:
 			case VARIANT:
 			case VERSION:
 			case WIDTH:
@@ -2787,7 +2830,7 @@ public partial class VBAExpressionParser : Parser {
 				_localctx = new SimpleNameExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 369; simpleNameExpression();
+				State = 371; simpleNameExpression();
 				}
 				break;
 			case EXCLAMATIONPOINT:
@@ -2796,14 +2839,14 @@ public partial class VBAExpressionParser : Parser {
 				_localctx = new WithExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 370; withExpression();
+				State = 372; withExpression();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
 			_ctx.stop = _input.Lt(-1);
-			State = 412;
+			State = 414;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,55,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
@@ -2811,48 +2854,48 @@ public partial class VBAExpressionParser : Parser {
 					if ( _parseListeners!=null ) TriggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					State = 410;
+					State = 412;
 					switch ( Interpreter.AdaptivePredict(_input,54,_ctx) ) {
 					case 1:
 						{
 						_localctx = new IndexExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 373;
-						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
 						State = 375;
+						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
+						State = 377;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 374; whiteSpace();
+							State = 376; whiteSpace();
 							}
 						}
 
-						State = 377; Match(LPAREN);
-						State = 379;
+						State = 379; Match(LPAREN);
+						State = 381;
 						switch ( Interpreter.AdaptivePredict(_input,50,_ctx) ) {
 						case 1:
 							{
-							State = 378; whiteSpace();
+							State = 380; whiteSpace();
 							}
 							break;
 						}
-						State = 382;
+						State = 384;
 						switch ( Interpreter.AdaptivePredict(_input,51,_ctx) ) {
 						case 1:
 							{
-							State = 381; argumentList();
+							State = 383; argumentList();
 							}
 							break;
 						}
-						State = 385;
+						State = 387;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 384; whiteSpace();
+							State = 386; whiteSpace();
 							}
 						}
 
-						State = 387; Match(RPAREN);
+						State = 389; Match(RPAREN);
 						}
 						break;
 
@@ -2860,10 +2903,10 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new MemberAccessExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 388;
+						State = 390;
 						if (!(Precpred(_ctx, 8))) throw new FailedPredicateException(this, "Precpred(_ctx, 8)");
-						State = 389; Match(DOT);
-						State = 390; unrestrictedName();
+						State = 391; Match(DOT);
+						State = 392; unrestrictedName();
 						}
 						break;
 
@@ -2871,19 +2914,19 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new MemberAccessExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 391;
+						State = 393;
 						if (!(Precpred(_ctx, 7))) throw new FailedPredicateException(this, "Precpred(_ctx, 7)");
-						State = 392; Match(LINE_CONTINUATION);
-						State = 394;
+						State = 394; Match(LINE_CONTINUATION);
+						State = 396;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 393; whiteSpace();
+							State = 395; whiteSpace();
 							}
 						}
 
-						State = 396; Match(DOT);
-						State = 397; unrestrictedName();
+						State = 398; Match(DOT);
+						State = 399; unrestrictedName();
 						}
 						break;
 
@@ -2891,10 +2934,10 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new DictionaryAccessExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 398;
+						State = 400;
 						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
-						State = 399; Match(EXCLAMATIONPOINT);
-						State = 400; unrestrictedName();
+						State = 401; Match(EXCLAMATIONPOINT);
+						State = 402; unrestrictedName();
 						}
 						break;
 
@@ -2902,11 +2945,11 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new DictionaryAccessExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 401;
+						State = 403;
 						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
-						State = 402; Match(LINE_CONTINUATION);
-						State = 403; Match(EXCLAMATIONPOINT);
-						State = 404; unrestrictedName();
+						State = 404; Match(LINE_CONTINUATION);
+						State = 405; Match(EXCLAMATIONPOINT);
+						State = 406; unrestrictedName();
 						}
 						break;
 
@@ -2914,18 +2957,18 @@ public partial class VBAExpressionParser : Parser {
 						{
 						_localctx = new DictionaryAccessExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 405;
+						State = 407;
 						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
-						State = 406; Match(LINE_CONTINUATION);
-						State = 407; Match(EXCLAMATIONPOINT);
 						State = 408; Match(LINE_CONTINUATION);
-						State = 409; unrestrictedName();
+						State = 409; Match(EXCLAMATIONPOINT);
+						State = 410; Match(LINE_CONTINUATION);
+						State = 411; unrestrictedName();
 						}
 						break;
 					}
 					} 
 				}
-				State = 414;
+				State = 416;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,55,_ctx);
 			}
@@ -2980,32 +3023,32 @@ public partial class VBAExpressionParser : Parser {
 		EnterRule(_localctx, 40, RULE_memberAccessExpression);
 		int _la;
 		try {
-			State = 427;
+			State = 429;
 			switch ( Interpreter.AdaptivePredict(_input,57,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 415; lExpression(0);
-				State = 416; Match(DOT);
-				State = 417; unrestrictedName();
+				State = 417; lExpression(0);
+				State = 418; Match(DOT);
+				State = 419; unrestrictedName();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 419; lExpression(0);
-				State = 420; Match(LINE_CONTINUATION);
-				State = 422;
+				State = 421; lExpression(0);
+				State = 422; Match(LINE_CONTINUATION);
+				State = 424;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 421; whiteSpace();
+					State = 423; whiteSpace();
 					}
 				}
 
-				State = 424; Match(DOT);
-				State = 425; unrestrictedName();
+				State = 426; Match(DOT);
+				State = 427; unrestrictedName();
 				}
 				break;
 			}
@@ -3064,41 +3107,41 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 429; lExpression(0);
-			State = 431;
+			State = 431; lExpression(0);
+			State = 433;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 430; whiteSpace();
+				State = 432; whiteSpace();
 				}
 			}
 
-			State = 433; Match(LPAREN);
-			State = 435;
+			State = 435; Match(LPAREN);
+			State = 437;
 			switch ( Interpreter.AdaptivePredict(_input,59,_ctx) ) {
 			case 1:
 				{
-				State = 434; whiteSpace();
+				State = 436; whiteSpace();
 				}
 				break;
 			}
-			State = 438;
+			State = 440;
 			switch ( Interpreter.AdaptivePredict(_input,60,_ctx) ) {
 			case 1:
 				{
-				State = 437; argumentList();
+				State = 439; argumentList();
 				}
 				break;
 			}
-			State = 441;
+			State = 443;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 440; whiteSpace();
+				State = 442; whiteSpace();
 				}
 			}
 
-			State = 443; Match(RPAREN);
+			State = 445; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3149,35 +3192,35 @@ public partial class VBAExpressionParser : Parser {
 		DictionaryAccessExpressionContext _localctx = new DictionaryAccessExpressionContext(_ctx, State);
 		EnterRule(_localctx, 44, RULE_dictionaryAccessExpression);
 		try {
-			State = 460;
+			State = 462;
 			switch ( Interpreter.AdaptivePredict(_input,62,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 445; lExpression(0);
-				State = 446; Match(EXCLAMATIONPOINT);
-				State = 447; unrestrictedName();
+				State = 447; lExpression(0);
+				State = 448; Match(EXCLAMATIONPOINT);
+				State = 449; unrestrictedName();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 449; lExpression(0);
-				State = 450; Match(LINE_CONTINUATION);
-				State = 451; Match(EXCLAMATIONPOINT);
-				State = 452; unrestrictedName();
+				State = 451; lExpression(0);
+				State = 452; Match(LINE_CONTINUATION);
+				State = 453; Match(EXCLAMATIONPOINT);
+				State = 454; unrestrictedName();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 454; lExpression(0);
-				State = 455; Match(LINE_CONTINUATION);
-				State = 456; Match(EXCLAMATIONPOINT);
+				State = 456; lExpression(0);
 				State = 457; Match(LINE_CONTINUATION);
-				State = 458; unrestrictedName();
+				State = 458; Match(EXCLAMATIONPOINT);
+				State = 459; Match(LINE_CONTINUATION);
+				State = 460; unrestrictedName();
 				}
 				break;
 			}
@@ -3224,7 +3267,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 462; positionalOrNamedArgumentList();
+			State = 464; positionalOrNamedArgumentList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3288,97 +3331,97 @@ public partial class VBAExpressionParser : Parser {
 		int _la;
 		try {
 			int _alt;
-			State = 496;
+			State = 498;
 			switch ( Interpreter.AdaptivePredict(_input,71,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 476;
+				State = 478;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,66,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 465;
+						State = 467;
 						_la = _input.La(1);
-						if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (INPUT - 64)) | (1L << (INTEGER - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OUTPUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (RESET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 194)) & ~0x3f) == 0 && ((1L << (_la - 194)) & ((1L << (VARIANT - 194)) | (1L << (VERSION - 194)) | (1L << (WIDTH - 194)) | (1L << (WRITE - 194)) | (1L << (LPAREN - 194)) | (1L << (MINUS - 194)) | (1L << (STRINGLITERAL - 194)) | (1L << (OCTLITERAL - 194)) | (1L << (HEXLITERAL - 194)) | (1L << (FLOATLITERAL - 194)) | (1L << (INTEGERLITERAL - 194)) | (1L << (DATELITERAL - 194)) | (1L << (IDENTIFIER - 194)) | (1L << (FOREIGNNAME - 194)) | (1L << (OBJECT - 194)) | (1L << (COLLECTION - 194)))) != 0)) {
+						if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (INPUT - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OUTPUT - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WRITE - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (FOREIGNNAME - 192)) | (1L << (OBJECT - 192)) | (1L << (COLLECTION - 192)))) != 0)) {
 							{
-							State = 464; positionalArgument();
+							State = 466; positionalArgument();
 							}
 						}
 
-						State = 468;
+						State = 470;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 467; whiteSpace();
+							State = 469; whiteSpace();
 							}
 						}
 
-						State = 470; Match(COMMA);
-						State = 472;
+						State = 472; Match(COMMA);
+						State = 474;
 						switch ( Interpreter.AdaptivePredict(_input,65,_ctx) ) {
 						case 1:
 							{
-							State = 471; whiteSpace();
+							State = 473; whiteSpace();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 478;
+					State = 480;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,66,_ctx);
 				}
-				State = 479; requiredPositionalArgument();
+				State = 481; requiredPositionalArgument();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 492;
+				State = 494;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,70,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 481;
+						State = 483;
 						_la = _input.La(1);
-						if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (INPUT - 64)) | (1L << (INTEGER - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OUTPUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (RESET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 194)) & ~0x3f) == 0 && ((1L << (_la - 194)) & ((1L << (VARIANT - 194)) | (1L << (VERSION - 194)) | (1L << (WIDTH - 194)) | (1L << (WRITE - 194)) | (1L << (LPAREN - 194)) | (1L << (MINUS - 194)) | (1L << (STRINGLITERAL - 194)) | (1L << (OCTLITERAL - 194)) | (1L << (HEXLITERAL - 194)) | (1L << (FLOATLITERAL - 194)) | (1L << (INTEGERLITERAL - 194)) | (1L << (DATELITERAL - 194)) | (1L << (IDENTIFIER - 194)) | (1L << (FOREIGNNAME - 194)) | (1L << (OBJECT - 194)) | (1L << (COLLECTION - 194)))) != 0)) {
+						if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (INPUT - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OUTPUT - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WRITE - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (FOREIGNNAME - 192)) | (1L << (OBJECT - 192)) | (1L << (COLLECTION - 192)))) != 0)) {
 							{
-							State = 480; positionalArgument();
+							State = 482; positionalArgument();
 							}
 						}
 
-						State = 484;
+						State = 486;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 483; whiteSpace();
+							State = 485; whiteSpace();
 							}
 						}
 
-						State = 486; Match(COMMA);
-						State = 488;
+						State = 488; Match(COMMA);
+						State = 490;
 						switch ( Interpreter.AdaptivePredict(_input,69,_ctx) ) {
 						case 1:
 							{
-							State = 487; whiteSpace();
+							State = 489; whiteSpace();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 494;
+					State = 496;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,70,_ctx);
 				}
-				State = 495; namedArgumentList();
+				State = 497; namedArgumentList();
 				}
 				break;
 			}
@@ -3425,7 +3468,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 498; argumentExpression();
+			State = 500; argumentExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3470,7 +3513,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 500; argumentExpression();
+			State = 502; argumentExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3530,36 +3573,36 @@ public partial class VBAExpressionParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 502; namedArgument();
-			State = 513;
+			State = 504; namedArgument();
+			State = 515;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,74,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 504;
+					State = 506;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 503; whiteSpace();
+						State = 505; whiteSpace();
 						}
 					}
 
-					State = 506; Match(COMMA);
-					State = 508;
+					State = 508; Match(COMMA);
+					State = 510;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 507; whiteSpace();
+						State = 509; whiteSpace();
 						}
 					}
 
-					State = 510; namedArgument();
+					State = 512; namedArgument();
 					}
 					} 
 				}
-				State = 515;
+				State = 517;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,74,_ctx);
 			}
@@ -3618,25 +3661,25 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 516; unrestrictedName();
-			State = 518;
+			State = 518; unrestrictedName();
+			State = 520;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 517; whiteSpace();
+				State = 519; whiteSpace();
 				}
 			}
 
-			State = 520; Match(ASSIGN);
-			State = 522;
+			State = 522; Match(ASSIGN);
+			State = 524;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 521; whiteSpace();
+				State = 523; whiteSpace();
 				}
 			}
 
-			State = 524; argumentExpression();
+			State = 526; argumentExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3687,7 +3730,7 @@ public partial class VBAExpressionParser : Parser {
 		EnterRule(_localctx, 58, RULE_argumentExpression);
 		int _la;
 		try {
-			State = 532;
+			State = 534;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -3727,6 +3770,7 @@ public partial class VBAExpressionParser : Parser {
 			case UBOUND:
 			case EXCLAMATIONPOINT:
 			case DOT:
+			case HASH:
 			case ACCESS:
 			case ALIAS:
 			case ATTRIBUTE:
@@ -3737,6 +3781,7 @@ public partial class VBAExpressionParser : Parser {
 			case BYVAL:
 			case BYTE:
 			case CLASS:
+			case CLOSE:
 			case DATABASE:
 			case DATE:
 			case DOUBLE:
@@ -3751,8 +3796,10 @@ public partial class VBAExpressionParser : Parser {
 			case EXIT_PROPERTY:
 			case EXIT_SUB:
 			case FALSE:
+			case GET:
 			case INPUT:
 			case INTEGER:
+			case LOCK:
 			case LONG:
 			case LIB:
 			case LINE_INPUT:
@@ -3767,11 +3814,14 @@ public partial class VBAExpressionParser : Parser {
 			case NULL:
 			case ON:
 			case ON_ERROR:
+			case OPEN:
 			case OUTPUT:
+			case PUT:
 			case RANDOM:
 			case READ:
 			case READ_WRITE:
 			case RESET:
+			case SEEK:
 			case SHARED:
 			case SINGLE:
 			case STEP:
@@ -3780,6 +3830,7 @@ public partial class VBAExpressionParser : Parser {
 			case TEXT:
 			case TRUE:
 			case TYPEOF:
+			case UNLOCK:
 			case VARIANT:
 			case VERSION:
 			case WIDTH:
@@ -3798,22 +3849,22 @@ public partial class VBAExpressionParser : Parser {
 			case COLLECTION:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 528;
+				State = 530;
 				_la = _input.La(1);
 				if (_la==BYVAL) {
 					{
-					State = 526; Match(BYVAL);
-					State = 527; whiteSpace();
+					State = 528; Match(BYVAL);
+					State = 529; whiteSpace();
 					}
 				}
 
-				State = 530; expression(0);
+				State = 532; expression(0);
 				}
 				break;
 			case ADDRESSOF:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 531; addressOfExpression();
+				State = 533; addressOfExpression();
 				}
 				break;
 			default:
@@ -3862,7 +3913,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 534; name();
+			State = 536; name();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3905,7 +3956,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 536; Match(ME);
+			State = 538; Match(ME);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3951,18 +4002,18 @@ public partial class VBAExpressionParser : Parser {
 		WithExpressionContext _localctx = new WithExpressionContext(_ctx, State);
 		EnterRule(_localctx, 64, RULE_withExpression);
 		try {
-			State = 540;
+			State = 542;
 			switch (_input.La(1)) {
 			case DOT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 538; withMemberAccessExpression();
+				State = 540; withMemberAccessExpression();
 				}
 				break;
 			case EXCLAMATIONPOINT:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 539; withDictionaryAccessExpression();
+				State = 541; withDictionaryAccessExpression();
 				}
 				break;
 			default:
@@ -4012,8 +4063,8 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 542; Match(DOT);
-			State = 543; unrestrictedName();
+			State = 544; Match(DOT);
+			State = 545; unrestrictedName();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4059,8 +4110,8 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 545; Match(EXCLAMATIONPOINT);
-			State = 546; unrestrictedName();
+			State = 547; Match(EXCLAMATIONPOINT);
+			State = 548; unrestrictedName();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4105,7 +4156,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 548; expression(0);
+			State = 550; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4151,19 +4202,19 @@ public partial class VBAExpressionParser : Parser {
 		TypeExpressionContext _localctx = new TypeExpressionContext(_ctx, State);
 		EnterRule(_localctx, 72, RULE_typeExpression);
 		try {
-			State = 552;
+			State = 554;
 			switch ( Interpreter.AdaptivePredict(_input,80,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 550; builtInType();
+				State = 552; builtInType();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 551; definedTypeExpression();
+				State = 553; definedTypeExpression();
 				}
 				break;
 			}
@@ -4211,19 +4262,19 @@ public partial class VBAExpressionParser : Parser {
 		DefinedTypeExpressionContext _localctx = new DefinedTypeExpressionContext(_ctx, State);
 		EnterRule(_localctx, 74, RULE_definedTypeExpression);
 		try {
-			State = 556;
+			State = 558;
 			switch ( Interpreter.AdaptivePredict(_input,81,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 554; simpleNameExpression();
+				State = 556; simpleNameExpression();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 555; memberAccessExpression();
+				State = 557; memberAccessExpression();
 				}
 				break;
 			}
@@ -4274,9 +4325,9 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 558; Match(ADDRESSOF);
-			State = 559; whiteSpace();
-			State = 560; procedurePointerExpression();
+			State = 560; Match(ADDRESSOF);
+			State = 561; whiteSpace();
+			State = 562; procedurePointerExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4322,19 +4373,19 @@ public partial class VBAExpressionParser : Parser {
 		ProcedurePointerExpressionContext _localctx = new ProcedurePointerExpressionContext(_ctx, State);
 		EnterRule(_localctx, 78, RULE_procedurePointerExpression);
 		try {
-			State = 564;
+			State = 566;
 			switch ( Interpreter.AdaptivePredict(_input,82,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 562; memberAccessExpression();
+				State = 564; memberAccessExpression();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 563; simpleNameExpression();
+				State = 565; simpleNameExpression();
 				}
 				break;
 			}
@@ -4400,61 +4451,61 @@ public partial class VBAExpressionParser : Parser {
 		ReservedIdentifierContext _localctx = new ReservedIdentifierContext(_ctx, State);
 		EnterRule(_localctx, 80, RULE_reservedIdentifier);
 		try {
-			State = 574;
+			State = 576;
 			switch ( Interpreter.AdaptivePredict(_input,83,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 566; statementKeyword();
+				State = 568; statementKeyword();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 567; markerKeyword();
+				State = 569; markerKeyword();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 568; operatorIdentifier();
+				State = 570; operatorIdentifier();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 569; specialForm();
+				State = 571; specialForm();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 570; reservedName();
+				State = 572; reservedName();
 				}
 				break;
 
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 571; literalIdentifier();
+				State = 573; literalIdentifier();
 				}
 				break;
 
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 572; remKeyword();
+				State = 574; remKeyword();
 				}
 				break;
 
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 573; reservedTypeIdentifier();
+				State = 575; reservedTypeIdentifier();
 				}
 				break;
 			}
@@ -4485,7 +4536,6 @@ public partial class VBAExpressionParser : Parser {
 		public ITerminalNode GOSUB() { return GetToken(VBAExpressionParser.GOSUB, 0); }
 		public ITerminalNode RETURN() { return GetToken(VBAExpressionParser.RETURN, 0); }
 		public ITerminalNode ENUM() { return GetToken(VBAExpressionParser.ENUM, 0); }
-		public ITerminalNode LOCK() { return GetToken(VBAExpressionParser.LOCK, 0); }
 		public ITerminalNode GLOBAL() { return GetToken(VBAExpressionParser.GLOBAL, 0); }
 		public ITerminalNode WEND() { return GetToken(VBAExpressionParser.WEND, 0); }
 		public ITerminalNode DEFSTR() { return GetToken(VBAExpressionParser.DEFSTR, 0); }
@@ -4499,35 +4549,28 @@ public partial class VBAExpressionParser : Parser {
 		public ITerminalNode SUB() { return GetToken(VBAExpressionParser.SUB, 0); }
 		public ITerminalNode FOR() { return GetToken(VBAExpressionParser.FOR, 0); }
 		public ITerminalNode LSET() { return GetToken(VBAExpressionParser.LSET, 0); }
-		public ITerminalNode INPUT() { return GetToken(VBAExpressionParser.INPUT, 0); }
-		public ITerminalNode SEEK() { return GetToken(VBAExpressionParser.SEEK, 0); }
 		public ITerminalNode LOOP() { return GetToken(VBAExpressionParser.LOOP, 0); }
 		public ITerminalNode DEFCUR() { return GetToken(VBAExpressionParser.DEFCUR, 0); }
 		public ITerminalNode PUBLIC() { return GetToken(VBAExpressionParser.PUBLIC, 0); }
 		public ITerminalNode DEFDATE() { return GetToken(VBAExpressionParser.DEFDATE, 0); }
-		public ITerminalNode PUT() { return GetToken(VBAExpressionParser.PUT, 0); }
 		public ITerminalNode LET() { return GetToken(VBAExpressionParser.LET, 0); }
 		public ITerminalNode FRIEND() { return GetToken(VBAExpressionParser.FRIEND, 0); }
 		public ITerminalNode TYPE() { return GetToken(VBAExpressionParser.TYPE, 0); }
 		public ITerminalNode CALL() { return GetToken(VBAExpressionParser.CALL, 0); }
 		public ITerminalNode DEFBOOL() { return GetToken(VBAExpressionParser.DEFBOOL, 0); }
-		public ITerminalNode OPEN() { return GetToken(VBAExpressionParser.OPEN, 0); }
 		public ITerminalNode STATIC() { return GetToken(VBAExpressionParser.STATIC, 0); }
 		public ITerminalNode DO() { return GetToken(VBAExpressionParser.DO, 0); }
 		public ITerminalNode DIM() { return GetToken(VBAExpressionParser.DIM, 0); }
 		public ITerminalNode OPTION() { return GetToken(VBAExpressionParser.OPTION, 0); }
-		public ITerminalNode CLOSE() { return GetToken(VBAExpressionParser.CLOSE, 0); }
 		public ITerminalNode DEFLNG() { return GetToken(VBAExpressionParser.DEFLNG, 0); }
 		public ITerminalNode IMPLEMENTS() { return GetToken(VBAExpressionParser.IMPLEMENTS, 0); }
 		public ITerminalNode ON() { return GetToken(VBAExpressionParser.ON, 0); }
 		public ITerminalNode WITH() { return GetToken(VBAExpressionParser.WITH, 0); }
 		public ITerminalNode DECLARE() { return GetToken(VBAExpressionParser.DECLARE, 0); }
 		public ITerminalNode RESUME() { return GetToken(VBAExpressionParser.RESUME, 0); }
-		public ITerminalNode WRITE() { return GetToken(VBAExpressionParser.WRITE, 0); }
 		public ITerminalNode DEFLNGPTR() { return GetToken(VBAExpressionParser.DEFLNGPTR, 0); }
 		public ITerminalNode WHILE() { return GetToken(VBAExpressionParser.WHILE, 0); }
 		public ITerminalNode EXIT() { return GetToken(VBAExpressionParser.EXIT, 0); }
-		public ITerminalNode GET() { return GetToken(VBAExpressionParser.GET, 0); }
 		public ITerminalNode DEFDBL() { return GetToken(VBAExpressionParser.DEFDBL, 0); }
 		public ITerminalNode NEXT() { return GetToken(VBAExpressionParser.NEXT, 0); }
 		public ITerminalNode FUNCTION() { return GetToken(VBAExpressionParser.FUNCTION, 0); }
@@ -4535,7 +4578,6 @@ public partial class VBAExpressionParser : Parser {
 		public ITerminalNode GOTO() { return GetToken(VBAExpressionParser.GOTO, 0); }
 		public ITerminalNode REDIM() { return GetToken(VBAExpressionParser.REDIM, 0); }
 		public ITerminalNode SELECT() { return GetToken(VBAExpressionParser.SELECT, 0); }
-		public ITerminalNode UNLOCK() { return GetToken(VBAExpressionParser.UNLOCK, 0); }
 		public ITerminalNode SET() { return GetToken(VBAExpressionParser.SET, 0); }
 		public StatementKeywordContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
@@ -4565,9 +4607,9 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 576;
+			State = 578;
 			_la = _input.La(1);
-			if ( !(((((_la - 22)) & ~0x3f) == 0 && ((1L << (_la - 22)) & ((1L << (EXIT - 22)) | (1L << (OPTION - 22)) | (1L << (CALL - 22)) | (1L << (CASE - 22)) | (1L << (CLOSE - 22)) | (1L << (CONST - 22)) | (1L << (DECLARE - 22)) | (1L << (DEFBOOL - 22)) | (1L << (DEFBYTE - 22)) | (1L << (DEFDATE - 22)) | (1L << (DEFDBL - 22)) | (1L << (DEFCUR - 22)) | (1L << (DEFINT - 22)) | (1L << (DEFLNG - 22)) | (1L << (DEFLNGLNG - 22)) | (1L << (DEFLNGPTR - 22)) | (1L << (DEFOBJ - 22)) | (1L << (DEFSNG - 22)) | (1L << (DEFSTR - 22)) | (1L << (DEFVAR - 22)) | (1L << (DIM - 22)) | (1L << (DO - 22)))) != 0) || ((((_la - 87)) & ~0x3f) == 0 && ((1L << (_la - 87)) & ((1L << (ELSE - 87)) | (1L << (ELSEIF - 87)) | (1L << (END_IF - 87)) | (1L << (ENUM - 87)) | (1L << (ERASE - 87)) | (1L << (EVENT - 87)) | (1L << (FRIEND - 87)) | (1L << (FOR - 87)) | (1L << (FUNCTION - 87)) | (1L << (GET - 87)) | (1L << (GLOBAL - 87)) | (1L << (GOSUB - 87)) | (1L << (GOTO - 87)) | (1L << (IF - 87)) | (1L << (IMPLEMENTS - 87)) | (1L << (INPUT - 87)) | (1L << (LOCK - 87)) | (1L << (LOOP - 87)) | (1L << (LET - 87)) | (1L << (LSET - 87)) | (1L << (NEXT - 87)) | (1L << (ON - 87)) | (1L << (OPEN - 87)))) != 0) || ((((_la - 156)) & ~0x3f) == 0 && ((1L << (_la - 156)) & ((1L << (PRINT - 156)) | (1L << (PRIVATE - 156)) | (1L << (PUBLIC - 156)) | (1L << (PUT - 156)) | (1L << (RAISEEVENT - 156)) | (1L << (REDIM - 156)) | (1L << (RESUME - 156)) | (1L << (RETURN - 156)) | (1L << (RSET - 156)) | (1L << (SEEK - 156)) | (1L << (SELECT - 156)) | (1L << (SET - 156)) | (1L << (STATIC - 156)) | (1L << (STOP - 156)) | (1L << (SUB - 156)) | (1L << (TYPE - 156)) | (1L << (UNLOCK - 156)) | (1L << (WEND - 156)) | (1L << (WHILE - 156)) | (1L << (WITH - 156)) | (1L << (WRITE - 156)))) != 0)) ) {
+			if ( !(((((_la - 22)) & ~0x3f) == 0 && ((1L << (_la - 22)) & ((1L << (EXIT - 22)) | (1L << (OPTION - 22)) | (1L << (CALL - 22)) | (1L << (CASE - 22)) | (1L << (CONST - 22)) | (1L << (DECLARE - 22)) | (1L << (DEFBOOL - 22)) | (1L << (DEFBYTE - 22)) | (1L << (DEFDATE - 22)) | (1L << (DEFDBL - 22)) | (1L << (DEFCUR - 22)) | (1L << (DEFINT - 22)) | (1L << (DEFLNG - 22)) | (1L << (DEFLNGLNG - 22)) | (1L << (DEFLNGPTR - 22)) | (1L << (DEFOBJ - 22)) | (1L << (DEFSNG - 22)) | (1L << (DEFSTR - 22)) | (1L << (DEFVAR - 22)) | (1L << (DIM - 22)) | (1L << (DO - 22)))) != 0) || ((((_la - 87)) & ~0x3f) == 0 && ((1L << (_la - 87)) & ((1L << (ELSE - 87)) | (1L << (ELSEIF - 87)) | (1L << (END_IF - 87)) | (1L << (ENUM - 87)) | (1L << (ERASE - 87)) | (1L << (EVENT - 87)) | (1L << (FRIEND - 87)) | (1L << (FOR - 87)) | (1L << (FUNCTION - 87)) | (1L << (GLOBAL - 87)) | (1L << (GOSUB - 87)) | (1L << (GOTO - 87)) | (1L << (IF - 87)) | (1L << (IMPLEMENTS - 87)) | (1L << (LOOP - 87)) | (1L << (LET - 87)) | (1L << (LSET - 87)) | (1L << (NEXT - 87)) | (1L << (ON - 87)))) != 0) || ((((_la - 156)) & ~0x3f) == 0 && ((1L << (_la - 156)) & ((1L << (PRINT - 156)) | (1L << (PRIVATE - 156)) | (1L << (PUBLIC - 156)) | (1L << (RAISEEVENT - 156)) | (1L << (REDIM - 156)) | (1L << (RESUME - 156)) | (1L << (RETURN - 156)) | (1L << (RSET - 156)) | (1L << (SELECT - 156)) | (1L << (SET - 156)) | (1L << (STATIC - 156)) | (1L << (STOP - 156)) | (1L << (SUB - 156)) | (1L << (TYPE - 156)) | (1L << (WEND - 156)) | (1L << (WHILE - 156)) | (1L << (WITH - 156)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
@@ -4613,7 +4655,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 578; Match(REM);
+			State = 580; Match(REM);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4676,7 +4718,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 580;
+			State = 582;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANY) | (1L << AS) | (1L << BYVAL) | (1L << BYREF) | (1L << CASE))) != 0) || ((((_la - 86)) & ~0x3f) == 0 && ((1L << (_la - 86)) & ((1L << (EACH - 86)) | (1L << (ELSE - 86)) | (1L << (IN - 86)) | (1L << (NEW - 86)) | (1L << (OPTIONAL - 86)))) != 0) || ((((_la - 154)) & ~0x3f) == 0 && ((1L << (_la - 154)) & ((1L << (PARAMARRAY - 154)) | (1L << (PRESERVE - 154)) | (1L << (SHARED - 154)) | (1L << (SPC - 154)) | (1L << (TAB - 154)) | (1L << (THEN - 154)) | (1L << (TO - 154)) | (1L << (UNTIL - 154)) | (1L << (WITHEVENTS - 154)) | (1L << (WRITE - 154)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -4736,7 +4778,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 582;
+			State = 584;
 			_la = _input.La(1);
 			if ( !(_la==ADDRESSOF || _la==AND || ((((_la - 100)) & ~0x3f) == 0 && ((1L << (_la - 100)) & ((1L << (EQV - 100)) | (1L << (IMP - 100)) | (1L << (IS - 100)) | (1L << (LIKE - 100)) | (1L << (MOD - 100)) | (1L << (NEW - 100)) | (1L << (NOT - 100)) | (1L << (OR - 100)))) != 0) || _la==TYPEOF || _la==XOR) ) {
 			_errHandler.RecoverInline(this);
@@ -4785,12 +4827,12 @@ public partial class VBAExpressionParser : Parser {
 		ReservedNameContext _localctx = new ReservedNameContext(_ctx, State);
 		EnterRule(_localctx, 90, RULE_reservedName);
 		try {
-			State = 586;
+			State = 588;
 			switch (_input.La(1)) {
 			case ME:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 584; Match(ME);
+				State = 586; Match(ME);
 				}
 				break;
 			case ABS:
@@ -4823,6 +4865,7 @@ public partial class VBAExpressionParser : Parser {
 			case ACCESS:
 			case APPEND:
 			case BINARY:
+			case CLOSE:
 			case END_SELECT:
 			case END_WITH:
 			case END:
@@ -4832,24 +4875,31 @@ public partial class VBAExpressionParser : Parser {
 			case EXIT_FUNCTION:
 			case EXIT_PROPERTY:
 			case EXIT_SUB:
+			case GET:
+			case INPUT:
+			case LOCK:
 			case LINE_INPUT:
 			case LOCK_READ:
 			case LOCK_WRITE:
 			case LOCK_READ_WRITE:
 			case MID:
 			case ON_ERROR:
+			case OPEN:
 			case OUTPUT:
+			case PUT:
 			case RANDOM:
 			case READ:
 			case READ_WRITE:
 			case RESET:
+			case SEEK:
 			case SHARED:
 			case STEP:
+			case UNLOCK:
 			case WIDTH:
 			case WRITE:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 585; reservedProcedureName();
+				State = 587; reservedProcedureName();
 				}
 				break;
 			default:
@@ -4873,6 +4923,9 @@ public partial class VBAExpressionParser : Parser {
 		public ITerminalNode RESET() { return GetToken(VBAExpressionParser.RESET, 0); }
 		public ITerminalNode END_SELECT() { return GetToken(VBAExpressionParser.END_SELECT, 0); }
 		public ITerminalNode ON_ERROR() { return GetToken(VBAExpressionParser.ON_ERROR, 0); }
+		public ITerminalNode WRITE(int i) {
+			return GetToken(VBAExpressionParser.WRITE, i);
+		}
 		public ITerminalNode SHARED() { return GetToken(VBAExpressionParser.SHARED, 0); }
 		public ITerminalNode LENB() { return GetToken(VBAExpressionParser.LENB, 0); }
 		public ITerminalNode APPEND() { return GetToken(VBAExpressionParser.APPEND, 0); }
@@ -4880,11 +4933,14 @@ public partial class VBAExpressionParser : Parser {
 		public ITerminalNode MIDTYPESUFFIX() { return GetToken(VBAExpressionParser.MIDTYPESUFFIX, 0); }
 		public ITerminalNode DEBUG() { return GetToken(VBAExpressionParser.DEBUG, 0); }
 		public ITerminalNode CLNGPTR() { return GetToken(VBAExpressionParser.CLNGPTR, 0); }
+		public ITerminalNode LOCK() { return GetToken(VBAExpressionParser.LOCK, 0); }
 		public ITerminalNode EXIT_DO() { return GetToken(VBAExpressionParser.EXIT_DO, 0); }
 		public ITerminalNode CDEC() { return GetToken(VBAExpressionParser.CDEC, 0); }
 		public ITerminalNode WIDTH() { return GetToken(VBAExpressionParser.WIDTH, 0); }
 		public ITerminalNode CSNG() { return GetToken(VBAExpressionParser.CSNG, 0); }
 		public ITerminalNode STEP() { return GetToken(VBAExpressionParser.STEP, 0); }
+		public ITerminalNode INPUT() { return GetToken(VBAExpressionParser.INPUT, 0); }
+		public ITerminalNode SEEK() { return GetToken(VBAExpressionParser.SEEK, 0); }
 		public ITerminalNode BINARY() { return GetToken(VBAExpressionParser.BINARY, 0); }
 		public ITerminalNode RANDOM() { return GetToken(VBAExpressionParser.RANDOM, 0); }
 		public ITerminalNode CBOOL() { return GetToken(VBAExpressionParser.CBOOL, 0); }
@@ -4893,6 +4949,7 @@ public partial class VBAExpressionParser : Parser {
 		public ITerminalNode CBYTE() { return GetToken(VBAExpressionParser.CBYTE, 0); }
 		public ITerminalNode CVERR() { return GetToken(VBAExpressionParser.CVERR, 0); }
 		public ITerminalNode FIX() { return GetToken(VBAExpressionParser.FIX, 0); }
+		public ITerminalNode PUT() { return GetToken(VBAExpressionParser.PUT, 0); }
 		public ITerminalNode CVAR() { return GetToken(VBAExpressionParser.CVAR, 0); }
 		public ITerminalNode CSTR() { return GetToken(VBAExpressionParser.CSTR, 0); }
 		public ITerminalNode CDATE() { return GetToken(VBAExpressionParser.CDATE, 0); }
@@ -4901,25 +4958,29 @@ public partial class VBAExpressionParser : Parser {
 		public ITerminalNode ABS() { return GetToken(VBAExpressionParser.ABS, 0); }
 		public ITerminalNode READ() { return GetToken(VBAExpressionParser.READ, 0); }
 		public ITerminalNode INT() { return GetToken(VBAExpressionParser.INT, 0); }
+		public ITerminalNode OPEN() { return GetToken(VBAExpressionParser.OPEN, 0); }
 		public ITerminalNode LOCK_READ() { return GetToken(VBAExpressionParser.LOCK_READ, 0); }
 		public ITerminalNode DOEVENTS() { return GetToken(VBAExpressionParser.DOEVENTS, 0); }
 		public ITerminalNode OUTPUT() { return GetToken(VBAExpressionParser.OUTPUT, 0); }
+		public ITerminalNode CLOSE() { return GetToken(VBAExpressionParser.CLOSE, 0); }
 		public ITerminalNode LINE_INPUT() { return GetToken(VBAExpressionParser.LINE_INPUT, 0); }
 		public ITerminalNode MID() { return GetToken(VBAExpressionParser.MID, 0); }
 		public ITerminalNode ACCESS() { return GetToken(VBAExpressionParser.ACCESS, 0); }
 		public ITerminalNode EXIT_SUB() { return GetToken(VBAExpressionParser.EXIT_SUB, 0); }
 		public ITerminalNode LOCK_READ_WRITE() { return GetToken(VBAExpressionParser.LOCK_READ_WRITE, 0); }
 		public ITerminalNode MIDB() { return GetToken(VBAExpressionParser.MIDB, 0); }
-		public ITerminalNode WRITE() { return GetToken(VBAExpressionParser.WRITE, 0); }
+		public IReadOnlyList<ITerminalNode> WRITE() { return GetTokens(VBAExpressionParser.WRITE); }
 		public ITerminalNode LEN() { return GetToken(VBAExpressionParser.LEN, 0); }
 		public ITerminalNode CCUR() { return GetToken(VBAExpressionParser.CCUR, 0); }
 		public ITerminalNode EXIT_FOR() { return GetToken(VBAExpressionParser.EXIT_FOR, 0); }
+		public ITerminalNode GET() { return GetToken(VBAExpressionParser.GET, 0); }
 		public ITerminalNode END_WITH() { return GetToken(VBAExpressionParser.END_WITH, 0); }
 		public ITerminalNode EXIT_PROPERTY() { return GetToken(VBAExpressionParser.EXIT_PROPERTY, 0); }
 		public ITerminalNode END() { return GetToken(VBAExpressionParser.END, 0); }
 		public ITerminalNode PSET() { return GetToken(VBAExpressionParser.PSET, 0); }
 		public ITerminalNode EXIT_FUNCTION() { return GetToken(VBAExpressionParser.EXIT_FUNCTION, 0); }
 		public ITerminalNode READ_WRITE() { return GetToken(VBAExpressionParser.READ_WRITE, 0); }
+		public ITerminalNode UNLOCK() { return GetToken(VBAExpressionParser.UNLOCK, 0); }
 		public ITerminalNode CDBL() { return GetToken(VBAExpressionParser.CDBL, 0); }
 		public ITerminalNode CLNG() { return GetToken(VBAExpressionParser.CLNG, 0); }
 		public ReservedProcedureNameContext(ParserRuleContext parent, int invokingState)
@@ -4950,9 +5011,9 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 588;
+			State = 590;
 			_la = _input.La(1);
-			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INT) | (1L << LEN) | (1L << LENB) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << ACCESS) | (1L << APPEND) | (1L << BINARY))) != 0) || ((((_la - 94)) & ~0x3f) == 0 && ((1L << (_la - 94)) & ((1L << (END_SELECT - 94)) | (1L << (END_WITH - 94)) | (1L << (END - 94)) | (1L << (ERROR - 94)) | (1L << (EXIT_DO - 94)) | (1L << (EXIT_FOR - 94)) | (1L << (EXIT_FUNCTION - 94)) | (1L << (EXIT_PROPERTY - 94)) | (1L << (EXIT_SUB - 94)) | (1L << (LINE_INPUT - 94)) | (1L << (LOCK_READ - 94)) | (1L << (LOCK_WRITE - 94)) | (1L << (LOCK_READ_WRITE - 94)) | (1L << (MID - 94)) | (1L << (ON_ERROR - 94)) | (1L << (OUTPUT - 94)))) != 0) || ((((_la - 164)) & ~0x3f) == 0 && ((1L << (_la - 164)) & ((1L << (RANDOM - 164)) | (1L << (READ - 164)) | (1L << (READ_WRITE - 164)) | (1L << (RESET - 164)) | (1L << (SHARED - 164)) | (1L << (STEP - 164)) | (1L << (WIDTH - 164)) | (1L << (WRITE - 164)))) != 0)) ) {
+			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INT) | (1L << LEN) | (1L << LENB) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << ACCESS) | (1L << APPEND) | (1L << BINARY))) != 0) || ((((_la - 65)) & ~0x3f) == 0 && ((1L << (_la - 65)) & ((1L << (CLOSE - 65)) | (1L << (END_SELECT - 65)) | (1L << (END_WITH - 65)) | (1L << (END - 65)) | (1L << (ERROR - 65)) | (1L << (EXIT_DO - 65)) | (1L << (EXIT_FOR - 65)) | (1L << (EXIT_FUNCTION - 65)) | (1L << (EXIT_PROPERTY - 65)) | (1L << (EXIT_SUB - 65)) | (1L << (GET - 65)) | (1L << (INPUT - 65)) | (1L << (LOCK - 65)))) != 0) || ((((_la - 130)) & ~0x3f) == 0 && ((1L << (_la - 130)) & ((1L << (LINE_INPUT - 130)) | (1L << (LOCK_READ - 130)) | (1L << (LOCK_WRITE - 130)) | (1L << (LOCK_READ_WRITE - 130)) | (1L << (MID - 130)) | (1L << (ON_ERROR - 130)) | (1L << (OPEN - 130)) | (1L << (OUTPUT - 130)) | (1L << (PUT - 130)) | (1L << (RANDOM - 130)) | (1L << (READ - 130)) | (1L << (READ_WRITE - 130)) | (1L << (RESET - 130)) | (1L << (SEEK - 130)) | (1L << (SHARED - 130)) | (1L << (STEP - 130)) | (1L << (UNLOCK - 130)))) != 0) || _la==WIDTH || _la==WRITE) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
@@ -5005,7 +5066,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 590;
+			State = 592;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ARRAY) | (1L << CIRCLE) | (1L << INPUTB) | (1L << LBOUND) | (1L << SCALE) | (1L << UBOUND))) != 0) || _la==INPUT) ) {
 			_errHandler.RecoverInline(this);
@@ -5066,7 +5127,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 592;
+			State = 594;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANY) | (1L << CURRENCY) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << BOOLEAN) | (1L << BYTE))) != 0) || ((((_la - 68)) & ~0x3f) == 0 && ((1L << (_la - 68)) & ((1L << (DATE - 68)) | (1L << (DOUBLE - 68)) | (1L << (INTEGER - 68)) | (1L << (LONG - 68)))) != 0) || ((((_la - 178)) & ~0x3f) == 0 && ((1L << (_la - 178)) & ((1L << (SINGLE - 178)) | (1L << (STRING - 178)) | (1L << (VARIANT - 178)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -5123,7 +5184,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 594;
+			State = 596;
 			_la = _input.La(1);
 			if ( !(((((_la - 51)) & ~0x3f) == 0 && ((1L << (_la - 51)) & ((1L << (ALIAS - 51)) | (1L << (ATTRIBUTE - 51)) | (1L << (BEGIN - 51)) | (1L << (CLASS - 51)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (ON - 128)) | (1L << (TAB - 128)))) != 0) || _la==VERSION || _la==COLLECTION) ) {
 			_errHandler.RecoverInline(this);
@@ -5177,26 +5238,26 @@ public partial class VBAExpressionParser : Parser {
 		LiteralIdentifierContext _localctx = new LiteralIdentifierContext(_ctx, State);
 		EnterRule(_localctx, 100, RULE_literalIdentifier);
 		try {
-			State = 599;
+			State = 601;
 			switch (_input.La(1)) {
 			case FALSE:
 			case TRUE:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 596; booleanLiteralIdentifier();
+				State = 598; booleanLiteralIdentifier();
 				}
 				break;
 			case NOTHING:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 597; objectLiteralIdentifier();
+				State = 599; objectLiteralIdentifier();
 				}
 				break;
 			case EMPTY:
 			case NULL:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 598; variantLiteralIdentifier();
+				State = 600; variantLiteralIdentifier();
 				}
 				break;
 			default:
@@ -5245,7 +5306,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 601;
+			State = 603;
 			_la = _input.La(1);
 			if ( !(_la==FALSE || _la==TRUE) ) {
 			_errHandler.RecoverInline(this);
@@ -5293,7 +5354,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 603; Match(NOTHING);
+			State = 605; Match(NOTHING);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5338,7 +5399,7 @@ public partial class VBAExpressionParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 605;
+			State = 607;
 			_la = _input.La(1);
 			if ( !(_la==EMPTY || _la==NULL) ) {
 			_errHandler.RecoverInline(this);
@@ -5395,7 +5456,7 @@ public partial class VBAExpressionParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 608;
+			State = 610;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -5403,7 +5464,7 @@ public partial class VBAExpressionParser : Parser {
 				case 1:
 					{
 					{
-					State = 607;
+					State = 609;
 					_la = _input.La(1);
 					if ( !(_la==WS || _la==LINE_CONTINUATION) ) {
 					_errHandler.RecoverInline(this);
@@ -5415,7 +5476,7 @@ public partial class VBAExpressionParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 610;
+				State = 612;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,86,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
@@ -5442,29 +5503,29 @@ public partial class VBAExpressionParser : Parser {
 	}
 	private bool expression_sempred(ExpressionContext _localctx, int predIndex) {
 		switch (predIndex) {
-		case 0: return Precpred(_ctx, 15);
+		case 0: return Precpred(_ctx, 16);
 
-		case 1: return Precpred(_ctx, 13);
+		case 1: return Precpred(_ctx, 14);
 
-		case 2: return Precpred(_ctx, 12);
+		case 2: return Precpred(_ctx, 13);
 
-		case 3: return Precpred(_ctx, 11);
+		case 3: return Precpred(_ctx, 12);
 
-		case 4: return Precpred(_ctx, 10);
+		case 4: return Precpred(_ctx, 11);
 
-		case 5: return Precpred(_ctx, 9);
+		case 5: return Precpred(_ctx, 10);
 
-		case 6: return Precpred(_ctx, 8);
+		case 6: return Precpred(_ctx, 9);
 
-		case 7: return Precpred(_ctx, 6);
+		case 7: return Precpred(_ctx, 7);
 
-		case 8: return Precpred(_ctx, 5);
+		case 8: return Precpred(_ctx, 6);
 
-		case 9: return Precpred(_ctx, 4);
+		case 9: return Precpred(_ctx, 5);
 
-		case 10: return Precpred(_ctx, 3);
+		case 10: return Precpred(_ctx, 4);
 
-		case 11: return Precpred(_ctx, 2);
+		case 11: return Precpred(_ctx, 3);
 		}
 		return true;
 	}
@@ -5486,7 +5547,7 @@ public partial class VBAExpressionParser : Parser {
 	}
 
 	public static readonly string _serializedATN =
-		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xF3\x267\x4\x2"+
+		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xF3\x269\x4\x2"+
 		"\t\x2\x4\x3\t\x3\x4\x4\t\x4\x4\x5\t\x5\x4\x6\t\x6\x4\a\t\a\x4\b\t\b\x4"+
 		"\t\t\t\x4\n\t\n\x4\v\t\v\x4\f\t\f\x4\r\t\r\x4\xE\t\xE\x4\xF\t\xF\x4\x10"+
 		"\t\x10\x4\x11\t\x11\x4\x12\t\x12\x4\x13\t\x13\x4\x14\t\x14\x4\x15\t\x15"+
@@ -5503,273 +5564,274 @@ public partial class VBAExpressionParser : Parser {
 		"\x3\f\x3\r\x3\r\x3\xE\x3\xE\x3\xE\x5\xE\xB1\n\xE\x3\xE\x3\xE\x5\xE\xB5"+
 		"\n\xE\x3\xE\x3\xE\x3\xE\x3\xE\x3\xE\x5\xE\xBC\n\xE\x3\xE\x3\xE\x5\xE\xC0"+
 		"\n\xE\x3\xE\x5\xE\xC3\n\xE\x3\xF\x3\xF\x3\xF\x5\xF\xC8\n\xF\x3\xF\x3\xF"+
-		"\x3\xF\x5\xF\xCD\n\xF\x3\xF\x3\xF\x3\xF\x3\xF\x5\xF\xD3\n\xF\x3\xF\x3"+
-		"\xF\x5\xF\xD7\n\xF\x3\xF\x3\xF\x3\xF\x3\xF\x3\xF\x5\xF\xDE\n\xF\x3\xF"+
-		"\x3\xF\x5\xF\xE2\n\xF\x3\xF\x3\xF\x5\xF\xE6\n\xF\x3\xF\x3\xF\x3\xF\x5"+
-		"\xF\xEB\n\xF\x3\xF\x3\xF\x5\xF\xEF\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\xF4\n"+
-		"\xF\x3\xF\x3\xF\x5\xF\xF8\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\xFD\n\xF\x3\xF"+
-		"\x3\xF\x5\xF\x101\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x106\n\xF\x3\xF\x3\xF\x5"+
-		"\xF\x10A\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x10F\n\xF\x3\xF\x3\xF\x5\xF\x113"+
-		"\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x118\n\xF\x3\xF\x3\xF\x5\xF\x11C\n\xF\x3"+
-		"\xF\x3\xF\x3\xF\x5\xF\x121\n\xF\x3\xF\x3\xF\x5\xF\x125\n\xF\x3\xF\x3\xF"+
-		"\x3\xF\x5\xF\x12A\n\xF\x3\xF\x3\xF\x5\xF\x12E\n\xF\x3\xF\x3\xF\x3\xF\x5"+
-		"\xF\x133\n\xF\x3\xF\x3\xF\x5\xF\x137\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x13C"+
-		"\n\xF\x3\xF\x3\xF\x5\xF\x140\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x145\n\xF\x3"+
-		"\xF\x3\xF\x5\xF\x149\n\xF\x3\xF\a\xF\x14C\n\xF\f\xF\xE\xF\x14F\v\xF\x3"+
-		"\x10\x3\x10\x3\x10\x3\x10\x3\x10\x5\x10\x156\n\x10\x5\x10\x158\n\x10\x3"+
-		"\x11\x3\x11\x3\x12\x3\x12\x5\x12\x15E\n\x12\x3\x12\x3\x12\x5\x12\x162"+
-		"\n\x12\x3\x12\x3\x12\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13"+
-		"\x3\x13\x3\x14\x3\x14\x3\x14\x3\x14\x3\x15\x3\x15\x3\x15\x3\x15\x5\x15"+
-		"\x176\n\x15\x3\x15\x3\x15\x5\x15\x17A\n\x15\x3\x15\x3\x15\x5\x15\x17E"+
-		"\n\x15\x3\x15\x5\x15\x181\n\x15\x3\x15\x5\x15\x184\n\x15\x3\x15\x3\x15"+
-		"\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x5\x15\x18D\n\x15\x3\x15\x3\x15\x3"+
-		"\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3"+
-		"\x15\x3\x15\a\x15\x19D\n\x15\f\x15\xE\x15\x1A0\v\x15\x3\x16\x3\x16\x3"+
-		"\x16\x3\x16\x3\x16\x3\x16\x3\x16\x5\x16\x1A9\n\x16\x3\x16\x3\x16\x3\x16"+
-		"\x5\x16\x1AE\n\x16\x3\x17\x3\x17\x5\x17\x1B2\n\x17\x3\x17\x3\x17\x5\x17"+
-		"\x1B6\n\x17\x3\x17\x5\x17\x1B9\n\x17\x3\x17\x5\x17\x1BC\n\x17\x3\x17\x3"+
-		"\x17\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3"+
-		"\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x5\x18\x1CF\n\x18\x3\x19\x3\x19"+
-		"\x3\x1A\x5\x1A\x1D4\n\x1A\x3\x1A\x5\x1A\x1D7\n\x1A\x3\x1A\x3\x1A\x5\x1A"+
-		"\x1DB\n\x1A\a\x1A\x1DD\n\x1A\f\x1A\xE\x1A\x1E0\v\x1A\x3\x1A\x3\x1A\x5"+
-		"\x1A\x1E4\n\x1A\x3\x1A\x5\x1A\x1E7\n\x1A\x3\x1A\x3\x1A\x5\x1A\x1EB\n\x1A"+
-		"\a\x1A\x1ED\n\x1A\f\x1A\xE\x1A\x1F0\v\x1A\x3\x1A\x5\x1A\x1F3\n\x1A\x3"+
-		"\x1B\x3\x1B\x3\x1C\x3\x1C\x3\x1D\x3\x1D\x5\x1D\x1FB\n\x1D\x3\x1D\x3\x1D"+
-		"\x5\x1D\x1FF\n\x1D\x3\x1D\a\x1D\x202\n\x1D\f\x1D\xE\x1D\x205\v\x1D\x3"+
-		"\x1E\x3\x1E\x5\x1E\x209\n\x1E\x3\x1E\x3\x1E\x5\x1E\x20D\n\x1E\x3\x1E\x3"+
-		"\x1E\x3\x1F\x3\x1F\x5\x1F\x213\n\x1F\x3\x1F\x3\x1F\x5\x1F\x217\n\x1F\x3"+
-		" \x3 \x3!\x3!\x3\"\x3\"\x5\"\x21F\n\"\x3#\x3#\x3#\x3$\x3$\x3$\x3%\x3%"+
-		"\x3&\x3&\x5&\x22B\n&\x3\'\x3\'\x5\'\x22F\n\'\x3(\x3(\x3(\x3(\x3)\x3)\x5"+
-		")\x237\n)\x3*\x3*\x3*\x3*\x3*\x3*\x3*\x3*\x5*\x241\n*\x3+\x3+\x3,\x3,"+
-		"\x3-\x3-\x3.\x3.\x3/\x3/\x5/\x24D\n/\x3\x30\x3\x30\x3\x31\x3\x31\x3\x32"+
-		"\x3\x32\x3\x33\x3\x33\x3\x34\x3\x34\x3\x34\x5\x34\x25A\n\x34\x3\x35\x3"+
-		"\x35\x3\x36\x3\x36\x3\x37\x3\x37\x3\x38\x6\x38\x263\n\x38\r\x38\xE\x38"+
-		"\x264\x3\x38\x2\x2\x4\x1C(\x39\x2\x2\x4\x2\x6\x2\b\x2\n\x2\f\x2\xE\x2"+
+		"\x3\xF\x5\xF\xCD\n\xF\x3\xF\x3\xF\x3\xF\x3\xF\x3\xF\x3\xF\x5\xF\xD5\n"+
+		"\xF\x3\xF\x3\xF\x5\xF\xD9\n\xF\x3\xF\x3\xF\x3\xF\x3\xF\x3\xF\x5\xF\xE0"+
+		"\n\xF\x3\xF\x3\xF\x5\xF\xE4\n\xF\x3\xF\x3\xF\x5\xF\xE8\n\xF\x3\xF\x3\xF"+
+		"\x3\xF\x5\xF\xED\n\xF\x3\xF\x3\xF\x5\xF\xF1\n\xF\x3\xF\x3\xF\x3\xF\x5"+
+		"\xF\xF6\n\xF\x3\xF\x3\xF\x5\xF\xFA\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\xFF\n"+
+		"\xF\x3\xF\x3\xF\x5\xF\x103\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x108\n\xF\x3\xF"+
+		"\x3\xF\x5\xF\x10C\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x111\n\xF\x3\xF\x3\xF\x5"+
+		"\xF\x115\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x11A\n\xF\x3\xF\x3\xF\x5\xF\x11E"+
+		"\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x123\n\xF\x3\xF\x3\xF\x5\xF\x127\n\xF\x3"+
+		"\xF\x3\xF\x3\xF\x5\xF\x12C\n\xF\x3\xF\x3\xF\x5\xF\x130\n\xF\x3\xF\x3\xF"+
+		"\x3\xF\x5\xF\x135\n\xF\x3\xF\x3\xF\x5\xF\x139\n\xF\x3\xF\x3\xF\x3\xF\x5"+
+		"\xF\x13E\n\xF\x3\xF\x3\xF\x5\xF\x142\n\xF\x3\xF\x3\xF\x3\xF\x5\xF\x147"+
+		"\n\xF\x3\xF\x3\xF\x5\xF\x14B\n\xF\x3\xF\a\xF\x14E\n\xF\f\xF\xE\xF\x151"+
+		"\v\xF\x3\x10\x3\x10\x3\x10\x3\x10\x3\x10\x5\x10\x158\n\x10\x5\x10\x15A"+
+		"\n\x10\x3\x11\x3\x11\x3\x12\x3\x12\x5\x12\x160\n\x12\x3\x12\x3\x12\x5"+
+		"\x12\x164\n\x12\x3\x12\x3\x12\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13"+
+		"\x3\x13\x3\x13\x3\x14\x3\x14\x3\x14\x3\x14\x3\x15\x3\x15\x3\x15\x3\x15"+
+		"\x5\x15\x178\n\x15\x3\x15\x3\x15\x5\x15\x17C\n\x15\x3\x15\x3\x15\x5\x15"+
+		"\x180\n\x15\x3\x15\x5\x15\x183\n\x15\x3\x15\x5\x15\x186\n\x15\x3\x15\x3"+
+		"\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x5\x15\x18F\n\x15\x3\x15\x3\x15"+
+		"\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15"+
+		"\x3\x15\x3\x15\a\x15\x19F\n\x15\f\x15\xE\x15\x1A2\v\x15\x3\x16\x3\x16"+
+		"\x3\x16\x3\x16\x3\x16\x3\x16\x3\x16\x5\x16\x1AB\n\x16\x3\x16\x3\x16\x3"+
+		"\x16\x5\x16\x1B0\n\x16\x3\x17\x3\x17\x5\x17\x1B4\n\x17\x3\x17\x3\x17\x5"+
+		"\x17\x1B8\n\x17\x3\x17\x5\x17\x1BB\n\x17\x3\x17\x5\x17\x1BE\n\x17\x3\x17"+
+		"\x3\x17\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18"+
+		"\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x3\x18\x5\x18\x1D1\n\x18\x3\x19\x3"+
+		"\x19\x3\x1A\x5\x1A\x1D6\n\x1A\x3\x1A\x5\x1A\x1D9\n\x1A\x3\x1A\x3\x1A\x5"+
+		"\x1A\x1DD\n\x1A\a\x1A\x1DF\n\x1A\f\x1A\xE\x1A\x1E2\v\x1A\x3\x1A\x3\x1A"+
+		"\x5\x1A\x1E6\n\x1A\x3\x1A\x5\x1A\x1E9\n\x1A\x3\x1A\x3\x1A\x5\x1A\x1ED"+
+		"\n\x1A\a\x1A\x1EF\n\x1A\f\x1A\xE\x1A\x1F2\v\x1A\x3\x1A\x5\x1A\x1F5\n\x1A"+
+		"\x3\x1B\x3\x1B\x3\x1C\x3\x1C\x3\x1D\x3\x1D\x5\x1D\x1FD\n\x1D\x3\x1D\x3"+
+		"\x1D\x5\x1D\x201\n\x1D\x3\x1D\a\x1D\x204\n\x1D\f\x1D\xE\x1D\x207\v\x1D"+
+		"\x3\x1E\x3\x1E\x5\x1E\x20B\n\x1E\x3\x1E\x3\x1E\x5\x1E\x20F\n\x1E\x3\x1E"+
+		"\x3\x1E\x3\x1F\x3\x1F\x5\x1F\x215\n\x1F\x3\x1F\x3\x1F\x5\x1F\x219\n\x1F"+
+		"\x3 \x3 \x3!\x3!\x3\"\x3\"\x5\"\x221\n\"\x3#\x3#\x3#\x3$\x3$\x3$\x3%\x3"+
+		"%\x3&\x3&\x5&\x22D\n&\x3\'\x3\'\x5\'\x231\n\'\x3(\x3(\x3(\x3(\x3)\x3)"+
+		"\x5)\x239\n)\x3*\x3*\x3*\x3*\x3*\x3*\x3*\x3*\x5*\x243\n*\x3+\x3+\x3,\x3"+
+		",\x3-\x3-\x3.\x3.\x3/\x3/\x5/\x24F\n/\x3\x30\x3\x30\x3\x31\x3\x31\x3\x32"+
+		"\x3\x32\x3\x33\x3\x33\x3\x34\x3\x34\x3\x34\x5\x34\x25C\n\x34\x3\x35\x3"+
+		"\x35\x3\x36\x3\x36\x3\x37\x3\x37\x3\x38\x6\x38\x265\n\x38\r\x38\xE\x38"+
+		"\x266\x3\x38\x2\x2\x4\x1C(\x39\x2\x2\x4\x2\x6\x2\b\x2\n\x2\f\x2\xE\x2"+
 		"\x10\x2\x12\x2\x14\x2\x16\x2\x18\x2\x1A\x2\x1C\x2\x1E\x2 \x2\"\x2$\x2"+
 		"&\x2(\x2*\x2,\x2.\x2\x30\x2\x32\x2\x34\x2\x36\x2\x38\x2:\x2<\x2>\x2@\x2"+
 		"\x42\x2\x44\x2\x46\x2H\x2J\x2L\x2N\x2P\x2R\x2T\x2V\x2X\x2Z\x2\\\x2^\x2"+
 		"`\x2\x62\x2\x64\x2\x66\x2h\x2j\x2l\x2n\x2\x2\x12\x5\x2,,.\x32\xDA\xDA"+
 		"\x5\x2;;\x45\x45\xBC\xBC\x4\x2\xCE\xCE\xD7\xD7\x4\x2\xD6\xD6\xD9\xD9\a"+
-		"\x2||\x83\x83\xD0\xD3\xD5\xD5\xD8\xD8\x3\x2\xE4\xE7\"\x2\x18\x18$$@\x41"+
-		"\x43\x44GVYZ^^\x65\x65ggiipwyy{{~~\x80\x81\x88\x88\x8C\x8C\x91\x91\x94"+
-		"\x94\x9E\x9F\xA4\xA5\xA7\xA7\xAA\xAA\xAD\xB2\xB6\xB6\xB8\xB8\xBA\xBA\xC0"+
-		"\xC0\xC2\xC2\xC6\xC7\xC9\xC9\xCB\xCB\x11\x2\x4\x4\x39\x39=>\x41\x41XY"+
-		"zz\x8D\x8D\x95\x95\x9C\x9D\xB3\xB3\xB5\xB5\xBB\xBB\xBD\xBE\xC3\xC3\xCA"+
-		"\xCB\r\x2\x34\x34\x36\x36\x66\x66xx||\x83\x83\x8B\x8B\x8D\x8E\x9A\x9A"+
-		"\xC1\xC1\xCC\xCC\x1D\x2\x3\x3\x6\f\xE\x12\x14\x17\x19\x19\x1B\x1B\x1D"+
-		"\x1E!#%\'\x33\x33\x38\x38;;``\x63\x64hhjn\x84\x87\x8A\x8A\x92\x92\x9B"+
-		"\x9B\xA6\xA6\xA8\xA9\xAC\xAC\xB3\xB3\xB7\xB7\xC8\xC8\xCB\xCB\t\x2\x5\x5"+
-		"\r\r\x1A\x1A\x1C\x1C&&(({{\xE\x2\x4\x4\x13\x13\x1F <<??\x46\x46WW}}\x7F"+
-		"\x7F\xB4\xB4\xB9\xB9\xC4\xC4\v\x2\x35\x35\x37\x37::\x42\x42\x82\x82\x91"+
-		"\x91\xBB\xBB\xC5\xC5\xF3\xF3\x4\x2oo\xBF\xBF\x4\x2[[\x90\x90\x4\x2\xEC"+
-		"\xEC\xEF\xEF\x2B4\x2r\x3\x2\x2\x2\x4y\x3\x2\x2\x2\x6\x82\x3\x2\x2\x2\b"+
-		"\x86\x3\x2\x2\x2\n\x8A\x3\x2\x2\x2\f\x8C\x3\x2\x2\x2\xE\x8E\x3\x2\x2\x2"+
-		"\x10\x9A\x3\x2\x2\x2\x12\x9C\x3\x2\x2\x2\x14\xA7\x3\x2\x2\x2\x16\xA9\x3"+
-		"\x2\x2\x2\x18\xAB\x3\x2\x2\x2\x1A\xC2\x3\x2\x2\x2\x1C\xDD\x3\x2\x2\x2"+
-		"\x1E\x157\x3\x2\x2\x2 \x159\x3\x2\x2\x2\"\x15B\x3\x2\x2\x2$\x165\x3\x2"+
-		"\x2\x2&\x16D\x3\x2\x2\x2(\x175\x3\x2\x2\x2*\x1AD\x3\x2\x2\x2,\x1AF\x3"+
-		"\x2\x2\x2.\x1CE\x3\x2\x2\x2\x30\x1D0\x3\x2\x2\x2\x32\x1F2\x3\x2\x2\x2"+
-		"\x34\x1F4\x3\x2\x2\x2\x36\x1F6\x3\x2\x2\x2\x38\x1F8\x3\x2\x2\x2:\x206"+
-		"\x3\x2\x2\x2<\x216\x3\x2\x2\x2>\x218\x3\x2\x2\x2@\x21A\x3\x2\x2\x2\x42"+
-		"\x21E\x3\x2\x2\x2\x44\x220\x3\x2\x2\x2\x46\x223\x3\x2\x2\x2H\x226\x3\x2"+
-		"\x2\x2J\x22A\x3\x2\x2\x2L\x22E\x3\x2\x2\x2N\x230\x3\x2\x2\x2P\x236\x3"+
-		"\x2\x2\x2R\x240\x3\x2\x2\x2T\x242\x3\x2\x2\x2V\x244\x3\x2\x2\x2X\x246"+
-		"\x3\x2\x2\x2Z\x248\x3\x2\x2\x2\\\x24C\x3\x2\x2\x2^\x24E\x3\x2\x2\x2`\x250"+
-		"\x3\x2\x2\x2\x62\x252\x3\x2\x2\x2\x64\x254\x3\x2\x2\x2\x66\x259\x3\x2"+
-		"\x2\x2h\x25B\x3\x2\x2\x2j\x25D\x3\x2\x2\x2l\x25F\x3\x2\x2\x2n\x262\x3"+
-		"\x2\x2\x2ps\x5\x1C\xF\x2qs\x5\x4\x3\x2rp\x3\x2\x2\x2rq\x3\x2\x2\x2st\x3"+
-		"\x2\x2\x2tu\a\x2\x2\x3u\x3\x3\x2\x2\x2vz\x5*\x16\x2wz\x5> \x2xz\x5\x42"+
-		"\"\x2yv\x3\x2\x2\x2yw\x3\x2\x2\x2yx\x3\x2\x2\x2z~\x3\x2\x2\x2{|\x5n\x38"+
-		"\x2|}\x5\x30\x19\x2}\x7F\x3\x2\x2\x2~{\x3\x2\x2\x2~\x7F\x3\x2\x2\x2\x7F"+
-		"\x5\x3\x2\x2\x2\x80\x83\x5\b\x5\x2\x81\x83\x5\n\x6\x2\x82\x80\x3\x2\x2"+
-		"\x2\x82\x81\x3\x2\x2\x2\x83\a\x3\x2\x2\x2\x84\x87\x5\x10\t\x2\x85\x87"+
-		"\x5\x12\n\x2\x86\x84\x3\x2\x2\x2\x86\x85\x3\x2\x2\x2\x87\t\x3\x2\x2\x2"+
-		"\x88\x8B\x5\f\a\x2\x89\x8B\x5\xE\b\x2\x8A\x88\x3\x2\x2\x2\x8A\x89\x3\x2"+
-		"\x2\x2\x8B\v\x3\x2\x2\x2\x8C\x8D\x5R*\x2\x8D\r\x3\x2\x2\x2\x8E\x8F\x5"+
-		"R*\x2\x8F\x90\x5\x16\f\x2\x90\xF\x3\x2\x2\x2\x91\x9B\a\xEE\x2\x2\x92\x9B"+
-		"\a\xF1\x2\x2\x93\x9B\x5^\x30\x2\x94\x9B\x5`\x31\x2\x95\x9B\x5\x18\r\x2"+
-		"\x96\x9B\a\xF2\x2\x2\x97\x9B\x5\x64\x33\x2\x98\x9B\ah\x2\x2\x99\x9B\x5"+
-		"\x62\x32\x2\x9A\x91\x3\x2\x2\x2\x9A\x92\x3\x2\x2\x2\x9A\x93\x3\x2\x2\x2"+
-		"\x9A\x94\x3\x2\x2\x2\x9A\x95\x3\x2\x2\x2\x9A\x96\x3\x2\x2\x2\x9A\x97\x3"+
-		"\x2\x2\x2\x9A\x98\x3\x2\x2\x2\x9A\x99\x3\x2\x2\x2\x9B\x11\x3\x2\x2\x2"+
-		"\x9C\x9D\x5\x14\v\x2\x9D\x9E\x5\x16\f\x2\x9E\x13\x3\x2\x2\x2\x9F\xA8\a"+
-		"\xEE\x2\x2\xA0\xA8\x5^\x30\x2\xA1\xA8\x5`\x31\x2\xA2\xA8\x5\x18\r\x2\xA3"+
-		"\xA8\a\xF2\x2\x2\xA4\xA8\x5\x64\x33\x2\xA5\xA8\ah\x2\x2\xA6\xA8\x5\x62"+
-		"\x32\x2\xA7\x9F\x3\x2\x2\x2\xA7\xA0\x3\x2\x2\x2\xA7\xA1\x3\x2\x2\x2\xA7"+
-		"\xA2\x3\x2\x2\x2\xA7\xA3\x3\x2\x2\x2\xA7\xA4\x3\x2\x2\x2\xA7\xA5\x3\x2"+
-		"\x2\x2\xA7\xA6\x3\x2\x2\x2\xA8\x15\x3\x2\x2\x2\xA9\xAA\t\x2\x2\x2\xAA"+
-		"\x17\x3\x2\x2\x2\xAB\xAC\t\x3\x2\x2\xAC\x19\x3\x2\x2\x2\xAD\xC3\x5\x62"+
-		"\x32\x2\xAE\xB0\a\xE1\x2\x2\xAF\xB1\x5n\x38\x2\xB0\xAF\x3\x2\x2\x2\xB0"+
-		"\xB1\x3\x2\x2\x2\xB1\xB2\x3\x2\x2\x2\xB2\xB4\x5\x62\x32\x2\xB3\xB5\x5"+
-		"n\x38\x2\xB4\xB3\x3\x2\x2\x2\xB4\xB5\x3\x2\x2\x2\xB5\xB6\x3\x2\x2\x2\xB6"+
-		"\xB7\a\xE2\x2\x2\xB7\xC3\x3\x2\x2\x2\xB8\xC3\a\xF2\x2\x2\xB9\xBB\a\xE1"+
-		"\x2\x2\xBA\xBC\x5n\x38\x2\xBB\xBA\x3\x2\x2\x2\xBB\xBC\x3\x2\x2\x2\xBC"+
-		"\xBD\x3\x2\x2\x2\xBD\xBF\a\xF2\x2\x2\xBE\xC0\x5n\x38\x2\xBF\xBE\x3\x2"+
-		"\x2\x2\xBF\xC0\x3\x2\x2\x2\xC0\xC1\x3\x2\x2\x2\xC1\xC3\a\xE2\x2\x2\xC2"+
-		"\xAD\x3\x2\x2\x2\xC2\xAE\x3\x2\x2\x2\xC2\xB8\x3\x2\x2\x2\xC2\xB9\x3\x2"+
-		"\x2\x2\xC3\x1B\x3\x2\x2\x2\xC4\xC5\b\xF\x1\x2\xC5\xC7\a\xD6\x2\x2\xC6"+
-		"\xC8\x5n\x38\x2\xC7\xC6\x3\x2\x2\x2\xC7\xC8\x3\x2\x2\x2\xC8\xC9\x3\x2"+
-		"\x2\x2\xC9\xDE\x5\x1C\xF\x10\xCA\xCC\a\x8E\x2\x2\xCB\xCD\x5n\x38\x2\xCC"+
-		"\xCB\x3\x2\x2\x2\xCC\xCD\x3\x2\x2\x2\xCD\xCE\x3\x2\x2\x2\xCE\xDE\x5\x1C"+
-		"\xF\t\xCF\xDE\x5(\x15\x2\xD0\xD2\a\xD4\x2\x2\xD1\xD3\x5n\x38\x2\xD2\xD1"+
-		"\x3\x2\x2\x2\xD2\xD3\x3\x2\x2\x2\xD3\xD4\x3\x2\x2\x2\xD4\xD6\x5\x1C\xF"+
-		"\x2\xD5\xD7\x5n\x38\x2\xD6\xD5\x3\x2\x2\x2\xD6\xD7\x3\x2\x2\x2\xD7\xD8"+
-		"\x3\x2\x2\x2\xD8\xD9\a\xDB\x2\x2\xD9\xDE\x3\x2\x2\x2\xDA\xDE\x5$\x13\x2"+
-		"\xDB\xDE\x5&\x14\x2\xDC\xDE\x5\x1E\x10\x2\xDD\xC4\x3\x2\x2\x2\xDD\xCA"+
-		"\x3\x2\x2\x2\xDD\xCF\x3\x2\x2\x2\xDD\xD0\x3\x2\x2\x2\xDD\xDA\x3\x2\x2"+
-		"\x2\xDD\xDB\x3\x2\x2\x2\xDD\xDC\x3\x2\x2\x2\xDE\x14D\x3\x2\x2\x2\xDF\xE1"+
-		"\f\x11\x2\x2\xE0\xE2\x5n\x38\x2\xE1\xE0\x3\x2\x2\x2\xE1\xE2\x3\x2\x2\x2"+
-		"\xE2\xE3\x3\x2\x2\x2\xE3\xE5\a\xDA\x2\x2\xE4\xE6\x5n\x38\x2\xE5\xE4\x3"+
-		"\x2\x2\x2\xE5\xE6\x3\x2\x2\x2\xE6\xE7\x3\x2\x2\x2\xE7\x14C\x5\x1C\xF\x12"+
-		"\xE8\xEA\f\xF\x2\x2\xE9\xEB\x5n\x38\x2\xEA\xE9\x3\x2\x2\x2\xEA\xEB\x3"+
-		"\x2\x2\x2\xEB\xEC\x3\x2\x2\x2\xEC\xEE\t\x4\x2\x2\xED\xEF\x5n\x38\x2\xEE"+
-		"\xED\x3\x2\x2\x2\xEE\xEF\x3\x2\x2\x2\xEF\xF0\x3\x2\x2\x2\xF0\x14C\x5\x1C"+
-		"\xF\x10\xF1\xF3\f\xE\x2\x2\xF2\xF4\x5n\x38\x2\xF3\xF2\x3\x2\x2\x2\xF3"+
-		"\xF4\x3\x2\x2\x2\xF4\xF5\x3\x2\x2\x2\xF5\xF7\a\xCF\x2\x2\xF6\xF8\x5n\x38"+
-		"\x2\xF7\xF6\x3\x2\x2\x2\xF7\xF8\x3\x2\x2\x2\xF8\xF9\x3\x2\x2\x2\xF9\x14C"+
-		"\x5\x1C\xF\xF\xFA\xFC\f\r\x2\x2\xFB\xFD\x5n\x38\x2\xFC\xFB\x3\x2\x2\x2"+
-		"\xFC\xFD\x3\x2\x2\x2\xFD\xFE\x3\x2\x2\x2\xFE\x100\a\x8B\x2\x2\xFF\x101"+
-		"\x5n\x38\x2\x100\xFF\x3\x2\x2\x2\x100\x101\x3\x2\x2\x2\x101\x102\x3\x2"+
-		"\x2\x2\x102\x14C\x5\x1C\xF\xE\x103\x105\f\f\x2\x2\x104\x106\x5n\x38\x2"+
-		"\x105\x104\x3\x2\x2\x2\x105\x106\x3\x2\x2\x2\x106\x107\x3\x2\x2\x2\x107"+
-		"\x109\t\x5\x2\x2\x108\x10A\x5n\x38\x2\x109\x108\x3\x2\x2\x2\x109\x10A"+
-		"\x3\x2\x2\x2\x10A\x10B\x3\x2\x2\x2\x10B\x14C\x5\x1C\xF\r\x10C\x10E\f\v"+
-		"\x2\x2\x10D\x10F\x5n\x38\x2\x10E\x10D\x3\x2\x2\x2\x10E\x10F\x3\x2\x2\x2"+
-		"\x10F\x110\x3\x2\x2\x2\x110\x112\a\x32\x2\x2\x111\x113\x5n\x38\x2\x112"+
-		"\x111\x3\x2\x2\x2\x112\x113\x3\x2\x2\x2\x113\x114\x3\x2\x2\x2\x114\x14C"+
-		"\x5\x1C\xF\f\x115\x117\f\n\x2\x2\x116\x118\x5n\x38\x2\x117\x116\x3\x2"+
-		"\x2\x2\x117\x118\x3\x2\x2\x2\x118\x119\x3\x2\x2\x2\x119\x11B\t\x6\x2\x2"+
-		"\x11A\x11C\x5n\x38\x2\x11B\x11A\x3\x2\x2\x2\x11B\x11C\x3\x2\x2\x2\x11C"+
-		"\x11D\x3\x2\x2\x2\x11D\x14C\x5\x1C\xF\v\x11E\x120\f\b\x2\x2\x11F\x121"+
-		"\x5n\x38\x2\x120\x11F\x3\x2\x2\x2\x120\x121\x3\x2\x2\x2\x121\x122\x3\x2"+
-		"\x2\x2\x122\x124\a\x36\x2\x2\x123\x125\x5n\x38\x2\x124\x123\x3\x2\x2\x2"+
-		"\x124\x125\x3\x2\x2\x2\x125\x126\x3\x2\x2\x2\x126\x14C\x5\x1C\xF\t\x127"+
-		"\x129\f\a\x2\x2\x128\x12A\x5n\x38\x2\x129\x128\x3\x2\x2\x2\x129\x12A\x3"+
-		"\x2\x2\x2\x12A\x12B\x3\x2\x2\x2\x12B\x12D\a\x9A\x2\x2\x12C\x12E\x5n\x38"+
-		"\x2\x12D\x12C\x3\x2\x2\x2\x12D\x12E\x3\x2\x2\x2\x12E\x12F\x3\x2\x2\x2"+
-		"\x12F\x14C\x5\x1C\xF\b\x130\x132\f\x6\x2\x2\x131\x133\x5n\x38\x2\x132"+
-		"\x131\x3\x2\x2\x2\x132\x133\x3\x2\x2\x2\x133\x134\x3\x2\x2\x2\x134\x136"+
-		"\a\xCC\x2\x2\x135\x137\x5n\x38\x2\x136\x135\x3\x2\x2\x2\x136\x137\x3\x2"+
-		"\x2\x2\x137\x138\x3\x2\x2\x2\x138\x14C\x5\x1C\xF\a\x139\x13B\f\x5\x2\x2"+
-		"\x13A\x13C\x5n\x38\x2\x13B\x13A\x3\x2\x2\x2\x13B\x13C\x3\x2\x2\x2\x13C"+
-		"\x13D\x3\x2\x2\x2\x13D\x13F\a\x66\x2\x2\x13E\x140\x5n\x38\x2\x13F\x13E"+
-		"\x3\x2\x2\x2\x13F\x140\x3\x2\x2\x2\x140\x141\x3\x2\x2\x2\x141\x14C\x5"+
-		"\x1C\xF\x6\x142\x144\f\x4\x2\x2\x143\x145\x5n\x38\x2\x144\x143\x3\x2\x2"+
-		"\x2\x144\x145\x3\x2\x2\x2\x145\x146\x3\x2\x2\x2\x146\x148\ax\x2\x2\x147"+
-		"\x149\x5n\x38\x2\x148\x147\x3\x2\x2\x2\x148\x149\x3\x2\x2\x2\x149\x14A"+
-		"\x3\x2\x2\x2\x14A\x14C\x5\x1C\xF\x5\x14B\xDF\x3\x2\x2\x2\x14B\xE8\x3\x2"+
-		"\x2\x2\x14B\xF1\x3\x2\x2\x2\x14B\xFA\x3\x2\x2\x2\x14B\x103\x3\x2\x2\x2"+
-		"\x14B\x10C\x3\x2\x2\x2\x14B\x115\x3\x2\x2\x2\x14B\x11E\x3\x2\x2\x2\x14B"+
-		"\x127\x3\x2\x2\x2\x14B\x130\x3\x2\x2\x2\x14B\x139\x3\x2\x2\x2\x14B\x142"+
-		"\x3\x2\x2\x2\x14C\x14F\x3\x2\x2\x2\x14D\x14B\x3\x2\x2\x2\x14D\x14E\x3"+
-		"\x2\x2\x2\x14E\x1D\x3\x2\x2\x2\x14F\x14D\x3\x2\x2\x2\x150\x158\x5 \x11"+
-		"\x2\x151\x158\a\xE8\x2\x2\x152\x158\a\xE3\x2\x2\x153\x155\x5\x66\x34\x2"+
-		"\x154\x156\x5\x16\f\x2\x155\x154\x3\x2\x2\x2\x155\x156\x3\x2\x2\x2\x156"+
-		"\x158\x3\x2\x2\x2\x157\x150\x3\x2\x2\x2\x157\x151\x3\x2\x2\x2\x157\x152"+
-		"\x3\x2\x2\x2\x157\x153\x3\x2\x2\x2\x158\x1F\x3\x2\x2\x2\x159\x15A\t\a"+
-		"\x2\x2\x15A!\x3\x2\x2\x2\x15B\x15D\a\xD4\x2\x2\x15C\x15E\x5n\x38\x2\x15D"+
-		"\x15C\x3\x2\x2\x2\x15D\x15E\x3\x2\x2\x2\x15E\x15F\x3\x2\x2\x2\x15F\x161"+
-		"\x5\x1C\xF\x2\x160\x162\x5n\x38\x2\x161\x160\x3\x2\x2\x2\x161\x162\x3"+
-		"\x2\x2\x2\x162\x163\x3\x2\x2\x2\x163\x164\a\xDB\x2\x2\x164#\x3\x2\x2\x2"+
-		"\x165\x166\a\xC1\x2\x2\x166\x167\x5n\x38\x2\x167\x168\x5\x1C\xF\x2\x168"+
-		"\x169\x5n\x38\x2\x169\x16A\a|\x2\x2\x16A\x16B\x5n\x38\x2\x16B\x16C\x5"+
-		"J&\x2\x16C%\x3\x2\x2\x2\x16D\x16E\a\x8D\x2\x2\x16E\x16F\x5n\x38\x2\x16F"+
-		"\x170\x5J&\x2\x170\'\x3\x2\x2\x2\x171\x172\b\x15\x1\x2\x172\x176\x5@!"+
-		"\x2\x173\x176\x5> \x2\x174\x176\x5\x42\"\x2\x175\x171\x3\x2\x2\x2\x175"+
-		"\x173\x3\x2\x2\x2\x175\x174\x3\x2\x2\x2\x176\x19E\x3\x2\x2\x2\x177\x179"+
-		"\f\v\x2\x2\x178\x17A\x5n\x38\x2\x179\x178\x3\x2\x2\x2\x179\x17A\x3\x2"+
-		"\x2\x2\x17A\x17B\x3\x2\x2\x2\x17B\x17D\a\xD4\x2\x2\x17C\x17E\x5n\x38\x2"+
-		"\x17D\x17C\x3\x2\x2\x2\x17D\x17E\x3\x2\x2\x2\x17E\x180\x3\x2\x2\x2\x17F"+
-		"\x181\x5\x30\x19\x2\x180\x17F\x3\x2\x2\x2\x180\x181\x3\x2\x2\x2\x181\x183"+
-		"\x3\x2\x2\x2\x182\x184\x5n\x38\x2\x183\x182\x3\x2\x2\x2\x183\x184\x3\x2"+
-		"\x2\x2\x184\x185\x3\x2\x2\x2\x185\x19D\a\xDB\x2\x2\x186\x187\f\n\x2\x2"+
-		"\x187\x188\a-\x2\x2\x188\x19D\x5\x6\x4\x2\x189\x18A\f\t\x2\x2\x18A\x18C"+
-		"\a\xEF\x2\x2\x18B\x18D\x5n\x38\x2\x18C\x18B\x3\x2\x2\x2\x18C\x18D\x3\x2"+
-		"\x2\x2\x18D\x18E\x3\x2\x2\x2\x18E\x18F\a-\x2\x2\x18F\x19D\x5\x6\x4\x2"+
-		"\x190\x191\f\b\x2\x2\x191\x192\a,\x2\x2\x192\x19D\x5\x6\x4\x2\x193\x194"+
-		"\f\a\x2\x2\x194\x195\a\xEF\x2\x2\x195\x196\a,\x2\x2\x196\x19D\x5\x6\x4"+
-		"\x2\x197\x198\f\x6\x2\x2\x198\x199\a\xEF\x2\x2\x199\x19A\a,\x2\x2\x19A"+
-		"\x19B\a\xEF\x2\x2\x19B\x19D\x5\x6\x4\x2\x19C\x177\x3\x2\x2\x2\x19C\x186"+
-		"\x3\x2\x2\x2\x19C\x189\x3\x2\x2\x2\x19C\x190\x3\x2\x2\x2\x19C\x193\x3"+
-		"\x2\x2\x2\x19C\x197\x3\x2\x2\x2\x19D\x1A0\x3\x2\x2\x2\x19E\x19C\x3\x2"+
-		"\x2\x2\x19E\x19F\x3\x2\x2\x2\x19F)\x3\x2\x2\x2\x1A0\x19E\x3\x2\x2\x2\x1A1"+
-		"\x1A2\x5(\x15\x2\x1A2\x1A3\a-\x2\x2\x1A3\x1A4\x5\x6\x4\x2\x1A4\x1AE\x3"+
-		"\x2\x2\x2\x1A5\x1A6\x5(\x15\x2\x1A6\x1A8\a\xEF\x2\x2\x1A7\x1A9\x5n\x38"+
-		"\x2\x1A8\x1A7\x3\x2\x2\x2\x1A8\x1A9\x3\x2\x2\x2\x1A9\x1AA\x3\x2\x2\x2"+
-		"\x1AA\x1AB\a-\x2\x2\x1AB\x1AC\x5\x6\x4\x2\x1AC\x1AE\x3\x2\x2\x2\x1AD\x1A1"+
-		"\x3\x2\x2\x2\x1AD\x1A5\x3\x2\x2\x2\x1AE+\x3\x2\x2\x2\x1AF\x1B1\x5(\x15"+
-		"\x2\x1B0\x1B2\x5n\x38\x2\x1B1\x1B0\x3\x2\x2\x2\x1B1\x1B2\x3\x2\x2\x2\x1B2"+
-		"\x1B3\x3\x2\x2\x2\x1B3\x1B5\a\xD4\x2\x2\x1B4\x1B6\x5n\x38\x2\x1B5\x1B4"+
-		"\x3\x2\x2\x2\x1B5\x1B6\x3\x2\x2\x2\x1B6\x1B8\x3\x2\x2\x2\x1B7\x1B9\x5"+
-		"\x30\x19\x2\x1B8\x1B7\x3\x2\x2\x2\x1B8\x1B9\x3\x2\x2\x2\x1B9\x1BB\x3\x2"+
-		"\x2\x2\x1BA\x1BC\x5n\x38\x2\x1BB\x1BA\x3\x2\x2\x2\x1BB\x1BC\x3\x2\x2\x2"+
-		"\x1BC\x1BD\x3\x2\x2\x2\x1BD\x1BE\a\xDB\x2\x2\x1BE-\x3\x2\x2\x2\x1BF\x1C0"+
-		"\x5(\x15\x2\x1C0\x1C1\a,\x2\x2\x1C1\x1C2\x5\x6\x4\x2\x1C2\x1CF\x3\x2\x2"+
-		"\x2\x1C3\x1C4\x5(\x15\x2\x1C4\x1C5\a\xEF\x2\x2\x1C5\x1C6\a,\x2\x2\x1C6"+
-		"\x1C7\x5\x6\x4\x2\x1C7\x1CF\x3\x2\x2\x2\x1C8\x1C9\x5(\x15\x2\x1C9\x1CA"+
-		"\a\xEF\x2\x2\x1CA\x1CB\a,\x2\x2\x1CB\x1CC\a\xEF\x2\x2\x1CC\x1CD\x5\x6"+
-		"\x4\x2\x1CD\x1CF\x3\x2\x2\x2\x1CE\x1BF\x3\x2\x2\x2\x1CE\x1C3\x3\x2\x2"+
-		"\x2\x1CE\x1C8\x3\x2\x2\x2\x1CF/\x3\x2\x2\x2\x1D0\x1D1\x5\x32\x1A\x2\x1D1"+
-		"\x31\x3\x2\x2\x2\x1D2\x1D4\x5\x34\x1B\x2\x1D3\x1D2\x3\x2\x2\x2\x1D3\x1D4"+
-		"\x3\x2\x2\x2\x1D4\x1D6\x3\x2\x2\x2\x1D5\x1D7\x5n\x38\x2\x1D6\x1D5\x3\x2"+
-		"\x2\x2\x1D6\x1D7\x3\x2\x2\x2\x1D7\x1D8\x3\x2\x2\x2\x1D8\x1DA\a)\x2\x2"+
-		"\x1D9\x1DB\x5n\x38\x2\x1DA\x1D9\x3\x2\x2\x2\x1DA\x1DB\x3\x2\x2\x2\x1DB"+
-		"\x1DD\x3\x2\x2\x2\x1DC\x1D3\x3\x2\x2\x2\x1DD\x1E0\x3\x2\x2\x2\x1DE\x1DC"+
-		"\x3\x2\x2\x2\x1DE\x1DF\x3\x2\x2\x2\x1DF\x1E1\x3\x2\x2\x2\x1E0\x1DE\x3"+
-		"\x2\x2\x2\x1E1\x1F3\x5\x36\x1C\x2\x1E2\x1E4\x5\x34\x1B\x2\x1E3\x1E2\x3"+
-		"\x2\x2\x2\x1E3\x1E4\x3\x2\x2\x2\x1E4\x1E6\x3\x2\x2\x2\x1E5\x1E7\x5n\x38"+
-		"\x2\x1E6\x1E5\x3\x2\x2\x2\x1E6\x1E7\x3\x2\x2\x2\x1E7\x1E8\x3\x2\x2\x2"+
-		"\x1E8\x1EA\a)\x2\x2\x1E9\x1EB\x5n\x38\x2\x1EA\x1E9\x3\x2\x2\x2\x1EA\x1EB"+
-		"\x3\x2\x2\x2\x1EB\x1ED\x3\x2\x2\x2\x1EC\x1E3\x3\x2\x2\x2\x1ED\x1F0\x3"+
-		"\x2\x2\x2\x1EE\x1EC\x3\x2\x2\x2\x1EE\x1EF\x3\x2\x2\x2\x1EF\x1F1\x3\x2"+
-		"\x2\x2\x1F0\x1EE\x3\x2\x2\x2\x1F1\x1F3\x5\x38\x1D\x2\x1F2\x1DE\x3\x2\x2"+
-		"\x2\x1F2\x1EE\x3\x2\x2\x2\x1F3\x33\x3\x2\x2\x2\x1F4\x1F5\x5<\x1F\x2\x1F5"+
-		"\x35\x3\x2\x2\x2\x1F6\x1F7\x5<\x1F\x2\x1F7\x37\x3\x2\x2\x2\x1F8\x203\x5"+
-		":\x1E\x2\x1F9\x1FB\x5n\x38\x2\x1FA\x1F9\x3\x2\x2\x2\x1FA\x1FB\x3\x2\x2"+
-		"\x2\x1FB\x1FC\x3\x2\x2\x2\x1FC\x1FE\a)\x2\x2\x1FD\x1FF\x5n\x38\x2\x1FE"+
-		"\x1FD\x3\x2\x2\x2\x1FE\x1FF\x3\x2\x2\x2\x1FF\x200\x3\x2\x2\x2\x200\x202"+
-		"\x5:\x1E\x2\x201\x1FA\x3\x2\x2\x2\x202\x205\x3\x2\x2\x2\x203\x201\x3\x2"+
-		"\x2\x2\x203\x204\x3\x2\x2\x2\x204\x39\x3\x2\x2\x2\x205\x203\x3\x2\x2\x2"+
-		"\x206\x208\x5\x6\x4\x2\x207\x209\x5n\x38\x2\x208\x207\x3\x2\x2\x2\x208"+
-		"\x209\x3\x2\x2\x2\x209\x20A\x3\x2\x2\x2\x20A\x20C\a\xCD\x2\x2\x20B\x20D"+
-		"\x5n\x38\x2\x20C\x20B\x3\x2\x2\x2\x20C\x20D\x3\x2\x2\x2\x20D\x20E\x3\x2"+
-		"\x2\x2\x20E\x20F\x5<\x1F\x2\x20F;\x3\x2\x2\x2\x210\x211\a=\x2\x2\x211"+
-		"\x213\x5n\x38\x2\x212\x210\x3\x2\x2\x2\x212\x213\x3\x2\x2\x2\x213\x214"+
-		"\x3\x2\x2\x2\x214\x217\x5\x1C\xF\x2\x215\x217\x5N(\x2\x216\x212\x3\x2"+
-		"\x2\x2\x216\x215\x3\x2\x2\x2\x217=\x3\x2\x2\x2\x218\x219\x5\b\x5\x2\x219"+
-		"?\x3\x2\x2\x2\x21A\x21B\a\x89\x2\x2\x21B\x41\x3\x2\x2\x2\x21C\x21F\x5"+
-		"\x44#\x2\x21D\x21F\x5\x46$\x2\x21E\x21C\x3\x2\x2\x2\x21E\x21D\x3\x2\x2"+
-		"\x2\x21F\x43\x3\x2\x2\x2\x220\x221\a-\x2\x2\x221\x222\x5\x6\x4\x2\x222"+
-		"\x45\x3\x2\x2\x2\x223\x224\a,\x2\x2\x224\x225\x5\x6\x4\x2\x225G\x3\x2"+
-		"\x2\x2\x226\x227\x5\x1C\xF\x2\x227I\x3\x2\x2\x2\x228\x22B\x5\x1A\xE\x2"+
-		"\x229\x22B\x5L\'\x2\x22A\x228\x3\x2\x2\x2\x22A\x229\x3\x2\x2\x2\x22BK"+
-		"\x3\x2\x2\x2\x22C\x22F\x5> \x2\x22D\x22F\x5*\x16\x2\x22E\x22C\x3\x2\x2"+
-		"\x2\x22E\x22D\x3\x2\x2\x2\x22FM\x3\x2\x2\x2\x230\x231\a\x34\x2\x2\x231"+
-		"\x232\x5n\x38\x2\x232\x233\x5P)\x2\x233O\x3\x2\x2\x2\x234\x237\x5*\x16"+
-		"\x2\x235\x237\x5> \x2\x236\x234\x3\x2\x2\x2\x236\x235\x3\x2\x2\x2\x237"+
-		"Q\x3\x2\x2\x2\x238\x241\x5T+\x2\x239\x241\x5X-\x2\x23A\x241\x5Z.\x2\x23B"+
-		"\x241\x5`\x31\x2\x23C\x241\x5\\/\x2\x23D\x241\x5\x66\x34\x2\x23E\x241"+
-		"\x5V,\x2\x23F\x241\x5\x62\x32\x2\x240\x238\x3\x2\x2\x2\x240\x239\x3\x2"+
-		"\x2\x2\x240\x23A\x3\x2\x2\x2\x240\x23B\x3\x2\x2\x2\x240\x23C\x3\x2\x2"+
-		"\x2\x240\x23D\x3\x2\x2\x2\x240\x23E\x3\x2\x2\x2\x240\x23F\x3\x2\x2\x2"+
-		"\x241S\x3\x2\x2\x2\x242\x243\t\b\x2\x2\x243U\x3\x2\x2\x2\x244\x245\a\xAB"+
-		"\x2\x2\x245W\x3\x2\x2\x2\x246\x247\t\t\x2\x2\x247Y\x3\x2\x2\x2\x248\x249"+
-		"\t\n\x2\x2\x249[\x3\x2\x2\x2\x24A\x24D\a\x89\x2\x2\x24B\x24D\x5^\x30\x2"+
-		"\x24C\x24A\x3\x2\x2\x2\x24C\x24B\x3\x2\x2\x2\x24D]\x3\x2\x2\x2\x24E\x24F"+
-		"\t\v\x2\x2\x24F_\x3\x2\x2\x2\x250\x251\t\f\x2\x2\x251\x61\x3\x2\x2\x2"+
-		"\x252\x253\t\r\x2\x2\x253\x63\x3\x2\x2\x2\x254\x255\t\xE\x2\x2\x255\x65"+
-		"\x3\x2\x2\x2\x256\x25A\x5h\x35\x2\x257\x25A\x5j\x36\x2\x258\x25A\x5l\x37"+
-		"\x2\x259\x256\x3\x2\x2\x2\x259\x257\x3\x2\x2\x2\x259\x258\x3\x2\x2\x2"+
-		"\x25Ag\x3\x2\x2\x2\x25B\x25C\t\xF\x2\x2\x25Ci\x3\x2\x2\x2\x25D\x25E\a"+
-		"\x8F\x2\x2\x25Ek\x3\x2\x2\x2\x25F\x260\t\x10\x2\x2\x260m\x3\x2\x2\x2\x261"+
-		"\x263\t\x11\x2\x2\x262\x261\x3\x2\x2\x2\x263\x264\x3\x2\x2\x2\x264\x262"+
-		"\x3\x2\x2\x2\x264\x265\x3\x2\x2\x2\x265o\x3\x2\x2\x2Yry~\x82\x86\x8A\x9A"+
-		"\xA7\xB0\xB4\xBB\xBF\xC2\xC7\xCC\xD2\xD6\xDD\xE1\xE5\xEA\xEE\xF3\xF7\xFC"+
-		"\x100\x105\x109\x10E\x112\x117\x11B\x120\x124\x129\x12D\x132\x136\x13B"+
-		"\x13F\x144\x148\x14B\x14D\x155\x157\x15D\x161\x175\x179\x17D\x180\x183"+
-		"\x18C\x19C\x19E\x1A8\x1AD\x1B1\x1B5\x1B8\x1BB\x1CE\x1D3\x1D6\x1DA\x1DE"+
-		"\x1E3\x1E6\x1EA\x1EE\x1F2\x1FA\x1FE\x203\x208\x20C\x212\x216\x21E\x22A"+
-		"\x22E\x236\x240\x24C\x259\x264";
+		"\x2||\x83\x83\xD0\xD3\xD5\xD5\xD8\xD8\x3\x2\xE4\xE7\x1F\x2\x18\x18$$@"+
+		"\x41\x44\x44GVYZ^^\x65\x65ggiiprtwyy\x80\x81\x88\x88\x8C\x8C\x91\x91\x9E"+
+		"\x9F\xA4\xA4\xA7\xA7\xAA\xAA\xAD\xAF\xB1\xB2\xB6\xB6\xB8\xB8\xBA\xBA\xC0"+
+		"\xC0\xC6\xC7\xC9\xC9\x11\x2\x4\x4\x39\x39=>\x41\x41XYzz\x8D\x8D\x95\x95"+
+		"\x9C\x9D\xB3\xB3\xB5\xB5\xBB\xBB\xBD\xBE\xC3\xC3\xCA\xCB\r\x2\x34\x34"+
+		"\x36\x36\x66\x66xx||\x83\x83\x8B\x8B\x8D\x8E\x9A\x9A\xC1\xC1\xCC\xCC$"+
+		"\x2\x3\x3\x6\f\xE\x12\x14\x17\x19\x19\x1B\x1B\x1D\x1E!#%\'\x33\x33\x38"+
+		"\x38;;\x43\x43``\x63\x64hhjnss{{~~\x84\x87\x8A\x8A\x92\x92\x94\x94\x9B"+
+		"\x9B\xA5\xA6\xA8\xA9\xAC\xAC\xB0\xB0\xB3\xB3\xB7\xB7\xC2\xC2\xC8\xC8\xCB"+
+		"\xCB\t\x2\x5\x5\r\r\x1A\x1A\x1C\x1C&&(({{\xE\x2\x4\x4\x13\x13\x1F <<?"+
+		"?\x46\x46WW}}\x7F\x7F\xB4\xB4\xB9\xB9\xC4\xC4\v\x2\x35\x35\x37\x37::\x42"+
+		"\x42\x82\x82\x91\x91\xBB\xBB\xC5\xC5\xF3\xF3\x4\x2oo\xBF\xBF\x4\x2[[\x90"+
+		"\x90\x4\x2\xEC\xEC\xEF\xEF\x2B7\x2r\x3\x2\x2\x2\x4y\x3\x2\x2\x2\x6\x82"+
+		"\x3\x2\x2\x2\b\x86\x3\x2\x2\x2\n\x8A\x3\x2\x2\x2\f\x8C\x3\x2\x2\x2\xE"+
+		"\x8E\x3\x2\x2\x2\x10\x9A\x3\x2\x2\x2\x12\x9C\x3\x2\x2\x2\x14\xA7\x3\x2"+
+		"\x2\x2\x16\xA9\x3\x2\x2\x2\x18\xAB\x3\x2\x2\x2\x1A\xC2\x3\x2\x2\x2\x1C"+
+		"\xDF\x3\x2\x2\x2\x1E\x159\x3\x2\x2\x2 \x15B\x3\x2\x2\x2\"\x15D\x3\x2\x2"+
+		"\x2$\x167\x3\x2\x2\x2&\x16F\x3\x2\x2\x2(\x177\x3\x2\x2\x2*\x1AF\x3\x2"+
+		"\x2\x2,\x1B1\x3\x2\x2\x2.\x1D0\x3\x2\x2\x2\x30\x1D2\x3\x2\x2\x2\x32\x1F4"+
+		"\x3\x2\x2\x2\x34\x1F6\x3\x2\x2\x2\x36\x1F8\x3\x2\x2\x2\x38\x1FA\x3\x2"+
+		"\x2\x2:\x208\x3\x2\x2\x2<\x218\x3\x2\x2\x2>\x21A\x3\x2\x2\x2@\x21C\x3"+
+		"\x2\x2\x2\x42\x220\x3\x2\x2\x2\x44\x222\x3\x2\x2\x2\x46\x225\x3\x2\x2"+
+		"\x2H\x228\x3\x2\x2\x2J\x22C\x3\x2\x2\x2L\x230\x3\x2\x2\x2N\x232\x3\x2"+
+		"\x2\x2P\x238\x3\x2\x2\x2R\x242\x3\x2\x2\x2T\x244\x3\x2\x2\x2V\x246\x3"+
+		"\x2\x2\x2X\x248\x3\x2\x2\x2Z\x24A\x3\x2\x2\x2\\\x24E\x3\x2\x2\x2^\x250"+
+		"\x3\x2\x2\x2`\x252\x3\x2\x2\x2\x62\x254\x3\x2\x2\x2\x64\x256\x3\x2\x2"+
+		"\x2\x66\x25B\x3\x2\x2\x2h\x25D\x3\x2\x2\x2j\x25F\x3\x2\x2\x2l\x261\x3"+
+		"\x2\x2\x2n\x264\x3\x2\x2\x2ps\x5\x1C\xF\x2qs\x5\x4\x3\x2rp\x3\x2\x2\x2"+
+		"rq\x3\x2\x2\x2st\x3\x2\x2\x2tu\a\x2\x2\x3u\x3\x3\x2\x2\x2vz\x5*\x16\x2"+
+		"wz\x5> \x2xz\x5\x42\"\x2yv\x3\x2\x2\x2yw\x3\x2\x2\x2yx\x3\x2\x2\x2z~\x3"+
+		"\x2\x2\x2{|\x5n\x38\x2|}\x5\x30\x19\x2}\x7F\x3\x2\x2\x2~{\x3\x2\x2\x2"+
+		"~\x7F\x3\x2\x2\x2\x7F\x5\x3\x2\x2\x2\x80\x83\x5\b\x5\x2\x81\x83\x5\n\x6"+
+		"\x2\x82\x80\x3\x2\x2\x2\x82\x81\x3\x2\x2\x2\x83\a\x3\x2\x2\x2\x84\x87"+
+		"\x5\x10\t\x2\x85\x87\x5\x12\n\x2\x86\x84\x3\x2\x2\x2\x86\x85\x3\x2\x2"+
+		"\x2\x87\t\x3\x2\x2\x2\x88\x8B\x5\f\a\x2\x89\x8B\x5\xE\b\x2\x8A\x88\x3"+
+		"\x2\x2\x2\x8A\x89\x3\x2\x2\x2\x8B\v\x3\x2\x2\x2\x8C\x8D\x5R*\x2\x8D\r"+
+		"\x3\x2\x2\x2\x8E\x8F\x5R*\x2\x8F\x90\x5\x16\f\x2\x90\xF\x3\x2\x2\x2\x91"+
+		"\x9B\a\xEE\x2\x2\x92\x9B\a\xF1\x2\x2\x93\x9B\x5^\x30\x2\x94\x9B\x5`\x31"+
+		"\x2\x95\x9B\x5\x18\r\x2\x96\x9B\a\xF2\x2\x2\x97\x9B\x5\x64\x33\x2\x98"+
+		"\x9B\ah\x2\x2\x99\x9B\x5\x62\x32\x2\x9A\x91\x3\x2\x2\x2\x9A\x92\x3\x2"+
+		"\x2\x2\x9A\x93\x3\x2\x2\x2\x9A\x94\x3\x2\x2\x2\x9A\x95\x3\x2\x2\x2\x9A"+
+		"\x96\x3\x2\x2\x2\x9A\x97\x3\x2\x2\x2\x9A\x98\x3\x2\x2\x2\x9A\x99\x3\x2"+
+		"\x2\x2\x9B\x11\x3\x2\x2\x2\x9C\x9D\x5\x14\v\x2\x9D\x9E\x5\x16\f\x2\x9E"+
+		"\x13\x3\x2\x2\x2\x9F\xA8\a\xEE\x2\x2\xA0\xA8\x5^\x30\x2\xA1\xA8\x5`\x31"+
+		"\x2\xA2\xA8\x5\x18\r\x2\xA3\xA8\a\xF2\x2\x2\xA4\xA8\x5\x64\x33\x2\xA5"+
+		"\xA8\ah\x2\x2\xA6\xA8\x5\x62\x32\x2\xA7\x9F\x3\x2\x2\x2\xA7\xA0\x3\x2"+
+		"\x2\x2\xA7\xA1\x3\x2\x2\x2\xA7\xA2\x3\x2\x2\x2\xA7\xA3\x3\x2\x2\x2\xA7"+
+		"\xA4\x3\x2\x2\x2\xA7\xA5\x3\x2\x2\x2\xA7\xA6\x3\x2\x2\x2\xA8\x15\x3\x2"+
+		"\x2\x2\xA9\xAA\t\x2\x2\x2\xAA\x17\x3\x2\x2\x2\xAB\xAC\t\x3\x2\x2\xAC\x19"+
+		"\x3\x2\x2\x2\xAD\xC3\x5\x62\x32\x2\xAE\xB0\a\xE1\x2\x2\xAF\xB1\x5n\x38"+
+		"\x2\xB0\xAF\x3\x2\x2\x2\xB0\xB1\x3\x2\x2\x2\xB1\xB2\x3\x2\x2\x2\xB2\xB4"+
+		"\x5\x62\x32\x2\xB3\xB5\x5n\x38\x2\xB4\xB3\x3\x2\x2\x2\xB4\xB5\x3\x2\x2"+
+		"\x2\xB5\xB6\x3\x2\x2\x2\xB6\xB7\a\xE2\x2\x2\xB7\xC3\x3\x2\x2\x2\xB8\xC3"+
+		"\a\xF2\x2\x2\xB9\xBB\a\xE1\x2\x2\xBA\xBC\x5n\x38\x2\xBB\xBA\x3\x2\x2\x2"+
+		"\xBB\xBC\x3\x2\x2\x2\xBC\xBD\x3\x2\x2\x2\xBD\xBF\a\xF2\x2\x2\xBE\xC0\x5"+
+		"n\x38\x2\xBF\xBE\x3\x2\x2\x2\xBF\xC0\x3\x2\x2\x2\xC0\xC1\x3\x2\x2\x2\xC1"+
+		"\xC3\a\xE2\x2\x2\xC2\xAD\x3\x2\x2\x2\xC2\xAE\x3\x2\x2\x2\xC2\xB8\x3\x2"+
+		"\x2\x2\xC2\xB9\x3\x2\x2\x2\xC3\x1B\x3\x2\x2\x2\xC4\xC5\b\xF\x1\x2\xC5"+
+		"\xC7\a\xD6\x2\x2\xC6\xC8\x5n\x38\x2\xC7\xC6\x3\x2\x2\x2\xC7\xC8\x3\x2"+
+		"\x2\x2\xC8\xC9\x3\x2\x2\x2\xC9\xE0\x5\x1C\xF\x11\xCA\xCC\a\x8E\x2\x2\xCB"+
+		"\xCD\x5n\x38\x2\xCC\xCB\x3\x2\x2\x2\xCC\xCD\x3\x2\x2\x2\xCD\xCE\x3\x2"+
+		"\x2\x2\xCE\xE0\x5\x1C\xF\n\xCF\xD0\a.\x2\x2\xD0\xE0\x5\x1C\xF\x3\xD1\xE0"+
+		"\x5(\x15\x2\xD2\xD4\a\xD4\x2\x2\xD3\xD5\x5n\x38\x2\xD4\xD3\x3\x2\x2\x2"+
+		"\xD4\xD5\x3\x2\x2\x2\xD5\xD6\x3\x2\x2\x2\xD6\xD8\x5\x1C\xF\x2\xD7\xD9"+
+		"\x5n\x38\x2\xD8\xD7\x3\x2\x2\x2\xD8\xD9\x3\x2\x2\x2\xD9\xDA\x3\x2\x2\x2"+
+		"\xDA\xDB\a\xDB\x2\x2\xDB\xE0\x3\x2\x2\x2\xDC\xE0\x5$\x13\x2\xDD\xE0\x5"+
+		"&\x14\x2\xDE\xE0\x5\x1E\x10\x2\xDF\xC4\x3\x2\x2\x2\xDF\xCA\x3\x2\x2\x2"+
+		"\xDF\xCF\x3\x2\x2\x2\xDF\xD1\x3\x2\x2\x2\xDF\xD2\x3\x2\x2\x2\xDF\xDC\x3"+
+		"\x2\x2\x2\xDF\xDD\x3\x2\x2\x2\xDF\xDE\x3\x2\x2\x2\xE0\x14F\x3\x2\x2\x2"+
+		"\xE1\xE3\f\x12\x2\x2\xE2\xE4\x5n\x38\x2\xE3\xE2\x3\x2\x2\x2\xE3\xE4\x3"+
+		"\x2\x2\x2\xE4\xE5\x3\x2\x2\x2\xE5\xE7\a\xDA\x2\x2\xE6\xE8\x5n\x38\x2\xE7"+
+		"\xE6\x3\x2\x2\x2\xE7\xE8\x3\x2\x2\x2\xE8\xE9\x3\x2\x2\x2\xE9\x14E\x5\x1C"+
+		"\xF\x13\xEA\xEC\f\x10\x2\x2\xEB\xED\x5n\x38\x2\xEC\xEB\x3\x2\x2\x2\xEC"+
+		"\xED\x3\x2\x2\x2\xED\xEE\x3\x2\x2\x2\xEE\xF0\t\x4\x2\x2\xEF\xF1\x5n\x38"+
+		"\x2\xF0\xEF\x3\x2\x2\x2\xF0\xF1\x3\x2\x2\x2\xF1\xF2\x3\x2\x2\x2\xF2\x14E"+
+		"\x5\x1C\xF\x11\xF3\xF5\f\xF\x2\x2\xF4\xF6\x5n\x38\x2\xF5\xF4\x3\x2\x2"+
+		"\x2\xF5\xF6\x3\x2\x2\x2\xF6\xF7\x3\x2\x2\x2\xF7\xF9\a\xCF\x2\x2\xF8\xFA"+
+		"\x5n\x38\x2\xF9\xF8\x3\x2\x2\x2\xF9\xFA\x3\x2\x2\x2\xFA\xFB\x3\x2\x2\x2"+
+		"\xFB\x14E\x5\x1C\xF\x10\xFC\xFE\f\xE\x2\x2\xFD\xFF\x5n\x38\x2\xFE\xFD"+
+		"\x3\x2\x2\x2\xFE\xFF\x3\x2\x2\x2\xFF\x100\x3\x2\x2\x2\x100\x102\a\x8B"+
+		"\x2\x2\x101\x103\x5n\x38\x2\x102\x101\x3\x2\x2\x2\x102\x103\x3\x2\x2\x2"+
+		"\x103\x104\x3\x2\x2\x2\x104\x14E\x5\x1C\xF\xF\x105\x107\f\r\x2\x2\x106"+
+		"\x108\x5n\x38\x2\x107\x106\x3\x2\x2\x2\x107\x108\x3\x2\x2\x2\x108\x109"+
+		"\x3\x2\x2\x2\x109\x10B\t\x5\x2\x2\x10A\x10C\x5n\x38\x2\x10B\x10A\x3\x2"+
+		"\x2\x2\x10B\x10C\x3\x2\x2\x2\x10C\x10D\x3\x2\x2\x2\x10D\x14E\x5\x1C\xF"+
+		"\xE\x10E\x110\f\f\x2\x2\x10F\x111\x5n\x38\x2\x110\x10F\x3\x2\x2\x2\x110"+
+		"\x111\x3\x2\x2\x2\x111\x112\x3\x2\x2\x2\x112\x114\a\x32\x2\x2\x113\x115"+
+		"\x5n\x38\x2\x114\x113\x3\x2\x2\x2\x114\x115\x3\x2\x2\x2\x115\x116\x3\x2"+
+		"\x2\x2\x116\x14E\x5\x1C\xF\r\x117\x119\f\v\x2\x2\x118\x11A\x5n\x38\x2"+
+		"\x119\x118\x3\x2\x2\x2\x119\x11A\x3\x2\x2\x2\x11A\x11B\x3\x2\x2\x2\x11B"+
+		"\x11D\t\x6\x2\x2\x11C\x11E\x5n\x38\x2\x11D\x11C\x3\x2\x2\x2\x11D\x11E"+
+		"\x3\x2\x2\x2\x11E\x11F\x3\x2\x2\x2\x11F\x14E\x5\x1C\xF\f\x120\x122\f\t"+
+		"\x2\x2\x121\x123\x5n\x38\x2\x122\x121\x3\x2\x2\x2\x122\x123\x3\x2\x2\x2"+
+		"\x123\x124\x3\x2\x2\x2\x124\x126\a\x36\x2\x2\x125\x127\x5n\x38\x2\x126"+
+		"\x125\x3\x2\x2\x2\x126\x127\x3\x2\x2\x2\x127\x128\x3\x2\x2\x2\x128\x14E"+
+		"\x5\x1C\xF\n\x129\x12B\f\b\x2\x2\x12A\x12C\x5n\x38\x2\x12B\x12A\x3\x2"+
+		"\x2\x2\x12B\x12C\x3\x2\x2\x2\x12C\x12D\x3\x2\x2\x2\x12D\x12F\a\x9A\x2"+
+		"\x2\x12E\x130\x5n\x38\x2\x12F\x12E\x3\x2\x2\x2\x12F\x130\x3\x2\x2\x2\x130"+
+		"\x131\x3\x2\x2\x2\x131\x14E\x5\x1C\xF\t\x132\x134\f\a\x2\x2\x133\x135"+
+		"\x5n\x38\x2\x134\x133\x3\x2\x2\x2\x134\x135\x3\x2\x2\x2\x135\x136\x3\x2"+
+		"\x2\x2\x136\x138\a\xCC\x2\x2\x137\x139\x5n\x38\x2\x138\x137\x3\x2\x2\x2"+
+		"\x138\x139\x3\x2\x2\x2\x139\x13A\x3\x2\x2\x2\x13A\x14E\x5\x1C\xF\b\x13B"+
+		"\x13D\f\x6\x2\x2\x13C\x13E\x5n\x38\x2\x13D\x13C\x3\x2\x2\x2\x13D\x13E"+
+		"\x3\x2\x2\x2\x13E\x13F\x3\x2\x2\x2\x13F\x141\a\x66\x2\x2\x140\x142\x5"+
+		"n\x38\x2\x141\x140\x3\x2\x2\x2\x141\x142\x3\x2\x2\x2\x142\x143\x3\x2\x2"+
+		"\x2\x143\x14E\x5\x1C\xF\a\x144\x146\f\x5\x2\x2\x145\x147\x5n\x38\x2\x146"+
+		"\x145\x3\x2\x2\x2\x146\x147\x3\x2\x2\x2\x147\x148\x3\x2\x2\x2\x148\x14A"+
+		"\ax\x2\x2\x149\x14B\x5n\x38\x2\x14A\x149\x3\x2\x2\x2\x14A\x14B\x3\x2\x2"+
+		"\x2\x14B\x14C\x3\x2\x2\x2\x14C\x14E\x5\x1C\xF\x6\x14D\xE1\x3\x2\x2\x2"+
+		"\x14D\xEA\x3\x2\x2\x2\x14D\xF3\x3\x2\x2\x2\x14D\xFC\x3\x2\x2\x2\x14D\x105"+
+		"\x3\x2\x2\x2\x14D\x10E\x3\x2\x2\x2\x14D\x117\x3\x2\x2\x2\x14D\x120\x3"+
+		"\x2\x2\x2\x14D\x129\x3\x2\x2\x2\x14D\x132\x3\x2\x2\x2\x14D\x13B\x3\x2"+
+		"\x2\x2\x14D\x144\x3\x2\x2\x2\x14E\x151\x3\x2\x2\x2\x14F\x14D\x3\x2\x2"+
+		"\x2\x14F\x150\x3\x2\x2\x2\x150\x1D\x3\x2\x2\x2\x151\x14F\x3\x2\x2\x2\x152"+
+		"\x15A\x5 \x11\x2\x153\x15A\a\xE8\x2\x2\x154\x15A\a\xE3\x2\x2\x155\x157"+
+		"\x5\x66\x34\x2\x156\x158\x5\x16\f\x2\x157\x156\x3\x2\x2\x2\x157\x158\x3"+
+		"\x2\x2\x2\x158\x15A\x3\x2\x2\x2\x159\x152\x3\x2\x2\x2\x159\x153\x3\x2"+
+		"\x2\x2\x159\x154\x3\x2\x2\x2\x159\x155\x3\x2\x2\x2\x15A\x1F\x3\x2\x2\x2"+
+		"\x15B\x15C\t\a\x2\x2\x15C!\x3\x2\x2\x2\x15D\x15F\a\xD4\x2\x2\x15E\x160"+
+		"\x5n\x38\x2\x15F\x15E\x3\x2\x2\x2\x15F\x160\x3\x2\x2\x2\x160\x161\x3\x2"+
+		"\x2\x2\x161\x163\x5\x1C\xF\x2\x162\x164\x5n\x38\x2\x163\x162\x3\x2\x2"+
+		"\x2\x163\x164\x3\x2\x2\x2\x164\x165\x3\x2\x2\x2\x165\x166\a\xDB\x2\x2"+
+		"\x166#\x3\x2\x2\x2\x167\x168\a\xC1\x2\x2\x168\x169\x5n\x38\x2\x169\x16A"+
+		"\x5\x1C\xF\x2\x16A\x16B\x5n\x38\x2\x16B\x16C\a|\x2\x2\x16C\x16D\x5n\x38"+
+		"\x2\x16D\x16E\x5J&\x2\x16E%\x3\x2\x2\x2\x16F\x170\a\x8D\x2\x2\x170\x171"+
+		"\x5n\x38\x2\x171\x172\x5J&\x2\x172\'\x3\x2\x2\x2\x173\x174\b\x15\x1\x2"+
+		"\x174\x178\x5@!\x2\x175\x178\x5> \x2\x176\x178\x5\x42\"\x2\x177\x173\x3"+
+		"\x2\x2\x2\x177\x175\x3\x2\x2\x2\x177\x176\x3\x2\x2\x2\x178\x1A0\x3\x2"+
+		"\x2\x2\x179\x17B\f\v\x2\x2\x17A\x17C\x5n\x38\x2\x17B\x17A\x3\x2\x2\x2"+
+		"\x17B\x17C\x3\x2\x2\x2\x17C\x17D\x3\x2\x2\x2\x17D\x17F\a\xD4\x2\x2\x17E"+
+		"\x180\x5n\x38\x2\x17F\x17E\x3\x2\x2\x2\x17F\x180\x3\x2\x2\x2\x180\x182"+
+		"\x3\x2\x2\x2\x181\x183\x5\x30\x19\x2\x182\x181\x3\x2\x2\x2\x182\x183\x3"+
+		"\x2\x2\x2\x183\x185\x3\x2\x2\x2\x184\x186\x5n\x38\x2\x185\x184\x3\x2\x2"+
+		"\x2\x185\x186\x3\x2\x2\x2\x186\x187\x3\x2\x2\x2\x187\x19F\a\xDB\x2\x2"+
+		"\x188\x189\f\n\x2\x2\x189\x18A\a-\x2\x2\x18A\x19F\x5\x6\x4\x2\x18B\x18C"+
+		"\f\t\x2\x2\x18C\x18E\a\xEF\x2\x2\x18D\x18F\x5n\x38\x2\x18E\x18D\x3\x2"+
+		"\x2\x2\x18E\x18F\x3\x2\x2\x2\x18F\x190\x3\x2\x2\x2\x190\x191\a-\x2\x2"+
+		"\x191\x19F\x5\x6\x4\x2\x192\x193\f\b\x2\x2\x193\x194\a,\x2\x2\x194\x19F"+
+		"\x5\x6\x4\x2\x195\x196\f\a\x2\x2\x196\x197\a\xEF\x2\x2\x197\x198\a,\x2"+
+		"\x2\x198\x19F\x5\x6\x4\x2\x199\x19A\f\x6\x2\x2\x19A\x19B\a\xEF\x2\x2\x19B"+
+		"\x19C\a,\x2\x2\x19C\x19D\a\xEF\x2\x2\x19D\x19F\x5\x6\x4\x2\x19E\x179\x3"+
+		"\x2\x2\x2\x19E\x188\x3\x2\x2\x2\x19E\x18B\x3\x2\x2\x2\x19E\x192\x3\x2"+
+		"\x2\x2\x19E\x195\x3\x2\x2\x2\x19E\x199\x3\x2\x2\x2\x19F\x1A2\x3\x2\x2"+
+		"\x2\x1A0\x19E\x3\x2\x2\x2\x1A0\x1A1\x3\x2\x2\x2\x1A1)\x3\x2\x2\x2\x1A2"+
+		"\x1A0\x3\x2\x2\x2\x1A3\x1A4\x5(\x15\x2\x1A4\x1A5\a-\x2\x2\x1A5\x1A6\x5"+
+		"\x6\x4\x2\x1A6\x1B0\x3\x2\x2\x2\x1A7\x1A8\x5(\x15\x2\x1A8\x1AA\a\xEF\x2"+
+		"\x2\x1A9\x1AB\x5n\x38\x2\x1AA\x1A9\x3\x2\x2\x2\x1AA\x1AB\x3\x2\x2\x2\x1AB"+
+		"\x1AC\x3\x2\x2\x2\x1AC\x1AD\a-\x2\x2\x1AD\x1AE\x5\x6\x4\x2\x1AE\x1B0\x3"+
+		"\x2\x2\x2\x1AF\x1A3\x3\x2\x2\x2\x1AF\x1A7\x3\x2\x2\x2\x1B0+\x3\x2\x2\x2"+
+		"\x1B1\x1B3\x5(\x15\x2\x1B2\x1B4\x5n\x38\x2\x1B3\x1B2\x3\x2\x2\x2\x1B3"+
+		"\x1B4\x3\x2\x2\x2\x1B4\x1B5\x3\x2\x2\x2\x1B5\x1B7\a\xD4\x2\x2\x1B6\x1B8"+
+		"\x5n\x38\x2\x1B7\x1B6\x3\x2\x2\x2\x1B7\x1B8\x3\x2\x2\x2\x1B8\x1BA\x3\x2"+
+		"\x2\x2\x1B9\x1BB\x5\x30\x19\x2\x1BA\x1B9\x3\x2\x2\x2\x1BA\x1BB\x3\x2\x2"+
+		"\x2\x1BB\x1BD\x3\x2\x2\x2\x1BC\x1BE\x5n\x38\x2\x1BD\x1BC\x3\x2\x2\x2\x1BD"+
+		"\x1BE\x3\x2\x2\x2\x1BE\x1BF\x3\x2\x2\x2\x1BF\x1C0\a\xDB\x2\x2\x1C0-\x3"+
+		"\x2\x2\x2\x1C1\x1C2\x5(\x15\x2\x1C2\x1C3\a,\x2\x2\x1C3\x1C4\x5\x6\x4\x2"+
+		"\x1C4\x1D1\x3\x2\x2\x2\x1C5\x1C6\x5(\x15\x2\x1C6\x1C7\a\xEF\x2\x2\x1C7"+
+		"\x1C8\a,\x2\x2\x1C8\x1C9\x5\x6\x4\x2\x1C9\x1D1\x3\x2\x2\x2\x1CA\x1CB\x5"+
+		"(\x15\x2\x1CB\x1CC\a\xEF\x2\x2\x1CC\x1CD\a,\x2\x2\x1CD\x1CE\a\xEF\x2\x2"+
+		"\x1CE\x1CF\x5\x6\x4\x2\x1CF\x1D1\x3\x2\x2\x2\x1D0\x1C1\x3\x2\x2\x2\x1D0"+
+		"\x1C5\x3\x2\x2\x2\x1D0\x1CA\x3\x2\x2\x2\x1D1/\x3\x2\x2\x2\x1D2\x1D3\x5"+
+		"\x32\x1A\x2\x1D3\x31\x3\x2\x2\x2\x1D4\x1D6\x5\x34\x1B\x2\x1D5\x1D4\x3"+
+		"\x2\x2\x2\x1D5\x1D6\x3\x2\x2\x2\x1D6\x1D8\x3\x2\x2\x2\x1D7\x1D9\x5n\x38"+
+		"\x2\x1D8\x1D7\x3\x2\x2\x2\x1D8\x1D9\x3\x2\x2\x2\x1D9\x1DA\x3\x2\x2\x2"+
+		"\x1DA\x1DC\a)\x2\x2\x1DB\x1DD\x5n\x38\x2\x1DC\x1DB\x3\x2\x2\x2\x1DC\x1DD"+
+		"\x3\x2\x2\x2\x1DD\x1DF\x3\x2\x2\x2\x1DE\x1D5\x3\x2\x2\x2\x1DF\x1E2\x3"+
+		"\x2\x2\x2\x1E0\x1DE\x3\x2\x2\x2\x1E0\x1E1\x3\x2\x2\x2\x1E1\x1E3\x3\x2"+
+		"\x2\x2\x1E2\x1E0\x3\x2\x2\x2\x1E3\x1F5\x5\x36\x1C\x2\x1E4\x1E6\x5\x34"+
+		"\x1B\x2\x1E5\x1E4\x3\x2\x2\x2\x1E5\x1E6\x3\x2\x2\x2\x1E6\x1E8\x3\x2\x2"+
+		"\x2\x1E7\x1E9\x5n\x38\x2\x1E8\x1E7\x3\x2\x2\x2\x1E8\x1E9\x3\x2\x2\x2\x1E9"+
+		"\x1EA\x3\x2\x2\x2\x1EA\x1EC\a)\x2\x2\x1EB\x1ED\x5n\x38\x2\x1EC\x1EB\x3"+
+		"\x2\x2\x2\x1EC\x1ED\x3\x2\x2\x2\x1ED\x1EF\x3\x2\x2\x2\x1EE\x1E5\x3\x2"+
+		"\x2\x2\x1EF\x1F2\x3\x2\x2\x2\x1F0\x1EE\x3\x2\x2\x2\x1F0\x1F1\x3\x2\x2"+
+		"\x2\x1F1\x1F3\x3\x2\x2\x2\x1F2\x1F0\x3\x2\x2\x2\x1F3\x1F5\x5\x38\x1D\x2"+
+		"\x1F4\x1E0\x3\x2\x2\x2\x1F4\x1F0\x3\x2\x2\x2\x1F5\x33\x3\x2\x2\x2\x1F6"+
+		"\x1F7\x5<\x1F\x2\x1F7\x35\x3\x2\x2\x2\x1F8\x1F9\x5<\x1F\x2\x1F9\x37\x3"+
+		"\x2\x2\x2\x1FA\x205\x5:\x1E\x2\x1FB\x1FD\x5n\x38\x2\x1FC\x1FB\x3\x2\x2"+
+		"\x2\x1FC\x1FD\x3\x2\x2\x2\x1FD\x1FE\x3\x2\x2\x2\x1FE\x200\a)\x2\x2\x1FF"+
+		"\x201\x5n\x38\x2\x200\x1FF\x3\x2\x2\x2\x200\x201\x3\x2\x2\x2\x201\x202"+
+		"\x3\x2\x2\x2\x202\x204\x5:\x1E\x2\x203\x1FC\x3\x2\x2\x2\x204\x207\x3\x2"+
+		"\x2\x2\x205\x203\x3\x2\x2\x2\x205\x206\x3\x2\x2\x2\x206\x39\x3\x2\x2\x2"+
+		"\x207\x205\x3\x2\x2\x2\x208\x20A\x5\x6\x4\x2\x209\x20B\x5n\x38\x2\x20A"+
+		"\x209\x3\x2\x2\x2\x20A\x20B\x3\x2\x2\x2\x20B\x20C\x3\x2\x2\x2\x20C\x20E"+
+		"\a\xCD\x2\x2\x20D\x20F\x5n\x38\x2\x20E\x20D\x3\x2\x2\x2\x20E\x20F\x3\x2"+
+		"\x2\x2\x20F\x210\x3\x2\x2\x2\x210\x211\x5<\x1F\x2\x211;\x3\x2\x2\x2\x212"+
+		"\x213\a=\x2\x2\x213\x215\x5n\x38\x2\x214\x212\x3\x2\x2\x2\x214\x215\x3"+
+		"\x2\x2\x2\x215\x216\x3\x2\x2\x2\x216\x219\x5\x1C\xF\x2\x217\x219\x5N("+
+		"\x2\x218\x214\x3\x2\x2\x2\x218\x217\x3\x2\x2\x2\x219=\x3\x2\x2\x2\x21A"+
+		"\x21B\x5\b\x5\x2\x21B?\x3\x2\x2\x2\x21C\x21D\a\x89\x2\x2\x21D\x41\x3\x2"+
+		"\x2\x2\x21E\x221\x5\x44#\x2\x21F\x221\x5\x46$\x2\x220\x21E\x3\x2\x2\x2"+
+		"\x220\x21F\x3\x2\x2\x2\x221\x43\x3\x2\x2\x2\x222\x223\a-\x2\x2\x223\x224"+
+		"\x5\x6\x4\x2\x224\x45\x3\x2\x2\x2\x225\x226\a,\x2\x2\x226\x227\x5\x6\x4"+
+		"\x2\x227G\x3\x2\x2\x2\x228\x229\x5\x1C\xF\x2\x229I\x3\x2\x2\x2\x22A\x22D"+
+		"\x5\x1A\xE\x2\x22B\x22D\x5L\'\x2\x22C\x22A\x3\x2\x2\x2\x22C\x22B\x3\x2"+
+		"\x2\x2\x22DK\x3\x2\x2\x2\x22E\x231\x5> \x2\x22F\x231\x5*\x16\x2\x230\x22E"+
+		"\x3\x2\x2\x2\x230\x22F\x3\x2\x2\x2\x231M\x3\x2\x2\x2\x232\x233\a\x34\x2"+
+		"\x2\x233\x234\x5n\x38\x2\x234\x235\x5P)\x2\x235O\x3\x2\x2\x2\x236\x239"+
+		"\x5*\x16\x2\x237\x239\x5> \x2\x238\x236\x3\x2\x2\x2\x238\x237\x3\x2\x2"+
+		"\x2\x239Q\x3\x2\x2\x2\x23A\x243\x5T+\x2\x23B\x243\x5X-\x2\x23C\x243\x5"+
+		"Z.\x2\x23D\x243\x5`\x31\x2\x23E\x243\x5\\/\x2\x23F\x243\x5\x66\x34\x2"+
+		"\x240\x243\x5V,\x2\x241\x243\x5\x62\x32\x2\x242\x23A\x3\x2\x2\x2\x242"+
+		"\x23B\x3\x2\x2\x2\x242\x23C\x3\x2\x2\x2\x242\x23D\x3\x2\x2\x2\x242\x23E"+
+		"\x3\x2\x2\x2\x242\x23F\x3\x2\x2\x2\x242\x240\x3\x2\x2\x2\x242\x241\x3"+
+		"\x2\x2\x2\x243S\x3\x2\x2\x2\x244\x245\t\b\x2\x2\x245U\x3\x2\x2\x2\x246"+
+		"\x247\a\xAB\x2\x2\x247W\x3\x2\x2\x2\x248\x249\t\t\x2\x2\x249Y\x3\x2\x2"+
+		"\x2\x24A\x24B\t\n\x2\x2\x24B[\x3\x2\x2\x2\x24C\x24F\a\x89\x2\x2\x24D\x24F"+
+		"\x5^\x30\x2\x24E\x24C\x3\x2\x2\x2\x24E\x24D\x3\x2\x2\x2\x24F]\x3\x2\x2"+
+		"\x2\x250\x251\t\v\x2\x2\x251_\x3\x2\x2\x2\x252\x253\t\f\x2\x2\x253\x61"+
+		"\x3\x2\x2\x2\x254\x255\t\r\x2\x2\x255\x63\x3\x2\x2\x2\x256\x257\t\xE\x2"+
+		"\x2\x257\x65\x3\x2\x2\x2\x258\x25C\x5h\x35\x2\x259\x25C\x5j\x36\x2\x25A"+
+		"\x25C\x5l\x37\x2\x25B\x258\x3\x2\x2\x2\x25B\x259\x3\x2\x2\x2\x25B\x25A"+
+		"\x3\x2\x2\x2\x25Cg\x3\x2\x2\x2\x25D\x25E\t\xF\x2\x2\x25Ei\x3\x2\x2\x2"+
+		"\x25F\x260\a\x8F\x2\x2\x260k\x3\x2\x2\x2\x261\x262\t\x10\x2\x2\x262m\x3"+
+		"\x2\x2\x2\x263\x265\t\x11\x2\x2\x264\x263\x3\x2\x2\x2\x265\x266\x3\x2"+
+		"\x2\x2\x266\x264\x3\x2\x2\x2\x266\x267\x3\x2\x2\x2\x267o\x3\x2\x2\x2Y"+
+		"ry~\x82\x86\x8A\x9A\xA7\xB0\xB4\xBB\xBF\xC2\xC7\xCC\xD4\xD8\xDF\xE3\xE7"+
+		"\xEC\xF0\xF5\xF9\xFE\x102\x107\x10B\x110\x114\x119\x11D\x122\x126\x12B"+
+		"\x12F\x134\x138\x13D\x141\x146\x14A\x14D\x14F\x157\x159\x15F\x163\x177"+
+		"\x17B\x17F\x182\x185\x18E\x19E\x1A0\x1AA\x1AF\x1B3\x1B7\x1BA\x1BD\x1D0"+
+		"\x1D5\x1D8\x1DC\x1E0\x1E5\x1E8\x1EC\x1F0\x1F4\x1FC\x200\x205\x20A\x20E"+
+		"\x214\x218\x220\x22C\x230\x238\x242\x24E\x25B\x266";
 	public static readonly ATN _ATN =
 		new ATNDeserializer().Deserialize(_serializedATN.ToCharArray());
 }

--- a/Rubberduck.Parsing/Binding/VBAExpressionParser.g4
+++ b/Rubberduck.Parsing/Binding/VBAExpressionParser.g4
@@ -69,6 +69,9 @@ expression :
 	| expression whiteSpace? EQV whiteSpace? expression                                             # logicalEqvOp
 	| expression whiteSpace? IMP whiteSpace? expression                                             # logicalImpOp
     | literalExpression                                                                             # literalExpr
+    // This has been added so that we can deal with legacy functions that allow file numbers as arguments which are usually not allowed
+    // e.g. Input(file1, #file1)
+    | HASH expression                                                                               # markedFileNumberExpr 
 ;
 
 // 5.6.5 Literal Expressions
@@ -168,7 +171,6 @@ reservedIdentifier :
 statementKeyword :
     CALL
     | CASE
-    | CLOSE
     | CONST
     | DECLARE
     | DEFBOOL
@@ -196,42 +198,34 @@ statementKeyword :
     | FOR
     | FRIEND
     | FUNCTION
-    | GET
     | GLOBAL
     | GOSUB
     | GOTO
     | IF
     | IMPLEMENTS
-    | INPUT
     | LET
-    | LOCK
     | LOOP
     | LSET
     | NEXT
     | ON
-    | OPEN
     | OPTION
     | PRINT
     | PRIVATE
     | PUBLIC
-    | PUT
     | RAISEEVENT
     | REDIM
     | RESUME
     | RETURN
     | RSET
-    | SEEK
     | SELECT
     | SET
     | STATIC
     | STOP
     | SUB
     | TYPE
-    | UNLOCK
     | WEND
     | WHILE
     | WITH
-    | WRITE
 ;
 remKeyword : REM;
 markerKeyword :
@@ -329,6 +323,15 @@ reservedProcedureName :
     | LINE_INPUT
     | WIDTH
     | END
+    | CLOSE
+    | GET
+    | INPUT
+    | LOCK
+    | OPEN
+    | PUT
+    | SEEK
+    | UNLOCK
+    | WRITE
 ;
 specialForm :
     ARRAY

--- a/Rubberduck.Parsing/Binding/VBAExpressionParserBaseListener.cs
+++ b/Rubberduck.Parsing/Binding/VBAExpressionParserBaseListener.cs
@@ -918,6 +918,19 @@ public partial class VBAExpressionParserBaseListener : IVBAExpressionParserListe
 	public virtual void ExitReservedName([NotNull] VBAExpressionParser.ReservedNameContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAExpressionParser.markedFileNumberExpr"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterMarkedFileNumberExpr([NotNull] VBAExpressionParser.MarkedFileNumberExprContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAExpressionParser.markedFileNumberExpr"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitMarkedFileNumberExpr([NotNull] VBAExpressionParser.MarkedFileNumberExprContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAExpressionParser.logicalXorOp"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>

--- a/Rubberduck.Parsing/Binding/VBAExpressionParserBaseVisitor.cs
+++ b/Rubberduck.Parsing/Binding/VBAExpressionParserBaseVisitor.cs
@@ -781,6 +781,17 @@ public partial class VBAExpressionParserBaseVisitor<Result> : AbstractParseTreeV
 	public virtual Result VisitReservedName([NotNull] VBAExpressionParser.ReservedNameContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAExpressionParser.markedFileNumberExpr"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitMarkedFileNumberExpr([NotNull] VBAExpressionParser.MarkedFileNumberExprContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAExpressionParser.logicalXorOp"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>

--- a/Rubberduck.Parsing/Binding/VBAExpressionParserListener.cs
+++ b/Rubberduck.Parsing/Binding/VBAExpressionParserListener.cs
@@ -824,6 +824,19 @@ public interface IVBAExpressionParserListener : IParseTreeListener {
 	void ExitReservedName([NotNull] VBAExpressionParser.ReservedNameContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by the <c>markedFileNumberExpr</c>
+	/// labeled alternative in <see cref="VBAExpressionParser.expression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterMarkedFileNumberExpr([NotNull] VBAExpressionParser.MarkedFileNumberExprContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>markedFileNumberExpr</c>
+	/// labeled alternative in <see cref="VBAExpressionParser.expression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitMarkedFileNumberExpr([NotNull] VBAExpressionParser.MarkedFileNumberExprContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by the <c>logicalXorOp</c>
 	/// labeled alternative in <see cref="VBAExpressionParser.expression"/>.
 	/// </summary>

--- a/Rubberduck.Parsing/Binding/VBAExpressionParserVisitor.cs
+++ b/Rubberduck.Parsing/Binding/VBAExpressionParserVisitor.cs
@@ -530,6 +530,14 @@ public interface IVBAExpressionParserVisitor<Result> : IParseTreeVisitor<Result>
 	Result VisitReservedName([NotNull] VBAExpressionParser.ReservedNameContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by the <c>markedFileNumberExpr</c>
+	/// labeled alternative in <see cref="VBAExpressionParser.expression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitMarkedFileNumberExpr([NotNull] VBAExpressionParser.MarkedFileNumberExprContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by the <c>logicalXorOp</c>
 	/// labeled alternative in <see cref="VBAExpressionParser.expression"/>.
 	/// </summary>

--- a/Rubberduck.Parsing/Grammar/VBAParser.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParser.cs
@@ -107,84 +107,99 @@ public partial class VBAParser : Parser {
 		RULE_moduleConfigElement = 4, RULE_moduleAttributes = 5, RULE_moduleDeclarations = 6, 
 		RULE_moduleOption = 7, RULE_moduleDeclarationsElement = 8, RULE_moduleBody = 9, 
 		RULE_moduleBodyElement = 10, RULE_attributeStmt = 11, RULE_attributeName = 12, 
-		RULE_attributeValue = 13, RULE_block = 14, RULE_blockStmt = 15, RULE_closeStmt = 16, 
-		RULE_constStmt = 17, RULE_constSubStmt = 18, RULE_declareStmt = 19, RULE_defDirective = 20, 
-		RULE_defType = 21, RULE_letterSpec = 22, RULE_singleLetter = 23, RULE_universalLetterRange = 24, 
-		RULE_upperCaseA = 25, RULE_upperCaseZ = 26, RULE_letterRange = 27, RULE_firstLetter = 28, 
-		RULE_lastLetter = 29, RULE_doLoopStmt = 30, RULE_enumerationStmt = 31, 
-		RULE_enumerationStmt_Constant = 32, RULE_endStmt = 33, RULE_eraseStmt = 34, 
-		RULE_errorStmt = 35, RULE_eventStmt = 36, RULE_exitStmt = 37, RULE_forEachStmt = 38, 
-		RULE_forNextStmt = 39, RULE_functionStmt = 40, RULE_functionName = 41, 
-		RULE_getStmt = 42, RULE_goSubStmt = 43, RULE_goToStmt = 44, RULE_ifStmt = 45, 
-		RULE_elseIfBlock = 46, RULE_elseBlock = 47, RULE_singleLineIfStmt = 48, 
-		RULE_ifWithNonEmptyThen = 49, RULE_ifWithEmptyThen = 50, RULE_singleLineElseClause = 51, 
-		RULE_listOrLabel = 52, RULE_sameLineStatement = 53, RULE_booleanExpression = 54, 
-		RULE_implementsStmt = 55, RULE_inputStmt = 56, RULE_letStmt = 57, RULE_lineInputStmt = 58, 
-		RULE_lockStmt = 59, RULE_lsetStmt = 60, RULE_midStmt = 61, RULE_onErrorStmt = 62, 
-		RULE_onGoToStmt = 63, RULE_onGoSubStmt = 64, RULE_openStmt = 65, RULE_outputList = 66, 
-		RULE_outputList_Expression = 67, RULE_printStmt = 68, RULE_propertyGetStmt = 69, 
-		RULE_propertySetStmt = 70, RULE_propertyLetStmt = 71, RULE_putStmt = 72, 
-		RULE_raiseEventStmt = 73, RULE_redimStmt = 74, RULE_redimSubStmt = 75, 
-		RULE_resetStmt = 76, RULE_resumeStmt = 77, RULE_returnStmt = 78, RULE_rsetStmt = 79, 
-		RULE_stopStmt = 80, RULE_seekStmt = 81, RULE_selectCaseStmt = 82, RULE_sC_Selection = 83, 
-		RULE_sC_Case = 84, RULE_sC_Cond = 85, RULE_setStmt = 86, RULE_subStmt = 87, 
-		RULE_subroutineName = 88, RULE_typeStmt = 89, RULE_typeStmt_Element = 90, 
-		RULE_unlockStmt = 91, RULE_valueStmt = 92, RULE_typeOfIsExpression = 93, 
-		RULE_variableStmt = 94, RULE_variableListStmt = 95, RULE_variableSubStmt = 96, 
-		RULE_whileWendStmt = 97, RULE_widthStmt = 98, RULE_withStmt = 99, RULE_withStmtExpression = 100, 
-		RULE_writeStmt = 101, RULE_fileNumber = 102, RULE_explicitCallStmt = 103, 
-		RULE_explicitCallStmtExpression = 104, RULE_implicitCallStmt_InBlock = 105, 
-		RULE_iCS_B_MemberProcedureCall = 106, RULE_iCS_B_ProcedureCall = 107, 
-		RULE_implicitCallStmt_InStmt = 108, RULE_iCS_S_VariableOrProcedureCall = 109, 
-		RULE_iCS_S_ProcedureOrArrayCall = 110, RULE_iCS_S_VariableOrProcedureCallUnrestricted = 111, 
-		RULE_iCS_S_ProcedureOrArrayCallUnrestricted = 112, RULE_iCS_S_MembersCall = 113, 
-		RULE_iCS_S_MemberCall = 114, RULE_iCS_S_DictionaryCall = 115, RULE_argsCall = 116, 
-		RULE_argCall = 117, RULE_dictionaryCallStmt = 118, RULE_argList = 119, 
-		RULE_arg = 120, RULE_argDefaultValue = 121, RULE_subscripts = 122, RULE_subscript = 123, 
-		RULE_unrestrictedIdentifier = 124, RULE_identifier = 125, RULE_asTypeClause = 126, 
-		RULE_baseType = 127, RULE_comparisonOperator = 128, RULE_complexType = 129, 
-		RULE_fieldLength = 130, RULE_statementLabelDefinition = 131, RULE_statementLabel = 132, 
-		RULE_identifierStatementLabel = 133, RULE_lineNumberLabel = 134, RULE_literal = 135, 
-		RULE_numberLiteral = 136, RULE_type = 137, RULE_typeHint = 138, RULE_visibility = 139, 
-		RULE_keyword = 140, RULE_markerKeyword = 141, RULE_statementKeyword = 142, 
-		RULE_endOfLine = 143, RULE_endOfStatement = 144, RULE_commentOrAnnotation = 145, 
-		RULE_remComment = 146, RULE_comment = 147, RULE_commentBody = 148, RULE_annotationList = 149, 
-		RULE_annotation = 150, RULE_annotationName = 151, RULE_annotationArgList = 152, 
-		RULE_annotationArg = 153, RULE_whiteSpace = 154;
+		RULE_attributeValue = 13, RULE_block = 14, RULE_blockStmt = 15, RULE_fileStmt = 16, 
+		RULE_openStmt = 17, RULE_pathName = 18, RULE_modeClause = 19, RULE_fileMode = 20, 
+		RULE_accessClause = 21, RULE_access = 22, RULE_lock = 23, RULE_lenClause = 24, 
+		RULE_recLength = 25, RULE_fileNumber = 26, RULE_markedFileNumber = 27, 
+		RULE_unmarkedFileNumber = 28, RULE_closeStmt = 29, RULE_resetStmt = 30, 
+		RULE_fileNumberList = 31, RULE_seekStmt = 32, RULE_position = 33, RULE_lockStmt = 34, 
+		RULE_recordRange = 35, RULE_startRecordNumber = 36, RULE_endRecordNumber = 37, 
+		RULE_unlockStmt = 38, RULE_lineInputStmt = 39, RULE_variableName = 40, 
+		RULE_widthStmt = 41, RULE_lineWidth = 42, RULE_printStmt = 43, RULE_outputList = 44, 
+		RULE_outputItem = 45, RULE_outputClause = 46, RULE_charPosition = 47, 
+		RULE_outputExpression = 48, RULE_spcClause = 49, RULE_spcNumber = 50, 
+		RULE_tabClause = 51, RULE_tabNumberClause = 52, RULE_tabNumber = 53, RULE_writeStmt = 54, 
+		RULE_inputStmt = 55, RULE_inputList = 56, RULE_inputVariable = 57, RULE_putStmt = 58, 
+		RULE_recordNumber = 59, RULE_data = 60, RULE_getStmt = 61, RULE_variable = 62, 
+		RULE_constStmt = 63, RULE_constSubStmt = 64, RULE_declareStmt = 65, RULE_defDirective = 66, 
+		RULE_defType = 67, RULE_letterSpec = 68, RULE_singleLetter = 69, RULE_universalLetterRange = 70, 
+		RULE_upperCaseA = 71, RULE_upperCaseZ = 72, RULE_letterRange = 73, RULE_firstLetter = 74, 
+		RULE_lastLetter = 75, RULE_doLoopStmt = 76, RULE_enumerationStmt = 77, 
+		RULE_enumerationStmt_Constant = 78, RULE_endStmt = 79, RULE_eraseStmt = 80, 
+		RULE_errorStmt = 81, RULE_eventStmt = 82, RULE_exitStmt = 83, RULE_forEachStmt = 84, 
+		RULE_forNextStmt = 85, RULE_functionStmt = 86, RULE_functionName = 87, 
+		RULE_goSubStmt = 88, RULE_goToStmt = 89, RULE_ifStmt = 90, RULE_elseIfBlock = 91, 
+		RULE_elseBlock = 92, RULE_singleLineIfStmt = 93, RULE_ifWithNonEmptyThen = 94, 
+		RULE_ifWithEmptyThen = 95, RULE_singleLineElseClause = 96, RULE_listOrLabel = 97, 
+		RULE_sameLineStatement = 98, RULE_booleanExpression = 99, RULE_implementsStmt = 100, 
+		RULE_letStmt = 101, RULE_lsetStmt = 102, RULE_midStmt = 103, RULE_onErrorStmt = 104, 
+		RULE_onGoToStmt = 105, RULE_onGoSubStmt = 106, RULE_propertyGetStmt = 107, 
+		RULE_propertySetStmt = 108, RULE_propertyLetStmt = 109, RULE_raiseEventStmt = 110, 
+		RULE_redimStmt = 111, RULE_redimSubStmt = 112, RULE_resumeStmt = 113, 
+		RULE_returnStmt = 114, RULE_rsetStmt = 115, RULE_stopStmt = 116, RULE_selectCaseStmt = 117, 
+		RULE_sC_Selection = 118, RULE_sC_Case = 119, RULE_sC_Cond = 120, RULE_setStmt = 121, 
+		RULE_subStmt = 122, RULE_subroutineName = 123, RULE_typeStmt = 124, RULE_typeStmt_Element = 125, 
+		RULE_valueStmt = 126, RULE_typeOfIsExpression = 127, RULE_variableStmt = 128, 
+		RULE_variableListStmt = 129, RULE_variableSubStmt = 130, RULE_whileWendStmt = 131, 
+		RULE_withStmt = 132, RULE_withStmtExpression = 133, RULE_explicitCallStmt = 134, 
+		RULE_explicitCallStmtExpression = 135, RULE_implicitCallStmt_InBlock = 136, 
+		RULE_iCS_B_MemberProcedureCall = 137, RULE_iCS_B_ProcedureCall = 138, 
+		RULE_implicitCallStmt_InStmt = 139, RULE_iCS_S_VariableOrProcedureCall = 140, 
+		RULE_iCS_S_ProcedureOrArrayCall = 141, RULE_iCS_S_VariableOrProcedureCallUnrestricted = 142, 
+		RULE_iCS_S_ProcedureOrArrayCallUnrestricted = 143, RULE_iCS_S_MembersCall = 144, 
+		RULE_iCS_S_MemberCall = 145, RULE_iCS_S_DictionaryCall = 146, RULE_argsCall = 147, 
+		RULE_argCall = 148, RULE_dictionaryCallStmt = 149, RULE_argList = 150, 
+		RULE_arg = 151, RULE_argDefaultValue = 152, RULE_subscripts = 153, RULE_subscript = 154, 
+		RULE_unrestrictedIdentifier = 155, RULE_identifier = 156, RULE_asTypeClause = 157, 
+		RULE_baseType = 158, RULE_comparisonOperator = 159, RULE_complexType = 160, 
+		RULE_fieldLength = 161, RULE_statementLabelDefinition = 162, RULE_statementLabel = 163, 
+		RULE_identifierStatementLabel = 164, RULE_lineNumberLabel = 165, RULE_literal = 166, 
+		RULE_numberLiteral = 167, RULE_type = 168, RULE_typeHint = 169, RULE_visibility = 170, 
+		RULE_keyword = 171, RULE_markerKeyword = 172, RULE_statementKeyword = 173, 
+		RULE_endOfLine = 174, RULE_endOfStatement = 175, RULE_commentOrAnnotation = 176, 
+		RULE_remComment = 177, RULE_comment = 178, RULE_commentBody = 179, RULE_annotationList = 180, 
+		RULE_annotation = 181, RULE_annotationName = 182, RULE_annotationArgList = 183, 
+		RULE_annotationArg = 184, RULE_whiteSpace = 185;
 	public static readonly string[] ruleNames = {
 		"startRule", "module", "moduleHeader", "moduleConfig", "moduleConfigElement", 
 		"moduleAttributes", "moduleDeclarations", "moduleOption", "moduleDeclarationsElement", 
 		"moduleBody", "moduleBodyElement", "attributeStmt", "attributeName", "attributeValue", 
-		"block", "blockStmt", "closeStmt", "constStmt", "constSubStmt", "declareStmt", 
-		"defDirective", "defType", "letterSpec", "singleLetter", "universalLetterRange", 
-		"upperCaseA", "upperCaseZ", "letterRange", "firstLetter", "lastLetter", 
-		"doLoopStmt", "enumerationStmt", "enumerationStmt_Constant", "endStmt", 
-		"eraseStmt", "errorStmt", "eventStmt", "exitStmt", "forEachStmt", "forNextStmt", 
-		"functionStmt", "functionName", "getStmt", "goSubStmt", "goToStmt", "ifStmt", 
-		"elseIfBlock", "elseBlock", "singleLineIfStmt", "ifWithNonEmptyThen", 
-		"ifWithEmptyThen", "singleLineElseClause", "listOrLabel", "sameLineStatement", 
-		"booleanExpression", "implementsStmt", "inputStmt", "letStmt", "lineInputStmt", 
-		"lockStmt", "lsetStmt", "midStmt", "onErrorStmt", "onGoToStmt", "onGoSubStmt", 
-		"openStmt", "outputList", "outputList_Expression", "printStmt", "propertyGetStmt", 
-		"propertySetStmt", "propertyLetStmt", "putStmt", "raiseEventStmt", "redimStmt", 
-		"redimSubStmt", "resetStmt", "resumeStmt", "returnStmt", "rsetStmt", "stopStmt", 
-		"seekStmt", "selectCaseStmt", "sC_Selection", "sC_Case", "sC_Cond", "setStmt", 
-		"subStmt", "subroutineName", "typeStmt", "typeStmt_Element", "unlockStmt", 
-		"valueStmt", "typeOfIsExpression", "variableStmt", "variableListStmt", 
-		"variableSubStmt", "whileWendStmt", "widthStmt", "withStmt", "withStmtExpression", 
-		"writeStmt", "fileNumber", "explicitCallStmt", "explicitCallStmtExpression", 
-		"implicitCallStmt_InBlock", "iCS_B_MemberProcedureCall", "iCS_B_ProcedureCall", 
-		"implicitCallStmt_InStmt", "iCS_S_VariableOrProcedureCall", "iCS_S_ProcedureOrArrayCall", 
-		"iCS_S_VariableOrProcedureCallUnrestricted", "iCS_S_ProcedureOrArrayCallUnrestricted", 
-		"iCS_S_MembersCall", "iCS_S_MemberCall", "iCS_S_DictionaryCall", "argsCall", 
-		"argCall", "dictionaryCallStmt", "argList", "arg", "argDefaultValue", 
-		"subscripts", "subscript", "unrestrictedIdentifier", "identifier", "asTypeClause", 
-		"baseType", "comparisonOperator", "complexType", "fieldLength", "statementLabelDefinition", 
-		"statementLabel", "identifierStatementLabel", "lineNumberLabel", "literal", 
-		"numberLiteral", "type", "typeHint", "visibility", "keyword", "markerKeyword", 
-		"statementKeyword", "endOfLine", "endOfStatement", "commentOrAnnotation", 
-		"remComment", "comment", "commentBody", "annotationList", "annotation", 
-		"annotationName", "annotationArgList", "annotationArg", "whiteSpace"
+		"block", "blockStmt", "fileStmt", "openStmt", "pathName", "modeClause", 
+		"fileMode", "accessClause", "access", "lock", "lenClause", "recLength", 
+		"fileNumber", "markedFileNumber", "unmarkedFileNumber", "closeStmt", "resetStmt", 
+		"fileNumberList", "seekStmt", "position", "lockStmt", "recordRange", "startRecordNumber", 
+		"endRecordNumber", "unlockStmt", "lineInputStmt", "variableName", "widthStmt", 
+		"lineWidth", "printStmt", "outputList", "outputItem", "outputClause", 
+		"charPosition", "outputExpression", "spcClause", "spcNumber", "tabClause", 
+		"tabNumberClause", "tabNumber", "writeStmt", "inputStmt", "inputList", 
+		"inputVariable", "putStmt", "recordNumber", "data", "getStmt", "variable", 
+		"constStmt", "constSubStmt", "declareStmt", "defDirective", "defType", 
+		"letterSpec", "singleLetter", "universalLetterRange", "upperCaseA", "upperCaseZ", 
+		"letterRange", "firstLetter", "lastLetter", "doLoopStmt", "enumerationStmt", 
+		"enumerationStmt_Constant", "endStmt", "eraseStmt", "errorStmt", "eventStmt", 
+		"exitStmt", "forEachStmt", "forNextStmt", "functionStmt", "functionName", 
+		"goSubStmt", "goToStmt", "ifStmt", "elseIfBlock", "elseBlock", "singleLineIfStmt", 
+		"ifWithNonEmptyThen", "ifWithEmptyThen", "singleLineElseClause", "listOrLabel", 
+		"sameLineStatement", "booleanExpression", "implementsStmt", "letStmt", 
+		"lsetStmt", "midStmt", "onErrorStmt", "onGoToStmt", "onGoSubStmt", "propertyGetStmt", 
+		"propertySetStmt", "propertyLetStmt", "raiseEventStmt", "redimStmt", "redimSubStmt", 
+		"resumeStmt", "returnStmt", "rsetStmt", "stopStmt", "selectCaseStmt", 
+		"sC_Selection", "sC_Case", "sC_Cond", "setStmt", "subStmt", "subroutineName", 
+		"typeStmt", "typeStmt_Element", "valueStmt", "typeOfIsExpression", "variableStmt", 
+		"variableListStmt", "variableSubStmt", "whileWendStmt", "withStmt", "withStmtExpression", 
+		"explicitCallStmt", "explicitCallStmtExpression", "implicitCallStmt_InBlock", 
+		"iCS_B_MemberProcedureCall", "iCS_B_ProcedureCall", "implicitCallStmt_InStmt", 
+		"iCS_S_VariableOrProcedureCall", "iCS_S_ProcedureOrArrayCall", "iCS_S_VariableOrProcedureCallUnrestricted", 
+		"iCS_S_ProcedureOrArrayCallUnrestricted", "iCS_S_MembersCall", "iCS_S_MemberCall", 
+		"iCS_S_DictionaryCall", "argsCall", "argCall", "dictionaryCallStmt", "argList", 
+		"arg", "argDefaultValue", "subscripts", "subscript", "unrestrictedIdentifier", 
+		"identifier", "asTypeClause", "baseType", "comparisonOperator", "complexType", 
+		"fieldLength", "statementLabelDefinition", "statementLabel", "identifierStatementLabel", 
+		"lineNumberLabel", "literal", "numberLiteral", "type", "typeHint", "visibility", 
+		"keyword", "markerKeyword", "statementKeyword", "endOfLine", "endOfStatement", 
+		"commentOrAnnotation", "remComment", "comment", "commentBody", "annotationList", 
+		"annotation", "annotationName", "annotationArgList", "annotationArg", 
+		"whiteSpace"
 	};
 
 	public override string GrammarFileName { get { return "VBAParser.g4"; } }
@@ -231,7 +246,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 310; module();
+			State = 372; module();
 			}
 		}
 		catch (RecognitionException re) {
@@ -297,60 +312,60 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 313;
+			State = 375;
 			switch ( Interpreter.AdaptivePredict(_input,0,_ctx) ) {
 			case 1:
 				{
-				State = 312; whiteSpace();
+				State = 374; whiteSpace();
 				}
 				break;
 			}
-			State = 315; endOfStatement();
-			State = 319;
+			State = 377; endOfStatement();
+			State = 381;
 			switch ( Interpreter.AdaptivePredict(_input,1,_ctx) ) {
 			case 1:
 				{
-				State = 316; moduleHeader();
-				State = 317; endOfStatement();
+				State = 378; moduleHeader();
+				State = 379; endOfStatement();
 				}
 				break;
 			}
-			State = 322;
+			State = 384;
 			switch ( Interpreter.AdaptivePredict(_input,2,_ctx) ) {
 			case 1:
 				{
-				State = 321; moduleConfig();
+				State = 383; moduleConfig();
 				}
 				break;
 			}
-			State = 324; endOfStatement();
-			State = 326;
+			State = 386; endOfStatement();
+			State = 388;
 			switch ( Interpreter.AdaptivePredict(_input,3,_ctx) ) {
 			case 1:
 				{
-				State = 325; moduleAttributes();
+				State = 387; moduleAttributes();
 				}
 				break;
 			}
-			State = 328; endOfStatement();
-			State = 330;
+			State = 390; endOfStatement();
+			State = 392;
 			switch ( Interpreter.AdaptivePredict(_input,4,_ctx) ) {
 			case 1:
 				{
-				State = 329; moduleDeclarations();
+				State = 391; moduleDeclarations();
 				}
 				break;
 			}
-			State = 332; endOfStatement();
-			State = 334;
+			State = 394; endOfStatement();
+			State = 396;
 			switch ( Interpreter.AdaptivePredict(_input,5,_ctx) ) {
 			case 1:
 				{
-				State = 333; moduleBody();
+				State = 395; moduleBody();
 				}
 				break;
 			}
-			State = 336; endOfStatement();
+			State = 398; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -406,26 +421,26 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 338; Match(VERSION);
-			State = 339; whiteSpace();
-			State = 340; numberLiteral();
-			State = 342;
+			State = 400; Match(VERSION);
+			State = 401; whiteSpace();
+			State = 402; numberLiteral();
+			State = 404;
 			switch ( Interpreter.AdaptivePredict(_input,6,_ctx) ) {
 			case 1:
 				{
-				State = 341; whiteSpace();
+				State = 403; whiteSpace();
 				}
 				break;
 			}
-			State = 345;
+			State = 407;
 			switch ( Interpreter.AdaptivePredict(_input,7,_ctx) ) {
 			case 1:
 				{
-				State = 344; Match(CLASS);
+				State = 406; Match(CLASS);
 				}
 				break;
 			}
-			State = 347; endOfStatement();
+			State = 409; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -489,28 +504,28 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 349; Match(BEGIN);
-			State = 357;
+			State = 411; Match(BEGIN);
+			State = 419;
 			switch ( Interpreter.AdaptivePredict(_input,9,_ctx) ) {
 			case 1:
 				{
-				State = 350; whiteSpace();
-				State = 351; Match(GUIDLITERAL);
-				State = 352; whiteSpace();
-				State = 353; unrestrictedIdentifier();
-				State = 355;
+				State = 412; whiteSpace();
+				State = 413; Match(GUIDLITERAL);
+				State = 414; whiteSpace();
+				State = 415; unrestrictedIdentifier();
+				State = 417;
 				switch ( Interpreter.AdaptivePredict(_input,8,_ctx) ) {
 				case 1:
 					{
-					State = 354; whiteSpace();
+					State = 416; whiteSpace();
 					}
 					break;
 				}
 				}
 				break;
 			}
-			State = 359; endOfStatement();
-			State = 361;
+			State = 421; endOfStatement();
+			State = 423;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -518,18 +533,18 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 360; moduleConfigElement();
+					State = 422; moduleConfigElement();
 					}
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 363;
+				State = 425;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,10,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-			State = 365; Match(END);
+			State = 427; Match(END);
 			}
 		}
 		catch (RecognitionException re) {
@@ -593,47 +608,47 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 367; unrestrictedIdentifier();
-			State = 371;
+			State = 429; unrestrictedIdentifier();
+			State = 433;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==WS || _la==LINE_CONTINUATION) {
 				{
 				{
-				State = 368; whiteSpace();
+				State = 430; whiteSpace();
 				}
 				}
-				State = 373;
+				State = 435;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 374; Match(EQ);
-			State = 378;
+			State = 436; Match(EQ);
+			State = 440;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,12,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 375; whiteSpace();
+					State = 437; whiteSpace();
 					}
 					} 
 				}
-				State = 380;
+				State = 442;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,12,_ctx);
 			}
-			State = 381; valueStmt(0);
-			State = 384;
+			State = 443; valueStmt(0);
+			State = 446;
 			switch ( Interpreter.AdaptivePredict(_input,13,_ctx) ) {
 			case 1:
 				{
-				State = 382; Match(COLON);
-				State = 383; numberLiteral();
+				State = 444; Match(COLON);
+				State = 445; numberLiteral();
 				}
 				break;
 			}
-			State = 386; endOfStatement();
+			State = 448; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -688,7 +703,7 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 391;
+			State = 453;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -696,15 +711,15 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 388; attributeStmt();
-					State = 389; endOfStatement();
+					State = 450; attributeStmt();
+					State = 451; endOfStatement();
 					}
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 393;
+				State = 455;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,14,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
@@ -762,24 +777,24 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 395; moduleDeclarationsElement();
-			State = 401;
+			State = 457; moduleDeclarationsElement();
+			State = 463;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,15,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 396; endOfStatement();
-					State = 397; moduleDeclarationsElement();
+					State = 458; endOfStatement();
+					State = 459; moduleDeclarationsElement();
 					}
 					} 
 				}
-				State = 403;
+				State = 465;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,15,_ctx);
 			}
-			State = 404; endOfStatement();
+			State = 466; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -892,24 +907,24 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 14, RULE_moduleOption);
 		int _la;
 		try {
-			State = 416;
+			State = 478;
 			switch (_input.La(1)) {
 			case OPTION_BASE:
 				_localctx = new OptionBaseStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 406; Match(OPTION_BASE);
-				State = 407; whiteSpace();
-				State = 408; numberLiteral();
+				State = 468; Match(OPTION_BASE);
+				State = 469; whiteSpace();
+				State = 470; numberLiteral();
 				}
 				break;
 			case OPTION_COMPARE:
 				_localctx = new OptionCompareStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 410; Match(OPTION_COMPARE);
-				State = 411; whiteSpace();
-				State = 412;
+				State = 472; Match(OPTION_COMPARE);
+				State = 473; whiteSpace();
+				State = 474;
 				_la = _input.La(1);
 				if ( !(_la==BINARY || _la==DATABASE || _la==TEXT) ) {
 				_errHandler.RecoverInline(this);
@@ -921,14 +936,14 @@ public partial class VBAParser : Parser {
 				_localctx = new OptionExplicitStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 414; Match(OPTION_EXPLICIT);
+				State = 476; Match(OPTION_EXPLICIT);
 				}
 				break;
 			case OPTION_PRIVATE_MODULE:
 				_localctx = new OptionPrivateModuleStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 415; Match(OPTION_PRIVATE_MODULE);
+				State = 477; Match(OPTION_PRIVATE_MODULE);
 				}
 				break;
 			default:
@@ -999,68 +1014,68 @@ public partial class VBAParser : Parser {
 		ModuleDeclarationsElementContext _localctx = new ModuleDeclarationsElementContext(_ctx, State);
 		EnterRule(_localctx, 16, RULE_moduleDeclarationsElement);
 		try {
-			State = 427;
+			State = 489;
 			switch ( Interpreter.AdaptivePredict(_input,17,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 418; declareStmt();
+				State = 480; declareStmt();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 419; defDirective();
+				State = 481; defDirective();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 420; enumerationStmt();
+				State = 482; enumerationStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 421; eventStmt();
+				State = 483; eventStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 422; constStmt();
+				State = 484; constStmt();
 				}
 				break;
 
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 423; implementsStmt();
+				State = 485; implementsStmt();
 				}
 				break;
 
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 424; variableStmt();
+				State = 486; variableStmt();
 				}
 				break;
 
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 425; moduleOption();
+				State = 487; moduleOption();
 				}
 				break;
 
 			case 9:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 426; typeStmt();
+				State = 488; typeStmt();
 				}
 				break;
 			}
@@ -1117,24 +1132,24 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 429; moduleBodyElement();
-			State = 435;
+			State = 491; moduleBodyElement();
+			State = 497;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,18,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 430; endOfStatement();
-					State = 431; moduleBodyElement();
+					State = 492; endOfStatement();
+					State = 493; moduleBodyElement();
 					}
 					} 
 				}
-				State = 437;
+				State = 499;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,18,_ctx);
 			}
-			State = 438; endOfStatement();
+			State = 500; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -1189,40 +1204,40 @@ public partial class VBAParser : Parser {
 		ModuleBodyElementContext _localctx = new ModuleBodyElementContext(_ctx, State);
 		EnterRule(_localctx, 20, RULE_moduleBodyElement);
 		try {
-			State = 445;
+			State = 507;
 			switch ( Interpreter.AdaptivePredict(_input,19,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 440; functionStmt();
+				State = 502; functionStmt();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 441; propertyGetStmt();
+				State = 503; propertyGetStmt();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 442; propertySetStmt();
+				State = 504; propertySetStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 443; propertyLetStmt();
+				State = 505; propertyLetStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 444; subStmt();
+				State = 506; subStmt();
 				}
 				break;
 			}
@@ -1289,56 +1304,56 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 447; Match(ATTRIBUTE);
-			State = 448; whiteSpace();
-			State = 449; attributeName();
-			State = 451;
+			State = 509; Match(ATTRIBUTE);
+			State = 510; whiteSpace();
+			State = 511; attributeName();
+			State = 513;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 450; whiteSpace();
+				State = 512; whiteSpace();
 				}
 			}
 
-			State = 453; Match(EQ);
-			State = 455;
+			State = 515; Match(EQ);
+			State = 517;
 			switch ( Interpreter.AdaptivePredict(_input,21,_ctx) ) {
 			case 1:
 				{
-				State = 454; whiteSpace();
+				State = 516; whiteSpace();
 				}
 				break;
 			}
-			State = 457; attributeValue();
-			State = 468;
+			State = 519; attributeValue();
+			State = 530;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,24,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 459;
+					State = 521;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 458; whiteSpace();
+						State = 520; whiteSpace();
 						}
 					}
 
-					State = 461; Match(COMMA);
-					State = 463;
+					State = 523; Match(COMMA);
+					State = 525;
 					switch ( Interpreter.AdaptivePredict(_input,23,_ctx) ) {
 					case 1:
 						{
-						State = 462; whiteSpace();
+						State = 524; whiteSpace();
 						}
 						break;
 					}
-					State = 465; attributeValue();
+					State = 527; attributeValue();
 					}
 					} 
 				}
-				State = 470;
+				State = 532;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,24,_ctx);
 			}
@@ -1386,7 +1401,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 471; implicitCallStmt_InStmt();
+			State = 533; implicitCallStmt_InStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -1431,7 +1446,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 473; valueStmt(0);
+			State = 535; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -1486,24 +1501,24 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 475; blockStmt();
-			State = 481;
+			State = 537; blockStmt();
+			State = 543;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,25,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 476; endOfStatement();
-					State = 477; blockStmt();
+					State = 538; endOfStatement();
+					State = 539; blockStmt();
 					}
 					} 
 				}
-				State = 483;
+				State = 545;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,25,_ctx);
 			}
-			State = 484; endOfStatement();
+			State = 546; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -1521,9 +1536,6 @@ public partial class VBAParser : Parser {
 		public GoToStmtContext goToStmt() {
 			return GetRuleContext<GoToStmtContext>(0);
 		}
-		public LineInputStmtContext lineInputStmt() {
-			return GetRuleContext<LineInputStmtContext>(0);
-		}
 		public StatementLabelDefinitionContext statementLabelDefinition() {
 			return GetRuleContext<StatementLabelDefinitionContext>(0);
 		}
@@ -1533,17 +1545,8 @@ public partial class VBAParser : Parser {
 		public LetStmtContext letStmt() {
 			return GetRuleContext<LetStmtContext>(0);
 		}
-		public InputStmtContext inputStmt() {
-			return GetRuleContext<InputStmtContext>(0);
-		}
-		public ResetStmtContext resetStmt() {
-			return GetRuleContext<ResetStmtContext>(0);
-		}
 		public ImplementsStmtContext implementsStmt() {
 			return GetRuleContext<ImplementsStmtContext>(0);
-		}
-		public CloseStmtContext closeStmt() {
-			return GetRuleContext<CloseStmtContext>(0);
 		}
 		public GoSubStmtContext goSubStmt() {
 			return GetRuleContext<GoSubStmtContext>(0);
@@ -1557,17 +1560,14 @@ public partial class VBAParser : Parser {
 		public EraseStmtContext eraseStmt() {
 			return GetRuleContext<EraseStmtContext>(0);
 		}
-		public LockStmtContext lockStmt() {
-			return GetRuleContext<LockStmtContext>(0);
-		}
 		public DoLoopStmtContext doLoopStmt() {
 			return GetRuleContext<DoLoopStmtContext>(0);
 		}
 		public SingleLineIfStmtContext singleLineIfStmt() {
 			return GetRuleContext<SingleLineIfStmtContext>(0);
 		}
-		public WriteStmtContext writeStmt() {
-			return GetRuleContext<WriteStmtContext>(0);
+		public FileStmtContext fileStmt() {
+			return GetRuleContext<FileStmtContext>(0);
 		}
 		public ExplicitCallStmtContext explicitCallStmt() {
 			return GetRuleContext<ExplicitCallStmtContext>(0);
@@ -1577,9 +1577,6 @@ public partial class VBAParser : Parser {
 		}
 		public MidStmtContext midStmt() {
 			return GetRuleContext<MidStmtContext>(0);
-		}
-		public GetStmtContext getStmt() {
-			return GetRuleContext<GetStmtContext>(0);
 		}
 		public OnGoToStmtContext onGoToStmt() {
 			return GetRuleContext<OnGoToStmtContext>(0);
@@ -1596,17 +1593,8 @@ public partial class VBAParser : Parser {
 		public RaiseEventStmtContext raiseEventStmt() {
 			return GetRuleContext<RaiseEventStmtContext>(0);
 		}
-		public WidthStmtContext widthStmt() {
-			return GetRuleContext<WidthStmtContext>(0);
-		}
-		public PrintStmtContext printStmt() {
-			return GetRuleContext<PrintStmtContext>(0);
-		}
 		public ExitStmtContext exitStmt() {
 			return GetRuleContext<ExitStmtContext>(0);
-		}
-		public OpenStmtContext openStmt() {
-			return GetRuleContext<OpenStmtContext>(0);
 		}
 		public AttributeStmtContext attributeStmt() {
 			return GetRuleContext<AttributeStmtContext>(0);
@@ -1622,9 +1610,6 @@ public partial class VBAParser : Parser {
 		}
 		public OnGoSubStmtContext onGoSubStmt() {
 			return GetRuleContext<OnGoSubStmtContext>(0);
-		}
-		public SeekStmtContext seekStmt() {
-			return GetRuleContext<SeekStmtContext>(0);
 		}
 		public ErrorStmtContext errorStmt() {
 			return GetRuleContext<ErrorStmtContext>(0);
@@ -1647,14 +1632,8 @@ public partial class VBAParser : Parser {
 		public OnErrorStmtContext onErrorStmt() {
 			return GetRuleContext<OnErrorStmtContext>(0);
 		}
-		public PutStmtContext putStmt() {
-			return GetRuleContext<PutStmtContext>(0);
-		}
 		public WhileWendStmtContext whileWendStmt() {
 			return GetRuleContext<WhileWendStmtContext>(0);
-		}
-		public UnlockStmtContext unlockStmt() {
-			return GetRuleContext<UnlockStmtContext>(0);
 		}
 		public StopStmtContext stopStmt() {
 			return GetRuleContext<StopStmtContext>(0);
@@ -1684,334 +1663,250 @@ public partial class VBAParser : Parser {
 		BlockStmtContext _localctx = new BlockStmtContext(_ctx, State);
 		EnterRule(_localctx, 30, RULE_blockStmt);
 		try {
-			State = 533;
+			State = 583;
 			switch ( Interpreter.AdaptivePredict(_input,26,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 486; statementLabelDefinition();
+				State = 548; statementLabelDefinition();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 487; attributeStmt();
+				State = 549; fileStmt();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 488; closeStmt();
+				State = 550; attributeStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 489; constStmt();
+				State = 551; constStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 490; doLoopStmt();
+				State = 552; doLoopStmt();
 				}
 				break;
 
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 491; endStmt();
+				State = 553; endStmt();
 				}
 				break;
 
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 492; eraseStmt();
+				State = 554; eraseStmt();
 				}
 				break;
 
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 493; errorStmt();
+				State = 555; errorStmt();
 				}
 				break;
 
 			case 9:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 494; exitStmt();
+				State = 556; exitStmt();
 				}
 				break;
 
 			case 10:
 				EnterOuterAlt(_localctx, 10);
 				{
-				State = 495; explicitCallStmt();
+				State = 557; explicitCallStmt();
 				}
 				break;
 
 			case 11:
 				EnterOuterAlt(_localctx, 11);
 				{
-				State = 496; forEachStmt();
+				State = 558; forEachStmt();
 				}
 				break;
 
 			case 12:
 				EnterOuterAlt(_localctx, 12);
 				{
-				State = 497; forNextStmt();
+				State = 559; forNextStmt();
 				}
 				break;
 
 			case 13:
 				EnterOuterAlt(_localctx, 13);
 				{
-				State = 498; getStmt();
+				State = 560; goSubStmt();
 				}
 				break;
 
 			case 14:
 				EnterOuterAlt(_localctx, 14);
 				{
-				State = 499; goSubStmt();
+				State = 561; goToStmt();
 				}
 				break;
 
 			case 15:
 				EnterOuterAlt(_localctx, 15);
 				{
-				State = 500; goToStmt();
+				State = 562; ifStmt();
 				}
 				break;
 
 			case 16:
 				EnterOuterAlt(_localctx, 16);
 				{
-				State = 501; ifStmt();
+				State = 563; singleLineIfStmt();
 				}
 				break;
 
 			case 17:
 				EnterOuterAlt(_localctx, 17);
 				{
-				State = 502; singleLineIfStmt();
+				State = 564; implementsStmt();
 				}
 				break;
 
 			case 18:
 				EnterOuterAlt(_localctx, 18);
 				{
-				State = 503; implementsStmt();
+				State = 565; letStmt();
 				}
 				break;
 
 			case 19:
 				EnterOuterAlt(_localctx, 19);
 				{
-				State = 504; inputStmt();
+				State = 566; lsetStmt();
 				}
 				break;
 
 			case 20:
 				EnterOuterAlt(_localctx, 20);
 				{
-				State = 505; letStmt();
+				State = 567; midStmt();
 				}
 				break;
 
 			case 21:
 				EnterOuterAlt(_localctx, 21);
 				{
-				State = 506; lineInputStmt();
+				State = 568; onErrorStmt();
 				}
 				break;
 
 			case 22:
 				EnterOuterAlt(_localctx, 22);
 				{
-				State = 507; lockStmt();
+				State = 569; onGoToStmt();
 				}
 				break;
 
 			case 23:
 				EnterOuterAlt(_localctx, 23);
 				{
-				State = 508; lsetStmt();
+				State = 570; onGoSubStmt();
 				}
 				break;
 
 			case 24:
 				EnterOuterAlt(_localctx, 24);
 				{
-				State = 509; midStmt();
+				State = 571; raiseEventStmt();
 				}
 				break;
 
 			case 25:
 				EnterOuterAlt(_localctx, 25);
 				{
-				State = 510; onErrorStmt();
+				State = 572; redimStmt();
 				}
 				break;
 
 			case 26:
 				EnterOuterAlt(_localctx, 26);
 				{
-				State = 511; onGoToStmt();
+				State = 573; resumeStmt();
 				}
 				break;
 
 			case 27:
 				EnterOuterAlt(_localctx, 27);
 				{
-				State = 512; onGoSubStmt();
+				State = 574; returnStmt();
 				}
 				break;
 
 			case 28:
 				EnterOuterAlt(_localctx, 28);
 				{
-				State = 513; openStmt();
+				State = 575; rsetStmt();
 				}
 				break;
 
 			case 29:
 				EnterOuterAlt(_localctx, 29);
 				{
-				State = 514; printStmt();
+				State = 576; selectCaseStmt();
 				}
 				break;
 
 			case 30:
 				EnterOuterAlt(_localctx, 30);
 				{
-				State = 515; putStmt();
+				State = 577; setStmt();
 				}
 				break;
 
 			case 31:
 				EnterOuterAlt(_localctx, 31);
 				{
-				State = 516; raiseEventStmt();
+				State = 578; stopStmt();
 				}
 				break;
 
 			case 32:
 				EnterOuterAlt(_localctx, 32);
 				{
-				State = 517; redimStmt();
+				State = 579; variableStmt();
 				}
 				break;
 
 			case 33:
 				EnterOuterAlt(_localctx, 33);
 				{
-				State = 518; resetStmt();
+				State = 580; whileWendStmt();
 				}
 				break;
 
 			case 34:
 				EnterOuterAlt(_localctx, 34);
 				{
-				State = 519; resumeStmt();
+				State = 581; withStmt();
 				}
 				break;
 
 			case 35:
 				EnterOuterAlt(_localctx, 35);
 				{
-				State = 520; returnStmt();
-				}
-				break;
-
-			case 36:
-				EnterOuterAlt(_localctx, 36);
-				{
-				State = 521; rsetStmt();
-				}
-				break;
-
-			case 37:
-				EnterOuterAlt(_localctx, 37);
-				{
-				State = 522; seekStmt();
-				}
-				break;
-
-			case 38:
-				EnterOuterAlt(_localctx, 38);
-				{
-				State = 523; selectCaseStmt();
-				}
-				break;
-
-			case 39:
-				EnterOuterAlt(_localctx, 39);
-				{
-				State = 524; setStmt();
-				}
-				break;
-
-			case 40:
-				EnterOuterAlt(_localctx, 40);
-				{
-				State = 525; stopStmt();
-				}
-				break;
-
-			case 41:
-				EnterOuterAlt(_localctx, 41);
-				{
-				State = 526; unlockStmt();
-				}
-				break;
-
-			case 42:
-				EnterOuterAlt(_localctx, 42);
-				{
-				State = 527; variableStmt();
-				}
-				break;
-
-			case 43:
-				EnterOuterAlt(_localctx, 43);
-				{
-				State = 528; whileWendStmt();
-				}
-				break;
-
-			case 44:
-				EnterOuterAlt(_localctx, 44);
-				{
-				State = 529; widthStmt();
-				}
-				break;
-
-			case 45:
-				EnterOuterAlt(_localctx, 45);
-				{
-				State = 530; withStmt();
-				}
-				break;
-
-			case 46:
-				EnterOuterAlt(_localctx, 46);
-				{
-				State = 531; writeStmt();
-				}
-				break;
-
-			case 47:
-				EnterOuterAlt(_localctx, 47);
-				{
-				State = 532; implicitCallStmt_InBlock();
+				State = 582; implicitCallStmt_InBlock();
 				}
 				break;
 			}
@@ -2027,23 +1922,855 @@ public partial class VBAParser : Parser {
 		return _localctx;
 	}
 
-	public partial class CloseStmtContext : ParserRuleContext {
+	public partial class FileStmtContext : ParserRuleContext {
+		public LineInputStmtContext lineInputStmt() {
+			return GetRuleContext<LineInputStmtContext>(0);
+		}
+		public GetStmtContext getStmt() {
+			return GetRuleContext<GetStmtContext>(0);
+		}
+		public ResetStmtContext resetStmt() {
+			return GetRuleContext<ResetStmtContext>(0);
+		}
+		public WidthStmtContext widthStmt() {
+			return GetRuleContext<WidthStmtContext>(0);
+		}
+		public InputStmtContext inputStmt() {
+			return GetRuleContext<InputStmtContext>(0);
+		}
+		public PrintStmtContext printStmt() {
+			return GetRuleContext<PrintStmtContext>(0);
+		}
+		public OpenStmtContext openStmt() {
+			return GetRuleContext<OpenStmtContext>(0);
+		}
+		public CloseStmtContext closeStmt() {
+			return GetRuleContext<CloseStmtContext>(0);
+		}
+		public LockStmtContext lockStmt() {
+			return GetRuleContext<LockStmtContext>(0);
+		}
+		public SeekStmtContext seekStmt() {
+			return GetRuleContext<SeekStmtContext>(0);
+		}
+		public WriteStmtContext writeStmt() {
+			return GetRuleContext<WriteStmtContext>(0);
+		}
+		public PutStmtContext putStmt() {
+			return GetRuleContext<PutStmtContext>(0);
+		}
+		public UnlockStmtContext unlockStmt() {
+			return GetRuleContext<UnlockStmtContext>(0);
+		}
+		public FileStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_fileStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterFileStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitFileStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitFileStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public FileStmtContext fileStmt() {
+		FileStmtContext _localctx = new FileStmtContext(_ctx, State);
+		EnterRule(_localctx, 32, RULE_fileStmt);
+		try {
+			State = 598;
+			switch (_input.La(1)) {
+			case OPEN:
+				EnterOuterAlt(_localctx, 1);
+				{
+				State = 585; openStmt();
+				}
+				break;
+			case RESET:
+				EnterOuterAlt(_localctx, 2);
+				{
+				State = 586; resetStmt();
+				}
+				break;
+			case CLOSE:
+				EnterOuterAlt(_localctx, 3);
+				{
+				State = 587; closeStmt();
+				}
+				break;
+			case SEEK:
+				EnterOuterAlt(_localctx, 4);
+				{
+				State = 588; seekStmt();
+				}
+				break;
+			case LOCK:
+				EnterOuterAlt(_localctx, 5);
+				{
+				State = 589; lockStmt();
+				}
+				break;
+			case UNLOCK:
+				EnterOuterAlt(_localctx, 6);
+				{
+				State = 590; unlockStmt();
+				}
+				break;
+			case LINE_INPUT:
+				EnterOuterAlt(_localctx, 7);
+				{
+				State = 591; lineInputStmt();
+				}
+				break;
+			case WIDTH:
+				EnterOuterAlt(_localctx, 8);
+				{
+				State = 592; widthStmt();
+				}
+				break;
+			case PRINT:
+				EnterOuterAlt(_localctx, 9);
+				{
+				State = 593; printStmt();
+				}
+				break;
+			case WRITE:
+				EnterOuterAlt(_localctx, 10);
+				{
+				State = 594; writeStmt();
+				}
+				break;
+			case INPUT:
+				EnterOuterAlt(_localctx, 11);
+				{
+				State = 595; inputStmt();
+				}
+				break;
+			case PUT:
+				EnterOuterAlt(_localctx, 12);
+				{
+				State = 596; putStmt();
+				}
+				break;
+			case GET:
+				EnterOuterAlt(_localctx, 13);
+				{
+				State = 597; getStmt();
+				}
+				break;
+			default:
+				throw new NoViableAltException(this);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class OpenStmtContext : ParserRuleContext {
+		public ModeClauseContext modeClause() {
+			return GetRuleContext<ModeClauseContext>(0);
+		}
+		public ITerminalNode OPEN() { return GetToken(VBAParser.OPEN, 0); }
 		public WhiteSpaceContext whiteSpace(int i) {
 			return GetRuleContext<WhiteSpaceContext>(i);
 		}
-		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
-		public ITerminalNode CLOSE() { return GetToken(VBAParser.CLOSE, 0); }
+		public AccessClauseContext accessClause() {
+			return GetRuleContext<AccessClauseContext>(0);
+		}
+		public LockContext @lock() {
+			return GetRuleContext<LockContext>(0);
+		}
 		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
 			return GetRuleContexts<WhiteSpaceContext>();
 		}
-		public IReadOnlyList<FileNumberContext> fileNumber() {
-			return GetRuleContexts<FileNumberContext>();
+		public LenClauseContext lenClause() {
+			return GetRuleContext<LenClauseContext>(0);
 		}
-		public FileNumberContext fileNumber(int i) {
-			return GetRuleContext<FileNumberContext>(i);
+		public FileNumberContext fileNumber() {
+			return GetRuleContext<FileNumberContext>(0);
 		}
-		public ITerminalNode COMMA(int i) {
-			return GetToken(VBAParser.COMMA, i);
+		public PathNameContext pathName() {
+			return GetRuleContext<PathNameContext>(0);
+		}
+		public ITerminalNode AS() { return GetToken(VBAParser.AS, 0); }
+		public OpenStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_openStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterOpenStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitOpenStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitOpenStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public OpenStmtContext openStmt() {
+		OpenStmtContext _localctx = new OpenStmtContext(_ctx, State);
+		EnterRule(_localctx, 34, RULE_openStmt);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 600; Match(OPEN);
+			State = 601; whiteSpace();
+			State = 602; pathName();
+			State = 606;
+			switch ( Interpreter.AdaptivePredict(_input,28,_ctx) ) {
+			case 1:
+				{
+				State = 603; whiteSpace();
+				State = 604; modeClause();
+				}
+				break;
+			}
+			State = 611;
+			switch ( Interpreter.AdaptivePredict(_input,29,_ctx) ) {
+			case 1:
+				{
+				State = 608; whiteSpace();
+				State = 609; accessClause();
+				}
+				break;
+			}
+			State = 616;
+			switch ( Interpreter.AdaptivePredict(_input,30,_ctx) ) {
+			case 1:
+				{
+				State = 613; whiteSpace();
+				State = 614; @lock();
+				}
+				break;
+			}
+			State = 618; whiteSpace();
+			State = 619; Match(AS);
+			State = 620; whiteSpace();
+			State = 621; fileNumber();
+			State = 625;
+			switch ( Interpreter.AdaptivePredict(_input,31,_ctx) ) {
+			case 1:
+				{
+				State = 622; whiteSpace();
+				State = 623; lenClause();
+				}
+				break;
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class PathNameContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public PathNameContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_pathName; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterPathName(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitPathName(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitPathName(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public PathNameContext pathName() {
+		PathNameContext _localctx = new PathNameContext(_ctx, State);
+		EnterRule(_localctx, 36, RULE_pathName);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 627; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class ModeClauseContext : ParserRuleContext {
+		public FileModeContext fileMode() {
+			return GetRuleContext<FileModeContext>(0);
+		}
+		public ITerminalNode FOR() { return GetToken(VBAParser.FOR, 0); }
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public ModeClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_modeClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterModeClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitModeClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitModeClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public ModeClauseContext modeClause() {
+		ModeClauseContext _localctx = new ModeClauseContext(_ctx, State);
+		EnterRule(_localctx, 38, RULE_modeClause);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 629; Match(FOR);
+			State = 630; whiteSpace();
+			State = 631; fileMode();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class FileModeContext : ParserRuleContext {
+		public ITerminalNode RANDOM() { return GetToken(VBAParser.RANDOM, 0); }
+		public ITerminalNode OUTPUT() { return GetToken(VBAParser.OUTPUT, 0); }
+		public ITerminalNode INPUT() { return GetToken(VBAParser.INPUT, 0); }
+		public ITerminalNode APPEND() { return GetToken(VBAParser.APPEND, 0); }
+		public ITerminalNode BINARY() { return GetToken(VBAParser.BINARY, 0); }
+		public FileModeContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_fileMode; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterFileMode(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitFileMode(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitFileMode(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public FileModeContext fileMode() {
+		FileModeContext _localctx = new FileModeContext(_ctx, State);
+		EnterRule(_localctx, 40, RULE_fileMode);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 633;
+			_la = _input.La(1);
+			if ( !(_la==APPEND || _la==BINARY || ((((_la - 121)) & ~0x3f) == 0 && ((1L << (_la - 121)) & ((1L << (INPUT - 121)) | (1L << (OUTPUT - 121)) | (1L << (RANDOM - 121)))) != 0)) ) {
+			_errHandler.RecoverInline(this);
+			}
+			Consume();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class AccessClauseContext : ParserRuleContext {
+		public ITerminalNode ACCESS() { return GetToken(VBAParser.ACCESS, 0); }
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public AccessContext access() {
+			return GetRuleContext<AccessContext>(0);
+		}
+		public AccessClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_accessClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterAccessClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitAccessClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitAccessClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public AccessClauseContext accessClause() {
+		AccessClauseContext _localctx = new AccessClauseContext(_ctx, State);
+		EnterRule(_localctx, 42, RULE_accessClause);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 635; Match(ACCESS);
+			State = 636; whiteSpace();
+			State = 637; access();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class AccessContext : ParserRuleContext {
+		public ITerminalNode WRITE() { return GetToken(VBAParser.WRITE, 0); }
+		public ITerminalNode READ() { return GetToken(VBAParser.READ, 0); }
+		public ITerminalNode READ_WRITE() { return GetToken(VBAParser.READ_WRITE, 0); }
+		public AccessContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_access; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterAccess(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitAccess(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitAccess(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public AccessContext access() {
+		AccessContext _localctx = new AccessContext(_ctx, State);
+		EnterRule(_localctx, 44, RULE_access);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 639;
+			_la = _input.La(1);
+			if ( !(((((_la - 166)) & ~0x3f) == 0 && ((1L << (_la - 166)) & ((1L << (READ - 166)) | (1L << (READ_WRITE - 166)) | (1L << (WRITE - 166)))) != 0)) ) {
+			_errHandler.RecoverInline(this);
+			}
+			Consume();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class LockContext : ParserRuleContext {
+		public ITerminalNode LOCK_WRITE() { return GetToken(VBAParser.LOCK_WRITE, 0); }
+		public ITerminalNode LOCK_READ() { return GetToken(VBAParser.LOCK_READ, 0); }
+		public ITerminalNode LOCK_READ_WRITE() { return GetToken(VBAParser.LOCK_READ_WRITE, 0); }
+		public ITerminalNode SHARED() { return GetToken(VBAParser.SHARED, 0); }
+		public LockContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_lock; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterLock(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitLock(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitLock(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public LockContext @lock() {
+		LockContext _localctx = new LockContext(_ctx, State);
+		EnterRule(_localctx, 46, RULE_lock);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 641;
+			_la = _input.La(1);
+			if ( !(((((_la - 131)) & ~0x3f) == 0 && ((1L << (_la - 131)) & ((1L << (LOCK_READ - 131)) | (1L << (LOCK_WRITE - 131)) | (1L << (LOCK_READ_WRITE - 131)) | (1L << (SHARED - 131)))) != 0)) ) {
+			_errHandler.RecoverInline(this);
+			}
+			Consume();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class LenClauseContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode LEN() { return GetToken(VBAParser.LEN, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode EQ() { return GetToken(VBAParser.EQ, 0); }
+		public RecLengthContext recLength() {
+			return GetRuleContext<RecLengthContext>(0);
+		}
+		public LenClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_lenClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterLenClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitLenClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitLenClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public LenClauseContext lenClause() {
+		LenClauseContext _localctx = new LenClauseContext(_ctx, State);
+		EnterRule(_localctx, 48, RULE_lenClause);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 643; Match(LEN);
+			State = 645;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 644; whiteSpace();
+				}
+			}
+
+			State = 647; Match(EQ);
+			State = 649;
+			switch ( Interpreter.AdaptivePredict(_input,33,_ctx) ) {
+			case 1:
+				{
+				State = 648; whiteSpace();
+				}
+				break;
+			}
+			State = 651; recLength();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class RecLengthContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public RecLengthContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_recLength; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterRecLength(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitRecLength(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitRecLength(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public RecLengthContext recLength() {
+		RecLengthContext _localctx = new RecLengthContext(_ctx, State);
+		EnterRule(_localctx, 50, RULE_recLength);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 653; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class FileNumberContext : ParserRuleContext {
+		public UnmarkedFileNumberContext unmarkedFileNumber() {
+			return GetRuleContext<UnmarkedFileNumberContext>(0);
+		}
+		public MarkedFileNumberContext markedFileNumber() {
+			return GetRuleContext<MarkedFileNumberContext>(0);
+		}
+		public FileNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_fileNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterFileNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitFileNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitFileNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public FileNumberContext fileNumber() {
+		FileNumberContext _localctx = new FileNumberContext(_ctx, State);
+		EnterRule(_localctx, 52, RULE_fileNumber);
+		try {
+			State = 657;
+			switch ( Interpreter.AdaptivePredict(_input,34,_ctx) ) {
+			case 1:
+				EnterOuterAlt(_localctx, 1);
+				{
+				State = 655; markedFileNumber();
+				}
+				break;
+
+			case 2:
+				EnterOuterAlt(_localctx, 2);
+				{
+				State = 656; unmarkedFileNumber();
+				}
+				break;
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class MarkedFileNumberContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public ITerminalNode HASH() { return GetToken(VBAParser.HASH, 0); }
+		public MarkedFileNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_markedFileNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterMarkedFileNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitMarkedFileNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitMarkedFileNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public MarkedFileNumberContext markedFileNumber() {
+		MarkedFileNumberContext _localctx = new MarkedFileNumberContext(_ctx, State);
+		EnterRule(_localctx, 54, RULE_markedFileNumber);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 659; Match(HASH);
+			State = 660; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class UnmarkedFileNumberContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public UnmarkedFileNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_unmarkedFileNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterUnmarkedFileNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitUnmarkedFileNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitUnmarkedFileNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public UnmarkedFileNumberContext unmarkedFileNumber() {
+		UnmarkedFileNumberContext _localctx = new UnmarkedFileNumberContext(_ctx, State);
+		EnterRule(_localctx, 56, RULE_unmarkedFileNumber);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 662; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class CloseStmtContext : ParserRuleContext {
+		public ITerminalNode CLOSE() { return GetToken(VBAParser.CLOSE, 0); }
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public FileNumberListContext fileNumberList() {
+			return GetRuleContext<FileNumberListContext>(0);
 		}
 		public CloseStmtContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
@@ -2068,54 +2795,2223 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CloseStmtContext closeStmt() {
 		CloseStmtContext _localctx = new CloseStmtContext(_ctx, State);
-		EnterRule(_localctx, 32, RULE_closeStmt);
+		EnterRule(_localctx, 58, RULE_closeStmt);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 664; Match(CLOSE);
+			State = 668;
+			switch ( Interpreter.AdaptivePredict(_input,35,_ctx) ) {
+			case 1:
+				{
+				State = 665; whiteSpace();
+				State = 666; fileNumberList();
+				}
+				break;
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class ResetStmtContext : ParserRuleContext {
+		public ITerminalNode RESET() { return GetToken(VBAParser.RESET, 0); }
+		public ResetStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_resetStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterResetStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitResetStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitResetStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public ResetStmtContext resetStmt() {
+		ResetStmtContext _localctx = new ResetStmtContext(_ctx, State);
+		EnterRule(_localctx, 60, RULE_resetStmt);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 670; Match(RESET);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class FileNumberListContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public IReadOnlyList<FileNumberContext> fileNumber() {
+			return GetRuleContexts<FileNumberContext>();
+		}
+		public FileNumberContext fileNumber(int i) {
+			return GetRuleContext<FileNumberContext>(i);
+		}
+		public ITerminalNode COMMA(int i) {
+			return GetToken(VBAParser.COMMA, i);
+		}
+		public FileNumberListContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_fileNumberList; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterFileNumberList(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitFileNumberList(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitFileNumberList(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public FileNumberListContext fileNumberList() {
+		FileNumberListContext _localctx = new FileNumberListContext(_ctx, State);
+		EnterRule(_localctx, 62, RULE_fileNumberList);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 535; Match(CLOSE);
-			State = 551;
-			switch ( Interpreter.AdaptivePredict(_input,30,_ctx) ) {
+			State = 672; fileNumber();
+			State = 683;
+			_errHandler.Sync(this);
+			_alt = Interpreter.AdaptivePredict(_input,38,_ctx);
+			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
+				if ( _alt==1 ) {
+					{
+					{
+					State = 674;
+					_la = _input.La(1);
+					if (_la==WS || _la==LINE_CONTINUATION) {
+						{
+						State = 673; whiteSpace();
+						}
+					}
+
+					State = 676; Match(COMMA);
+					State = 678;
+					switch ( Interpreter.AdaptivePredict(_input,37,_ctx) ) {
+					case 1:
+						{
+						State = 677; whiteSpace();
+						}
+						break;
+					}
+					State = 680; fileNumber();
+					}
+					} 
+				}
+				State = 685;
+				_errHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(_input,38,_ctx);
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class SeekStmtContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public PositionContext position() {
+			return GetRuleContext<PositionContext>(0);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public FileNumberContext fileNumber() {
+			return GetRuleContext<FileNumberContext>(0);
+		}
+		public ITerminalNode SEEK() { return GetToken(VBAParser.SEEK, 0); }
+		public SeekStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_seekStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterSeekStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitSeekStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitSeekStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public SeekStmtContext seekStmt() {
+		SeekStmtContext _localctx = new SeekStmtContext(_ctx, State);
+		EnterRule(_localctx, 64, RULE_seekStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 686; Match(SEEK);
+			State = 687; whiteSpace();
+			State = 688; fileNumber();
+			State = 690;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 689; whiteSpace();
+				}
+			}
+
+			State = 692; Match(COMMA);
+			State = 694;
+			switch ( Interpreter.AdaptivePredict(_input,40,_ctx) ) {
 			case 1:
 				{
-				State = 536; whiteSpace();
-				State = 537; fileNumber();
-				State = 548;
-				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,29,_ctx);
-				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
-					if ( _alt==1 ) {
-						{
-						{
-						State = 539;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 538; whiteSpace();
-							}
-						}
-
-						State = 541; Match(COMMA);
-						State = 543;
-						switch ( Interpreter.AdaptivePredict(_input,28,_ctx) ) {
-						case 1:
-							{
-							State = 542; whiteSpace();
-							}
-							break;
-						}
-						State = 545; fileNumber();
-						}
-						} 
-					}
-					State = 550;
-					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,29,_ctx);
-				}
+				State = 693; whiteSpace();
 				}
 				break;
 			}
+			State = 696; position();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class PositionContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public PositionContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_position; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterPosition(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitPosition(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitPosition(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public PositionContext position() {
+		PositionContext _localctx = new PositionContext(_ctx, State);
+		EnterRule(_localctx, 66, RULE_position);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 698; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class LockStmtContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public RecordRangeContext recordRange() {
+			return GetRuleContext<RecordRangeContext>(0);
+		}
+		public ITerminalNode LOCK() { return GetToken(VBAParser.LOCK, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public FileNumberContext fileNumber() {
+			return GetRuleContext<FileNumberContext>(0);
+		}
+		public LockStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_lockStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterLockStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitLockStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitLockStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public LockStmtContext lockStmt() {
+		LockStmtContext _localctx = new LockStmtContext(_ctx, State);
+		EnterRule(_localctx, 68, RULE_lockStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 700; Match(LOCK);
+			State = 701; whiteSpace();
+			State = 702; fileNumber();
+			State = 711;
+			switch ( Interpreter.AdaptivePredict(_input,43,_ctx) ) {
+			case 1:
+				{
+				State = 704;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 703; whiteSpace();
+					}
+				}
+
+				State = 706; Match(COMMA);
+				State = 708;
+				switch ( Interpreter.AdaptivePredict(_input,42,_ctx) ) {
+				case 1:
+					{
+					State = 707; whiteSpace();
+					}
+					break;
+				}
+				State = 710; recordRange();
+				}
+				break;
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class RecordRangeContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public StartRecordNumberContext startRecordNumber() {
+			return GetRuleContext<StartRecordNumberContext>(0);
+		}
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode TO() { return GetToken(VBAParser.TO, 0); }
+		public EndRecordNumberContext endRecordNumber() {
+			return GetRuleContext<EndRecordNumberContext>(0);
+		}
+		public RecordRangeContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_recordRange; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterRecordRange(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitRecordRange(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitRecordRange(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public RecordRangeContext recordRange() {
+		RecordRangeContext _localctx = new RecordRangeContext(_ctx, State);
+		EnterRule(_localctx, 70, RULE_recordRange);
+		try {
+			State = 723;
+			switch ( Interpreter.AdaptivePredict(_input,45,_ctx) ) {
+			case 1:
+				EnterOuterAlt(_localctx, 1);
+				{
+				State = 713; startRecordNumber();
+				}
+				break;
+
+			case 2:
+				EnterOuterAlt(_localctx, 2);
+				{
+				State = 717;
+				switch ( Interpreter.AdaptivePredict(_input,44,_ctx) ) {
+				case 1:
+					{
+					State = 714; startRecordNumber();
+					State = 715; whiteSpace();
+					}
+					break;
+				}
+				State = 719; Match(TO);
+				State = 720; whiteSpace();
+				State = 721; endRecordNumber();
+				}
+				break;
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class StartRecordNumberContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public StartRecordNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_startRecordNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterStartRecordNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitStartRecordNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitStartRecordNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public StartRecordNumberContext startRecordNumber() {
+		StartRecordNumberContext _localctx = new StartRecordNumberContext(_ctx, State);
+		EnterRule(_localctx, 72, RULE_startRecordNumber);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 725; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class EndRecordNumberContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public EndRecordNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_endRecordNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterEndRecordNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitEndRecordNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitEndRecordNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public EndRecordNumberContext endRecordNumber() {
+		EndRecordNumberContext _localctx = new EndRecordNumberContext(_ctx, State);
+		EnterRule(_localctx, 74, RULE_endRecordNumber);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 727; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class UnlockStmtContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public RecordRangeContext recordRange() {
+			return GetRuleContext<RecordRangeContext>(0);
+		}
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public FileNumberContext fileNumber() {
+			return GetRuleContext<FileNumberContext>(0);
+		}
+		public ITerminalNode UNLOCK() { return GetToken(VBAParser.UNLOCK, 0); }
+		public UnlockStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_unlockStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterUnlockStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitUnlockStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitUnlockStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public UnlockStmtContext unlockStmt() {
+		UnlockStmtContext _localctx = new UnlockStmtContext(_ctx, State);
+		EnterRule(_localctx, 76, RULE_unlockStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 729; Match(UNLOCK);
+			State = 730; whiteSpace();
+			State = 731; fileNumber();
+			State = 740;
+			switch ( Interpreter.AdaptivePredict(_input,48,_ctx) ) {
+			case 1:
+				{
+				State = 733;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 732; whiteSpace();
+					}
+				}
+
+				State = 735; Match(COMMA);
+				State = 737;
+				switch ( Interpreter.AdaptivePredict(_input,47,_ctx) ) {
+				case 1:
+					{
+					State = 736; whiteSpace();
+					}
+					break;
+				}
+				State = 739; recordRange();
+				}
+				break;
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class LineInputStmtContext : ParserRuleContext {
+		public VariableNameContext variableName() {
+			return GetRuleContext<VariableNameContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode LINE_INPUT() { return GetToken(VBAParser.LINE_INPUT, 0); }
+		public MarkedFileNumberContext markedFileNumber() {
+			return GetRuleContext<MarkedFileNumberContext>(0);
+		}
+		public LineInputStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_lineInputStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterLineInputStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitLineInputStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitLineInputStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public LineInputStmtContext lineInputStmt() {
+		LineInputStmtContext _localctx = new LineInputStmtContext(_ctx, State);
+		EnterRule(_localctx, 78, RULE_lineInputStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 742; Match(LINE_INPUT);
+			State = 743; whiteSpace();
+			State = 744; markedFileNumber();
+			State = 746;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 745; whiteSpace();
+				}
+			}
+
+			State = 748; Match(COMMA);
+			State = 750;
+			switch ( Interpreter.AdaptivePredict(_input,50,_ctx) ) {
+			case 1:
+				{
+				State = 749; whiteSpace();
+				}
+				break;
+			}
+			State = 752; variableName();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class VariableNameContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public VariableNameContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_variableName; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterVariableName(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitVariableName(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitVariableName(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public VariableNameContext variableName() {
+		VariableNameContext _localctx = new VariableNameContext(_ctx, State);
+		EnterRule(_localctx, 80, RULE_variableName);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 754; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class WidthStmtContext : ParserRuleContext {
+		public LineWidthContext lineWidth() {
+			return GetRuleContext<LineWidthContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public ITerminalNode WIDTH() { return GetToken(VBAParser.WIDTH, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public MarkedFileNumberContext markedFileNumber() {
+			return GetRuleContext<MarkedFileNumberContext>(0);
+		}
+		public WidthStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_widthStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterWidthStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitWidthStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitWidthStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public WidthStmtContext widthStmt() {
+		WidthStmtContext _localctx = new WidthStmtContext(_ctx, State);
+		EnterRule(_localctx, 82, RULE_widthStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 756; Match(WIDTH);
+			State = 757; whiteSpace();
+			State = 758; markedFileNumber();
+			State = 760;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 759; whiteSpace();
+				}
+			}
+
+			State = 762; Match(COMMA);
+			State = 764;
+			switch ( Interpreter.AdaptivePredict(_input,52,_ctx) ) {
+			case 1:
+				{
+				State = 763; whiteSpace();
+				}
+				break;
+			}
+			State = 766; lineWidth();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class LineWidthContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public LineWidthContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_lineWidth; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterLineWidth(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitLineWidth(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitLineWidth(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public LineWidthContext lineWidth() {
+		LineWidthContext _localctx = new LineWidthContext(_ctx, State);
+		EnterRule(_localctx, 84, RULE_lineWidth);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 768; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class PrintStmtContext : ParserRuleContext {
+		public ITerminalNode PRINT() { return GetToken(VBAParser.PRINT, 0); }
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public OutputListContext outputList() {
+			return GetRuleContext<OutputListContext>(0);
+		}
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public MarkedFileNumberContext markedFileNumber() {
+			return GetRuleContext<MarkedFileNumberContext>(0);
+		}
+		public PrintStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_printStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterPrintStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitPrintStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitPrintStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public PrintStmtContext printStmt() {
+		PrintStmtContext _localctx = new PrintStmtContext(_ctx, State);
+		EnterRule(_localctx, 86, RULE_printStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 770; Match(PRINT);
+			State = 771; whiteSpace();
+			State = 772; markedFileNumber();
+			State = 774;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 773; whiteSpace();
+				}
+			}
+
+			State = 776; Match(COMMA);
+			State = 781;
+			switch ( Interpreter.AdaptivePredict(_input,55,_ctx) ) {
+			case 1:
+				{
+				State = 778;
+				switch ( Interpreter.AdaptivePredict(_input,54,_ctx) ) {
+				case 1:
+					{
+					State = 777; whiteSpace();
+					}
+					break;
+				}
+				State = 780; outputList();
+				}
+				break;
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class OutputListContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public OutputItemContext outputItem(int i) {
+			return GetRuleContext<OutputItemContext>(i);
+		}
+		public IReadOnlyList<OutputItemContext> outputItem() {
+			return GetRuleContexts<OutputItemContext>();
+		}
+		public OutputListContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_outputList; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterOutputList(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitOutputList(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitOutputList(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public OutputListContext outputList() {
+		OutputListContext _localctx = new OutputListContext(_ctx, State);
+		EnterRule(_localctx, 88, RULE_outputList);
+		try {
+			int _alt;
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 783; outputItem();
+			State = 790;
+			_errHandler.Sync(this);
+			_alt = Interpreter.AdaptivePredict(_input,57,_ctx);
+			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
+				if ( _alt==1 ) {
+					{
+					{
+					State = 785;
+					switch ( Interpreter.AdaptivePredict(_input,56,_ctx) ) {
+					case 1:
+						{
+						State = 784; whiteSpace();
+						}
+						break;
+					}
+					State = 787; outputItem();
+					}
+					} 
+				}
+				State = 792;
+				_errHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(_input,57,_ctx);
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class OutputItemContext : ParserRuleContext {
+		public OutputClauseContext outputClause() {
+			return GetRuleContext<OutputClauseContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public CharPositionContext charPosition() {
+			return GetRuleContext<CharPositionContext>(0);
+		}
+		public OutputItemContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_outputItem; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterOutputItem(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitOutputItem(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitOutputItem(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public OutputItemContext outputItem() {
+		OutputItemContext _localctx = new OutputItemContext(_ctx, State);
+		EnterRule(_localctx, 90, RULE_outputItem);
+		int _la;
+		try {
+			State = 801;
+			switch ( Interpreter.AdaptivePredict(_input,59,_ctx) ) {
+			case 1:
+				EnterOuterAlt(_localctx, 1);
+				{
+				State = 793; outputClause();
+				}
+				break;
+
+			case 2:
+				EnterOuterAlt(_localctx, 2);
+				{
+				State = 794; charPosition();
+				}
+				break;
+
+			case 3:
+				EnterOuterAlt(_localctx, 3);
+				{
+				State = 795; outputClause();
+				State = 797;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 796; whiteSpace();
+					}
+				}
+
+				State = 799; charPosition();
+				}
+				break;
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class OutputClauseContext : ParserRuleContext {
+		public TabClauseContext tabClause() {
+			return GetRuleContext<TabClauseContext>(0);
+		}
+		public OutputExpressionContext outputExpression() {
+			return GetRuleContext<OutputExpressionContext>(0);
+		}
+		public SpcClauseContext spcClause() {
+			return GetRuleContext<SpcClauseContext>(0);
+		}
+		public OutputClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_outputClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterOutputClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitOutputClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitOutputClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public OutputClauseContext outputClause() {
+		OutputClauseContext _localctx = new OutputClauseContext(_ctx, State);
+		EnterRule(_localctx, 92, RULE_outputClause);
+		try {
+			State = 806;
+			switch ( Interpreter.AdaptivePredict(_input,60,_ctx) ) {
+			case 1:
+				EnterOuterAlt(_localctx, 1);
+				{
+				State = 803; spcClause();
+				}
+				break;
+
+			case 2:
+				EnterOuterAlt(_localctx, 2);
+				{
+				State = 804; tabClause();
+				}
+				break;
+
+			case 3:
+				EnterOuterAlt(_localctx, 3);
+				{
+				State = 805; outputExpression();
+				}
+				break;
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class CharPositionContext : ParserRuleContext {
+		public ITerminalNode SEMICOLON() { return GetToken(VBAParser.SEMICOLON, 0); }
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public CharPositionContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_charPosition; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterCharPosition(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitCharPosition(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitCharPosition(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public CharPositionContext charPosition() {
+		CharPositionContext _localctx = new CharPositionContext(_ctx, State);
+		EnterRule(_localctx, 94, RULE_charPosition);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 808;
+			_la = _input.La(1);
+			if ( !(_la==COMMA || _la==SEMICOLON) ) {
+			_errHandler.RecoverInline(this);
+			}
+			Consume();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class OutputExpressionContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public OutputExpressionContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_outputExpression; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterOutputExpression(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitOutputExpression(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitOutputExpression(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public OutputExpressionContext outputExpression() {
+		OutputExpressionContext _localctx = new OutputExpressionContext(_ctx, State);
+		EnterRule(_localctx, 96, RULE_outputExpression);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 810; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class SpcClauseContext : ParserRuleContext {
+		public SpcNumberContext spcNumber() {
+			return GetRuleContext<SpcNumberContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode LPAREN() { return GetToken(VBAParser.LPAREN, 0); }
+		public ITerminalNode SPC() { return GetToken(VBAParser.SPC, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode RPAREN() { return GetToken(VBAParser.RPAREN, 0); }
+		public SpcClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_spcClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterSpcClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitSpcClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitSpcClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public SpcClauseContext spcClause() {
+		SpcClauseContext _localctx = new SpcClauseContext(_ctx, State);
+		EnterRule(_localctx, 98, RULE_spcClause);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 812; Match(SPC);
+			State = 814;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 813; whiteSpace();
+				}
+			}
+
+			State = 816; Match(LPAREN);
+			State = 818;
+			switch ( Interpreter.AdaptivePredict(_input,62,_ctx) ) {
+			case 1:
+				{
+				State = 817; whiteSpace();
+				}
+				break;
+			}
+			State = 820; spcNumber();
+			State = 822;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 821; whiteSpace();
+				}
+			}
+
+			State = 824; Match(RPAREN);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class SpcNumberContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public SpcNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_spcNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterSpcNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitSpcNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitSpcNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public SpcNumberContext spcNumber() {
+		SpcNumberContext _localctx = new SpcNumberContext(_ctx, State);
+		EnterRule(_localctx, 100, RULE_spcNumber);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 826; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class TabClauseContext : ParserRuleContext {
+		public ITerminalNode TAB() { return GetToken(VBAParser.TAB, 0); }
+		public TabNumberClauseContext tabNumberClause() {
+			return GetRuleContext<TabNumberClauseContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public TabClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_tabClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterTabClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitTabClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitTabClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public TabClauseContext tabClause() {
+		TabClauseContext _localctx = new TabClauseContext(_ctx, State);
+		EnterRule(_localctx, 102, RULE_tabClause);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 828; Match(TAB);
+			State = 833;
+			switch ( Interpreter.AdaptivePredict(_input,65,_ctx) ) {
+			case 1:
+				{
+				State = 830;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 829; whiteSpace();
+					}
+				}
+
+				State = 832; tabNumberClause();
+				}
+				break;
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class TabNumberClauseContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode LPAREN() { return GetToken(VBAParser.LPAREN, 0); }
+		public TabNumberContext tabNumber() {
+			return GetRuleContext<TabNumberContext>(0);
+		}
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode RPAREN() { return GetToken(VBAParser.RPAREN, 0); }
+		public TabNumberClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_tabNumberClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterTabNumberClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitTabNumberClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitTabNumberClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public TabNumberClauseContext tabNumberClause() {
+		TabNumberClauseContext _localctx = new TabNumberClauseContext(_ctx, State);
+		EnterRule(_localctx, 104, RULE_tabNumberClause);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 835; Match(LPAREN);
+			State = 837;
+			switch ( Interpreter.AdaptivePredict(_input,66,_ctx) ) {
+			case 1:
+				{
+				State = 836; whiteSpace();
+				}
+				break;
+			}
+			State = 839; tabNumber();
+			State = 841;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 840; whiteSpace();
+				}
+			}
+
+			State = 843; Match(RPAREN);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class TabNumberContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public TabNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_tabNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterTabNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitTabNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitTabNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public TabNumberContext tabNumber() {
+		TabNumberContext _localctx = new TabNumberContext(_ctx, State);
+		EnterRule(_localctx, 106, RULE_tabNumber);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 845; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class WriteStmtContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public OutputListContext outputList() {
+			return GetRuleContext<OutputListContext>(0);
+		}
+		public ITerminalNode WRITE() { return GetToken(VBAParser.WRITE, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public MarkedFileNumberContext markedFileNumber() {
+			return GetRuleContext<MarkedFileNumberContext>(0);
+		}
+		public WriteStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_writeStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterWriteStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitWriteStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitWriteStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public WriteStmtContext writeStmt() {
+		WriteStmtContext _localctx = new WriteStmtContext(_ctx, State);
+		EnterRule(_localctx, 108, RULE_writeStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 847; Match(WRITE);
+			State = 848; whiteSpace();
+			State = 849; markedFileNumber();
+			State = 851;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 850; whiteSpace();
+				}
+			}
+
+			State = 853; Match(COMMA);
+			State = 858;
+			switch ( Interpreter.AdaptivePredict(_input,70,_ctx) ) {
+			case 1:
+				{
+				State = 855;
+				switch ( Interpreter.AdaptivePredict(_input,69,_ctx) ) {
+				case 1:
+					{
+					State = 854; whiteSpace();
+					}
+					break;
+				}
+				State = 857; outputList();
+				}
+				break;
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class InputStmtContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public InputListContext inputList() {
+			return GetRuleContext<InputListContext>(0);
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode INPUT() { return GetToken(VBAParser.INPUT, 0); }
+		public MarkedFileNumberContext markedFileNumber() {
+			return GetRuleContext<MarkedFileNumberContext>(0);
+		}
+		public InputStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_inputStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterInputStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitInputStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitInputStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public InputStmtContext inputStmt() {
+		InputStmtContext _localctx = new InputStmtContext(_ctx, State);
+		EnterRule(_localctx, 110, RULE_inputStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 860; Match(INPUT);
+			State = 861; whiteSpace();
+			State = 862; markedFileNumber();
+			State = 864;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 863; whiteSpace();
+				}
+			}
+
+			State = 866; Match(COMMA);
+			State = 868;
+			switch ( Interpreter.AdaptivePredict(_input,72,_ctx) ) {
+			case 1:
+				{
+				State = 867; whiteSpace();
+				}
+				break;
+			}
+			State = 870; inputList();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class InputListContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public IReadOnlyList<InputVariableContext> inputVariable() {
+			return GetRuleContexts<InputVariableContext>();
+		}
+		public InputVariableContext inputVariable(int i) {
+			return GetRuleContext<InputVariableContext>(i);
+		}
+		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode COMMA(int i) {
+			return GetToken(VBAParser.COMMA, i);
+		}
+		public InputListContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_inputList; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterInputList(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitInputList(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitInputList(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public InputListContext inputList() {
+		InputListContext _localctx = new InputListContext(_ctx, State);
+		EnterRule(_localctx, 112, RULE_inputList);
+		int _la;
+		try {
+			int _alt;
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 872; inputVariable();
+			State = 883;
+			_errHandler.Sync(this);
+			_alt = Interpreter.AdaptivePredict(_input,75,_ctx);
+			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
+				if ( _alt==1 ) {
+					{
+					{
+					State = 874;
+					_la = _input.La(1);
+					if (_la==WS || _la==LINE_CONTINUATION) {
+						{
+						State = 873; whiteSpace();
+						}
+					}
+
+					State = 876; Match(COMMA);
+					State = 878;
+					switch ( Interpreter.AdaptivePredict(_input,74,_ctx) ) {
+					case 1:
+						{
+						State = 877; whiteSpace();
+						}
+						break;
+					}
+					State = 880; inputVariable();
+					}
+					} 
+				}
+				State = 885;
+				_errHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(_input,75,_ctx);
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class InputVariableContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public InputVariableContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_inputVariable; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterInputVariable(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitInputVariable(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitInputVariable(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public InputVariableContext inputVariable() {
+		InputVariableContext _localctx = new InputVariableContext(_ctx, State);
+		EnterRule(_localctx, 114, RULE_inputVariable);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 886; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class PutStmtContext : ParserRuleContext {
+		public DataContext data() {
+			return GetRuleContext<DataContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public RecordNumberContext recordNumber() {
+			return GetRuleContext<RecordNumberContext>(0);
+		}
+		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public FileNumberContext fileNumber() {
+			return GetRuleContext<FileNumberContext>(0);
+		}
+		public ITerminalNode PUT() { return GetToken(VBAParser.PUT, 0); }
+		public ITerminalNode COMMA(int i) {
+			return GetToken(VBAParser.COMMA, i);
+		}
+		public PutStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_putStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterPutStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitPutStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitPutStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public PutStmtContext putStmt() {
+		PutStmtContext _localctx = new PutStmtContext(_ctx, State);
+		EnterRule(_localctx, 116, RULE_putStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 888; Match(PUT);
+			State = 889; whiteSpace();
+			State = 890; fileNumber();
+			State = 892;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 891; whiteSpace();
+				}
+			}
+
+			State = 894; Match(COMMA);
+			State = 896;
+			switch ( Interpreter.AdaptivePredict(_input,77,_ctx) ) {
+			case 1:
+				{
+				State = 895; whiteSpace();
+				}
+				break;
+			}
+			State = 899;
+			switch ( Interpreter.AdaptivePredict(_input,78,_ctx) ) {
+			case 1:
+				{
+				State = 898; recordNumber();
+				}
+				break;
+			}
+			State = 902;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 901; whiteSpace();
+				}
+			}
+
+			State = 904; Match(COMMA);
+			State = 906;
+			switch ( Interpreter.AdaptivePredict(_input,80,_ctx) ) {
+			case 1:
+				{
+				State = 905; whiteSpace();
+				}
+				break;
+			}
+			State = 908; data();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class RecordNumberContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public RecordNumberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_recordNumber; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterRecordNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitRecordNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitRecordNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public RecordNumberContext recordNumber() {
+		RecordNumberContext _localctx = new RecordNumberContext(_ctx, State);
+		EnterRule(_localctx, 118, RULE_recordNumber);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 910; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class DataContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public DataContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_data; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterData(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitData(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitData(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public DataContext data() {
+		DataContext _localctx = new DataContext(_ctx, State);
+		EnterRule(_localctx, 120, RULE_data);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 912; valueStmt(0);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class GetStmtContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public RecordNumberContext recordNumber() {
+			return GetRuleContext<RecordNumberContext>(0);
+		}
+		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public FileNumberContext fileNumber() {
+			return GetRuleContext<FileNumberContext>(0);
+		}
+		public ITerminalNode GET() { return GetToken(VBAParser.GET, 0); }
+		public ITerminalNode COMMA(int i) {
+			return GetToken(VBAParser.COMMA, i);
+		}
+		public VariableContext variable() {
+			return GetRuleContext<VariableContext>(0);
+		}
+		public GetStmtContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_getStmt; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterGetStmt(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitGetStmt(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitGetStmt(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public GetStmtContext getStmt() {
+		GetStmtContext _localctx = new GetStmtContext(_ctx, State);
+		EnterRule(_localctx, 122, RULE_getStmt);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 914; Match(GET);
+			State = 915; whiteSpace();
+			State = 916; fileNumber();
+			State = 918;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 917; whiteSpace();
+				}
+			}
+
+			State = 920; Match(COMMA);
+			State = 922;
+			switch ( Interpreter.AdaptivePredict(_input,82,_ctx) ) {
+			case 1:
+				{
+				State = 921; whiteSpace();
+				}
+				break;
+			}
+			State = 925;
+			switch ( Interpreter.AdaptivePredict(_input,83,_ctx) ) {
+			case 1:
+				{
+				State = 924; recordNumber();
+				}
+				break;
+			}
+			State = 928;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 927; whiteSpace();
+				}
+			}
+
+			State = 930; Match(COMMA);
+			State = 932;
+			switch ( Interpreter.AdaptivePredict(_input,85,_ctx) ) {
+			case 1:
+				{
+				State = 931; whiteSpace();
+				}
+				break;
+			}
+			State = 934; variable();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class VariableContext : ParserRuleContext {
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public VariableContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_variable; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterVariable(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitVariable(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitVariable(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public VariableContext variable() {
+		VariableContext _localctx = new VariableContext(_ctx, State);
+		EnterRule(_localctx, 124, RULE_variable);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 936; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2173,55 +5069,55 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ConstStmtContext constStmt() {
 		ConstStmtContext _localctx = new ConstStmtContext(_ctx, State);
-		EnterRule(_localctx, 34, RULE_constStmt);
+		EnterRule(_localctx, 126, RULE_constStmt);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 556;
+			State = 941;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 553; visibility();
-				State = 554; whiteSpace();
+				State = 938; visibility();
+				State = 939; whiteSpace();
 				}
 			}
 
-			State = 558; Match(CONST);
-			State = 559; whiteSpace();
-			State = 560; constSubStmt();
-			State = 571;
+			State = 943; Match(CONST);
+			State = 944; whiteSpace();
+			State = 945; constSubStmt();
+			State = 956;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,34,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,89,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 562;
+					State = 947;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 561; whiteSpace();
+						State = 946; whiteSpace();
 						}
 					}
 
-					State = 564; Match(COMMA);
-					State = 566;
+					State = 949; Match(COMMA);
+					State = 951;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 565; whiteSpace();
+						State = 950; whiteSpace();
 						}
 					}
 
-					State = 568; constSubStmt();
+					State = 953; constSubStmt();
 					}
 					} 
 				}
-				State = 573;
+				State = 958;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,34,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,89,_ctx);
 			}
 			}
 		}
@@ -2279,47 +5175,47 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ConstSubStmtContext constSubStmt() {
 		ConstSubStmtContext _localctx = new ConstSubStmtContext(_ctx, State);
-		EnterRule(_localctx, 36, RULE_constSubStmt);
+		EnterRule(_localctx, 128, RULE_constSubStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 574; identifier();
-			State = 576;
+			State = 959; identifier();
+			State = 961;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 575; typeHint();
+				State = 960; typeHint();
 				}
 			}
 
-			State = 581;
-			switch ( Interpreter.AdaptivePredict(_input,36,_ctx) ) {
+			State = 966;
+			switch ( Interpreter.AdaptivePredict(_input,91,_ctx) ) {
 			case 1:
 				{
-				State = 578; whiteSpace();
-				State = 579; asTypeClause();
+				State = 963; whiteSpace();
+				State = 964; asTypeClause();
 				}
 				break;
 			}
-			State = 584;
+			State = 969;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 583; whiteSpace();
+				State = 968; whiteSpace();
 				}
 			}
 
-			State = 586; Match(EQ);
-			State = 588;
-			switch ( Interpreter.AdaptivePredict(_input,38,_ctx) ) {
+			State = 971; Match(EQ);
+			State = 973;
+			switch ( Interpreter.AdaptivePredict(_input,93,_ctx) ) {
 			case 1:
 				{
-				State = 587; whiteSpace();
+				State = 972; whiteSpace();
 				}
 				break;
 			}
-			State = 590; valueStmt(0);
+			State = 975; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2388,84 +5284,84 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public DeclareStmtContext declareStmt() {
 		DeclareStmtContext _localctx = new DeclareStmtContext(_ctx, State);
-		EnterRule(_localctx, 38, RULE_declareStmt);
+		EnterRule(_localctx, 130, RULE_declareStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 595;
+			State = 980;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 592; visibility();
-				State = 593; whiteSpace();
+				State = 977; visibility();
+				State = 978; whiteSpace();
 				}
 			}
 
-			State = 597; Match(DECLARE);
-			State = 598; whiteSpace();
-			State = 601;
+			State = 982; Match(DECLARE);
+			State = 983; whiteSpace();
+			State = 986;
 			_la = _input.La(1);
 			if (_la==PTRSAFE) {
 				{
-				State = 599; Match(PTRSAFE);
-				State = 600; whiteSpace();
+				State = 984; Match(PTRSAFE);
+				State = 985; whiteSpace();
 				}
 			}
 
-			State = 603;
+			State = 988;
 			_la = _input.La(1);
 			if ( !(_la==FUNCTION || _la==SUB) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 604; whiteSpace();
-			State = 605; identifier();
-			State = 607;
+			State = 989; whiteSpace();
+			State = 990; identifier();
+			State = 992;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 606; typeHint();
+				State = 991; typeHint();
 				}
 			}
 
-			State = 609; whiteSpace();
-			State = 610; Match(LIB);
-			State = 611; whiteSpace();
-			State = 612; Match(STRINGLITERAL);
-			State = 618;
-			switch ( Interpreter.AdaptivePredict(_input,42,_ctx) ) {
+			State = 994; whiteSpace();
+			State = 995; Match(LIB);
+			State = 996; whiteSpace();
+			State = 997; Match(STRINGLITERAL);
+			State = 1003;
+			switch ( Interpreter.AdaptivePredict(_input,97,_ctx) ) {
 			case 1:
 				{
-				State = 613; whiteSpace();
-				State = 614; Match(ALIAS);
-				State = 615; whiteSpace();
-				State = 616; Match(STRINGLITERAL);
+				State = 998; whiteSpace();
+				State = 999; Match(ALIAS);
+				State = 1000; whiteSpace();
+				State = 1001; Match(STRINGLITERAL);
 				}
 				break;
 			}
-			State = 624;
-			switch ( Interpreter.AdaptivePredict(_input,44,_ctx) ) {
+			State = 1009;
+			switch ( Interpreter.AdaptivePredict(_input,99,_ctx) ) {
 			case 1:
 				{
-				State = 621;
+				State = 1006;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 620; whiteSpace();
+					State = 1005; whiteSpace();
 					}
 				}
 
-				State = 623; argList();
+				State = 1008; argList();
 				}
 				break;
 			}
-			State = 629;
-			switch ( Interpreter.AdaptivePredict(_input,45,_ctx) ) {
+			State = 1014;
+			switch ( Interpreter.AdaptivePredict(_input,100,_ctx) ) {
 			case 1:
 				{
-				State = 626; whiteSpace();
-				State = 627; asTypeClause();
+				State = 1011; whiteSpace();
+				State = 1012; asTypeClause();
 				}
 				break;
 			}
@@ -2525,46 +5421,46 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public DefDirectiveContext defDirective() {
 		DefDirectiveContext _localctx = new DefDirectiveContext(_ctx, State);
-		EnterRule(_localctx, 40, RULE_defDirective);
+		EnterRule(_localctx, 132, RULE_defDirective);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 631; defType();
-			State = 632; whiteSpace();
-			State = 633; letterSpec();
-			State = 644;
+			State = 1016; defType();
+			State = 1017; whiteSpace();
+			State = 1018; letterSpec();
+			State = 1029;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,48,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,103,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 635;
+					State = 1020;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 634; whiteSpace();
+						State = 1019; whiteSpace();
 						}
 					}
 
-					State = 637; Match(COMMA);
-					State = 639;
-					switch ( Interpreter.AdaptivePredict(_input,47,_ctx) ) {
+					State = 1022; Match(COMMA);
+					State = 1024;
+					switch ( Interpreter.AdaptivePredict(_input,102,_ctx) ) {
 					case 1:
 						{
-						State = 638; whiteSpace();
+						State = 1023; whiteSpace();
 						}
 						break;
 					}
-					State = 641; letterSpec();
+					State = 1026; letterSpec();
 					}
 					} 
 				}
-				State = 646;
+				State = 1031;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,48,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,103,_ctx);
 			}
 			}
 		}
@@ -2616,12 +5512,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public DefTypeContext defType() {
 		DefTypeContext _localctx = new DefTypeContext(_ctx, State);
-		EnterRule(_localctx, 42, RULE_defType);
+		EnterRule(_localctx, 134, RULE_defType);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 647;
+			State = 1032;
 			_la = _input.La(1);
 			if ( !(((((_la - 70)) & ~0x3f) == 0 && ((1L << (_la - 70)) & ((1L << (DEFBOOL - 70)) | (1L << (DEFBYTE - 70)) | (1L << (DEFDATE - 70)) | (1L << (DEFDBL - 70)) | (1L << (DEFCUR - 70)) | (1L << (DEFINT - 70)) | (1L << (DEFLNG - 70)) | (1L << (DEFLNGLNG - 70)) | (1L << (DEFLNGPTR - 70)) | (1L << (DEFOBJ - 70)) | (1L << (DEFSNG - 70)) | (1L << (DEFSTR - 70)) | (1L << (DEFVAR - 70)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2673,28 +5569,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LetterSpecContext letterSpec() {
 		LetterSpecContext _localctx = new LetterSpecContext(_ctx, State);
-		EnterRule(_localctx, 44, RULE_letterSpec);
+		EnterRule(_localctx, 136, RULE_letterSpec);
 		try {
-			State = 652;
-			switch ( Interpreter.AdaptivePredict(_input,49,_ctx) ) {
+			State = 1037;
+			switch ( Interpreter.AdaptivePredict(_input,104,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 649; singleLetter();
+				State = 1034; singleLetter();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 650; universalLetterRange();
+				State = 1035; universalLetterRange();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 651; letterRange();
+				State = 1036; letterRange();
 				}
 				break;
 			}
@@ -2737,11 +5633,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SingleLetterContext singleLetter() {
 		SingleLetterContext _localctx = new SingleLetterContext(_ctx, State);
-		EnterRule(_localctx, 46, RULE_singleLetter);
+		EnterRule(_localctx, 138, RULE_singleLetter);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 654; unrestrictedIdentifier();
+			State = 1039; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2792,30 +5688,30 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UniversalLetterRangeContext universalLetterRange() {
 		UniversalLetterRangeContext _localctx = new UniversalLetterRangeContext(_ctx, State);
-		EnterRule(_localctx, 48, RULE_universalLetterRange);
+		EnterRule(_localctx, 140, RULE_universalLetterRange);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 656; upperCaseA();
-			State = 658;
+			State = 1041; upperCaseA();
+			State = 1043;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 657; whiteSpace();
+				State = 1042; whiteSpace();
 				}
 			}
 
-			State = 660; Match(MINUS);
-			State = 662;
-			switch ( Interpreter.AdaptivePredict(_input,51,_ctx) ) {
+			State = 1045; Match(MINUS);
+			State = 1047;
+			switch ( Interpreter.AdaptivePredict(_input,106,_ctx) ) {
 			case 1:
 				{
-				State = 661; whiteSpace();
+				State = 1046; whiteSpace();
 				}
 				break;
 			}
-			State = 664; upperCaseZ();
+			State = 1049; upperCaseZ();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2856,13 +5752,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UpperCaseAContext upperCaseA() {
 		UpperCaseAContext _localctx = new UpperCaseAContext(_ctx, State);
-		EnterRule(_localctx, 50, RULE_upperCaseA);
+		EnterRule(_localctx, 142, RULE_upperCaseA);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 666;
+			State = 1051;
 			if (!(_input.Lt(1).Text.Equals("A"))) throw new FailedPredicateException(this, "_input.Lt(1).Text.Equals(\"A\")");
-			State = 667; unrestrictedIdentifier();
+			State = 1052; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2903,13 +5799,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UpperCaseZContext upperCaseZ() {
 		UpperCaseZContext _localctx = new UpperCaseZContext(_ctx, State);
-		EnterRule(_localctx, 52, RULE_upperCaseZ);
+		EnterRule(_localctx, 144, RULE_upperCaseZ);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 669;
+			State = 1054;
 			if (!(_input.Lt(1).Text.Equals("Z"))) throw new FailedPredicateException(this, "_input.Lt(1).Text.Equals(\"Z\")");
-			State = 670; unrestrictedIdentifier();
+			State = 1055; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2960,30 +5856,30 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LetterRangeContext letterRange() {
 		LetterRangeContext _localctx = new LetterRangeContext(_ctx, State);
-		EnterRule(_localctx, 54, RULE_letterRange);
+		EnterRule(_localctx, 146, RULE_letterRange);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 672; firstLetter();
-			State = 674;
+			State = 1057; firstLetter();
+			State = 1059;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 673; whiteSpace();
+				State = 1058; whiteSpace();
 				}
 			}
 
-			State = 676; Match(MINUS);
-			State = 678;
+			State = 1061; Match(MINUS);
+			State = 1063;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 677; whiteSpace();
+				State = 1062; whiteSpace();
 				}
 			}
 
-			State = 680; lastLetter();
+			State = 1065; lastLetter();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3024,11 +5920,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public FirstLetterContext firstLetter() {
 		FirstLetterContext _localctx = new FirstLetterContext(_ctx, State);
-		EnterRule(_localctx, 56, RULE_firstLetter);
+		EnterRule(_localctx, 148, RULE_firstLetter);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 682; unrestrictedIdentifier();
+			State = 1067; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3069,11 +5965,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LastLetterContext lastLetter() {
 		LastLetterContext _localctx = new LastLetterContext(_ctx, State);
-		EnterRule(_localctx, 58, RULE_lastLetter);
+		EnterRule(_localctx, 150, RULE_lastLetter);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 684; unrestrictedIdentifier();
+			State = 1069; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3130,77 +6026,77 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public DoLoopStmtContext doLoopStmt() {
 		DoLoopStmtContext _localctx = new DoLoopStmtContext(_ctx, State);
-		EnterRule(_localctx, 60, RULE_doLoopStmt);
+		EnterRule(_localctx, 152, RULE_doLoopStmt);
 		int _la;
 		try {
-			State = 715;
-			switch ( Interpreter.AdaptivePredict(_input,57,_ctx) ) {
+			State = 1100;
+			switch ( Interpreter.AdaptivePredict(_input,112,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 686; Match(DO);
-				State = 687; endOfStatement();
-				State = 689;
-				switch ( Interpreter.AdaptivePredict(_input,54,_ctx) ) {
+				State = 1071; Match(DO);
+				State = 1072; endOfStatement();
+				State = 1074;
+				switch ( Interpreter.AdaptivePredict(_input,109,_ctx) ) {
 				case 1:
 					{
-					State = 688; block();
+					State = 1073; block();
 					}
 					break;
 				}
-				State = 691; Match(LOOP);
+				State = 1076; Match(LOOP);
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 693; Match(DO);
-				State = 694; whiteSpace();
-				State = 695;
+				State = 1078; Match(DO);
+				State = 1079; whiteSpace();
+				State = 1080;
 				_la = _input.La(1);
 				if ( !(_la==UNTIL || _la==WHILE) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 696; whiteSpace();
-				State = 697; valueStmt(0);
-				State = 698; endOfStatement();
-				State = 700;
-				switch ( Interpreter.AdaptivePredict(_input,55,_ctx) ) {
+				State = 1081; whiteSpace();
+				State = 1082; valueStmt(0);
+				State = 1083; endOfStatement();
+				State = 1085;
+				switch ( Interpreter.AdaptivePredict(_input,110,_ctx) ) {
 				case 1:
 					{
-					State = 699; block();
+					State = 1084; block();
 					}
 					break;
 				}
-				State = 702; Match(LOOP);
+				State = 1087; Match(LOOP);
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 704; Match(DO);
-				State = 705; endOfStatement();
-				State = 707;
-				switch ( Interpreter.AdaptivePredict(_input,56,_ctx) ) {
+				State = 1089; Match(DO);
+				State = 1090; endOfStatement();
+				State = 1092;
+				switch ( Interpreter.AdaptivePredict(_input,111,_ctx) ) {
 				case 1:
 					{
-					State = 706; block();
+					State = 1091; block();
 					}
 					break;
 				}
-				State = 709; Match(LOOP);
-				State = 710; whiteSpace();
-				State = 711;
+				State = 1094; Match(LOOP);
+				State = 1095; whiteSpace();
+				State = 1096;
 				_la = _input.La(1);
 				if ( !(_la==UNTIL || _la==WHILE) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 712; whiteSpace();
-				State = 713; valueStmt(0);
+				State = 1097; whiteSpace();
+				State = 1098; valueStmt(0);
 				}
 				break;
 			}
@@ -3263,38 +6159,38 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EnumerationStmtContext enumerationStmt() {
 		EnumerationStmtContext _localctx = new EnumerationStmtContext(_ctx, State);
-		EnterRule(_localctx, 62, RULE_enumerationStmt);
+		EnterRule(_localctx, 154, RULE_enumerationStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 720;
+			State = 1105;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 717; visibility();
-				State = 718; whiteSpace();
+				State = 1102; visibility();
+				State = 1103; whiteSpace();
 				}
 			}
 
-			State = 722; Match(ENUM);
-			State = 723; whiteSpace();
-			State = 724; identifier();
-			State = 725; endOfStatement();
-			State = 729;
+			State = 1107; Match(ENUM);
+			State = 1108; whiteSpace();
+			State = 1109; identifier();
+			State = 1110; endOfStatement();
+			State = 1114;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 193)) & ~0x3f) == 0 && ((1L << (_la - 193)) & ((1L << (UNTIL - 193)) | (1L << (VARIANT - 193)) | (1L << (VERSION - 193)) | (1L << (WIDTH - 193)) | (1L << (WITHEVENTS - 193)) | (1L << (WRITE - 193)) | (1L << (XOR - 193)) | (1L << (IDENTIFIER - 193)) | (1L << (COLLECTION - 193)) | (1L << (DELETESETTING - 193)) | (1L << (LOAD - 193)) | (1L << (RMDIR - 193)) | (1L << (SENDKEYS - 193)) | (1L << (SETATTR - 193)) | (1L << (RESUME_NEXT - 193)))) != 0)) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
 				{
-				State = 726; enumerationStmt_Constant();
+				State = 1111; enumerationStmt_Constant();
 				}
 				}
-				State = 731;
+				State = 1116;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 732; Match(END_ENUM);
+			State = 1117; Match(END_ENUM);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3348,38 +6244,38 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EnumerationStmt_ConstantContext enumerationStmt_Constant() {
 		EnumerationStmt_ConstantContext _localctx = new EnumerationStmt_ConstantContext(_ctx, State);
-		EnterRule(_localctx, 64, RULE_enumerationStmt_Constant);
+		EnterRule(_localctx, 156, RULE_enumerationStmt_Constant);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 734; identifier();
-			State = 743;
-			switch ( Interpreter.AdaptivePredict(_input,62,_ctx) ) {
+			State = 1119; identifier();
+			State = 1128;
+			switch ( Interpreter.AdaptivePredict(_input,117,_ctx) ) {
 			case 1:
 				{
-				State = 736;
+				State = 1121;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 735; whiteSpace();
+					State = 1120; whiteSpace();
 					}
 				}
 
-				State = 738; Match(EQ);
-				State = 740;
-				switch ( Interpreter.AdaptivePredict(_input,61,_ctx) ) {
+				State = 1123; Match(EQ);
+				State = 1125;
+				switch ( Interpreter.AdaptivePredict(_input,116,_ctx) ) {
 				case 1:
 					{
-					State = 739; whiteSpace();
+					State = 1124; whiteSpace();
 					}
 					break;
 				}
-				State = 742; valueStmt(0);
+				State = 1127; valueStmt(0);
 				}
 				break;
 			}
-			State = 745; endOfStatement();
+			State = 1130; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3418,11 +6314,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EndStmtContext endStmt() {
 		EndStmtContext _localctx = new EndStmtContext(_ctx, State);
-		EnterRule(_localctx, 66, RULE_endStmt);
+		EnterRule(_localctx, 158, RULE_endStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 747; Match(END);
+			State = 1132; Match(END);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3477,46 +6373,46 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EraseStmtContext eraseStmt() {
 		EraseStmtContext _localctx = new EraseStmtContext(_ctx, State);
-		EnterRule(_localctx, 68, RULE_eraseStmt);
+		EnterRule(_localctx, 160, RULE_eraseStmt);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 749; Match(ERASE);
-			State = 750; whiteSpace();
-			State = 751; valueStmt(0);
-			State = 762;
+			State = 1134; Match(ERASE);
+			State = 1135; whiteSpace();
+			State = 1136; valueStmt(0);
+			State = 1147;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,65,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,120,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 753;
+					State = 1138;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 752; whiteSpace();
+						State = 1137; whiteSpace();
 						}
 					}
 
-					State = 755; Match(COMMA);
-					State = 757;
-					switch ( Interpreter.AdaptivePredict(_input,64,_ctx) ) {
+					State = 1140; Match(COMMA);
+					State = 1142;
+					switch ( Interpreter.AdaptivePredict(_input,119,_ctx) ) {
 					case 1:
 						{
-						State = 756; whiteSpace();
+						State = 1141; whiteSpace();
 						}
 						break;
 					}
-					State = 759; valueStmt(0);
+					State = 1144; valueStmt(0);
 					}
 					} 
 				}
-				State = 764;
+				State = 1149;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,65,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,120,_ctx);
 			}
 			}
 		}
@@ -3562,13 +6458,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ErrorStmtContext errorStmt() {
 		ErrorStmtContext _localctx = new ErrorStmtContext(_ctx, State);
-		EnterRule(_localctx, 70, RULE_errorStmt);
+		EnterRule(_localctx, 162, RULE_errorStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 765; Match(ERROR);
-			State = 766; whiteSpace();
-			State = 767; valueStmt(0);
+			State = 1150; Match(ERROR);
+			State = 1151; whiteSpace();
+			State = 1152; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3622,32 +6518,32 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EventStmtContext eventStmt() {
 		EventStmtContext _localctx = new EventStmtContext(_ctx, State);
-		EnterRule(_localctx, 72, RULE_eventStmt);
+		EnterRule(_localctx, 164, RULE_eventStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 772;
+			State = 1157;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 769; visibility();
-				State = 770; whiteSpace();
+				State = 1154; visibility();
+				State = 1155; whiteSpace();
 				}
 			}
 
-			State = 774; Match(EVENT);
-			State = 775; whiteSpace();
-			State = 776; identifier();
-			State = 778;
+			State = 1159; Match(EVENT);
+			State = 1160; whiteSpace();
+			State = 1161; identifier();
+			State = 1163;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 777; whiteSpace();
+				State = 1162; whiteSpace();
 				}
 			}
 
-			State = 780; argList();
+			State = 1165; argList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3690,12 +6586,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ExitStmtContext exitStmt() {
 		ExitStmtContext _localctx = new ExitStmtContext(_ctx, State);
-		EnterRule(_localctx, 74, RULE_exitStmt);
+		EnterRule(_localctx, 166, RULE_exitStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 782;
+			State = 1167;
 			_la = _input.La(1);
 			if ( !(((((_la - 104)) & ~0x3f) == 0 && ((1L << (_la - 104)) & ((1L << (EXIT_DO - 104)) | (1L << (EXIT_FOR - 104)) | (1L << (EXIT_FUNCTION - 104)) | (1L << (EXIT_PROPERTY - 104)) | (1L << (EXIT_SUB - 104)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -3760,35 +6656,35 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ForEachStmtContext forEachStmt() {
 		ForEachStmtContext _localctx = new ForEachStmtContext(_ctx, State);
-		EnterRule(_localctx, 76, RULE_forEachStmt);
+		EnterRule(_localctx, 168, RULE_forEachStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 784; Match(FOR);
-			State = 785; whiteSpace();
-			State = 786; Match(EACH);
-			State = 787; whiteSpace();
-			State = 788; valueStmt(0);
-			State = 789; whiteSpace();
-			State = 790; Match(IN);
-			State = 791; whiteSpace();
-			State = 792; valueStmt(0);
-			State = 793; endOfStatement();
-			State = 795;
-			switch ( Interpreter.AdaptivePredict(_input,68,_ctx) ) {
+			State = 1169; Match(FOR);
+			State = 1170; whiteSpace();
+			State = 1171; Match(EACH);
+			State = 1172; whiteSpace();
+			State = 1173; valueStmt(0);
+			State = 1174; whiteSpace();
+			State = 1175; Match(IN);
+			State = 1176; whiteSpace();
+			State = 1177; valueStmt(0);
+			State = 1178; endOfStatement();
+			State = 1180;
+			switch ( Interpreter.AdaptivePredict(_input,123,_ctx) ) {
 			case 1:
 				{
-				State = 794; block();
+				State = 1179; block();
 				}
 				break;
 			}
-			State = 797; Match(NEXT);
-			State = 801;
-			switch ( Interpreter.AdaptivePredict(_input,69,_ctx) ) {
+			State = 1182; Match(NEXT);
+			State = 1186;
+			switch ( Interpreter.AdaptivePredict(_input,124,_ctx) ) {
 			case 1:
 				{
-				State = 798; whiteSpace();
-				State = 799; valueStmt(0);
+				State = 1183; whiteSpace();
+				State = 1184; valueStmt(0);
 				}
 				break;
 			}
@@ -3852,63 +6748,63 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ForNextStmtContext forNextStmt() {
 		ForNextStmtContext _localctx = new ForNextStmtContext(_ctx, State);
-		EnterRule(_localctx, 78, RULE_forNextStmt);
+		EnterRule(_localctx, 170, RULE_forNextStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 803; Match(FOR);
-			State = 804; whiteSpace();
-			State = 805; valueStmt(0);
-			State = 807;
+			State = 1188; Match(FOR);
+			State = 1189; whiteSpace();
+			State = 1190; valueStmt(0);
+			State = 1192;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 806; whiteSpace();
+				State = 1191; whiteSpace();
 				}
 			}
 
-			State = 809; Match(EQ);
-			State = 811;
-			switch ( Interpreter.AdaptivePredict(_input,71,_ctx) ) {
+			State = 1194; Match(EQ);
+			State = 1196;
+			switch ( Interpreter.AdaptivePredict(_input,126,_ctx) ) {
 			case 1:
 				{
-				State = 810; whiteSpace();
+				State = 1195; whiteSpace();
 				}
 				break;
 			}
-			State = 813; valueStmt(0);
-			State = 814; whiteSpace();
-			State = 815; Match(TO);
-			State = 816; whiteSpace();
-			State = 817; valueStmt(0);
-			State = 823;
-			switch ( Interpreter.AdaptivePredict(_input,72,_ctx) ) {
+			State = 1198; valueStmt(0);
+			State = 1199; whiteSpace();
+			State = 1200; Match(TO);
+			State = 1201; whiteSpace();
+			State = 1202; valueStmt(0);
+			State = 1208;
+			switch ( Interpreter.AdaptivePredict(_input,127,_ctx) ) {
 			case 1:
 				{
-				State = 818; whiteSpace();
-				State = 819; Match(STEP);
-				State = 820; whiteSpace();
-				State = 821; valueStmt(0);
+				State = 1203; whiteSpace();
+				State = 1204; Match(STEP);
+				State = 1205; whiteSpace();
+				State = 1206; valueStmt(0);
 				}
 				break;
 			}
-			State = 825; endOfStatement();
-			State = 827;
-			switch ( Interpreter.AdaptivePredict(_input,73,_ctx) ) {
+			State = 1210; endOfStatement();
+			State = 1212;
+			switch ( Interpreter.AdaptivePredict(_input,128,_ctx) ) {
 			case 1:
 				{
-				State = 826; block();
+				State = 1211; block();
 				}
 				break;
 			}
-			State = 829; Match(NEXT);
-			State = 833;
-			switch ( Interpreter.AdaptivePredict(_input,74,_ctx) ) {
+			State = 1214; Match(NEXT);
+			State = 1218;
+			switch ( Interpreter.AdaptivePredict(_input,129,_ctx) ) {
 			case 1:
 				{
-				State = 830; whiteSpace();
-				State = 831; valueStmt(0);
+				State = 1215; whiteSpace();
+				State = 1216; valueStmt(0);
 				}
 				break;
 			}
@@ -3979,89 +6875,89 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public FunctionStmtContext functionStmt() {
 		FunctionStmtContext _localctx = new FunctionStmtContext(_ctx, State);
-		EnterRule(_localctx, 80, RULE_functionStmt);
+		EnterRule(_localctx, 172, RULE_functionStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 838;
+			State = 1223;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 835; visibility();
-				State = 836; whiteSpace();
+				State = 1220; visibility();
+				State = 1221; whiteSpace();
 				}
 			}
 
-			State = 842;
+			State = 1227;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 840; Match(STATIC);
-				State = 841; whiteSpace();
+				State = 1225; Match(STATIC);
+				State = 1226; whiteSpace();
 				}
 			}
 
-			State = 844; Match(FUNCTION);
-			State = 846;
+			State = 1229; Match(FUNCTION);
+			State = 1231;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 845; whiteSpace();
+				State = 1230; whiteSpace();
 				}
 			}
 
-			State = 848; functionName();
-			State = 850;
-			switch ( Interpreter.AdaptivePredict(_input,78,_ctx) ) {
+			State = 1233; functionName();
+			State = 1235;
+			switch ( Interpreter.AdaptivePredict(_input,133,_ctx) ) {
 			case 1:
 				{
-				State = 849; typeHint();
+				State = 1234; typeHint();
 				}
 				break;
 			}
-			State = 856;
-			switch ( Interpreter.AdaptivePredict(_input,80,_ctx) ) {
+			State = 1241;
+			switch ( Interpreter.AdaptivePredict(_input,135,_ctx) ) {
 			case 1:
 				{
-				State = 853;
+				State = 1238;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 852; whiteSpace();
+					State = 1237; whiteSpace();
 					}
 				}
 
-				State = 855; argList();
+				State = 1240; argList();
 				}
 				break;
 			}
-			State = 862;
-			switch ( Interpreter.AdaptivePredict(_input,82,_ctx) ) {
+			State = 1247;
+			switch ( Interpreter.AdaptivePredict(_input,137,_ctx) ) {
 			case 1:
 				{
-				State = 859;
+				State = 1244;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 858; whiteSpace();
+					State = 1243; whiteSpace();
 					}
 				}
 
-				State = 861; asTypeClause();
+				State = 1246; asTypeClause();
 				}
 				break;
 			}
-			State = 864; endOfStatement();
-			State = 866;
+			State = 1249; endOfStatement();
+			State = 1251;
 			_la = _input.La(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 865; block();
+				State = 1250; block();
 				}
 			}
 
-			State = 868; Match(END_FUNCTION);
+			State = 1253; Match(END_FUNCTION);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4102,119 +6998,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public FunctionNameContext functionName() {
 		FunctionNameContext _localctx = new FunctionNameContext(_ctx, State);
-		EnterRule(_localctx, 82, RULE_functionName);
+		EnterRule(_localctx, 174, RULE_functionName);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 870; identifier();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class GetStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public IReadOnlyList<ValueStmtContext> valueStmt() {
-			return GetRuleContexts<ValueStmtContext>();
-		}
-		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public ITerminalNode GET() { return GetToken(VBAParser.GET, 0); }
-		public ITerminalNode COMMA(int i) {
-			return GetToken(VBAParser.COMMA, i);
-		}
-		public ValueStmtContext valueStmt(int i) {
-			return GetRuleContext<ValueStmtContext>(i);
-		}
-		public GetStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_getStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterGetStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitGetStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitGetStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public GetStmtContext getStmt() {
-		GetStmtContext _localctx = new GetStmtContext(_ctx, State);
-		EnterRule(_localctx, 84, RULE_getStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 872; Match(GET);
-			State = 873; whiteSpace();
-			State = 874; fileNumber();
-			State = 876;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 875; whiteSpace();
-				}
-			}
-
-			State = 878; Match(COMMA);
-			State = 880;
-			switch ( Interpreter.AdaptivePredict(_input,85,_ctx) ) {
-			case 1:
-				{
-				State = 879; whiteSpace();
-				}
-				break;
-			}
-			State = 883;
-			switch ( Interpreter.AdaptivePredict(_input,86,_ctx) ) {
-			case 1:
-				{
-				State = 882; valueStmt(0);
-				}
-				break;
-			}
-			State = 886;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 885; whiteSpace();
-				}
-			}
-
-			State = 888; Match(COMMA);
-			State = 890;
-			switch ( Interpreter.AdaptivePredict(_input,88,_ctx) ) {
-			case 1:
-				{
-				State = 889; whiteSpace();
-				}
-				break;
-			}
-			State = 892; valueStmt(0);
+			State = 1255; identifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4259,13 +7047,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public GoSubStmtContext goSubStmt() {
 		GoSubStmtContext _localctx = new GoSubStmtContext(_ctx, State);
-		EnterRule(_localctx, 86, RULE_goSubStmt);
+		EnterRule(_localctx, 176, RULE_goSubStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 894; Match(GOSUB);
-			State = 895; whiteSpace();
-			State = 896; valueStmt(0);
+			State = 1257; Match(GOSUB);
+			State = 1258; whiteSpace();
+			State = 1259; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4310,13 +7098,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public GoToStmtContext goToStmt() {
 		GoToStmtContext _localctx = new GoToStmtContext(_ctx, State);
-		EnterRule(_localctx, 88, RULE_goToStmt);
+		EnterRule(_localctx, 178, RULE_goToStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 898; Match(GOTO);
-			State = 899; whiteSpace();
-			State = 900; valueStmt(0);
+			State = 1261; Match(GOTO);
+			State = 1262; whiteSpace();
+			State = 1263; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4381,47 +7169,47 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IfStmtContext ifStmt() {
 		IfStmtContext _localctx = new IfStmtContext(_ctx, State);
-		EnterRule(_localctx, 90, RULE_ifStmt);
+		EnterRule(_localctx, 180, RULE_ifStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 902; Match(IF);
-			State = 903; whiteSpace();
-			State = 904; booleanExpression();
-			State = 905; whiteSpace();
-			State = 906; Match(THEN);
-			State = 907; endOfStatement();
-			State = 909;
-			switch ( Interpreter.AdaptivePredict(_input,89,_ctx) ) {
+			State = 1265; Match(IF);
+			State = 1266; whiteSpace();
+			State = 1267; booleanExpression();
+			State = 1268; whiteSpace();
+			State = 1269; Match(THEN);
+			State = 1270; endOfStatement();
+			State = 1272;
+			switch ( Interpreter.AdaptivePredict(_input,139,_ctx) ) {
 			case 1:
 				{
-				State = 908; block();
+				State = 1271; block();
 				}
 				break;
 			}
-			State = 914;
+			State = 1277;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==ELSEIF) {
 				{
 				{
-				State = 911; elseIfBlock();
+				State = 1274; elseIfBlock();
 				}
 				}
-				State = 916;
+				State = 1279;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 918;
+			State = 1281;
 			_la = _input.La(1);
 			if (_la==ELSE) {
 				{
-				State = 917; elseBlock();
+				State = 1280; elseBlock();
 				}
 			}
 
-			State = 920; Match(END_IF);
+			State = 1283; Match(END_IF);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4476,24 +7264,24 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ElseIfBlockContext elseIfBlock() {
 		ElseIfBlockContext _localctx = new ElseIfBlockContext(_ctx, State);
-		EnterRule(_localctx, 92, RULE_elseIfBlock);
+		EnterRule(_localctx, 182, RULE_elseIfBlock);
 		try {
-			State = 942;
-			switch ( Interpreter.AdaptivePredict(_input,95,_ctx) ) {
+			State = 1305;
+			switch ( Interpreter.AdaptivePredict(_input,145,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 922; Match(ELSEIF);
-				State = 923; whiteSpace();
-				State = 924; booleanExpression();
-				State = 925; whiteSpace();
-				State = 926; Match(THEN);
-				State = 927; endOfStatement();
-				State = 929;
-				switch ( Interpreter.AdaptivePredict(_input,92,_ctx) ) {
+				State = 1285; Match(ELSEIF);
+				State = 1286; whiteSpace();
+				State = 1287; booleanExpression();
+				State = 1288; whiteSpace();
+				State = 1289; Match(THEN);
+				State = 1290; endOfStatement();
+				State = 1292;
+				switch ( Interpreter.AdaptivePredict(_input,142,_ctx) ) {
 				case 1:
 					{
-					State = 928; block();
+					State = 1291; block();
 					}
 					break;
 				}
@@ -4503,24 +7291,24 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 931; Match(ELSEIF);
-				State = 932; whiteSpace();
-				State = 933; booleanExpression();
-				State = 934; whiteSpace();
-				State = 935; Match(THEN);
-				State = 937;
-				switch ( Interpreter.AdaptivePredict(_input,93,_ctx) ) {
+				State = 1294; Match(ELSEIF);
+				State = 1295; whiteSpace();
+				State = 1296; booleanExpression();
+				State = 1297; whiteSpace();
+				State = 1298; Match(THEN);
+				State = 1300;
+				switch ( Interpreter.AdaptivePredict(_input,143,_ctx) ) {
 				case 1:
 					{
-					State = 936; whiteSpace();
+					State = 1299; whiteSpace();
 					}
 					break;
 				}
-				State = 940;
-				switch ( Interpreter.AdaptivePredict(_input,94,_ctx) ) {
+				State = 1303;
+				switch ( Interpreter.AdaptivePredict(_input,144,_ctx) ) {
 				case 1:
 					{
-					State = 939; block();
+					State = 1302; block();
 					}
 					break;
 				}
@@ -4570,18 +7358,18 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ElseBlockContext elseBlock() {
 		ElseBlockContext _localctx = new ElseBlockContext(_ctx, State);
-		EnterRule(_localctx, 94, RULE_elseBlock);
+		EnterRule(_localctx, 184, RULE_elseBlock);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 944; Match(ELSE);
-			State = 945; endOfStatement();
-			State = 947;
+			State = 1307; Match(ELSE);
+			State = 1308; endOfStatement();
+			State = 1310;
 			_la = _input.La(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 946; block();
+				State = 1309; block();
 				}
 			}
 
@@ -4628,21 +7416,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SingleLineIfStmtContext singleLineIfStmt() {
 		SingleLineIfStmtContext _localctx = new SingleLineIfStmtContext(_ctx, State);
-		EnterRule(_localctx, 96, RULE_singleLineIfStmt);
+		EnterRule(_localctx, 186, RULE_singleLineIfStmt);
 		try {
-			State = 951;
-			switch ( Interpreter.AdaptivePredict(_input,97,_ctx) ) {
+			State = 1314;
+			switch ( Interpreter.AdaptivePredict(_input,147,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 949; ifWithNonEmptyThen();
+				State = 1312; ifWithNonEmptyThen();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 950; ifWithEmptyThen();
+				State = 1313; ifWithEmptyThen();
 				}
 				break;
 			}
@@ -4699,45 +7487,45 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IfWithNonEmptyThenContext ifWithNonEmptyThen() {
 		IfWithNonEmptyThenContext _localctx = new IfWithNonEmptyThenContext(_ctx, State);
-		EnterRule(_localctx, 98, RULE_ifWithNonEmptyThen);
+		EnterRule(_localctx, 188, RULE_ifWithNonEmptyThen);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 953; Match(IF);
-			State = 955;
-			switch ( Interpreter.AdaptivePredict(_input,98,_ctx) ) {
+			State = 1316; Match(IF);
+			State = 1318;
+			switch ( Interpreter.AdaptivePredict(_input,148,_ctx) ) {
 			case 1:
 				{
-				State = 954; whiteSpace();
+				State = 1317; whiteSpace();
 				}
 				break;
 			}
-			State = 957; booleanExpression();
-			State = 959;
+			State = 1320; booleanExpression();
+			State = 1322;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 958; whiteSpace();
+				State = 1321; whiteSpace();
 				}
 			}
 
-			State = 961; Match(THEN);
-			State = 963;
-			switch ( Interpreter.AdaptivePredict(_input,100,_ctx) ) {
+			State = 1324; Match(THEN);
+			State = 1326;
+			switch ( Interpreter.AdaptivePredict(_input,150,_ctx) ) {
 			case 1:
 				{
-				State = 962; whiteSpace();
+				State = 1325; whiteSpace();
 				}
 				break;
 			}
-			State = 965; listOrLabel();
-			State = 969;
-			switch ( Interpreter.AdaptivePredict(_input,101,_ctx) ) {
+			State = 1328; listOrLabel();
+			State = 1332;
+			switch ( Interpreter.AdaptivePredict(_input,151,_ctx) ) {
 			case 1:
 				{
-				State = 966; whiteSpace();
-				State = 967; singleLineElseClause();
+				State = 1329; whiteSpace();
+				State = 1330; singleLineElseClause();
 				}
 				break;
 			}
@@ -4795,40 +7583,40 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IfWithEmptyThenContext ifWithEmptyThen() {
 		IfWithEmptyThenContext _localctx = new IfWithEmptyThenContext(_ctx, State);
-		EnterRule(_localctx, 100, RULE_ifWithEmptyThen);
+		EnterRule(_localctx, 190, RULE_ifWithEmptyThen);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 971; Match(IF);
-			State = 973;
-			switch ( Interpreter.AdaptivePredict(_input,102,_ctx) ) {
+			State = 1334; Match(IF);
+			State = 1336;
+			switch ( Interpreter.AdaptivePredict(_input,152,_ctx) ) {
 			case 1:
 				{
-				State = 972; whiteSpace();
+				State = 1335; whiteSpace();
 				}
 				break;
 			}
-			State = 975; booleanExpression();
-			State = 977;
+			State = 1338; booleanExpression();
+			State = 1340;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 976; whiteSpace();
+				State = 1339; whiteSpace();
 				}
 			}
 
-			State = 979; Match(THEN);
-			State = 980; endOfStatement();
-			State = 982;
+			State = 1342; Match(THEN);
+			State = 1343; endOfStatement();
+			State = 1345;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 981; whiteSpace();
+				State = 1344; whiteSpace();
 				}
 			}
 
-			State = 984; singleLineElseClause();
+			State = 1347; singleLineElseClause();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4873,24 +7661,24 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SingleLineElseClauseContext singleLineElseClause() {
 		SingleLineElseClauseContext _localctx = new SingleLineElseClauseContext(_ctx, State);
-		EnterRule(_localctx, 102, RULE_singleLineElseClause);
+		EnterRule(_localctx, 192, RULE_singleLineElseClause);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 986; Match(ELSE);
-			State = 988;
-			switch ( Interpreter.AdaptivePredict(_input,105,_ctx) ) {
+			State = 1349; Match(ELSE);
+			State = 1351;
+			switch ( Interpreter.AdaptivePredict(_input,155,_ctx) ) {
 			case 1:
 				{
-				State = 987; whiteSpace();
+				State = 1350; whiteSpace();
 				}
 				break;
 			}
-			State = 991;
-			switch ( Interpreter.AdaptivePredict(_input,106,_ctx) ) {
+			State = 1354;
+			switch ( Interpreter.AdaptivePredict(_input,156,_ctx) ) {
 			case 1:
 				{
-				State = 990; listOrLabel();
+				State = 1353; listOrLabel();
 				}
 				break;
 			}
@@ -4950,54 +7738,54 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ListOrLabelContext listOrLabel() {
 		ListOrLabelContext _localctx = new ListOrLabelContext(_ctx, State);
-		EnterRule(_localctx, 104, RULE_listOrLabel);
+		EnterRule(_localctx, 194, RULE_listOrLabel);
 		int _la;
 		try {
 			int _alt;
-			State = 1031;
-			switch ( Interpreter.AdaptivePredict(_input,117,_ctx) ) {
+			State = 1394;
+			switch ( Interpreter.AdaptivePredict(_input,167,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 993; lineNumberLabel();
-				State = 1006;
+				State = 1356; lineNumberLabel();
+				State = 1369;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,110,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,160,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 995;
+						State = 1358;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 994; whiteSpace();
+							State = 1357; whiteSpace();
 							}
 						}
 
-						State = 997; Match(COLON);
-						State = 999;
-						switch ( Interpreter.AdaptivePredict(_input,108,_ctx) ) {
+						State = 1360; Match(COLON);
+						State = 1362;
+						switch ( Interpreter.AdaptivePredict(_input,158,_ctx) ) {
 						case 1:
 							{
-							State = 998; whiteSpace();
+							State = 1361; whiteSpace();
 							}
 							break;
 						}
-						State = 1002;
-						switch ( Interpreter.AdaptivePredict(_input,109,_ctx) ) {
+						State = 1365;
+						switch ( Interpreter.AdaptivePredict(_input,159,_ctx) ) {
 						case 1:
 							{
-							State = 1001; sameLineStatement();
+							State = 1364; sameLineStatement();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 1008;
+					State = 1371;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,110,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,160,_ctx);
 				}
 				}
 				break;
@@ -5005,61 +7793,61 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1013;
+				State = 1376;
 				_la = _input.La(1);
 				if (_la==COLON) {
 					{
-					State = 1009; Match(COLON);
-					State = 1011;
-					switch ( Interpreter.AdaptivePredict(_input,111,_ctx) ) {
+					State = 1372; Match(COLON);
+					State = 1374;
+					switch ( Interpreter.AdaptivePredict(_input,161,_ctx) ) {
 					case 1:
 						{
-						State = 1010; whiteSpace();
+						State = 1373; whiteSpace();
 						}
 						break;
 					}
 					}
 				}
 
-				State = 1015; sameLineStatement();
-				State = 1028;
+				State = 1378; sameLineStatement();
+				State = 1391;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,116,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,166,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1017;
+						State = 1380;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1016; whiteSpace();
+							State = 1379; whiteSpace();
 							}
 						}
 
-						State = 1019; Match(COLON);
-						State = 1021;
-						switch ( Interpreter.AdaptivePredict(_input,114,_ctx) ) {
+						State = 1382; Match(COLON);
+						State = 1384;
+						switch ( Interpreter.AdaptivePredict(_input,164,_ctx) ) {
 						case 1:
 							{
-							State = 1020; whiteSpace();
+							State = 1383; whiteSpace();
 							}
 							break;
 						}
-						State = 1024;
-						switch ( Interpreter.AdaptivePredict(_input,115,_ctx) ) {
+						State = 1387;
+						switch ( Interpreter.AdaptivePredict(_input,165,_ctx) ) {
 						case 1:
 							{
-							State = 1023; sameLineStatement();
+							State = 1386; sameLineStatement();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 1030;
+					State = 1393;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,116,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,166,_ctx);
 				}
 				}
 				break;
@@ -5103,11 +7891,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SameLineStatementContext sameLineStatement() {
 		SameLineStatementContext _localctx = new SameLineStatementContext(_ctx, State);
-		EnterRule(_localctx, 106, RULE_sameLineStatement);
+		EnterRule(_localctx, 196, RULE_sameLineStatement);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1033; blockStmt();
+			State = 1396; blockStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5148,11 +7936,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public BooleanExpressionContext booleanExpression() {
 		BooleanExpressionContext _localctx = new BooleanExpressionContext(_ctx, State);
-		EnterRule(_localctx, 108, RULE_booleanExpression);
+		EnterRule(_localctx, 198, RULE_booleanExpression);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1035; valueStmt(0);
+			State = 1398; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5197,115 +7985,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ImplementsStmtContext implementsStmt() {
 		ImplementsStmtContext _localctx = new ImplementsStmtContext(_ctx, State);
-		EnterRule(_localctx, 110, RULE_implementsStmt);
+		EnterRule(_localctx, 200, RULE_implementsStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1037; Match(IMPLEMENTS);
-			State = 1038; whiteSpace();
-			State = 1039; valueStmt(0);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class InputStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public IReadOnlyList<ValueStmtContext> valueStmt() {
-			return GetRuleContexts<ValueStmtContext>();
-		}
-		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public ITerminalNode INPUT() { return GetToken(VBAParser.INPUT, 0); }
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public ITerminalNode COMMA(int i) {
-			return GetToken(VBAParser.COMMA, i);
-		}
-		public ValueStmtContext valueStmt(int i) {
-			return GetRuleContext<ValueStmtContext>(i);
-		}
-		public InputStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_inputStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterInputStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitInputStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitInputStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public InputStmtContext inputStmt() {
-		InputStmtContext _localctx = new InputStmtContext(_ctx, State);
-		EnterRule(_localctx, 112, RULE_inputStmt);
-		int _la;
-		try {
-			int _alt;
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1041; Match(INPUT);
-			State = 1042; whiteSpace();
-			State = 1043; fileNumber();
-			State = 1052;
-			_errHandler.Sync(this);
-			_alt = 1;
-			do {
-				switch (_alt) {
-				case 1:
-					{
-					{
-					State = 1045;
-					_la = _input.La(1);
-					if (_la==WS || _la==LINE_CONTINUATION) {
-						{
-						State = 1044; whiteSpace();
-						}
-					}
-
-					State = 1047; Match(COMMA);
-					State = 1049;
-					switch ( Interpreter.AdaptivePredict(_input,119,_ctx) ) {
-					case 1:
-						{
-						State = 1048; whiteSpace();
-						}
-						break;
-					}
-					State = 1051; valueStmt(0);
-					}
-					}
-					break;
-				default:
-					throw new NoViableAltException(this);
-				}
-				State = 1054;
-				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,120,_ctx);
-			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
+			State = 1400; Match(IMPLEMENTS);
+			State = 1401; whiteSpace();
+			State = 1402; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5357,212 +8043,39 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LetStmtContext letStmt() {
 		LetStmtContext _localctx = new LetStmtContext(_ctx, State);
-		EnterRule(_localctx, 114, RULE_letStmt);
+		EnterRule(_localctx, 202, RULE_letStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1058;
-			switch ( Interpreter.AdaptivePredict(_input,121,_ctx) ) {
+			State = 1406;
+			switch ( Interpreter.AdaptivePredict(_input,168,_ctx) ) {
 			case 1:
 				{
-				State = 1056; Match(LET);
-				State = 1057; whiteSpace();
+				State = 1404; Match(LET);
+				State = 1405; whiteSpace();
 				}
 				break;
 			}
-			State = 1060; valueStmt(0);
-			State = 1062;
+			State = 1408; valueStmt(0);
+			State = 1410;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1061; whiteSpace();
+				State = 1409; whiteSpace();
 				}
 			}
 
-			State = 1064; Match(EQ);
-			State = 1066;
-			switch ( Interpreter.AdaptivePredict(_input,123,_ctx) ) {
+			State = 1412; Match(EQ);
+			State = 1414;
+			switch ( Interpreter.AdaptivePredict(_input,170,_ctx) ) {
 			case 1:
 				{
-				State = 1065; whiteSpace();
+				State = 1413; whiteSpace();
 				}
 				break;
 			}
-			State = 1068; valueStmt(0);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class LineInputStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public ValueStmtContext valueStmt() {
-			return GetRuleContext<ValueStmtContext>(0);
-		}
-		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public ITerminalNode LINE_INPUT() { return GetToken(VBAParser.LINE_INPUT, 0); }
-		public LineInputStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_lineInputStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterLineInputStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitLineInputStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitLineInputStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public LineInputStmtContext lineInputStmt() {
-		LineInputStmtContext _localctx = new LineInputStmtContext(_ctx, State);
-		EnterRule(_localctx, 116, RULE_lineInputStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1070; Match(LINE_INPUT);
-			State = 1071; whiteSpace();
-			State = 1072; fileNumber();
-			State = 1074;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1073; whiteSpace();
-				}
-			}
-
-			State = 1076; Match(COMMA);
-			State = 1078;
-			switch ( Interpreter.AdaptivePredict(_input,125,_ctx) ) {
-			case 1:
-				{
-				State = 1077; whiteSpace();
-				}
-				break;
-			}
-			State = 1080; valueStmt(0);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class LockStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public IReadOnlyList<ValueStmtContext> valueStmt() {
-			return GetRuleContexts<ValueStmtContext>();
-		}
-		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
-		public ITerminalNode LOCK() { return GetToken(VBAParser.LOCK, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public ITerminalNode TO() { return GetToken(VBAParser.TO, 0); }
-		public ValueStmtContext valueStmt(int i) {
-			return GetRuleContext<ValueStmtContext>(i);
-		}
-		public LockStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_lockStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterLockStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitLockStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitLockStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public LockStmtContext lockStmt() {
-		LockStmtContext _localctx = new LockStmtContext(_ctx, State);
-		EnterRule(_localctx, 118, RULE_lockStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1082; Match(LOCK);
-			State = 1083; whiteSpace();
-			State = 1084; valueStmt(0);
-			State = 1100;
-			switch ( Interpreter.AdaptivePredict(_input,129,_ctx) ) {
-			case 1:
-				{
-				State = 1086;
-				_la = _input.La(1);
-				if (_la==WS || _la==LINE_CONTINUATION) {
-					{
-					State = 1085; whiteSpace();
-					}
-				}
-
-				State = 1088; Match(COMMA);
-				State = 1090;
-				switch ( Interpreter.AdaptivePredict(_input,127,_ctx) ) {
-				case 1:
-					{
-					State = 1089; whiteSpace();
-					}
-					break;
-				}
-				State = 1092; valueStmt(0);
-				State = 1098;
-				switch ( Interpreter.AdaptivePredict(_input,128,_ctx) ) {
-				case 1:
-					{
-					State = 1093; whiteSpace();
-					State = 1094; Match(TO);
-					State = 1095; whiteSpace();
-					State = 1096; valueStmt(0);
-					}
-					break;
-				}
-				}
-				break;
-			}
+			State = 1416; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5614,32 +8127,32 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LsetStmtContext lsetStmt() {
 		LsetStmtContext _localctx = new LsetStmtContext(_ctx, State);
-		EnterRule(_localctx, 120, RULE_lsetStmt);
+		EnterRule(_localctx, 204, RULE_lsetStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1102; Match(LSET);
-			State = 1103; whiteSpace();
-			State = 1104; valueStmt(0);
-			State = 1106;
+			State = 1418; Match(LSET);
+			State = 1419; whiteSpace();
+			State = 1420; valueStmt(0);
+			State = 1422;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1105; whiteSpace();
+				State = 1421; whiteSpace();
 				}
 			}
 
-			State = 1108; Match(EQ);
-			State = 1110;
-			switch ( Interpreter.AdaptivePredict(_input,131,_ctx) ) {
+			State = 1424; Match(EQ);
+			State = 1426;
+			switch ( Interpreter.AdaptivePredict(_input,172,_ctx) ) {
 			case 1:
 				{
-				State = 1109; whiteSpace();
+				State = 1425; whiteSpace();
 				}
 				break;
 			}
-			State = 1112; valueStmt(0);
+			State = 1428; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5689,39 +8202,39 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public MidStmtContext midStmt() {
 		MidStmtContext _localctx = new MidStmtContext(_ctx, State);
-		EnterRule(_localctx, 122, RULE_midStmt);
+		EnterRule(_localctx, 206, RULE_midStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1114; Match(MID);
-			State = 1116;
+			State = 1430; Match(MID);
+			State = 1432;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1115; whiteSpace();
+				State = 1431; whiteSpace();
 				}
 			}
 
-			State = 1118; Match(LPAREN);
-			State = 1120;
-			switch ( Interpreter.AdaptivePredict(_input,133,_ctx) ) {
+			State = 1434; Match(LPAREN);
+			State = 1436;
+			switch ( Interpreter.AdaptivePredict(_input,174,_ctx) ) {
 			case 1:
 				{
-				State = 1119; whiteSpace();
+				State = 1435; whiteSpace();
 				}
 				break;
 			}
-			State = 1122; argsCall();
-			State = 1124;
+			State = 1438; argsCall();
+			State = 1440;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1123; whiteSpace();
+				State = 1439; whiteSpace();
 				}
 			}
 
-			State = 1126; Match(RPAREN);
+			State = 1442; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5773,32 +8286,32 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public OnErrorStmtContext onErrorStmt() {
 		OnErrorStmtContext _localctx = new OnErrorStmtContext(_ctx, State);
-		EnterRule(_localctx, 124, RULE_onErrorStmt);
+		EnterRule(_localctx, 208, RULE_onErrorStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1128;
+			State = 1444;
 			_la = _input.La(1);
 			if ( !(_la==ON_ERROR || _la==ON_LOCAL_ERROR) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 1129; whiteSpace();
-			State = 1138;
+			State = 1445; whiteSpace();
+			State = 1454;
 			switch (_input.La(1)) {
 			case GOTO:
 				{
-				State = 1130; Match(GOTO);
-				State = 1131; whiteSpace();
-				State = 1132; valueStmt(0);
+				State = 1446; Match(GOTO);
+				State = 1447; whiteSpace();
+				State = 1448; valueStmt(0);
 				}
 				break;
 			case RESUME:
 				{
-				State = 1134; Match(RESUME);
-				State = 1135; whiteSpace();
-				State = 1136; Match(NEXT);
+				State = 1450; Match(RESUME);
+				State = 1451; whiteSpace();
+				State = 1452; Match(NEXT);
 				}
 				break;
 			default:
@@ -5859,50 +8372,50 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public OnGoToStmtContext onGoToStmt() {
 		OnGoToStmtContext _localctx = new OnGoToStmtContext(_ctx, State);
-		EnterRule(_localctx, 126, RULE_onGoToStmt);
+		EnterRule(_localctx, 210, RULE_onGoToStmt);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1140; Match(ON);
-			State = 1141; whiteSpace();
-			State = 1142; valueStmt(0);
-			State = 1143; whiteSpace();
-			State = 1144; Match(GOTO);
-			State = 1145; whiteSpace();
-			State = 1146; valueStmt(0);
-			State = 1157;
+			State = 1456; Match(ON);
+			State = 1457; whiteSpace();
+			State = 1458; valueStmt(0);
+			State = 1459; whiteSpace();
+			State = 1460; Match(GOTO);
+			State = 1461; whiteSpace();
+			State = 1462; valueStmt(0);
+			State = 1473;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,138,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,179,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1148;
+					State = 1464;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1147; whiteSpace();
+						State = 1463; whiteSpace();
 						}
 					}
 
-					State = 1150; Match(COMMA);
-					State = 1152;
-					switch ( Interpreter.AdaptivePredict(_input,137,_ctx) ) {
+					State = 1466; Match(COMMA);
+					State = 1468;
+					switch ( Interpreter.AdaptivePredict(_input,178,_ctx) ) {
 					case 1:
 						{
-						State = 1151; whiteSpace();
+						State = 1467; whiteSpace();
 						}
 						break;
 					}
-					State = 1154; valueStmt(0);
+					State = 1470; valueStmt(0);
 					}
 					} 
 				}
-				State = 1159;
+				State = 1475;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,138,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,179,_ctx);
 			}
 			}
 		}
@@ -5959,567 +8472,50 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public OnGoSubStmtContext onGoSubStmt() {
 		OnGoSubStmtContext _localctx = new OnGoSubStmtContext(_ctx, State);
-		EnterRule(_localctx, 128, RULE_onGoSubStmt);
+		EnterRule(_localctx, 212, RULE_onGoSubStmt);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1160; Match(ON);
-			State = 1161; whiteSpace();
-			State = 1162; valueStmt(0);
-			State = 1163; whiteSpace();
-			State = 1164; Match(GOSUB);
-			State = 1165; whiteSpace();
-			State = 1166; valueStmt(0);
-			State = 1177;
+			State = 1476; Match(ON);
+			State = 1477; whiteSpace();
+			State = 1478; valueStmt(0);
+			State = 1479; whiteSpace();
+			State = 1480; Match(GOSUB);
+			State = 1481; whiteSpace();
+			State = 1482; valueStmt(0);
+			State = 1493;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,141,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,182,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1168;
+					State = 1484;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1167; whiteSpace();
+						State = 1483; whiteSpace();
 						}
 					}
 
-					State = 1170; Match(COMMA);
-					State = 1172;
-					switch ( Interpreter.AdaptivePredict(_input,140,_ctx) ) {
+					State = 1486; Match(COMMA);
+					State = 1488;
+					switch ( Interpreter.AdaptivePredict(_input,181,_ctx) ) {
 					case 1:
 						{
-						State = 1171; whiteSpace();
+						State = 1487; whiteSpace();
 						}
 						break;
 					}
-					State = 1174; valueStmt(0);
+					State = 1490; valueStmt(0);
 					}
 					} 
 				}
-				State = 1179;
+				State = 1495;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,141,_ctx);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class OpenStmtContext : ParserRuleContext {
-		public ITerminalNode LOCK_WRITE() { return GetToken(VBAParser.LOCK_WRITE, 0); }
-		public ITerminalNode ACCESS() { return GetToken(VBAParser.ACCESS, 0); }
-		public IReadOnlyList<ValueStmtContext> valueStmt() {
-			return GetRuleContexts<ValueStmtContext>();
-		}
-		public ITerminalNode LOCK_READ_WRITE() { return GetToken(VBAParser.LOCK_READ_WRITE, 0); }
-		public ITerminalNode FOR() { return GetToken(VBAParser.FOR, 0); }
-		public ITerminalNode WRITE() { return GetToken(VBAParser.WRITE, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public ITerminalNode LEN() { return GetToken(VBAParser.LEN, 0); }
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public ITerminalNode INPUT() { return GetToken(VBAParser.INPUT, 0); }
-		public ITerminalNode READ() { return GetToken(VBAParser.READ, 0); }
-		public ITerminalNode SHARED() { return GetToken(VBAParser.SHARED, 0); }
-		public ITerminalNode AS() { return GetToken(VBAParser.AS, 0); }
-		public ITerminalNode APPEND() { return GetToken(VBAParser.APPEND, 0); }
-		public ITerminalNode BINARY() { return GetToken(VBAParser.BINARY, 0); }
-		public ITerminalNode RANDOM() { return GetToken(VBAParser.RANDOM, 0); }
-		public ITerminalNode OPEN() { return GetToken(VBAParser.OPEN, 0); }
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public ITerminalNode LOCK_READ() { return GetToken(VBAParser.LOCK_READ, 0); }
-		public ITerminalNode OUTPUT() { return GetToken(VBAParser.OUTPUT, 0); }
-		public ITerminalNode EQ() { return GetToken(VBAParser.EQ, 0); }
-		public ITerminalNode READ_WRITE() { return GetToken(VBAParser.READ_WRITE, 0); }
-		public ValueStmtContext valueStmt(int i) {
-			return GetRuleContext<ValueStmtContext>(i);
-		}
-		public OpenStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_openStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterOpenStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitOpenStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitOpenStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public OpenStmtContext openStmt() {
-		OpenStmtContext _localctx = new OpenStmtContext(_ctx, State);
-		EnterRule(_localctx, 130, RULE_openStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1180; Match(OPEN);
-			State = 1181; whiteSpace();
-			State = 1182; valueStmt(0);
-			State = 1183; whiteSpace();
-			State = 1184; Match(FOR);
-			State = 1185; whiteSpace();
-			State = 1186;
-			_la = _input.La(1);
-			if ( !(_la==APPEND || _la==BINARY || ((((_la - 121)) & ~0x3f) == 0 && ((1L << (_la - 121)) & ((1L << (INPUT - 121)) | (1L << (OUTPUT - 121)) | (1L << (RANDOM - 121)))) != 0)) ) {
-			_errHandler.RecoverInline(this);
-			}
-			Consume();
-			State = 1192;
-			switch ( Interpreter.AdaptivePredict(_input,142,_ctx) ) {
-			case 1:
-				{
-				State = 1187; whiteSpace();
-				State = 1188; Match(ACCESS);
-				State = 1189; whiteSpace();
-				State = 1190;
-				_la = _input.La(1);
-				if ( !(((((_la - 166)) & ~0x3f) == 0 && ((1L << (_la - 166)) & ((1L << (READ - 166)) | (1L << (READ_WRITE - 166)) | (1L << (WRITE - 166)))) != 0)) ) {
-				_errHandler.RecoverInline(this);
-				}
-				Consume();
-				}
-				break;
-			}
-			State = 1197;
-			switch ( Interpreter.AdaptivePredict(_input,143,_ctx) ) {
-			case 1:
-				{
-				State = 1194; whiteSpace();
-				State = 1195;
-				_la = _input.La(1);
-				if ( !(((((_la - 131)) & ~0x3f) == 0 && ((1L << (_la - 131)) & ((1L << (LOCK_READ - 131)) | (1L << (LOCK_WRITE - 131)) | (1L << (LOCK_READ_WRITE - 131)) | (1L << (SHARED - 131)))) != 0)) ) {
-				_errHandler.RecoverInline(this);
-				}
-				Consume();
-				}
-				break;
-			}
-			State = 1199; whiteSpace();
-			State = 1200; Match(AS);
-			State = 1201; whiteSpace();
-			State = 1202; fileNumber();
-			State = 1214;
-			switch ( Interpreter.AdaptivePredict(_input,146,_ctx) ) {
-			case 1:
-				{
-				State = 1203; whiteSpace();
-				State = 1204; Match(LEN);
-				State = 1206;
-				_la = _input.La(1);
-				if (_la==WS || _la==LINE_CONTINUATION) {
-					{
-					State = 1205; whiteSpace();
-					}
-				}
-
-				State = 1208; Match(EQ);
-				State = 1210;
-				switch ( Interpreter.AdaptivePredict(_input,145,_ctx) ) {
-				case 1:
-					{
-					State = 1209; whiteSpace();
-					}
-					break;
-				}
-				State = 1212; valueStmt(0);
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class OutputListContext : ParserRuleContext {
-		public IReadOnlyList<ITerminalNode> SEMICOLON() { return GetTokens(VBAParser.SEMICOLON); }
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
-		public ITerminalNode SEMICOLON(int i) {
-			return GetToken(VBAParser.SEMICOLON, i);
-		}
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public IReadOnlyList<OutputList_ExpressionContext> outputList_Expression() {
-			return GetRuleContexts<OutputList_ExpressionContext>();
-		}
-		public ITerminalNode COMMA(int i) {
-			return GetToken(VBAParser.COMMA, i);
-		}
-		public OutputList_ExpressionContext outputList_Expression(int i) {
-			return GetRuleContext<OutputList_ExpressionContext>(i);
-		}
-		public OutputListContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_outputList; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterOutputList(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitOutputList(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitOutputList(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public OutputListContext outputList() {
-		OutputListContext _localctx = new OutputListContext(_ctx, State);
-		EnterRule(_localctx, 132, RULE_outputList);
-		int _la;
-		try {
-			int _alt;
-			State = 1249;
-			switch ( Interpreter.AdaptivePredict(_input,156,_ctx) ) {
-			case 1:
-				EnterOuterAlt(_localctx, 1);
-				{
-				State = 1216; outputList_Expression();
-				State = 1229;
-				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,150,_ctx);
-				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
-					if ( _alt==1 ) {
-						{
-						{
-						State = 1218;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 1217; whiteSpace();
-							}
-						}
-
-						State = 1220;
-						_la = _input.La(1);
-						if ( !(_la==COMMA || _la==SEMICOLON) ) {
-						_errHandler.RecoverInline(this);
-						}
-						Consume();
-						State = 1222;
-						switch ( Interpreter.AdaptivePredict(_input,148,_ctx) ) {
-						case 1:
-							{
-							State = 1221; whiteSpace();
-							}
-							break;
-						}
-						State = 1225;
-						switch ( Interpreter.AdaptivePredict(_input,149,_ctx) ) {
-						case 1:
-							{
-							State = 1224; outputList_Expression();
-							}
-							break;
-						}
-						}
-						} 
-					}
-					State = 1231;
-					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,150,_ctx);
-				}
-				}
-				break;
-
-			case 2:
-				EnterOuterAlt(_localctx, 2);
-				{
-				State = 1233;
-				switch ( Interpreter.AdaptivePredict(_input,151,_ctx) ) {
-				case 1:
-					{
-					State = 1232; outputList_Expression();
-					}
-					break;
-				}
-				State = 1245;
-				_errHandler.Sync(this);
-				_alt = 1;
-				do {
-					switch (_alt) {
-					case 1:
-						{
-						{
-						State = 1236;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 1235; whiteSpace();
-							}
-						}
-
-						State = 1238;
-						_la = _input.La(1);
-						if ( !(_la==COMMA || _la==SEMICOLON) ) {
-						_errHandler.RecoverInline(this);
-						}
-						Consume();
-						State = 1240;
-						switch ( Interpreter.AdaptivePredict(_input,153,_ctx) ) {
-						case 1:
-							{
-							State = 1239; whiteSpace();
-							}
-							break;
-						}
-						State = 1243;
-						switch ( Interpreter.AdaptivePredict(_input,154,_ctx) ) {
-						case 1:
-							{
-							State = 1242; outputList_Expression();
-							}
-							break;
-						}
-						}
-						}
-						break;
-					default:
-						throw new NoViableAltException(this);
-					}
-					State = 1247;
-					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,155,_ctx);
-				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-				}
-				break;
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class OutputList_ExpressionContext : ParserRuleContext {
-		public ITerminalNode TAB() { return GetToken(VBAParser.TAB, 0); }
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public ValueStmtContext valueStmt() {
-			return GetRuleContext<ValueStmtContext>(0);
-		}
-		public ITerminalNode LPAREN() { return GetToken(VBAParser.LPAREN, 0); }
-		public ITerminalNode SPC() { return GetToken(VBAParser.SPC, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public ArgsCallContext argsCall() {
-			return GetRuleContext<ArgsCallContext>(0);
-		}
-		public ITerminalNode RPAREN() { return GetToken(VBAParser.RPAREN, 0); }
-		public OutputList_ExpressionContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_outputList_Expression; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterOutputList_Expression(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitOutputList_Expression(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitOutputList_Expression(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public OutputList_ExpressionContext outputList_Expression() {
-		OutputList_ExpressionContext _localctx = new OutputList_ExpressionContext(_ctx, State);
-		EnterRule(_localctx, 134, RULE_outputList_Expression);
-		int _la;
-		try {
-			State = 1268;
-			switch ( Interpreter.AdaptivePredict(_input,161,_ctx) ) {
-			case 1:
-				EnterOuterAlt(_localctx, 1);
-				{
-				State = 1251; valueStmt(0);
-				}
-				break;
-
-			case 2:
-				EnterOuterAlt(_localctx, 2);
-				{
-				State = 1252;
-				_la = _input.La(1);
-				if ( !(_la==SPC || _la==TAB) ) {
-				_errHandler.RecoverInline(this);
-				}
-				Consume();
-				State = 1266;
-				switch ( Interpreter.AdaptivePredict(_input,160,_ctx) ) {
-				case 1:
-					{
-					State = 1254;
-					_la = _input.La(1);
-					if (_la==WS || _la==LINE_CONTINUATION) {
-						{
-						State = 1253; whiteSpace();
-						}
-					}
-
-					State = 1256; Match(LPAREN);
-					State = 1258;
-					switch ( Interpreter.AdaptivePredict(_input,158,_ctx) ) {
-					case 1:
-						{
-						State = 1257; whiteSpace();
-						}
-						break;
-					}
-					State = 1260; argsCall();
-					State = 1262;
-					_la = _input.La(1);
-					if (_la==WS || _la==LINE_CONTINUATION) {
-						{
-						State = 1261; whiteSpace();
-						}
-					}
-
-					State = 1264; Match(RPAREN);
-					}
-					break;
-				}
-				}
-				break;
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class PrintStmtContext : ParserRuleContext {
-		public ITerminalNode PRINT() { return GetToken(VBAParser.PRINT, 0); }
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
-		public OutputListContext outputList() {
-			return GetRuleContext<OutputListContext>(0);
-		}
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public PrintStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_printStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterPrintStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitPrintStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitPrintStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public PrintStmtContext printStmt() {
-		PrintStmtContext _localctx = new PrintStmtContext(_ctx, State);
-		EnterRule(_localctx, 136, RULE_printStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1270; Match(PRINT);
-			State = 1271; whiteSpace();
-			State = 1272; fileNumber();
-			State = 1274;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1273; whiteSpace();
-				}
-			}
-
-			State = 1276; Match(COMMA);
-			State = 1281;
-			switch ( Interpreter.AdaptivePredict(_input,164,_ctx) ) {
-			case 1:
-				{
-				State = 1278;
-				switch ( Interpreter.AdaptivePredict(_input,163,_ctx) ) {
-				case 1:
-					{
-					State = 1277; whiteSpace();
-					}
-					break;
-				}
-				State = 1280; outputList();
-				}
-				break;
+				_alt = Interpreter.AdaptivePredict(_input,182,_ctx);
 			}
 			}
 		}
@@ -6588,75 +8584,75 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public PropertyGetStmtContext propertyGetStmt() {
 		PropertyGetStmtContext _localctx = new PropertyGetStmtContext(_ctx, State);
-		EnterRule(_localctx, 138, RULE_propertyGetStmt);
+		EnterRule(_localctx, 214, RULE_propertyGetStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1286;
+			State = 1499;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1283; visibility();
-				State = 1284; whiteSpace();
+				State = 1496; visibility();
+				State = 1497; whiteSpace();
 				}
 			}
 
-			State = 1290;
+			State = 1503;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1288; Match(STATIC);
-				State = 1289; whiteSpace();
+				State = 1501; Match(STATIC);
+				State = 1502; whiteSpace();
 				}
 			}
 
-			State = 1292; Match(PROPERTY_GET);
-			State = 1293; whiteSpace();
-			State = 1294; functionName();
-			State = 1296;
-			switch ( Interpreter.AdaptivePredict(_input,167,_ctx) ) {
+			State = 1505; Match(PROPERTY_GET);
+			State = 1506; whiteSpace();
+			State = 1507; functionName();
+			State = 1509;
+			switch ( Interpreter.AdaptivePredict(_input,185,_ctx) ) {
 			case 1:
 				{
-				State = 1295; typeHint();
+				State = 1508; typeHint();
 				}
 				break;
 			}
-			State = 1302;
-			switch ( Interpreter.AdaptivePredict(_input,169,_ctx) ) {
+			State = 1515;
+			switch ( Interpreter.AdaptivePredict(_input,187,_ctx) ) {
 			case 1:
 				{
-				State = 1299;
+				State = 1512;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1298; whiteSpace();
+					State = 1511; whiteSpace();
 					}
 				}
 
-				State = 1301; argList();
+				State = 1514; argList();
 				}
 				break;
 			}
-			State = 1307;
-			switch ( Interpreter.AdaptivePredict(_input,170,_ctx) ) {
+			State = 1520;
+			switch ( Interpreter.AdaptivePredict(_input,188,_ctx) ) {
 			case 1:
 				{
-				State = 1304; whiteSpace();
-				State = 1305; asTypeClause();
+				State = 1517; whiteSpace();
+				State = 1518; asTypeClause();
 				}
 				break;
 			}
-			State = 1309; endOfStatement();
-			State = 1311;
+			State = 1522; endOfStatement();
+			State = 1524;
 			_la = _input.La(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1310; block();
+				State = 1523; block();
 				}
 			}
 
-			State = 1313; Match(END_PROPERTY);
+			State = 1526; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -6718,58 +8714,58 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public PropertySetStmtContext propertySetStmt() {
 		PropertySetStmtContext _localctx = new PropertySetStmtContext(_ctx, State);
-		EnterRule(_localctx, 140, RULE_propertySetStmt);
+		EnterRule(_localctx, 216, RULE_propertySetStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1318;
+			State = 1531;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1315; visibility();
-				State = 1316; whiteSpace();
+				State = 1528; visibility();
+				State = 1529; whiteSpace();
 				}
 			}
 
-			State = 1322;
+			State = 1535;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1320; Match(STATIC);
-				State = 1321; whiteSpace();
+				State = 1533; Match(STATIC);
+				State = 1534; whiteSpace();
 				}
 			}
 
-			State = 1324; Match(PROPERTY_SET);
-			State = 1325; whiteSpace();
-			State = 1326; subroutineName();
-			State = 1331;
-			switch ( Interpreter.AdaptivePredict(_input,175,_ctx) ) {
+			State = 1537; Match(PROPERTY_SET);
+			State = 1538; whiteSpace();
+			State = 1539; subroutineName();
+			State = 1544;
+			switch ( Interpreter.AdaptivePredict(_input,193,_ctx) ) {
 			case 1:
 				{
-				State = 1328;
+				State = 1541;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1327; whiteSpace();
+					State = 1540; whiteSpace();
 					}
 				}
 
-				State = 1330; argList();
+				State = 1543; argList();
 				}
 				break;
 			}
-			State = 1333; endOfStatement();
-			State = 1335;
+			State = 1546; endOfStatement();
+			State = 1548;
 			_la = _input.La(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1334; block();
+				State = 1547; block();
 				}
 			}
 
-			State = 1337; Match(END_PROPERTY);
+			State = 1550; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -6831,166 +8827,58 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public PropertyLetStmtContext propertyLetStmt() {
 		PropertyLetStmtContext _localctx = new PropertyLetStmtContext(_ctx, State);
-		EnterRule(_localctx, 142, RULE_propertyLetStmt);
+		EnterRule(_localctx, 218, RULE_propertyLetStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1342;
+			State = 1555;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1339; visibility();
-				State = 1340; whiteSpace();
+				State = 1552; visibility();
+				State = 1553; whiteSpace();
 				}
 			}
 
-			State = 1346;
+			State = 1559;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1344; Match(STATIC);
-				State = 1345; whiteSpace();
+				State = 1557; Match(STATIC);
+				State = 1558; whiteSpace();
 				}
 			}
 
-			State = 1348; Match(PROPERTY_LET);
-			State = 1349; whiteSpace();
-			State = 1350; subroutineName();
-			State = 1355;
-			switch ( Interpreter.AdaptivePredict(_input,180,_ctx) ) {
+			State = 1561; Match(PROPERTY_LET);
+			State = 1562; whiteSpace();
+			State = 1563; subroutineName();
+			State = 1568;
+			switch ( Interpreter.AdaptivePredict(_input,198,_ctx) ) {
 			case 1:
 				{
-				State = 1352;
+				State = 1565;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1351; whiteSpace();
+					State = 1564; whiteSpace();
 					}
 				}
 
-				State = 1354; argList();
+				State = 1567; argList();
 				}
 				break;
 			}
-			State = 1357; endOfStatement();
-			State = 1359;
+			State = 1570; endOfStatement();
+			State = 1572;
 			_la = _input.La(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1358; block();
+				State = 1571; block();
 				}
 			}
 
-			State = 1361; Match(END_PROPERTY);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class PutStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public IReadOnlyList<ValueStmtContext> valueStmt() {
-			return GetRuleContexts<ValueStmtContext>();
-		}
-		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public ITerminalNode PUT() { return GetToken(VBAParser.PUT, 0); }
-		public ITerminalNode COMMA(int i) {
-			return GetToken(VBAParser.COMMA, i);
-		}
-		public ValueStmtContext valueStmt(int i) {
-			return GetRuleContext<ValueStmtContext>(i);
-		}
-		public PutStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_putStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterPutStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitPutStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitPutStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public PutStmtContext putStmt() {
-		PutStmtContext _localctx = new PutStmtContext(_ctx, State);
-		EnterRule(_localctx, 144, RULE_putStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1363; Match(PUT);
-			State = 1364; whiteSpace();
-			State = 1365; fileNumber();
-			State = 1367;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1366; whiteSpace();
-				}
-			}
-
-			State = 1369; Match(COMMA);
-			State = 1371;
-			switch ( Interpreter.AdaptivePredict(_input,183,_ctx) ) {
-			case 1:
-				{
-				State = 1370; whiteSpace();
-				}
-				break;
-			}
-			State = 1374;
-			switch ( Interpreter.AdaptivePredict(_input,184,_ctx) ) {
-			case 1:
-				{
-				State = 1373; valueStmt(0);
-				}
-				break;
-			}
-			State = 1377;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1376; whiteSpace();
-				}
-			}
-
-			State = 1379; Match(COMMA);
-			State = 1381;
-			switch ( Interpreter.AdaptivePredict(_input,186,_ctx) ) {
-			case 1:
-				{
-				State = 1380; whiteSpace();
-				}
-				break;
-			}
-			State = 1383; valueStmt(0);
+			State = 1574; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7043,52 +8931,52 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RaiseEventStmtContext raiseEventStmt() {
 		RaiseEventStmtContext _localctx = new RaiseEventStmtContext(_ctx, State);
-		EnterRule(_localctx, 146, RULE_raiseEventStmt);
+		EnterRule(_localctx, 220, RULE_raiseEventStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1385; Match(RAISEEVENT);
-			State = 1386; whiteSpace();
-			State = 1387; identifier();
-			State = 1402;
-			switch ( Interpreter.AdaptivePredict(_input,191,_ctx) ) {
+			State = 1576; Match(RAISEEVENT);
+			State = 1577; whiteSpace();
+			State = 1578; identifier();
+			State = 1593;
+			switch ( Interpreter.AdaptivePredict(_input,204,_ctx) ) {
 			case 1:
 				{
-				State = 1389;
+				State = 1580;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1388; whiteSpace();
+					State = 1579; whiteSpace();
 					}
 				}
 
-				State = 1391; Match(LPAREN);
-				State = 1393;
-				switch ( Interpreter.AdaptivePredict(_input,188,_ctx) ) {
+				State = 1582; Match(LPAREN);
+				State = 1584;
+				switch ( Interpreter.AdaptivePredict(_input,201,_ctx) ) {
 				case 1:
 					{
-					State = 1392; whiteSpace();
+					State = 1583; whiteSpace();
 					}
 					break;
 				}
-				State = 1399;
-				switch ( Interpreter.AdaptivePredict(_input,190,_ctx) ) {
+				State = 1590;
+				switch ( Interpreter.AdaptivePredict(_input,203,_ctx) ) {
 				case 1:
 					{
-					State = 1395; argsCall();
-					State = 1397;
+					State = 1586; argsCall();
+					State = 1588;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1396; whiteSpace();
+						State = 1587; whiteSpace();
 						}
 					}
 
 					}
 					break;
 				}
-				State = 1401; Match(RPAREN);
+				State = 1592; Match(RPAREN);
 				}
 				break;
 			}
@@ -7147,55 +9035,55 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RedimStmtContext redimStmt() {
 		RedimStmtContext _localctx = new RedimStmtContext(_ctx, State);
-		EnterRule(_localctx, 148, RULE_redimStmt);
+		EnterRule(_localctx, 222, RULE_redimStmt);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1404; Match(REDIM);
-			State = 1405; whiteSpace();
-			State = 1408;
-			switch ( Interpreter.AdaptivePredict(_input,192,_ctx) ) {
+			State = 1595; Match(REDIM);
+			State = 1596; whiteSpace();
+			State = 1599;
+			switch ( Interpreter.AdaptivePredict(_input,205,_ctx) ) {
 			case 1:
 				{
-				State = 1406; Match(PRESERVE);
-				State = 1407; whiteSpace();
+				State = 1597; Match(PRESERVE);
+				State = 1598; whiteSpace();
 				}
 				break;
 			}
-			State = 1410; redimSubStmt();
-			State = 1421;
+			State = 1601; redimSubStmt();
+			State = 1612;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,195,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,208,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1412;
+					State = 1603;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1411; whiteSpace();
+						State = 1602; whiteSpace();
 						}
 					}
 
-					State = 1414; Match(COMMA);
-					State = 1416;
-					switch ( Interpreter.AdaptivePredict(_input,194,_ctx) ) {
+					State = 1605; Match(COMMA);
+					State = 1607;
+					switch ( Interpreter.AdaptivePredict(_input,207,_ctx) ) {
 					case 1:
 						{
-						State = 1415; whiteSpace();
+						State = 1606; whiteSpace();
 						}
 						break;
 					}
-					State = 1418; redimSubStmt();
+					State = 1609; redimSubStmt();
 					}
 					} 
 				}
-				State = 1423;
+				State = 1614;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,195,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,208,_ctx);
 			}
 			}
 		}
@@ -7251,91 +9139,48 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RedimSubStmtContext redimSubStmt() {
 		RedimSubStmtContext _localctx = new RedimSubStmtContext(_ctx, State);
-		EnterRule(_localctx, 150, RULE_redimSubStmt);
+		EnterRule(_localctx, 224, RULE_redimSubStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1424; implicitCallStmt_InStmt();
-			State = 1426;
+			State = 1615; implicitCallStmt_InStmt();
+			State = 1617;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1425; whiteSpace();
+				State = 1616; whiteSpace();
 				}
 			}
 
-			State = 1428; Match(LPAREN);
-			State = 1430;
-			switch ( Interpreter.AdaptivePredict(_input,197,_ctx) ) {
+			State = 1619; Match(LPAREN);
+			State = 1621;
+			switch ( Interpreter.AdaptivePredict(_input,210,_ctx) ) {
 			case 1:
 				{
-				State = 1429; whiteSpace();
+				State = 1620; whiteSpace();
 				}
 				break;
 			}
-			State = 1432; subscripts();
-			State = 1434;
+			State = 1623; subscripts();
+			State = 1625;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1433; whiteSpace();
+				State = 1624; whiteSpace();
 				}
 			}
 
-			State = 1436; Match(RPAREN);
-			State = 1440;
-			switch ( Interpreter.AdaptivePredict(_input,199,_ctx) ) {
+			State = 1627; Match(RPAREN);
+			State = 1631;
+			switch ( Interpreter.AdaptivePredict(_input,212,_ctx) ) {
 			case 1:
 				{
-				State = 1437; whiteSpace();
-				State = 1438; asTypeClause();
+				State = 1628; whiteSpace();
+				State = 1629; asTypeClause();
 				}
 				break;
 			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class ResetStmtContext : ParserRuleContext {
-		public ITerminalNode RESET() { return GetToken(VBAParser.RESET, 0); }
-		public ResetStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_resetStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterResetStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitResetStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitResetStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public ResetStmtContext resetStmt() {
-		ResetStmtContext _localctx = new ResetStmtContext(_ctx, State);
-		EnterRule(_localctx, 152, RULE_resetStmt);
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1442; Match(RESET);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7381,27 +9226,27 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ResumeStmtContext resumeStmt() {
 		ResumeStmtContext _localctx = new ResumeStmtContext(_ctx, State);
-		EnterRule(_localctx, 154, RULE_resumeStmt);
+		EnterRule(_localctx, 226, RULE_resumeStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1444; Match(RESUME);
-			State = 1450;
-			switch ( Interpreter.AdaptivePredict(_input,201,_ctx) ) {
+			State = 1633; Match(RESUME);
+			State = 1639;
+			switch ( Interpreter.AdaptivePredict(_input,214,_ctx) ) {
 			case 1:
 				{
-				State = 1445; whiteSpace();
-				State = 1448;
-				switch ( Interpreter.AdaptivePredict(_input,200,_ctx) ) {
+				State = 1634; whiteSpace();
+				State = 1637;
+				switch ( Interpreter.AdaptivePredict(_input,213,_ctx) ) {
 				case 1:
 					{
-					State = 1446; Match(NEXT);
+					State = 1635; Match(NEXT);
 					}
 					break;
 
 				case 2:
 					{
-					State = 1447; valueStmt(0);
+					State = 1636; valueStmt(0);
 					}
 					break;
 				}
@@ -7446,11 +9291,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ReturnStmtContext returnStmt() {
 		ReturnStmtContext _localctx = new ReturnStmtContext(_ctx, State);
-		EnterRule(_localctx, 156, RULE_returnStmt);
+		EnterRule(_localctx, 228, RULE_returnStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1452; Match(RETURN);
+			State = 1641; Match(RETURN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7502,32 +9347,32 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RsetStmtContext rsetStmt() {
 		RsetStmtContext _localctx = new RsetStmtContext(_ctx, State);
-		EnterRule(_localctx, 158, RULE_rsetStmt);
+		EnterRule(_localctx, 230, RULE_rsetStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1454; Match(RSET);
-			State = 1455; whiteSpace();
-			State = 1456; valueStmt(0);
-			State = 1458;
+			State = 1643; Match(RSET);
+			State = 1644; whiteSpace();
+			State = 1645; valueStmt(0);
+			State = 1647;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1457; whiteSpace();
+				State = 1646; whiteSpace();
 				}
 			}
 
-			State = 1460; Match(EQ);
-			State = 1462;
-			switch ( Interpreter.AdaptivePredict(_input,203,_ctx) ) {
+			State = 1649; Match(EQ);
+			State = 1651;
+			switch ( Interpreter.AdaptivePredict(_input,216,_ctx) ) {
 			case 1:
 				{
-				State = 1461; whiteSpace();
+				State = 1650; whiteSpace();
 				}
 				break;
 			}
-			State = 1464; valueStmt(0);
+			State = 1653; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7566,88 +9411,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StopStmtContext stopStmt() {
 		StopStmtContext _localctx = new StopStmtContext(_ctx, State);
-		EnterRule(_localctx, 160, RULE_stopStmt);
+		EnterRule(_localctx, 232, RULE_stopStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1466; Match(STOP);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class SeekStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public ValueStmtContext valueStmt() {
-			return GetRuleContext<ValueStmtContext>(0);
-		}
-		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public ITerminalNode SEEK() { return GetToken(VBAParser.SEEK, 0); }
-		public SeekStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_seekStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterSeekStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitSeekStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitSeekStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public SeekStmtContext seekStmt() {
-		SeekStmtContext _localctx = new SeekStmtContext(_ctx, State);
-		EnterRule(_localctx, 162, RULE_seekStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1468; Match(SEEK);
-			State = 1469; whiteSpace();
-			State = 1470; fileNumber();
-			State = 1472;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1471; whiteSpace();
-				}
-			}
-
-			State = 1474; Match(COMMA);
-			State = 1476;
-			switch ( Interpreter.AdaptivePredict(_input,205,_ctx) ) {
-			case 1:
-				{
-				State = 1475; whiteSpace();
-				}
-				break;
-			}
-			State = 1478; valueStmt(0);
+			State = 1655; Match(STOP);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7706,31 +9474,31 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SelectCaseStmtContext selectCaseStmt() {
 		SelectCaseStmtContext _localctx = new SelectCaseStmtContext(_ctx, State);
-		EnterRule(_localctx, 164, RULE_selectCaseStmt);
+		EnterRule(_localctx, 234, RULE_selectCaseStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1480; Match(SELECT);
-			State = 1481; whiteSpace();
-			State = 1482; Match(CASE);
-			State = 1483; whiteSpace();
-			State = 1484; valueStmt(0);
-			State = 1485; endOfStatement();
-			State = 1489;
+			State = 1657; Match(SELECT);
+			State = 1658; whiteSpace();
+			State = 1659; Match(CASE);
+			State = 1660; whiteSpace();
+			State = 1661; valueStmt(0);
+			State = 1662; endOfStatement();
+			State = 1666;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==CASE) {
 				{
 				{
-				State = 1486; sC_Case();
+				State = 1663; sC_Case();
 				}
 				}
-				State = 1491;
+				State = 1668;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1492; Match(END_SELECT);
+			State = 1669; Match(END_SELECT);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7837,34 +9605,34 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SC_SelectionContext sC_Selection() {
 		SC_SelectionContext _localctx = new SC_SelectionContext(_ctx, State);
-		EnterRule(_localctx, 166, RULE_sC_Selection);
+		EnterRule(_localctx, 236, RULE_sC_Selection);
 		int _la;
 		try {
-			State = 1511;
-			switch ( Interpreter.AdaptivePredict(_input,209,_ctx) ) {
+			State = 1688;
+			switch ( Interpreter.AdaptivePredict(_input,220,_ctx) ) {
 			case 1:
 				_localctx = new CaseCondIsContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1494; Match(IS);
-				State = 1496;
+				State = 1671; Match(IS);
+				State = 1673;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1495; whiteSpace();
+					State = 1672; whiteSpace();
 					}
 				}
 
-				State = 1498; comparisonOperator();
-				State = 1500;
-				switch ( Interpreter.AdaptivePredict(_input,208,_ctx) ) {
+				State = 1675; comparisonOperator();
+				State = 1677;
+				switch ( Interpreter.AdaptivePredict(_input,219,_ctx) ) {
 				case 1:
 					{
-					State = 1499; whiteSpace();
+					State = 1676; whiteSpace();
 					}
 					break;
 				}
-				State = 1502; valueStmt(0);
+				State = 1679; valueStmt(0);
 				}
 				break;
 
@@ -7872,11 +9640,11 @@ public partial class VBAParser : Parser {
 				_localctx = new CaseCondToContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1504; valueStmt(0);
-				State = 1505; whiteSpace();
-				State = 1506; Match(TO);
-				State = 1507; whiteSpace();
-				State = 1508; valueStmt(0);
+				State = 1681; valueStmt(0);
+				State = 1682; whiteSpace();
+				State = 1683; Match(TO);
+				State = 1684; whiteSpace();
+				State = 1685; valueStmt(0);
 				}
 				break;
 
@@ -7884,7 +9652,7 @@ public partial class VBAParser : Parser {
 				_localctx = new CaseCondValueContext(_localctx);
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1510; valueStmt(0);
+				State = 1687; valueStmt(0);
 				}
 				break;
 			}
@@ -7937,19 +9705,19 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SC_CaseContext sC_Case() {
 		SC_CaseContext _localctx = new SC_CaseContext(_ctx, State);
-		EnterRule(_localctx, 168, RULE_sC_Case);
+		EnterRule(_localctx, 238, RULE_sC_Case);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1513; Match(CASE);
-			State = 1514; whiteSpace();
-			State = 1515; sC_Cond();
-			State = 1516; endOfStatement();
-			State = 1518;
-			switch ( Interpreter.AdaptivePredict(_input,210,_ctx) ) {
+			State = 1690; Match(CASE);
+			State = 1691; whiteSpace();
+			State = 1692; sC_Cond();
+			State = 1693; endOfStatement();
+			State = 1695;
+			switch ( Interpreter.AdaptivePredict(_input,221,_ctx) ) {
 			case 1:
 				{
-				State = 1517; block();
+				State = 1694; block();
 				}
 				break;
 			}
@@ -8031,17 +9799,17 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SC_CondContext sC_Cond() {
 		SC_CondContext _localctx = new SC_CondContext(_ctx, State);
-		EnterRule(_localctx, 170, RULE_sC_Cond);
+		EnterRule(_localctx, 240, RULE_sC_Cond);
 		int _la;
 		try {
 			int _alt;
-			State = 1535;
-			switch ( Interpreter.AdaptivePredict(_input,214,_ctx) ) {
+			State = 1712;
+			switch ( Interpreter.AdaptivePredict(_input,225,_ctx) ) {
 			case 1:
 				_localctx = new CaseCondElseContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1520; Match(ELSE);
+				State = 1697; Match(ELSE);
 				}
 				break;
 
@@ -8049,38 +9817,38 @@ public partial class VBAParser : Parser {
 				_localctx = new CaseCondSelectionContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1521; sC_Selection();
-				State = 1532;
+				State = 1698; sC_Selection();
+				State = 1709;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,213,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,224,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1523;
+						State = 1700;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1522; whiteSpace();
+							State = 1699; whiteSpace();
 							}
 						}
 
-						State = 1525; Match(COMMA);
-						State = 1527;
-						switch ( Interpreter.AdaptivePredict(_input,212,_ctx) ) {
+						State = 1702; Match(COMMA);
+						State = 1704;
+						switch ( Interpreter.AdaptivePredict(_input,223,_ctx) ) {
 						case 1:
 							{
-							State = 1526; whiteSpace();
+							State = 1703; whiteSpace();
 							}
 							break;
 						}
-						State = 1529; sC_Selection();
+						State = 1706; sC_Selection();
 						}
 						} 
 					}
-					State = 1534;
+					State = 1711;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,213,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,224,_ctx);
 				}
 				}
 				break;
@@ -8135,32 +9903,32 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SetStmtContext setStmt() {
 		SetStmtContext _localctx = new SetStmtContext(_ctx, State);
-		EnterRule(_localctx, 172, RULE_setStmt);
+		EnterRule(_localctx, 242, RULE_setStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1537; Match(SET);
-			State = 1538; whiteSpace();
-			State = 1539; valueStmt(0);
-			State = 1541;
+			State = 1714; Match(SET);
+			State = 1715; whiteSpace();
+			State = 1716; valueStmt(0);
+			State = 1718;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1540; whiteSpace();
+				State = 1717; whiteSpace();
 				}
 			}
 
-			State = 1543; Match(EQ);
-			State = 1545;
-			switch ( Interpreter.AdaptivePredict(_input,216,_ctx) ) {
+			State = 1720; Match(EQ);
+			State = 1722;
+			switch ( Interpreter.AdaptivePredict(_input,227,_ctx) ) {
 			case 1:
 				{
-				State = 1544; whiteSpace();
+				State = 1721; whiteSpace();
 				}
 				break;
 			}
-			State = 1547; valueStmt(0);
+			State = 1724; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8222,65 +9990,65 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubStmtContext subStmt() {
 		SubStmtContext _localctx = new SubStmtContext(_ctx, State);
-		EnterRule(_localctx, 174, RULE_subStmt);
+		EnterRule(_localctx, 244, RULE_subStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1552;
+			State = 1729;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1549; visibility();
-				State = 1550; whiteSpace();
+				State = 1726; visibility();
+				State = 1727; whiteSpace();
 				}
 			}
 
-			State = 1556;
+			State = 1733;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1554; Match(STATIC);
-				State = 1555; whiteSpace();
+				State = 1731; Match(STATIC);
+				State = 1732; whiteSpace();
 				}
 			}
 
-			State = 1558; Match(SUB);
-			State = 1560;
+			State = 1735; Match(SUB);
+			State = 1737;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1559; whiteSpace();
+				State = 1736; whiteSpace();
 				}
 			}
 
-			State = 1562; subroutineName();
-			State = 1567;
-			switch ( Interpreter.AdaptivePredict(_input,221,_ctx) ) {
+			State = 1739; subroutineName();
+			State = 1744;
+			switch ( Interpreter.AdaptivePredict(_input,232,_ctx) ) {
 			case 1:
 				{
-				State = 1564;
+				State = 1741;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1563; whiteSpace();
+					State = 1740; whiteSpace();
 					}
 				}
 
-				State = 1566; argList();
+				State = 1743; argList();
 				}
 				break;
 			}
-			State = 1569; endOfStatement();
-			State = 1571;
+			State = 1746; endOfStatement();
+			State = 1748;
 			_la = _input.La(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1570; block();
+				State = 1747; block();
 				}
 			}
 
-			State = 1573; Match(END_SUB);
+			State = 1750; Match(END_SUB);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8321,11 +10089,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubroutineNameContext subroutineName() {
 		SubroutineNameContext _localctx = new SubroutineNameContext(_ctx, State);
-		EnterRule(_localctx, 176, RULE_subroutineName);
+		EnterRule(_localctx, 246, RULE_subroutineName);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1575; identifier();
+			State = 1752; identifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -8386,38 +10154,38 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeStmtContext typeStmt() {
 		TypeStmtContext _localctx = new TypeStmtContext(_ctx, State);
-		EnterRule(_localctx, 178, RULE_typeStmt);
+		EnterRule(_localctx, 248, RULE_typeStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1580;
+			State = 1757;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1577; visibility();
-				State = 1578; whiteSpace();
+				State = 1754; visibility();
+				State = 1755; whiteSpace();
 				}
 			}
 
-			State = 1582; Match(TYPE);
-			State = 1583; whiteSpace();
-			State = 1584; identifier();
-			State = 1585; endOfStatement();
-			State = 1589;
+			State = 1759; Match(TYPE);
+			State = 1760; whiteSpace();
+			State = 1761; identifier();
+			State = 1762; endOfStatement();
+			State = 1766;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 193)) & ~0x3f) == 0 && ((1L << (_la - 193)) & ((1L << (UNTIL - 193)) | (1L << (VARIANT - 193)) | (1L << (VERSION - 193)) | (1L << (WIDTH - 193)) | (1L << (WITHEVENTS - 193)) | (1L << (WRITE - 193)) | (1L << (XOR - 193)) | (1L << (IDENTIFIER - 193)) | (1L << (COLLECTION - 193)) | (1L << (DELETESETTING - 193)) | (1L << (LOAD - 193)) | (1L << (RMDIR - 193)) | (1L << (SENDKEYS - 193)) | (1L << (SETATTR - 193)) | (1L << (RESUME_NEXT - 193)))) != 0)) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
 				{
-				State = 1586; typeStmt_Element();
+				State = 1763; typeStmt_Element();
 				}
 				}
-				State = 1591;
+				State = 1768;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1592; Match(END_TYPE);
+			State = 1769; Match(END_TYPE);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8475,162 +10243,63 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeStmt_ElementContext typeStmt_Element() {
 		TypeStmt_ElementContext _localctx = new TypeStmt_ElementContext(_ctx, State);
-		EnterRule(_localctx, 180, RULE_typeStmt_Element);
+		EnterRule(_localctx, 250, RULE_typeStmt_Element);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1594; identifier();
-			State = 1609;
-			switch ( Interpreter.AdaptivePredict(_input,229,_ctx) ) {
+			State = 1771; identifier();
+			State = 1786;
+			switch ( Interpreter.AdaptivePredict(_input,240,_ctx) ) {
 			case 1:
 				{
-				State = 1596;
+				State = 1773;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1595; whiteSpace();
+					State = 1772; whiteSpace();
 					}
 				}
 
-				State = 1598; Match(LPAREN);
-				State = 1603;
-				switch ( Interpreter.AdaptivePredict(_input,227,_ctx) ) {
+				State = 1775; Match(LPAREN);
+				State = 1780;
+				switch ( Interpreter.AdaptivePredict(_input,238,_ctx) ) {
 				case 1:
 					{
-					State = 1600;
-					switch ( Interpreter.AdaptivePredict(_input,226,_ctx) ) {
+					State = 1777;
+					switch ( Interpreter.AdaptivePredict(_input,237,_ctx) ) {
 					case 1:
 						{
-						State = 1599; whiteSpace();
+						State = 1776; whiteSpace();
 						}
 						break;
 					}
-					State = 1602; subscripts();
+					State = 1779; subscripts();
 					}
 					break;
 				}
-				State = 1606;
+				State = 1783;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1605; whiteSpace();
+					State = 1782; whiteSpace();
 					}
 				}
 
-				State = 1608; Match(RPAREN);
+				State = 1785; Match(RPAREN);
 				}
 				break;
 			}
-			State = 1614;
-			switch ( Interpreter.AdaptivePredict(_input,230,_ctx) ) {
+			State = 1791;
+			switch ( Interpreter.AdaptivePredict(_input,241,_ctx) ) {
 			case 1:
 				{
-				State = 1611; whiteSpace();
-				State = 1612; asTypeClause();
+				State = 1788; whiteSpace();
+				State = 1789; asTypeClause();
 				}
 				break;
 			}
-			State = 1616; endOfStatement();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class UnlockStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public IReadOnlyList<ValueStmtContext> valueStmt() {
-			return GetRuleContexts<ValueStmtContext>();
-		}
-		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public ITerminalNode TO() { return GetToken(VBAParser.TO, 0); }
-		public ITerminalNode UNLOCK() { return GetToken(VBAParser.UNLOCK, 0); }
-		public ValueStmtContext valueStmt(int i) {
-			return GetRuleContext<ValueStmtContext>(i);
-		}
-		public UnlockStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_unlockStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterUnlockStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitUnlockStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitUnlockStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public UnlockStmtContext unlockStmt() {
-		UnlockStmtContext _localctx = new UnlockStmtContext(_ctx, State);
-		EnterRule(_localctx, 182, RULE_unlockStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1618; Match(UNLOCK);
-			State = 1619; whiteSpace();
-			State = 1620; fileNumber();
-			State = 1636;
-			switch ( Interpreter.AdaptivePredict(_input,234,_ctx) ) {
-			case 1:
-				{
-				State = 1622;
-				_la = _input.La(1);
-				if (_la==WS || _la==LINE_CONTINUATION) {
-					{
-					State = 1621; whiteSpace();
-					}
-				}
-
-				State = 1624; Match(COMMA);
-				State = 1626;
-				switch ( Interpreter.AdaptivePredict(_input,232,_ctx) ) {
-				case 1:
-					{
-					State = 1625; whiteSpace();
-					}
-					break;
-				}
-				State = 1628; valueStmt(0);
-				State = 1634;
-				switch ( Interpreter.AdaptivePredict(_input,233,_ctx) ) {
-				case 1:
-					{
-					State = 1629; whiteSpace();
-					State = 1630; Match(TO);
-					State = 1631; whiteSpace();
-					State = 1632; valueStmt(0);
-					}
-					break;
-				}
-				}
-				break;
-			}
+			State = 1793; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -8955,6 +10624,25 @@ public partial class VBAParser : Parser {
 			else return visitor.VisitChildren(this);
 		}
 	}
+	public partial class VsMarkedFileNumberContext : ValueStmtContext {
+		public MarkedFileNumberContext markedFileNumber() {
+			return GetRuleContext<MarkedFileNumberContext>(0);
+		}
+		public VsMarkedFileNumberContext(ValueStmtContext context) { CopyFrom(context); }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterVsMarkedFileNumber(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitVsMarkedFileNumber(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitVsMarkedFileNumber(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
 	public partial class VsIntDivContext : ValueStmtContext {
 		public WhiteSpaceContext whiteSpace(int i) {
 			return GetRuleContext<WhiteSpaceContext>(i);
@@ -9248,31 +10936,31 @@ public partial class VBAParser : Parser {
 		int _parentState = State;
 		ValueStmtContext _localctx = new ValueStmtContext(_ctx, _parentState);
 		ValueStmtContext _prevctx = _localctx;
-		int _startState = 184;
-		EnterRecursionRule(_localctx, 184, RULE_valueStmt, _p);
+		int _startState = 252;
+		EnterRecursionRule(_localctx, 252, RULE_valueStmt, _p);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1683;
-			switch ( Interpreter.AdaptivePredict(_input,243,_ctx) ) {
+			State = 1841;
+			switch ( Interpreter.AdaptivePredict(_input,250,_ctx) ) {
 			case 1:
 				{
 				_localctx = new VsNewContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
 
-				State = 1639; Match(NEW);
-				State = 1641;
-				switch ( Interpreter.AdaptivePredict(_input,235,_ctx) ) {
+				State = 1796; Match(NEW);
+				State = 1798;
+				switch ( Interpreter.AdaptivePredict(_input,242,_ctx) ) {
 				case 1:
 					{
-					State = 1640; whiteSpace();
+					State = 1797; whiteSpace();
 					}
 					break;
 				}
-				State = 1643; valueStmt(19);
+				State = 1800; valueStmt(20);
 				}
 				break;
 
@@ -9281,16 +10969,16 @@ public partial class VBAParser : Parser {
 				_localctx = new VsAddressOfContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1644; Match(ADDRESSOF);
-				State = 1646;
-				switch ( Interpreter.AdaptivePredict(_input,236,_ctx) ) {
+				State = 1801; Match(ADDRESSOF);
+				State = 1803;
+				switch ( Interpreter.AdaptivePredict(_input,243,_ctx) ) {
 				case 1:
 					{
-					State = 1645; whiteSpace();
+					State = 1802; whiteSpace();
 					}
 					break;
 				}
-				State = 1648; valueStmt(16);
+				State = 1805; valueStmt(17);
 				}
 				break;
 
@@ -9299,25 +10987,25 @@ public partial class VBAParser : Parser {
 				_localctx = new VsAssignContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1649; unrestrictedIdentifier();
-				State = 1651;
+				State = 1806; unrestrictedIdentifier();
+				State = 1808;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1650; whiteSpace();
+					State = 1807; whiteSpace();
 					}
 				}
 
-				State = 1653; Match(ASSIGN);
-				State = 1655;
-				switch ( Interpreter.AdaptivePredict(_input,238,_ctx) ) {
+				State = 1810; Match(ASSIGN);
+				State = 1812;
+				switch ( Interpreter.AdaptivePredict(_input,245,_ctx) ) {
 				case 1:
 					{
-					State = 1654; whiteSpace();
+					State = 1811; whiteSpace();
 					}
 					break;
 				}
-				State = 1657; valueStmt(15);
+				State = 1814; valueStmt(16);
 				}
 				break;
 
@@ -9326,16 +11014,16 @@ public partial class VBAParser : Parser {
 				_localctx = new VsNegationContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1659; Match(MINUS);
-				State = 1661;
-				switch ( Interpreter.AdaptivePredict(_input,239,_ctx) ) {
+				State = 1816; Match(MINUS);
+				State = 1818;
+				switch ( Interpreter.AdaptivePredict(_input,246,_ctx) ) {
 				case 1:
 					{
-					State = 1660; whiteSpace();
+					State = 1817; whiteSpace();
 					}
 					break;
 				}
-				State = 1663; valueStmt(13);
+				State = 1820; valueStmt(14);
 				}
 				break;
 
@@ -9344,16 +11032,16 @@ public partial class VBAParser : Parser {
 				_localctx = new VsNotContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1664; Match(NOT);
-				State = 1666;
-				switch ( Interpreter.AdaptivePredict(_input,240,_ctx) ) {
+				State = 1821; Match(NOT);
+				State = 1823;
+				switch ( Interpreter.AdaptivePredict(_input,247,_ctx) ) {
 				case 1:
 					{
-					State = 1665; whiteSpace();
+					State = 1822; whiteSpace();
 					}
 					break;
 				}
-				State = 1668; valueStmt(6);
+				State = 1825; valueStmt(7);
 				}
 				break;
 
@@ -9362,7 +11050,7 @@ public partial class VBAParser : Parser {
 				_localctx = new VsLiteralContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1669; literal();
+				State = 1826; literal();
 				}
 				break;
 
@@ -9371,7 +11059,7 @@ public partial class VBAParser : Parser {
 				_localctx = new VsICSContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1670; implicitCallStmt_InStmt();
+				State = 1827; implicitCallStmt_InStmt();
 				}
 				break;
 
@@ -9380,25 +11068,25 @@ public partial class VBAParser : Parser {
 				_localctx = new VsStructContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1671; Match(LPAREN);
-				State = 1673;
-				switch ( Interpreter.AdaptivePredict(_input,241,_ctx) ) {
+				State = 1828; Match(LPAREN);
+				State = 1830;
+				switch ( Interpreter.AdaptivePredict(_input,248,_ctx) ) {
 				case 1:
 					{
-					State = 1672; whiteSpace();
+					State = 1829; whiteSpace();
 					}
 					break;
 				}
-				State = 1675; valueStmt(0);
-				State = 1677;
+				State = 1832; valueStmt(0);
+				State = 1834;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1676; whiteSpace();
+					State = 1833; whiteSpace();
 					}
 				}
 
-				State = 1679; Match(RPAREN);
+				State = 1836; Match(RPAREN);
 				}
 				break;
 
@@ -9407,7 +11095,7 @@ public partial class VBAParser : Parser {
 				_localctx = new VsTypeOfContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1681; typeOfIsExpression();
+				State = 1838; typeOfIsExpression();
 				}
 				break;
 
@@ -9416,45 +11104,54 @@ public partial class VBAParser : Parser {
 				_localctx = new VsMidContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1682; midStmt();
+				State = 1839; midStmt();
+				}
+				break;
+
+			case 11:
+				{
+				_localctx = new VsMarkedFileNumberContext(_localctx);
+				_ctx = _localctx;
+				_prevctx = _localctx;
+				State = 1840; markedFileNumber();
 				}
 				break;
 			}
 			_ctx.stop = _input.Lt(-1);
-			State = 1795;
+			State = 1953;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,269,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,276,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					if ( _parseListeners!=null ) TriggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					State = 1793;
-					switch ( Interpreter.AdaptivePredict(_input,268,_ctx) ) {
+					State = 1951;
+					switch ( Interpreter.AdaptivePredict(_input,275,_ctx) ) {
 					case 1:
 						{
 						_localctx = new VsPowContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1685;
-						if (!(Precpred(_ctx, 14))) throw new FailedPredicateException(this, "Precpred(_ctx, 14)");
-						State = 1687;
+						State = 1843;
+						if (!(Precpred(_ctx, 15))) throw new FailedPredicateException(this, "Precpred(_ctx, 15)");
+						State = 1845;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1686; whiteSpace();
+							State = 1844; whiteSpace();
 							}
 						}
 
-						State = 1689; Match(POW);
-						State = 1691;
-						switch ( Interpreter.AdaptivePredict(_input,245,_ctx) ) {
+						State = 1847; Match(POW);
+						State = 1849;
+						switch ( Interpreter.AdaptivePredict(_input,252,_ctx) ) {
 						case 1:
 							{
-							State = 1690; whiteSpace();
+							State = 1848; whiteSpace();
 							}
 							break;
 						}
-						State = 1693; valueStmt(15);
+						State = 1851; valueStmt(16);
 						}
 						break;
 
@@ -9462,31 +11159,31 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsMultContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1694;
-						if (!(Precpred(_ctx, 12))) throw new FailedPredicateException(this, "Precpred(_ctx, 12)");
-						State = 1696;
+						State = 1852;
+						if (!(Precpred(_ctx, 13))) throw new FailedPredicateException(this, "Precpred(_ctx, 13)");
+						State = 1854;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1695; whiteSpace();
+							State = 1853; whiteSpace();
 							}
 						}
 
-						State = 1698;
+						State = 1856;
 						_la = _input.La(1);
 						if ( !(_la==DIV || _la==MULT) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 1700;
-						switch ( Interpreter.AdaptivePredict(_input,247,_ctx) ) {
+						State = 1858;
+						switch ( Interpreter.AdaptivePredict(_input,254,_ctx) ) {
 						case 1:
 							{
-							State = 1699; whiteSpace();
+							State = 1857; whiteSpace();
 							}
 							break;
 						}
-						State = 1702; valueStmt(13);
+						State = 1860; valueStmt(14);
 						}
 						break;
 
@@ -9494,26 +11191,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsIntDivContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1703;
-						if (!(Precpred(_ctx, 11))) throw new FailedPredicateException(this, "Precpred(_ctx, 11)");
-						State = 1705;
+						State = 1861;
+						if (!(Precpred(_ctx, 12))) throw new FailedPredicateException(this, "Precpred(_ctx, 12)");
+						State = 1863;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1704; whiteSpace();
+							State = 1862; whiteSpace();
 							}
 						}
 
-						State = 1707; Match(INTDIV);
-						State = 1709;
-						switch ( Interpreter.AdaptivePredict(_input,249,_ctx) ) {
+						State = 1865; Match(INTDIV);
+						State = 1867;
+						switch ( Interpreter.AdaptivePredict(_input,256,_ctx) ) {
 						case 1:
 							{
-							State = 1708; whiteSpace();
+							State = 1866; whiteSpace();
 							}
 							break;
 						}
-						State = 1711; valueStmt(12);
+						State = 1869; valueStmt(13);
 						}
 						break;
 
@@ -9521,26 +11218,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsModContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1712;
-						if (!(Precpred(_ctx, 10))) throw new FailedPredicateException(this, "Precpred(_ctx, 10)");
-						State = 1714;
+						State = 1870;
+						if (!(Precpred(_ctx, 11))) throw new FailedPredicateException(this, "Precpred(_ctx, 11)");
+						State = 1872;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1713; whiteSpace();
+							State = 1871; whiteSpace();
 							}
 						}
 
-						State = 1716; Match(MOD);
-						State = 1718;
-						switch ( Interpreter.AdaptivePredict(_input,251,_ctx) ) {
+						State = 1874; Match(MOD);
+						State = 1876;
+						switch ( Interpreter.AdaptivePredict(_input,258,_ctx) ) {
 						case 1:
 							{
-							State = 1717; whiteSpace();
+							State = 1875; whiteSpace();
 							}
 							break;
 						}
-						State = 1720; valueStmt(11);
+						State = 1878; valueStmt(12);
 						}
 						break;
 
@@ -9548,31 +11245,31 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsAddContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1721;
-						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
-						State = 1723;
+						State = 1879;
+						if (!(Precpred(_ctx, 10))) throw new FailedPredicateException(this, "Precpred(_ctx, 10)");
+						State = 1881;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1722; whiteSpace();
+							State = 1880; whiteSpace();
 							}
 						}
 
-						State = 1725;
+						State = 1883;
 						_la = _input.La(1);
 						if ( !(_la==MINUS || _la==PLUS) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 1727;
-						switch ( Interpreter.AdaptivePredict(_input,253,_ctx) ) {
+						State = 1885;
+						switch ( Interpreter.AdaptivePredict(_input,260,_ctx) ) {
 						case 1:
 							{
-							State = 1726; whiteSpace();
+							State = 1884; whiteSpace();
 							}
 							break;
 						}
-						State = 1729; valueStmt(10);
+						State = 1887; valueStmt(11);
 						}
 						break;
 
@@ -9580,26 +11277,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsAmpContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1730;
-						if (!(Precpred(_ctx, 8))) throw new FailedPredicateException(this, "Precpred(_ctx, 8)");
-						State = 1732;
+						State = 1888;
+						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
+						State = 1890;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1731; whiteSpace();
+							State = 1889; whiteSpace();
 							}
 						}
 
-						State = 1734; Match(AMPERSAND);
-						State = 1736;
-						switch ( Interpreter.AdaptivePredict(_input,255,_ctx) ) {
+						State = 1892; Match(AMPERSAND);
+						State = 1894;
+						switch ( Interpreter.AdaptivePredict(_input,262,_ctx) ) {
 						case 1:
 							{
-							State = 1735; whiteSpace();
+							State = 1893; whiteSpace();
 							}
 							break;
 						}
-						State = 1738; valueStmt(9);
+						State = 1896; valueStmt(10);
 						}
 						break;
 
@@ -9607,31 +11304,31 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsRelationalContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1739;
-						if (!(Precpred(_ctx, 7))) throw new FailedPredicateException(this, "Precpred(_ctx, 7)");
-						State = 1741;
+						State = 1897;
+						if (!(Precpred(_ctx, 8))) throw new FailedPredicateException(this, "Precpred(_ctx, 8)");
+						State = 1899;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1740; whiteSpace();
+							State = 1898; whiteSpace();
 							}
 						}
 
-						State = 1743;
+						State = 1901;
 						_la = _input.La(1);
 						if ( !(_la==IS || _la==LIKE || ((((_la - 206)) & ~0x3f) == 0 && ((1L << (_la - 206)) & ((1L << (EQ - 206)) | (1L << (GEQ - 206)) | (1L << (GT - 206)) | (1L << (LEQ - 206)) | (1L << (LT - 206)) | (1L << (NEQ - 206)))) != 0)) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 1745;
-						switch ( Interpreter.AdaptivePredict(_input,257,_ctx) ) {
+						State = 1903;
+						switch ( Interpreter.AdaptivePredict(_input,264,_ctx) ) {
 						case 1:
 							{
-							State = 1744; whiteSpace();
+							State = 1902; whiteSpace();
 							}
 							break;
 						}
-						State = 1747; valueStmt(8);
+						State = 1905; valueStmt(9);
 						}
 						break;
 
@@ -9639,26 +11336,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsAndContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1748;
-						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
-						State = 1750;
+						State = 1906;
+						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
+						State = 1908;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1749; whiteSpace();
+							State = 1907; whiteSpace();
 							}
 						}
 
-						State = 1752; Match(AND);
-						State = 1754;
-						switch ( Interpreter.AdaptivePredict(_input,259,_ctx) ) {
+						State = 1910; Match(AND);
+						State = 1912;
+						switch ( Interpreter.AdaptivePredict(_input,266,_ctx) ) {
 						case 1:
 							{
-							State = 1753; whiteSpace();
+							State = 1911; whiteSpace();
 							}
 							break;
 						}
-						State = 1756; valueStmt(6);
+						State = 1914; valueStmt(7);
 						}
 						break;
 
@@ -9666,26 +11363,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsOrContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1757;
-						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
-						State = 1759;
+						State = 1915;
+						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
+						State = 1917;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1758; whiteSpace();
+							State = 1916; whiteSpace();
 							}
 						}
 
-						State = 1761; Match(OR);
-						State = 1763;
-						switch ( Interpreter.AdaptivePredict(_input,261,_ctx) ) {
+						State = 1919; Match(OR);
+						State = 1921;
+						switch ( Interpreter.AdaptivePredict(_input,268,_ctx) ) {
 						case 1:
 							{
-							State = 1762; whiteSpace();
+							State = 1920; whiteSpace();
 							}
 							break;
 						}
-						State = 1765; valueStmt(5);
+						State = 1923; valueStmt(6);
 						}
 						break;
 
@@ -9693,26 +11390,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsXorContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1766;
-						if (!(Precpred(_ctx, 3))) throw new FailedPredicateException(this, "Precpred(_ctx, 3)");
-						State = 1768;
+						State = 1924;
+						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
+						State = 1926;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1767; whiteSpace();
+							State = 1925; whiteSpace();
 							}
 						}
 
-						State = 1770; Match(XOR);
-						State = 1772;
-						switch ( Interpreter.AdaptivePredict(_input,263,_ctx) ) {
+						State = 1928; Match(XOR);
+						State = 1930;
+						switch ( Interpreter.AdaptivePredict(_input,270,_ctx) ) {
 						case 1:
 							{
-							State = 1771; whiteSpace();
+							State = 1929; whiteSpace();
 							}
 							break;
 						}
-						State = 1774; valueStmt(4);
+						State = 1932; valueStmt(5);
 						}
 						break;
 
@@ -9720,26 +11417,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsEqvContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1775;
-						if (!(Precpred(_ctx, 2))) throw new FailedPredicateException(this, "Precpred(_ctx, 2)");
-						State = 1777;
+						State = 1933;
+						if (!(Precpred(_ctx, 3))) throw new FailedPredicateException(this, "Precpred(_ctx, 3)");
+						State = 1935;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1776; whiteSpace();
+							State = 1934; whiteSpace();
 							}
 						}
 
-						State = 1779; Match(EQV);
-						State = 1781;
-						switch ( Interpreter.AdaptivePredict(_input,265,_ctx) ) {
+						State = 1937; Match(EQV);
+						State = 1939;
+						switch ( Interpreter.AdaptivePredict(_input,272,_ctx) ) {
 						case 1:
 							{
-							State = 1780; whiteSpace();
+							State = 1938; whiteSpace();
 							}
 							break;
 						}
-						State = 1783; valueStmt(3);
+						State = 1941; valueStmt(4);
 						}
 						break;
 
@@ -9747,34 +11444,34 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsImpContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1784;
-						if (!(Precpred(_ctx, 1))) throw new FailedPredicateException(this, "Precpred(_ctx, 1)");
-						State = 1786;
+						State = 1942;
+						if (!(Precpred(_ctx, 2))) throw new FailedPredicateException(this, "Precpred(_ctx, 2)");
+						State = 1944;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1785; whiteSpace();
+							State = 1943; whiteSpace();
 							}
 						}
 
-						State = 1788; Match(IMP);
-						State = 1790;
-						switch ( Interpreter.AdaptivePredict(_input,267,_ctx) ) {
+						State = 1946; Match(IMP);
+						State = 1948;
+						switch ( Interpreter.AdaptivePredict(_input,274,_ctx) ) {
 						case 1:
 							{
-							State = 1789; whiteSpace();
+							State = 1947; whiteSpace();
 							}
 							break;
 						}
-						State = 1792; valueStmt(2);
+						State = 1950; valueStmt(3);
 						}
 						break;
 					}
 					} 
 				}
-				State = 1797;
+				State = 1955;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,269,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,276,_ctx);
 			}
 			}
 		}
@@ -9827,21 +11524,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeOfIsExpressionContext typeOfIsExpression() {
 		TypeOfIsExpressionContext _localctx = new TypeOfIsExpressionContext(_ctx, State);
-		EnterRule(_localctx, 186, RULE_typeOfIsExpression);
+		EnterRule(_localctx, 254, RULE_typeOfIsExpression);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1798; Match(TYPEOF);
-			State = 1799; whiteSpace();
-			State = 1800; valueStmt(0);
-			State = 1806;
-			switch ( Interpreter.AdaptivePredict(_input,270,_ctx) ) {
+			State = 1956; Match(TYPEOF);
+			State = 1957; whiteSpace();
+			State = 1958; valueStmt(0);
+			State = 1964;
+			switch ( Interpreter.AdaptivePredict(_input,277,_ctx) ) {
 			case 1:
 				{
-				State = 1801; whiteSpace();
-				State = 1802; Match(IS);
-				State = 1803; whiteSpace();
-				State = 1804; type();
+				State = 1959; whiteSpace();
+				State = 1960; Match(IS);
+				State = 1961; whiteSpace();
+				State = 1962; type();
 				}
 				break;
 			}
@@ -9897,20 +11594,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VariableStmtContext variableStmt() {
 		VariableStmtContext _localctx = new VariableStmtContext(_ctx, State);
-		EnterRule(_localctx, 188, RULE_variableStmt);
+		EnterRule(_localctx, 256, RULE_variableStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1811;
+			State = 1969;
 			switch (_input.La(1)) {
 			case DIM:
 				{
-				State = 1808; Match(DIM);
+				State = 1966; Match(DIM);
 				}
 				break;
 			case STATIC:
 				{
-				State = 1809; Match(STATIC);
+				State = 1967; Match(STATIC);
 				}
 				break;
 			case FRIEND:
@@ -9918,23 +11615,23 @@ public partial class VBAParser : Parser {
 			case PRIVATE:
 			case PUBLIC:
 				{
-				State = 1810; visibility();
+				State = 1968; visibility();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 1813; whiteSpace();
-			State = 1816;
-			switch ( Interpreter.AdaptivePredict(_input,272,_ctx) ) {
+			State = 1971; whiteSpace();
+			State = 1974;
+			switch ( Interpreter.AdaptivePredict(_input,279,_ctx) ) {
 			case 1:
 				{
-				State = 1814; Match(WITHEVENTS);
-				State = 1815; whiteSpace();
+				State = 1972; Match(WITHEVENTS);
+				State = 1973; whiteSpace();
 				}
 				break;
 			}
-			State = 1818; variableListStmt();
+			State = 1976; variableListStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -9988,44 +11685,44 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VariableListStmtContext variableListStmt() {
 		VariableListStmtContext _localctx = new VariableListStmtContext(_ctx, State);
-		EnterRule(_localctx, 190, RULE_variableListStmt);
+		EnterRule(_localctx, 258, RULE_variableListStmt);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1820; variableSubStmt();
-			State = 1831;
+			State = 1978; variableSubStmt();
+			State = 1989;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,275,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,282,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1822;
+					State = 1980;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1821; whiteSpace();
+						State = 1979; whiteSpace();
 						}
 					}
 
-					State = 1824; Match(COMMA);
-					State = 1826;
+					State = 1982; Match(COMMA);
+					State = 1984;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1825; whiteSpace();
+						State = 1983; whiteSpace();
 						}
 					}
 
-					State = 1828; variableSubStmt();
+					State = 1986; variableSubStmt();
 					}
 					} 
 				}
-				State = 1833;
+				State = 1991;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,275,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,282,_ctx);
 			}
 			}
 		}
@@ -10084,75 +11781,75 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VariableSubStmtContext variableSubStmt() {
 		VariableSubStmtContext _localctx = new VariableSubStmtContext(_ctx, State);
-		EnterRule(_localctx, 192, RULE_variableSubStmt);
+		EnterRule(_localctx, 260, RULE_variableSubStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1834; identifier();
-			State = 1836;
-			switch ( Interpreter.AdaptivePredict(_input,276,_ctx) ) {
+			State = 1992; identifier();
+			State = 1994;
+			switch ( Interpreter.AdaptivePredict(_input,283,_ctx) ) {
 			case 1:
 				{
-				State = 1835; typeHint();
+				State = 1993; typeHint();
 				}
 				break;
 			}
-			State = 1855;
-			switch ( Interpreter.AdaptivePredict(_input,282,_ctx) ) {
+			State = 2013;
+			switch ( Interpreter.AdaptivePredict(_input,289,_ctx) ) {
 			case 1:
 				{
-				State = 1839;
+				State = 1997;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1838; whiteSpace();
+					State = 1996; whiteSpace();
 					}
 				}
 
-				State = 1841; Match(LPAREN);
-				State = 1843;
-				switch ( Interpreter.AdaptivePredict(_input,278,_ctx) ) {
+				State = 1999; Match(LPAREN);
+				State = 2001;
+				switch ( Interpreter.AdaptivePredict(_input,285,_ctx) ) {
 				case 1:
 					{
-					State = 1842; whiteSpace();
+					State = 2000; whiteSpace();
 					}
 					break;
 				}
-				State = 1849;
+				State = 2007;
 				_la = _input.La(1);
-				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 					{
-					State = 1845; subscripts();
-					State = 1847;
+					State = 2003; subscripts();
+					State = 2005;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1846; whiteSpace();
+						State = 2004; whiteSpace();
 						}
 					}
 
 					}
 				}
 
-				State = 1851; Match(RPAREN);
-				State = 1853;
-				switch ( Interpreter.AdaptivePredict(_input,281,_ctx) ) {
+				State = 2009; Match(RPAREN);
+				State = 2011;
+				switch ( Interpreter.AdaptivePredict(_input,288,_ctx) ) {
 				case 1:
 					{
-					State = 1852; whiteSpace();
+					State = 2010; whiteSpace();
 					}
 					break;
 				}
 				}
 				break;
 			}
-			State = 1860;
-			switch ( Interpreter.AdaptivePredict(_input,283,_ctx) ) {
+			State = 2018;
+			switch ( Interpreter.AdaptivePredict(_input,290,_ctx) ) {
 			case 1:
 				{
-				State = 1857; whiteSpace();
-				State = 1858; asTypeClause();
+				State = 2015; whiteSpace();
+				State = 2016; asTypeClause();
 				}
 				break;
 			}
@@ -10207,100 +11904,23 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WhileWendStmtContext whileWendStmt() {
 		WhileWendStmtContext _localctx = new WhileWendStmtContext(_ctx, State);
-		EnterRule(_localctx, 194, RULE_whileWendStmt);
+		EnterRule(_localctx, 262, RULE_whileWendStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1862; Match(WHILE);
-			State = 1863; whiteSpace();
-			State = 1864; valueStmt(0);
-			State = 1865; endOfStatement();
-			State = 1867;
-			switch ( Interpreter.AdaptivePredict(_input,284,_ctx) ) {
+			State = 2020; Match(WHILE);
+			State = 2021; whiteSpace();
+			State = 2022; valueStmt(0);
+			State = 2023; endOfStatement();
+			State = 2025;
+			switch ( Interpreter.AdaptivePredict(_input,291,_ctx) ) {
 			case 1:
 				{
-				State = 1866; block();
+				State = 2024; block();
 				}
 				break;
 			}
-			State = 1869; Match(WEND);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class WidthStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public ValueStmtContext valueStmt() {
-			return GetRuleContext<ValueStmtContext>(0);
-		}
-		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
-		public ITerminalNode WIDTH() { return GetToken(VBAParser.WIDTH, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public WidthStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_widthStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterWidthStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitWidthStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitWidthStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public WidthStmtContext widthStmt() {
-		WidthStmtContext _localctx = new WidthStmtContext(_ctx, State);
-		EnterRule(_localctx, 196, RULE_widthStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1871; Match(WIDTH);
-			State = 1872; whiteSpace();
-			State = 1873; fileNumber();
-			State = 1875;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1874; whiteSpace();
-				}
-			}
-
-			State = 1877; Match(COMMA);
-			State = 1879;
-			switch ( Interpreter.AdaptivePredict(_input,286,_ctx) ) {
-			case 1:
-				{
-				State = 1878; whiteSpace();
-				}
-				break;
-			}
-			State = 1881; valueStmt(0);
+			State = 2027; Match(WEND);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10352,23 +11972,23 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WithStmtContext withStmt() {
 		WithStmtContext _localctx = new WithStmtContext(_ctx, State);
-		EnterRule(_localctx, 198, RULE_withStmt);
+		EnterRule(_localctx, 264, RULE_withStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1883; Match(WITH);
-			State = 1884; whiteSpace();
-			State = 1885; withStmtExpression();
-			State = 1886; endOfStatement();
-			State = 1888;
-			switch ( Interpreter.AdaptivePredict(_input,287,_ctx) ) {
+			State = 2029; Match(WITH);
+			State = 2030; whiteSpace();
+			State = 2031; withStmtExpression();
+			State = 2032; endOfStatement();
+			State = 2034;
+			switch ( Interpreter.AdaptivePredict(_input,292,_ctx) ) {
 			case 1:
 				{
-				State = 1887; block();
+				State = 2033; block();
 				}
 				break;
 			}
-			State = 1890; Match(END_WITH);
+			State = 2036; Match(END_WITH);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10409,150 +12029,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WithStmtExpressionContext withStmtExpression() {
 		WithStmtExpressionContext _localctx = new WithStmtExpressionContext(_ctx, State);
-		EnterRule(_localctx, 200, RULE_withStmtExpression);
+		EnterRule(_localctx, 266, RULE_withStmtExpression);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1892; valueStmt(0);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class WriteStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
-		}
-		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
-		public OutputListContext outputList() {
-			return GetRuleContext<OutputListContext>(0);
-		}
-		public ITerminalNode WRITE() { return GetToken(VBAParser.WRITE, 0); }
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public FileNumberContext fileNumber() {
-			return GetRuleContext<FileNumberContext>(0);
-		}
-		public WriteStmtContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_writeStmt; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterWriteStmt(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitWriteStmt(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitWriteStmt(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public WriteStmtContext writeStmt() {
-		WriteStmtContext _localctx = new WriteStmtContext(_ctx, State);
-		EnterRule(_localctx, 202, RULE_writeStmt);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1894; Match(WRITE);
-			State = 1895; whiteSpace();
-			State = 1896; fileNumber();
-			State = 1898;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1897; whiteSpace();
-				}
-			}
-
-			State = 1900; Match(COMMA);
-			State = 1905;
-			switch ( Interpreter.AdaptivePredict(_input,290,_ctx) ) {
-			case 1:
-				{
-				State = 1902;
-				switch ( Interpreter.AdaptivePredict(_input,289,_ctx) ) {
-				case 1:
-					{
-					State = 1901; whiteSpace();
-					}
-					break;
-				}
-				State = 1904; outputList();
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.ReportError(this, re);
-			_errHandler.Recover(this, re);
-		}
-		finally {
-			ExitRule();
-		}
-		return _localctx;
-	}
-
-	public partial class FileNumberContext : ParserRuleContext {
-		public ValueStmtContext valueStmt() {
-			return GetRuleContext<ValueStmtContext>(0);
-		}
-		public ITerminalNode HASH() { return GetToken(VBAParser.HASH, 0); }
-		public FileNumberContext(ParserRuleContext parent, int invokingState)
-			: base(parent, invokingState)
-		{
-		}
-		public override int RuleIndex { get { return RULE_fileNumber; } }
-		public override void EnterRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterFileNumber(this);
-		}
-		public override void ExitRule(IParseTreeListener listener) {
-			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitFileNumber(this);
-		}
-		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
-			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitFileNumber(this);
-			else return visitor.VisitChildren(this);
-		}
-	}
-
-	[RuleVersion(0)]
-	public FileNumberContext fileNumber() {
-		FileNumberContext _localctx = new FileNumberContext(_ctx, State);
-		EnterRule(_localctx, 204, RULE_fileNumber);
-		int _la;
-		try {
-			EnterOuterAlt(_localctx, 1);
-			{
-			State = 1908;
-			_la = _input.La(1);
-			if (_la==HASH) {
-				{
-				State = 1907; Match(HASH);
-				}
-			}
-
-			State = 1910; valueStmt(0);
+			State = 2038; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10597,13 +12078,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ExplicitCallStmtContext explicitCallStmt() {
 		ExplicitCallStmtContext _localctx = new ExplicitCallStmtContext(_ctx, State);
-		EnterRule(_localctx, 206, RULE_explicitCallStmt);
+		EnterRule(_localctx, 268, RULE_explicitCallStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1912; Match(CALL);
-			State = 1913; whiteSpace();
-			State = 1914; explicitCallStmtExpression();
+			State = 2040; Match(CALL);
+			State = 2041; whiteSpace();
+			State = 2042; explicitCallStmtExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -10727,92 +12208,92 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ExplicitCallStmtExpressionContext explicitCallStmtExpression() {
 		ExplicitCallStmtExpressionContext _localctx = new ExplicitCallStmtExpressionContext(_ctx, State);
-		EnterRule(_localctx, 208, RULE_explicitCallStmtExpression);
+		EnterRule(_localctx, 270, RULE_explicitCallStmtExpression);
 		int _la;
 		try {
 			int _alt;
-			State = 1982;
-			switch ( Interpreter.AdaptivePredict(_input,307,_ctx) ) {
+			State = 2110;
+			switch ( Interpreter.AdaptivePredict(_input,308,_ctx) ) {
 			case 1:
 				_localctx = new ECS_MemberCallContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1917;
-				switch ( Interpreter.AdaptivePredict(_input,292,_ctx) ) {
-				case 1:
-					{
-					State = 1916; implicitCallStmt_InStmt();
-					}
-					break;
-				}
-				State = 1919; Match(DOT);
-				State = 1920; identifier();
-				State = 1922;
+				State = 2045;
 				switch ( Interpreter.AdaptivePredict(_input,293,_ctx) ) {
 				case 1:
 					{
-					State = 1921; typeHint();
+					State = 2044; implicitCallStmt_InStmt();
 					}
 					break;
 				}
-				State = 1937;
-				switch ( Interpreter.AdaptivePredict(_input,297,_ctx) ) {
+				State = 2047; Match(DOT);
+				State = 2048; identifier();
+				State = 2050;
+				switch ( Interpreter.AdaptivePredict(_input,294,_ctx) ) {
 				case 1:
 					{
-					State = 1925;
+					State = 2049; typeHint();
+					}
+					break;
+				}
+				State = 2065;
+				switch ( Interpreter.AdaptivePredict(_input,298,_ctx) ) {
+				case 1:
+					{
+					State = 2053;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1924; whiteSpace();
+						State = 2052; whiteSpace();
 						}
 					}
 
-					State = 1927; Match(LPAREN);
-					State = 1929;
-					switch ( Interpreter.AdaptivePredict(_input,295,_ctx) ) {
+					State = 2055; Match(LPAREN);
+					State = 2057;
+					switch ( Interpreter.AdaptivePredict(_input,296,_ctx) ) {
 					case 1:
 						{
-						State = 1928; whiteSpace();
+						State = 2056; whiteSpace();
 						}
 						break;
 					}
-					State = 1931; argsCall();
-					State = 1933;
+					State = 2059; argsCall();
+					State = 2061;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1932; whiteSpace();
+						State = 2060; whiteSpace();
 						}
 					}
 
-					State = 1935; Match(RPAREN);
+					State = 2063; Match(RPAREN);
 					}
 					break;
 				}
-				State = 1948;
+				State = 2076;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,299,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,300,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1940;
+						State = 2068;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1939; whiteSpace();
+							State = 2067; whiteSpace();
 							}
 						}
 
-						State = 1942; Match(LPAREN);
-						State = 1943; subscripts();
-						State = 1944; Match(RPAREN);
+						State = 2070; Match(LPAREN);
+						State = 2071; subscripts();
+						State = 2072; Match(RPAREN);
 						}
 						} 
 					}
-					State = 1950;
+					State = 2078;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,299,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,300,_ctx);
 				}
 				}
 				break;
@@ -10821,73 +12302,73 @@ public partial class VBAParser : Parser {
 				_localctx = new ECS_ProcedureCallContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1951; identifier();
-				State = 1953;
-				switch ( Interpreter.AdaptivePredict(_input,300,_ctx) ) {
+				State = 2079; identifier();
+				State = 2081;
+				switch ( Interpreter.AdaptivePredict(_input,301,_ctx) ) {
 				case 1:
 					{
-					State = 1952; typeHint();
+					State = 2080; typeHint();
 					}
 					break;
 				}
-				State = 1968;
-				switch ( Interpreter.AdaptivePredict(_input,304,_ctx) ) {
+				State = 2096;
+				switch ( Interpreter.AdaptivePredict(_input,305,_ctx) ) {
 				case 1:
 					{
-					State = 1956;
+					State = 2084;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1955; whiteSpace();
+						State = 2083; whiteSpace();
 						}
 					}
 
-					State = 1958; Match(LPAREN);
-					State = 1960;
-					switch ( Interpreter.AdaptivePredict(_input,302,_ctx) ) {
+					State = 2086; Match(LPAREN);
+					State = 2088;
+					switch ( Interpreter.AdaptivePredict(_input,303,_ctx) ) {
 					case 1:
 						{
-						State = 1959; whiteSpace();
+						State = 2087; whiteSpace();
 						}
 						break;
 					}
-					State = 1962; argsCall();
-					State = 1964;
+					State = 2090; argsCall();
+					State = 2092;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1963; whiteSpace();
+						State = 2091; whiteSpace();
 						}
 					}
 
-					State = 1966; Match(RPAREN);
+					State = 2094; Match(RPAREN);
 					}
 					break;
 				}
-				State = 1979;
+				State = 2107;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,306,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,307,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1971;
+						State = 2099;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1970; whiteSpace();
+							State = 2098; whiteSpace();
 							}
 						}
 
-						State = 1973; Match(LPAREN);
-						State = 1974; subscripts();
-						State = 1975; Match(RPAREN);
+						State = 2101; Match(LPAREN);
+						State = 2102; subscripts();
+						State = 2103; Match(RPAREN);
 						}
 						} 
 					}
-					State = 1981;
+					State = 2109;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,306,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,307,_ctx);
 				}
 				}
 				break;
@@ -10934,21 +12415,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ImplicitCallStmt_InBlockContext implicitCallStmt_InBlock() {
 		ImplicitCallStmt_InBlockContext _localctx = new ImplicitCallStmt_InBlockContext(_ctx, State);
-		EnterRule(_localctx, 210, RULE_implicitCallStmt_InBlock);
+		EnterRule(_localctx, 272, RULE_implicitCallStmt_InBlock);
 		try {
-			State = 1986;
-			switch ( Interpreter.AdaptivePredict(_input,308,_ctx) ) {
+			State = 2114;
+			switch ( Interpreter.AdaptivePredict(_input,309,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1984; iCS_B_MemberProcedureCall();
+				State = 2112; iCS_B_MemberProcedureCall();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1985; iCS_B_ProcedureCall();
+				State = 2113; iCS_B_ProcedureCall();
 				}
 				break;
 			}
@@ -11024,95 +12505,95 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_B_MemberProcedureCallContext iCS_B_MemberProcedureCall() {
 		ICS_B_MemberProcedureCallContext _localctx = new ICS_B_MemberProcedureCallContext(_ctx, State);
-		EnterRule(_localctx, 212, RULE_iCS_B_MemberProcedureCall);
+		EnterRule(_localctx, 274, RULE_iCS_B_MemberProcedureCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1989;
-			switch ( Interpreter.AdaptivePredict(_input,309,_ctx) ) {
+			State = 2117;
+			switch ( Interpreter.AdaptivePredict(_input,310,_ctx) ) {
 			case 1:
 				{
-				State = 1988; implicitCallStmt_InStmt();
+				State = 2116; implicitCallStmt_InStmt();
 				}
 				break;
 			}
-			State = 1992;
+			State = 2120;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1991; whiteSpace();
+				State = 2119; whiteSpace();
 				}
 			}
 
-			State = 1994; Match(DOT);
-			State = 1996;
+			State = 2122; Match(DOT);
+			State = 2124;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1995; whiteSpace();
+				State = 2123; whiteSpace();
 				}
 			}
 
-			State = 1998; unrestrictedIdentifier();
-			State = 2000;
-			switch ( Interpreter.AdaptivePredict(_input,312,_ctx) ) {
-			case 1:
-				{
-				State = 1999; typeHint();
-				}
-				break;
-			}
-			State = 2005;
+			State = 2126; unrestrictedIdentifier();
+			State = 2128;
 			switch ( Interpreter.AdaptivePredict(_input,313,_ctx) ) {
 			case 1:
 				{
-				State = 2002; whiteSpace();
-				State = 2003; argsCall();
+				State = 2127; typeHint();
 				}
 				break;
 			}
-			State = 2011;
-			switch ( Interpreter.AdaptivePredict(_input,315,_ctx) ) {
+			State = 2133;
+			switch ( Interpreter.AdaptivePredict(_input,314,_ctx) ) {
 			case 1:
 				{
-				State = 2008;
+				State = 2130; whiteSpace();
+				State = 2131; argsCall();
+				}
+				break;
+			}
+			State = 2139;
+			switch ( Interpreter.AdaptivePredict(_input,316,_ctx) ) {
+			case 1:
+				{
+				State = 2136;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2007; whiteSpace();
+					State = 2135; whiteSpace();
 					}
 				}
 
-				State = 2010; dictionaryCallStmt();
+				State = 2138; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2022;
+			State = 2150;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,317,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,318,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2014;
+					State = 2142;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2013; whiteSpace();
+						State = 2141; whiteSpace();
 						}
 					}
 
-					State = 2016; Match(LPAREN);
-					State = 2017; subscripts();
-					State = 2018; Match(RPAREN);
+					State = 2144; Match(LPAREN);
+					State = 2145; subscripts();
+					State = 2146; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2024;
+				State = 2152;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,317,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,318,_ctx);
 			}
 			}
 		}
@@ -11177,46 +12658,46 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_B_ProcedureCallContext iCS_B_ProcedureCall() {
 		ICS_B_ProcedureCallContext _localctx = new ICS_B_ProcedureCallContext(_ctx, State);
-		EnterRule(_localctx, 214, RULE_iCS_B_ProcedureCall);
+		EnterRule(_localctx, 276, RULE_iCS_B_ProcedureCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2025; identifier();
-			State = 2029;
-			switch ( Interpreter.AdaptivePredict(_input,318,_ctx) ) {
+			State = 2153; identifier();
+			State = 2157;
+			switch ( Interpreter.AdaptivePredict(_input,319,_ctx) ) {
 			case 1:
 				{
-				State = 2026; whiteSpace();
-				State = 2027; argsCall();
+				State = 2154; whiteSpace();
+				State = 2155; argsCall();
 				}
 				break;
 			}
-			State = 2040;
+			State = 2168;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,320,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,321,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2032;
+					State = 2160;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2031; whiteSpace();
+						State = 2159; whiteSpace();
 						}
 					}
 
-					State = 2034; Match(LPAREN);
-					State = 2035; subscripts();
-					State = 2036; Match(RPAREN);
+					State = 2162; Match(LPAREN);
+					State = 2163; subscripts();
+					State = 2164; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2042;
+				State = 2170;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,320,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,321,_ctx);
 			}
 			}
 		}
@@ -11267,35 +12748,35 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ImplicitCallStmt_InStmtContext implicitCallStmt_InStmt() {
 		ImplicitCallStmt_InStmtContext _localctx = new ImplicitCallStmt_InStmtContext(_ctx, State);
-		EnterRule(_localctx, 216, RULE_implicitCallStmt_InStmt);
+		EnterRule(_localctx, 278, RULE_implicitCallStmt_InStmt);
 		try {
-			State = 2047;
-			switch ( Interpreter.AdaptivePredict(_input,321,_ctx) ) {
+			State = 2175;
+			switch ( Interpreter.AdaptivePredict(_input,322,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2043; iCS_S_MembersCall();
+				State = 2171; iCS_S_MembersCall();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2044; iCS_S_VariableOrProcedureCall();
+				State = 2172; iCS_S_VariableOrProcedureCall();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2045; iCS_S_ProcedureOrArrayCall();
+				State = 2173; iCS_S_ProcedureOrArrayCall();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2046; iCS_S_DictionaryCall();
+				State = 2174; iCS_S_DictionaryCall();
 				}
 				break;
 			}
@@ -11364,61 +12845,61 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_VariableOrProcedureCallContext iCS_S_VariableOrProcedureCall() {
 		ICS_S_VariableOrProcedureCallContext _localctx = new ICS_S_VariableOrProcedureCallContext(_ctx, State);
-		EnterRule(_localctx, 218, RULE_iCS_S_VariableOrProcedureCall);
+		EnterRule(_localctx, 280, RULE_iCS_S_VariableOrProcedureCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2049; identifier();
-			State = 2051;
-			switch ( Interpreter.AdaptivePredict(_input,322,_ctx) ) {
+			State = 2177; identifier();
+			State = 2179;
+			switch ( Interpreter.AdaptivePredict(_input,323,_ctx) ) {
 			case 1:
 				{
-				State = 2050; typeHint();
+				State = 2178; typeHint();
 				}
 				break;
 			}
-			State = 2057;
-			switch ( Interpreter.AdaptivePredict(_input,324,_ctx) ) {
+			State = 2185;
+			switch ( Interpreter.AdaptivePredict(_input,325,_ctx) ) {
 			case 1:
 				{
-				State = 2054;
+				State = 2182;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2053; whiteSpace();
+					State = 2181; whiteSpace();
 					}
 				}
 
-				State = 2056; dictionaryCallStmt();
+				State = 2184; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2068;
+			State = 2196;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,326,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,327,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2060;
+					State = 2188;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2059; whiteSpace();
+						State = 2187; whiteSpace();
 						}
 					}
 
-					State = 2062; Match(LPAREN);
-					State = 2063; subscripts();
-					State = 2064; Match(RPAREN);
+					State = 2190; Match(LPAREN);
+					State = 2191; subscripts();
+					State = 2192; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2070;
+				State = 2198;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,326,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,327,_ctx);
 			}
 			}
 		}
@@ -11492,108 +12973,108 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_ProcedureOrArrayCallContext iCS_S_ProcedureOrArrayCall() {
 		ICS_S_ProcedureOrArrayCallContext _localctx = new ICS_S_ProcedureOrArrayCallContext(_ctx, State);
-		EnterRule(_localctx, 220, RULE_iCS_S_ProcedureOrArrayCall);
+		EnterRule(_localctx, 282, RULE_iCS_S_ProcedureOrArrayCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2073;
-			switch ( Interpreter.AdaptivePredict(_input,327,_ctx) ) {
+			State = 2201;
+			switch ( Interpreter.AdaptivePredict(_input,328,_ctx) ) {
 			case 1:
 				{
-				State = 2071; identifier();
+				State = 2199; identifier();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2072; baseType();
+				State = 2200; baseType();
 				}
 				break;
 			}
-			State = 2076;
+			State = 2204;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 2075; typeHint();
+				State = 2203; typeHint();
 				}
 			}
 
-			State = 2079;
+			State = 2207;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2078; whiteSpace();
+				State = 2206; whiteSpace();
 				}
 			}
 
-			State = 2081; Match(LPAREN);
-			State = 2083;
-			switch ( Interpreter.AdaptivePredict(_input,330,_ctx) ) {
+			State = 2209; Match(LPAREN);
+			State = 2211;
+			switch ( Interpreter.AdaptivePredict(_input,331,_ctx) ) {
 			case 1:
 				{
-				State = 2082; whiteSpace();
+				State = 2210; whiteSpace();
 				}
 				break;
 			}
-			State = 2089;
-			switch ( Interpreter.AdaptivePredict(_input,332,_ctx) ) {
+			State = 2217;
+			switch ( Interpreter.AdaptivePredict(_input,333,_ctx) ) {
 			case 1:
 				{
-				State = 2085; argsCall();
-				State = 2087;
+				State = 2213; argsCall();
+				State = 2215;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2086; whiteSpace();
+					State = 2214; whiteSpace();
 					}
 				}
 
 				}
 				break;
 			}
-			State = 2091; Match(RPAREN);
-			State = 2096;
-			switch ( Interpreter.AdaptivePredict(_input,334,_ctx) ) {
+			State = 2219; Match(RPAREN);
+			State = 2224;
+			switch ( Interpreter.AdaptivePredict(_input,335,_ctx) ) {
 			case 1:
 				{
-				State = 2093;
+				State = 2221;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2092; whiteSpace();
+					State = 2220; whiteSpace();
 					}
 				}
 
-				State = 2095; dictionaryCallStmt();
+				State = 2223; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2107;
+			State = 2235;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,336,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,337,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2099;
+					State = 2227;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2098; whiteSpace();
+						State = 2226; whiteSpace();
 						}
 					}
 
-					State = 2101; Match(LPAREN);
-					State = 2102; subscripts();
-					State = 2103; Match(RPAREN);
+					State = 2229; Match(LPAREN);
+					State = 2230; subscripts();
+					State = 2231; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2109;
+				State = 2237;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,336,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,337,_ctx);
 			}
 			}
 		}
@@ -11661,61 +13142,61 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_VariableOrProcedureCallUnrestrictedContext iCS_S_VariableOrProcedureCallUnrestricted() {
 		ICS_S_VariableOrProcedureCallUnrestrictedContext _localctx = new ICS_S_VariableOrProcedureCallUnrestrictedContext(_ctx, State);
-		EnterRule(_localctx, 222, RULE_iCS_S_VariableOrProcedureCallUnrestricted);
+		EnterRule(_localctx, 284, RULE_iCS_S_VariableOrProcedureCallUnrestricted);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2110; unrestrictedIdentifier();
-			State = 2112;
-			switch ( Interpreter.AdaptivePredict(_input,337,_ctx) ) {
+			State = 2238; unrestrictedIdentifier();
+			State = 2240;
+			switch ( Interpreter.AdaptivePredict(_input,338,_ctx) ) {
 			case 1:
 				{
-				State = 2111; typeHint();
+				State = 2239; typeHint();
 				}
 				break;
 			}
-			State = 2118;
-			switch ( Interpreter.AdaptivePredict(_input,339,_ctx) ) {
+			State = 2246;
+			switch ( Interpreter.AdaptivePredict(_input,340,_ctx) ) {
 			case 1:
 				{
-				State = 2115;
+				State = 2243;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2114; whiteSpace();
+					State = 2242; whiteSpace();
 					}
 				}
 
-				State = 2117; dictionaryCallStmt();
+				State = 2245; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2129;
+			State = 2257;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,341,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,342,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2121;
+					State = 2249;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2120; whiteSpace();
+						State = 2248; whiteSpace();
 						}
 					}
 
-					State = 2123; Match(LPAREN);
-					State = 2124; subscripts();
-					State = 2125; Match(RPAREN);
+					State = 2251; Match(LPAREN);
+					State = 2252; subscripts();
+					State = 2253; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2131;
+				State = 2259;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,341,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,342,_ctx);
 			}
 			}
 		}
@@ -11789,108 +13270,108 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_ProcedureOrArrayCallUnrestrictedContext iCS_S_ProcedureOrArrayCallUnrestricted() {
 		ICS_S_ProcedureOrArrayCallUnrestrictedContext _localctx = new ICS_S_ProcedureOrArrayCallUnrestrictedContext(_ctx, State);
-		EnterRule(_localctx, 224, RULE_iCS_S_ProcedureOrArrayCallUnrestricted);
+		EnterRule(_localctx, 286, RULE_iCS_S_ProcedureOrArrayCallUnrestricted);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2134;
-			switch ( Interpreter.AdaptivePredict(_input,342,_ctx) ) {
+			State = 2262;
+			switch ( Interpreter.AdaptivePredict(_input,343,_ctx) ) {
 			case 1:
 				{
-				State = 2132; unrestrictedIdentifier();
+				State = 2260; unrestrictedIdentifier();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2133; baseType();
+				State = 2261; baseType();
 				}
 				break;
 			}
-			State = 2137;
+			State = 2265;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 2136; typeHint();
+				State = 2264; typeHint();
 				}
 			}
 
-			State = 2140;
+			State = 2268;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2139; whiteSpace();
+				State = 2267; whiteSpace();
 				}
 			}
 
-			State = 2142; Match(LPAREN);
-			State = 2144;
-			switch ( Interpreter.AdaptivePredict(_input,345,_ctx) ) {
+			State = 2270; Match(LPAREN);
+			State = 2272;
+			switch ( Interpreter.AdaptivePredict(_input,346,_ctx) ) {
 			case 1:
 				{
-				State = 2143; whiteSpace();
+				State = 2271; whiteSpace();
 				}
 				break;
 			}
-			State = 2150;
-			switch ( Interpreter.AdaptivePredict(_input,347,_ctx) ) {
+			State = 2278;
+			switch ( Interpreter.AdaptivePredict(_input,348,_ctx) ) {
 			case 1:
 				{
-				State = 2146; argsCall();
-				State = 2148;
+				State = 2274; argsCall();
+				State = 2276;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2147; whiteSpace();
+					State = 2275; whiteSpace();
 					}
 				}
 
 				}
 				break;
 			}
-			State = 2152; Match(RPAREN);
-			State = 2157;
-			switch ( Interpreter.AdaptivePredict(_input,349,_ctx) ) {
+			State = 2280; Match(RPAREN);
+			State = 2285;
+			switch ( Interpreter.AdaptivePredict(_input,350,_ctx) ) {
 			case 1:
 				{
-				State = 2154;
+				State = 2282;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2153; whiteSpace();
+					State = 2281; whiteSpace();
 					}
 				}
 
-				State = 2156; dictionaryCallStmt();
+				State = 2284; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2168;
+			State = 2296;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,351,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,352,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2160;
+					State = 2288;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2159; whiteSpace();
+						State = 2287; whiteSpace();
 						}
 					}
 
-					State = 2162; Match(LPAREN);
-					State = 2163; subscripts();
-					State = 2164; Match(RPAREN);
+					State = 2290; Match(LPAREN);
+					State = 2291; subscripts();
+					State = 2292; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2170;
+				State = 2298;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,351,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,352,_ctx);
 			}
 			}
 		}
@@ -11964,27 +13445,27 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_MembersCallContext iCS_S_MembersCall() {
 		ICS_S_MembersCallContext _localctx = new ICS_S_MembersCallContext(_ctx, State);
-		EnterRule(_localctx, 226, RULE_iCS_S_MembersCall);
+		EnterRule(_localctx, 288, RULE_iCS_S_MembersCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2173;
-			switch ( Interpreter.AdaptivePredict(_input,352,_ctx) ) {
+			State = 2301;
+			switch ( Interpreter.AdaptivePredict(_input,353,_ctx) ) {
 			case 1:
 				{
-				State = 2171; iCS_S_VariableOrProcedureCall();
+				State = 2299; iCS_S_VariableOrProcedureCall();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2172; iCS_S_ProcedureOrArrayCall();
+				State = 2300; iCS_S_ProcedureOrArrayCall();
 				}
 				break;
 			}
-			State = 2179;
+			State = 2307;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -11992,12 +13473,12 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 2175; iCS_S_MemberCall();
-					State = 2177;
-					switch ( Interpreter.AdaptivePredict(_input,353,_ctx) ) {
+					State = 2303; iCS_S_MemberCall();
+					State = 2305;
+					switch ( Interpreter.AdaptivePredict(_input,354,_ctx) ) {
 					case 1:
 						{
-						State = 2176; whiteSpace();
+						State = 2304; whiteSpace();
 						}
 						break;
 					}
@@ -12007,50 +13488,50 @@ public partial class VBAParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 2181;
+				State = 2309;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,354,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,355,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-			State = 2187;
-			switch ( Interpreter.AdaptivePredict(_input,356,_ctx) ) {
+			State = 2315;
+			switch ( Interpreter.AdaptivePredict(_input,357,_ctx) ) {
 			case 1:
 				{
-				State = 2184;
+				State = 2312;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2183; whiteSpace();
+					State = 2311; whiteSpace();
 					}
 				}
 
-				State = 2186; dictionaryCallStmt();
+				State = 2314; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2198;
+			State = 2326;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,358,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,359,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2190;
+					State = 2318;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2189; whiteSpace();
+						State = 2317; whiteSpace();
 						}
 					}
 
-					State = 2192; Match(LPAREN);
-					State = 2193; subscripts();
-					State = 2194; Match(RPAREN);
+					State = 2320; Match(LPAREN);
+					State = 2321; subscripts();
+					State = 2322; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2200;
+				State = 2328;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,358,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,359,_ctx);
 			}
 			}
 		}
@@ -12100,36 +13581,36 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_MemberCallContext iCS_S_MemberCall() {
 		ICS_S_MemberCallContext _localctx = new ICS_S_MemberCallContext(_ctx, State);
-		EnterRule(_localctx, 228, RULE_iCS_S_MemberCall);
+		EnterRule(_localctx, 290, RULE_iCS_S_MemberCall);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2201;
+			State = 2329;
 			_la = _input.La(1);
 			if ( !(_la==EXCLAMATIONPOINT || _la==DOT) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 2203;
+			State = 2331;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2202; whiteSpace();
+				State = 2330; whiteSpace();
 				}
 			}
 
-			State = 2207;
-			switch ( Interpreter.AdaptivePredict(_input,360,_ctx) ) {
+			State = 2335;
+			switch ( Interpreter.AdaptivePredict(_input,361,_ctx) ) {
 			case 1:
 				{
-				State = 2205; iCS_S_VariableOrProcedureCallUnrestricted();
+				State = 2333; iCS_S_VariableOrProcedureCallUnrestricted();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2206; iCS_S_ProcedureOrArrayCallUnrestricted();
+				State = 2334; iCS_S_ProcedureOrArrayCallUnrestricted();
 				}
 				break;
 			}
@@ -12176,20 +13657,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_DictionaryCallContext iCS_S_DictionaryCall() {
 		ICS_S_DictionaryCallContext _localctx = new ICS_S_DictionaryCallContext(_ctx, State);
-		EnterRule(_localctx, 230, RULE_iCS_S_DictionaryCall);
+		EnterRule(_localctx, 292, RULE_iCS_S_DictionaryCall);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2210;
+			State = 2338;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2209; whiteSpace();
+				State = 2337; whiteSpace();
 				}
 			}
 
-			State = 2212; dictionaryCallStmt();
+			State = 2340; dictionaryCallStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -12247,100 +13728,100 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgsCallContext argsCall() {
 		ArgsCallContext _localctx = new ArgsCallContext(_ctx, State);
-		EnterRule(_localctx, 232, RULE_argsCall);
+		EnterRule(_localctx, 294, RULE_argsCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2226;
+			State = 2354;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,365,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,366,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2215;
-					switch ( Interpreter.AdaptivePredict(_input,362,_ctx) ) {
+					State = 2343;
+					switch ( Interpreter.AdaptivePredict(_input,363,_ctx) ) {
 					case 1:
 						{
-						State = 2214; argCall();
+						State = 2342; argCall();
 						}
 						break;
 					}
-					State = 2218;
+					State = 2346;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2217; whiteSpace();
+						State = 2345; whiteSpace();
 						}
 					}
 
-					State = 2220;
+					State = 2348;
 					_la = _input.La(1);
 					if ( !(_la==COMMA || _la==SEMICOLON) ) {
 					_errHandler.RecoverInline(this);
 					}
 					Consume();
-					State = 2222;
-					switch ( Interpreter.AdaptivePredict(_input,364,_ctx) ) {
+					State = 2350;
+					switch ( Interpreter.AdaptivePredict(_input,365,_ctx) ) {
 					case 1:
 						{
-						State = 2221; whiteSpace();
+						State = 2349; whiteSpace();
 						}
 						break;
 					}
 					}
 					} 
 				}
-				State = 2228;
+				State = 2356;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,365,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,366,_ctx);
 			}
-			State = 2229; argCall();
-			State = 2242;
+			State = 2357; argCall();
+			State = 2370;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,369,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,370,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2231;
+					State = 2359;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2230; whiteSpace();
+						State = 2358; whiteSpace();
 						}
 					}
 
-					State = 2233;
+					State = 2361;
 					_la = _input.La(1);
 					if ( !(_la==COMMA || _la==SEMICOLON) ) {
 					_errHandler.RecoverInline(this);
 					}
 					Consume();
-					State = 2235;
-					switch ( Interpreter.AdaptivePredict(_input,367,_ctx) ) {
-					case 1:
-						{
-						State = 2234; whiteSpace();
-						}
-						break;
-					}
-					State = 2238;
+					State = 2363;
 					switch ( Interpreter.AdaptivePredict(_input,368,_ctx) ) {
 					case 1:
 						{
-						State = 2237; argCall();
+						State = 2362; whiteSpace();
+						}
+						break;
+					}
+					State = 2366;
+					switch ( Interpreter.AdaptivePredict(_input,369,_ctx) ) {
+					case 1:
+						{
+						State = 2365; argCall();
 						}
 						break;
 					}
 					}
 					} 
 				}
-				State = 2244;
+				State = 2372;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,369,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,370,_ctx);
 			}
 			}
 		}
@@ -12390,42 +13871,42 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgCallContext argCall() {
 		ArgCallContext _localctx = new ArgCallContext(_ctx, State);
-		EnterRule(_localctx, 234, RULE_argCall);
+		EnterRule(_localctx, 296, RULE_argCall);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2246;
-			switch ( Interpreter.AdaptivePredict(_input,370,_ctx) ) {
-			case 1:
-				{
-				State = 2245; Match(LPAREN);
-				}
-				break;
-			}
-			State = 2250;
+			State = 2374;
 			switch ( Interpreter.AdaptivePredict(_input,371,_ctx) ) {
 			case 1:
 				{
-				State = 2248;
+				State = 2373; Match(LPAREN);
+				}
+				break;
+			}
+			State = 2378;
+			switch ( Interpreter.AdaptivePredict(_input,372,_ctx) ) {
+			case 1:
+				{
+				State = 2376;
 				_la = _input.La(1);
 				if ( !(_la==BYVAL || _la==BYREF || _la==PARAMARRAY) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 2249; whiteSpace();
+				State = 2377; whiteSpace();
 				}
 				break;
 			}
-			State = 2253;
+			State = 2381;
 			_la = _input.La(1);
 			if (_la==RPAREN) {
 				{
-				State = 2252; Match(RPAREN);
+				State = 2380; Match(RPAREN);
 				}
 			}
 
-			State = 2255; valueStmt(0);
+			State = 2383; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12473,26 +13954,26 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public DictionaryCallStmtContext dictionaryCallStmt() {
 		DictionaryCallStmtContext _localctx = new DictionaryCallStmtContext(_ctx, State);
-		EnterRule(_localctx, 236, RULE_dictionaryCallStmt);
+		EnterRule(_localctx, 298, RULE_dictionaryCallStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2257; Match(EXCLAMATIONPOINT);
-			State = 2259;
+			State = 2385; Match(EXCLAMATIONPOINT);
+			State = 2387;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2258; whiteSpace();
+				State = 2386; whiteSpace();
 				}
 			}
 
-			State = 2261; unrestrictedIdentifier();
-			State = 2263;
-			switch ( Interpreter.AdaptivePredict(_input,374,_ctx) ) {
+			State = 2389; unrestrictedIdentifier();
+			State = 2391;
+			switch ( Interpreter.AdaptivePredict(_input,375,_ctx) ) {
 			case 1:
 				{
-				State = 2262; typeHint();
+				State = 2390; typeHint();
 				}
 				break;
 			}
@@ -12551,70 +14032,70 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgListContext argList() {
 		ArgListContext _localctx = new ArgListContext(_ctx, State);
-		EnterRule(_localctx, 238, RULE_argList);
+		EnterRule(_localctx, 300, RULE_argList);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2265; Match(LPAREN);
-			State = 2283;
-			switch ( Interpreter.AdaptivePredict(_input,379,_ctx) ) {
+			State = 2393; Match(LPAREN);
+			State = 2411;
+			switch ( Interpreter.AdaptivePredict(_input,380,_ctx) ) {
 			case 1:
 				{
-				State = 2267;
+				State = 2395;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2266; whiteSpace();
+					State = 2394; whiteSpace();
 					}
 				}
 
-				State = 2269; arg();
-				State = 2280;
+				State = 2397; arg();
+				State = 2408;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,378,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,379,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2271;
+						State = 2399;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2270; whiteSpace();
+							State = 2398; whiteSpace();
 							}
 						}
 
-						State = 2273; Match(COMMA);
-						State = 2275;
+						State = 2401; Match(COMMA);
+						State = 2403;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2274; whiteSpace();
+							State = 2402; whiteSpace();
 							}
 						}
 
-						State = 2277; arg();
+						State = 2405; arg();
 						}
 						} 
 					}
-					State = 2282;
+					State = 2410;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,378,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,379,_ctx);
 				}
 				}
 				break;
 			}
-			State = 2286;
+			State = 2414;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2285; whiteSpace();
+				State = 2413; whiteSpace();
 				}
 			}
 
-			State = 2288; Match(RPAREN);
+			State = 2416; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12676,106 +14157,106 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgContext arg() {
 		ArgContext _localctx = new ArgContext(_ctx, State);
-		EnterRule(_localctx, 240, RULE_arg);
+		EnterRule(_localctx, 302, RULE_arg);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2292;
-			switch ( Interpreter.AdaptivePredict(_input,381,_ctx) ) {
-			case 1:
-				{
-				State = 2290; Match(OPTIONAL);
-				State = 2291; whiteSpace();
-				}
-				break;
-			}
-			State = 2296;
+			State = 2420;
 			switch ( Interpreter.AdaptivePredict(_input,382,_ctx) ) {
 			case 1:
 				{
-				State = 2294;
+				State = 2418; Match(OPTIONAL);
+				State = 2419; whiteSpace();
+				}
+				break;
+			}
+			State = 2424;
+			switch ( Interpreter.AdaptivePredict(_input,383,_ctx) ) {
+			case 1:
+				{
+				State = 2422;
 				_la = _input.La(1);
 				if ( !(_la==BYVAL || _la==BYREF) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 2295; whiteSpace();
+				State = 2423; whiteSpace();
 				}
 				break;
 			}
-			State = 2300;
-			switch ( Interpreter.AdaptivePredict(_input,383,_ctx) ) {
+			State = 2428;
+			switch ( Interpreter.AdaptivePredict(_input,384,_ctx) ) {
 			case 1:
 				{
-				State = 2298; Match(PARAMARRAY);
-				State = 2299; whiteSpace();
+				State = 2426; Match(PARAMARRAY);
+				State = 2427; whiteSpace();
 				}
 				break;
 			}
-			State = 2302; unrestrictedIdentifier();
-			State = 2304;
+			State = 2430; unrestrictedIdentifier();
+			State = 2432;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 2303; typeHint();
+				State = 2431; typeHint();
 				}
 			}
 
-			State = 2314;
-			switch ( Interpreter.AdaptivePredict(_input,387,_ctx) ) {
+			State = 2442;
+			switch ( Interpreter.AdaptivePredict(_input,388,_ctx) ) {
 			case 1:
 				{
-				State = 2307;
+				State = 2435;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2306; whiteSpace();
+					State = 2434; whiteSpace();
 					}
 				}
 
-				State = 2309; Match(LPAREN);
-				State = 2311;
+				State = 2437; Match(LPAREN);
+				State = 2439;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2310; whiteSpace();
+					State = 2438; whiteSpace();
 					}
 				}
 
-				State = 2313; Match(RPAREN);
+				State = 2441; Match(RPAREN);
 				}
 				break;
 			}
-			State = 2320;
-			switch ( Interpreter.AdaptivePredict(_input,389,_ctx) ) {
+			State = 2448;
+			switch ( Interpreter.AdaptivePredict(_input,390,_ctx) ) {
 			case 1:
 				{
-				State = 2317;
+				State = 2445;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2316; whiteSpace();
+					State = 2444; whiteSpace();
 					}
 				}
 
-				State = 2319; asTypeClause();
+				State = 2447; asTypeClause();
 				}
 				break;
 			}
-			State = 2326;
-			switch ( Interpreter.AdaptivePredict(_input,391,_ctx) ) {
+			State = 2454;
+			switch ( Interpreter.AdaptivePredict(_input,392,_ctx) ) {
 			case 1:
 				{
-				State = 2323;
+				State = 2451;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2322; whiteSpace();
+					State = 2450; whiteSpace();
 					}
 				}
 
-				State = 2325; argDefaultValue();
+				State = 2453; argDefaultValue();
 				}
 				break;
 			}
@@ -12823,20 +14304,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgDefaultValueContext argDefaultValue() {
 		ArgDefaultValueContext _localctx = new ArgDefaultValueContext(_ctx, State);
-		EnterRule(_localctx, 242, RULE_argDefaultValue);
+		EnterRule(_localctx, 304, RULE_argDefaultValue);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2328; Match(EQ);
-			State = 2330;
-			switch ( Interpreter.AdaptivePredict(_input,392,_ctx) ) {
+			State = 2456; Match(EQ);
+			State = 2458;
+			switch ( Interpreter.AdaptivePredict(_input,393,_ctx) ) {
 			case 1:
 				{
-				State = 2329; whiteSpace();
+				State = 2457; whiteSpace();
 				}
 				break;
 			}
-			State = 2332; valueStmt(0);
+			State = 2460; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12890,44 +14371,44 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubscriptsContext subscripts() {
 		SubscriptsContext _localctx = new SubscriptsContext(_ctx, State);
-		EnterRule(_localctx, 244, RULE_subscripts);
+		EnterRule(_localctx, 306, RULE_subscripts);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2334; subscript();
-			State = 2345;
+			State = 2462; subscript();
+			State = 2473;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,395,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,396,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2336;
+					State = 2464;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2335; whiteSpace();
+						State = 2463; whiteSpace();
 						}
 					}
 
-					State = 2338; Match(COMMA);
-					State = 2340;
-					switch ( Interpreter.AdaptivePredict(_input,394,_ctx) ) {
+					State = 2466; Match(COMMA);
+					State = 2468;
+					switch ( Interpreter.AdaptivePredict(_input,395,_ctx) ) {
 					case 1:
 						{
-						State = 2339; whiteSpace();
+						State = 2467; whiteSpace();
 						}
 						break;
 					}
-					State = 2342; subscript();
+					State = 2470; subscript();
 					}
 					} 
 				}
-				State = 2347;
+				State = 2475;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,395,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,396,_ctx);
 			}
 			}
 		}
@@ -12979,22 +14460,22 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubscriptContext subscript() {
 		SubscriptContext _localctx = new SubscriptContext(_ctx, State);
-		EnterRule(_localctx, 246, RULE_subscript);
+		EnterRule(_localctx, 308, RULE_subscript);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2353;
-			switch ( Interpreter.AdaptivePredict(_input,396,_ctx) ) {
+			State = 2481;
+			switch ( Interpreter.AdaptivePredict(_input,397,_ctx) ) {
 			case 1:
 				{
-				State = 2348; valueStmt(0);
-				State = 2349; whiteSpace();
-				State = 2350; Match(TO);
-				State = 2351; whiteSpace();
+				State = 2476; valueStmt(0);
+				State = 2477; whiteSpace();
+				State = 2478; Match(TO);
+				State = 2479; whiteSpace();
 				}
 				break;
 			}
-			State = 2355; valueStmt(0);
+			State = 2483; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -13041,30 +14522,210 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UnrestrictedIdentifierContext unrestrictedIdentifier() {
 		UnrestrictedIdentifierContext _localctx = new UnrestrictedIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 248, RULE_unrestrictedIdentifier);
+		EnterRule(_localctx, 310, RULE_unrestrictedIdentifier);
 		try {
-			State = 2360;
-			switch ( Interpreter.AdaptivePredict(_input,397,_ctx) ) {
-			case 1:
+			State = 2488;
+			switch (_input.La(1)) {
+			case ABS:
+			case ANY:
+			case ARRAY:
+			case CBOOL:
+			case CBYTE:
+			case CCUR:
+			case CDATE:
+			case CDBL:
+			case CDEC:
+			case CINT:
+			case CIRCLE:
+			case CLNG:
+			case CLNGLNG:
+			case CLNGPTR:
+			case CSNG:
+			case CSTR:
+			case CURRENCY:
+			case CVAR:
+			case CVERR:
+			case DEBUG:
+			case DOEVENTS:
+			case FIX:
+			case INPUTB:
+			case INT:
+			case LBOUND:
+			case LEN:
+			case LENB:
+			case LONGLONG:
+			case LONGPTR:
+			case MIDB:
+			case MIDBTYPESUFFIX:
+			case MIDTYPESUFFIX:
+			case PSET:
+			case SCALE:
+			case SGN:
+			case UBOUND:
+			case ACCESS:
+			case ADDRESSOF:
+			case ALIAS:
+			case AND:
+			case ATTRIBUTE:
+			case APPEND:
+			case BEGIN:
+			case BINARY:
+			case BOOLEAN:
+			case BYVAL:
+			case BYREF:
+			case BYTE:
+			case CLASS:
+			case CLOSE:
+			case DATABASE:
+			case DATE:
+			case DOUBLE:
+			case END_SELECT:
+			case END_WITH:
+			case END:
+			case EQV:
+			case ERROR:
+			case EXIT_DO:
+			case EXIT_FOR:
+			case EXIT_FUNCTION:
+			case EXIT_PROPERTY:
+			case EXIT_SUB:
+			case FALSE:
+			case GET:
+			case IMP:
+			case IN:
+			case INPUT:
+			case IS:
+			case INTEGER:
+			case LOCK:
+			case LONG:
+			case LIB:
+			case LIKE:
+			case LINE_INPUT:
+			case LOCK_READ:
+			case LOCK_WRITE:
+			case LOCK_READ_WRITE:
+			case ME:
+			case MID:
+			case MOD:
+			case NEW:
+			case NOT:
+			case NOTHING:
+			case NULL:
+			case ON_ERROR:
+			case OPEN:
+			case OPTIONAL:
+			case OR:
+			case OUTPUT:
+			case PARAMARRAY:
+			case PRESERVE:
+			case PUT:
+			case RANDOM:
+			case READ:
+			case READ_WRITE:
+			case REM:
+			case RESET:
+			case SEEK:
+			case SHARED:
+			case SINGLE:
+			case SPC:
+			case STEP:
+			case STRING:
+			case TAB:
+			case TEXT:
+			case THEN:
+			case TO:
+			case TRUE:
+			case TYPEOF:
+			case UNLOCK:
+			case UNTIL:
+			case VARIANT:
+			case VERSION:
+			case WIDTH:
+			case WITHEVENTS:
+			case WRITE:
+			case XOR:
+			case IDENTIFIER:
+			case COLLECTION:
+			case DELETESETTING:
+			case LOAD:
+			case RMDIR:
+			case SENDKEYS:
+			case SETATTR:
+			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2357; identifier();
+				State = 2485; identifier();
 				}
 				break;
-
-			case 2:
+			case EXIT:
+			case OPTION:
+			case CALL:
+			case CASE:
+			case CONST:
+			case DECLARE:
+			case DEFBOOL:
+			case DEFBYTE:
+			case DEFDATE:
+			case DEFDBL:
+			case DEFCUR:
+			case DEFINT:
+			case DEFLNG:
+			case DEFLNGLNG:
+			case DEFLNGPTR:
+			case DEFOBJ:
+			case DEFSNG:
+			case DEFSTR:
+			case DEFVAR:
+			case DIM:
+			case DO:
+			case ELSE:
+			case ELSEIF:
+			case ENUM:
+			case ERASE:
+			case EVENT:
+			case FRIEND:
+			case FOR:
+			case FUNCTION:
+			case GLOBAL:
+			case GOSUB:
+			case GOTO:
+			case IF:
+			case IMPLEMENTS:
+			case LOOP:
+			case LET:
+			case LSET:
+			case NEXT:
+			case ON:
+			case PRINT:
+			case PRIVATE:
+			case PUBLIC:
+			case RAISEEVENT:
+			case REDIM:
+			case RESUME:
+			case RETURN:
+			case RSET:
+			case SELECT:
+			case SET:
+			case STATIC:
+			case STOP:
+			case SUB:
+			case TYPE:
+			case WEND:
+			case WHILE:
+			case WITH:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2358; statementKeyword();
+				State = 2486; statementKeyword();
 				}
 				break;
-
-			case 3:
+			case AS:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2359; markerKeyword();
+				State = 2487; markerKeyword();
 				}
 				break;
+			default:
+				throw new NoViableAltException(this);
 			}
 		}
 		catch (RecognitionException re) {
@@ -13106,14 +14767,14 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IdentifierContext identifier() {
 		IdentifierContext _localctx = new IdentifierContext(_ctx, State);
-		EnterRule(_localctx, 250, RULE_identifier);
+		EnterRule(_localctx, 312, RULE_identifier);
 		try {
-			State = 2364;
+			State = 2492;
 			switch (_input.La(1)) {
 			case IDENTIFIER:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2362; Match(IDENTIFIER);
+				State = 2490; Match(IDENTIFIER);
 				}
 				break;
 			case ABS:
@@ -13165,6 +14826,7 @@ public partial class VBAParser : Parser {
 			case BYREF:
 			case BYTE:
 			case CLASS:
+			case CLOSE:
 			case DATABASE:
 			case DATE:
 			case DOUBLE:
@@ -13179,10 +14841,13 @@ public partial class VBAParser : Parser {
 			case EXIT_PROPERTY:
 			case EXIT_SUB:
 			case FALSE:
+			case GET:
 			case IMP:
 			case IN:
+			case INPUT:
 			case IS:
 			case INTEGER:
+			case LOCK:
 			case LONG:
 			case LIB:
 			case LIKE:
@@ -13198,16 +14863,19 @@ public partial class VBAParser : Parser {
 			case NOTHING:
 			case NULL:
 			case ON_ERROR:
+			case OPEN:
 			case OPTIONAL:
 			case OR:
 			case OUTPUT:
 			case PARAMARRAY:
 			case PRESERVE:
+			case PUT:
 			case RANDOM:
 			case READ:
 			case READ_WRITE:
 			case REM:
 			case RESET:
+			case SEEK:
 			case SHARED:
 			case SINGLE:
 			case SPC:
@@ -13219,6 +14887,7 @@ public partial class VBAParser : Parser {
 			case TO:
 			case TRUE:
 			case TYPEOF:
+			case UNLOCK:
 			case UNTIL:
 			case VARIANT:
 			case VERSION:
@@ -13235,7 +14904,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2363; keyword();
+				State = 2491; keyword();
 				}
 				break;
 			default:
@@ -13291,43 +14960,43 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AsTypeClauseContext asTypeClause() {
 		AsTypeClauseContext _localctx = new AsTypeClauseContext(_ctx, State);
-		EnterRule(_localctx, 252, RULE_asTypeClause);
+		EnterRule(_localctx, 314, RULE_asTypeClause);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2366; Match(AS);
-			State = 2368;
+			State = 2494; Match(AS);
+			State = 2496;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2367; whiteSpace();
+				State = 2495; whiteSpace();
 				}
 			}
 
-			State = 2372;
-			switch ( Interpreter.AdaptivePredict(_input,400,_ctx) ) {
+			State = 2500;
+			switch ( Interpreter.AdaptivePredict(_input,401,_ctx) ) {
 			case 1:
 				{
-				State = 2370; Match(NEW);
-				State = 2371; whiteSpace();
+				State = 2498; Match(NEW);
+				State = 2499; whiteSpace();
 				}
 				break;
 			}
-			State = 2374; type();
-			State = 2379;
-			switch ( Interpreter.AdaptivePredict(_input,402,_ctx) ) {
+			State = 2502; type();
+			State = 2507;
+			switch ( Interpreter.AdaptivePredict(_input,403,_ctx) ) {
 			case 1:
 				{
-				State = 2376;
+				State = 2504;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2375; whiteSpace();
+					State = 2503; whiteSpace();
 					}
 				}
 
-				State = 2378; fieldLength();
+				State = 2506; fieldLength();
 				}
 				break;
 			}
@@ -13380,12 +15049,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public BaseTypeContext baseType() {
 		BaseTypeContext _localctx = new BaseTypeContext(_ctx, State);
-		EnterRule(_localctx, 254, RULE_baseType);
+		EnterRule(_localctx, 316, RULE_baseType);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2381;
+			State = 2509;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << CURRENCY) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << BOOLEAN) | (1L << BYTE))) != 0) || ((((_la - 68)) & ~0x3f) == 0 && ((1L << (_la - 68)) & ((1L << (DATE - 68)) | (1L << (DOUBLE - 68)) | (1L << (INTEGER - 68)) | (1L << (LONG - 68)))) != 0) || ((((_la - 178)) & ~0x3f) == 0 && ((1L << (_la - 178)) & ((1L << (SINGLE - 178)) | (1L << (STRING - 178)) | (1L << (VARIANT - 178)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -13436,12 +15105,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ComparisonOperatorContext comparisonOperator() {
 		ComparisonOperatorContext _localctx = new ComparisonOperatorContext(_ctx, State);
-		EnterRule(_localctx, 256, RULE_comparisonOperator);
+		EnterRule(_localctx, 318, RULE_comparisonOperator);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2383;
+			State = 2511;
 			_la = _input.La(1);
 			if ( !(_la==IS || _la==LIKE || ((((_la - 206)) & ~0x3f) == 0 && ((1L << (_la - 206)) & ((1L << (EQ - 206)) | (1L << (GEQ - 206)) | (1L << (GT - 206)) | (1L << (LEQ - 206)) | (1L << (LT - 206)) | (1L << (NEQ - 206)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -13498,33 +15167,33 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ComplexTypeContext complexType() {
 		ComplexTypeContext _localctx = new ComplexTypeContext(_ctx, State);
-		EnterRule(_localctx, 258, RULE_complexType);
+		EnterRule(_localctx, 320, RULE_complexType);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2385; identifier();
-			State = 2390;
+			State = 2513; identifier();
+			State = 2518;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,403,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,404,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2386;
+					State = 2514;
 					_la = _input.La(1);
 					if ( !(_la==EXCLAMATIONPOINT || _la==DOT) ) {
 					_errHandler.RecoverInline(this);
 					}
 					Consume();
-					State = 2387; identifier();
+					State = 2515; identifier();
 					}
 					} 
 				}
-				State = 2392;
+				State = 2520;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,403,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,404,_ctx);
 			}
 			}
 		}
@@ -13573,28 +15242,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public FieldLengthContext fieldLength() {
 		FieldLengthContext _localctx = new FieldLengthContext(_ctx, State);
-		EnterRule(_localctx, 260, RULE_fieldLength);
+		EnterRule(_localctx, 322, RULE_fieldLength);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2393; Match(MULT);
-			State = 2395;
+			State = 2521; Match(MULT);
+			State = 2523;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2394; whiteSpace();
+				State = 2522; whiteSpace();
 				}
 			}
 
-			State = 2399;
+			State = 2527;
 			switch (_input.La(1)) {
 			case OCTLITERAL:
 			case HEXLITERAL:
 			case FLOATLITERAL:
 			case INTEGERLITERAL:
 				{
-				State = 2397; numberLiteral();
+				State = 2525; numberLiteral();
 				}
 				break;
 			case ABS:
@@ -13646,6 +15315,7 @@ public partial class VBAParser : Parser {
 			case BYREF:
 			case BYTE:
 			case CLASS:
+			case CLOSE:
 			case DATABASE:
 			case DATE:
 			case DOUBLE:
@@ -13660,10 +15330,13 @@ public partial class VBAParser : Parser {
 			case EXIT_PROPERTY:
 			case EXIT_SUB:
 			case FALSE:
+			case GET:
 			case IMP:
 			case IN:
+			case INPUT:
 			case IS:
 			case INTEGER:
+			case LOCK:
 			case LONG:
 			case LIB:
 			case LIKE:
@@ -13679,16 +15352,19 @@ public partial class VBAParser : Parser {
 			case NOTHING:
 			case NULL:
 			case ON_ERROR:
+			case OPEN:
 			case OPTIONAL:
 			case OR:
 			case OUTPUT:
 			case PARAMARRAY:
 			case PRESERVE:
+			case PUT:
 			case RANDOM:
 			case READ:
 			case READ_WRITE:
 			case REM:
 			case RESET:
+			case SEEK:
 			case SHARED:
 			case SINGLE:
 			case SPC:
@@ -13700,6 +15376,7 @@ public partial class VBAParser : Parser {
 			case TO:
 			case TRUE:
 			case TYPEOF:
+			case UNLOCK:
 			case UNTIL:
 			case VARIANT:
 			case VERSION:
@@ -13716,7 +15393,7 @@ public partial class VBAParser : Parser {
 			case SETATTR:
 			case RESUME_NEXT:
 				{
-				State = 2398; identifier();
+				State = 2526; identifier();
 				}
 				break;
 			default:
@@ -13766,21 +15443,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementLabelDefinitionContext statementLabelDefinition() {
 		StatementLabelDefinitionContext _localctx = new StatementLabelDefinitionContext(_ctx, State);
-		EnterRule(_localctx, 262, RULE_statementLabelDefinition);
+		EnterRule(_localctx, 324, RULE_statementLabelDefinition);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2401; statementLabel();
-			State = 2403;
+			State = 2529; statementLabel();
+			State = 2531;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2402; whiteSpace();
+				State = 2530; whiteSpace();
 				}
 			}
 
-			State = 2405; Match(COLON);
+			State = 2533; Match(COLON);
 			}
 		}
 		catch (RecognitionException re) {
@@ -13824,9 +15501,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementLabelContext statementLabel() {
 		StatementLabelContext _localctx = new StatementLabelContext(_ctx, State);
-		EnterRule(_localctx, 264, RULE_statementLabel);
+		EnterRule(_localctx, 326, RULE_statementLabel);
 		try {
-			State = 2409;
+			State = 2537;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -14013,7 +15690,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2407; identifierStatementLabel();
+				State = 2535; identifierStatementLabel();
 				}
 				break;
 			case OCTLITERAL:
@@ -14022,7 +15699,7 @@ public partial class VBAParser : Parser {
 			case INTEGERLITERAL:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2408; lineNumberLabel();
+				State = 2536; lineNumberLabel();
 				}
 				break;
 			default:
@@ -14067,11 +15744,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IdentifierStatementLabelContext identifierStatementLabel() {
 		IdentifierStatementLabelContext _localctx = new IdentifierStatementLabelContext(_ctx, State);
-		EnterRule(_localctx, 266, RULE_identifierStatementLabel);
+		EnterRule(_localctx, 328, RULE_identifierStatementLabel);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2411; unrestrictedIdentifier();
+			State = 2539; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -14112,11 +15789,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LineNumberLabelContext lineNumberLabel() {
 		LineNumberLabelContext _localctx = new LineNumberLabelContext(_ctx, State);
-		EnterRule(_localctx, 268, RULE_lineNumberLabel);
+		EnterRule(_localctx, 330, RULE_lineNumberLabel);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2413; numberLiteral();
+			State = 2541; numberLiteral();
 			}
 		}
 		catch (RecognitionException re) {
@@ -14164,9 +15841,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LiteralContext literal() {
 		LiteralContext _localctx = new LiteralContext(_ctx, State);
-		EnterRule(_localctx, 270, RULE_literal);
+		EnterRule(_localctx, 332, RULE_literal);
 		try {
-			State = 2423;
+			State = 2551;
 			switch (_input.La(1)) {
 			case OCTLITERAL:
 			case HEXLITERAL:
@@ -14174,49 +15851,49 @@ public partial class VBAParser : Parser {
 			case INTEGERLITERAL:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2415; numberLiteral();
+				State = 2543; numberLiteral();
 				}
 				break;
 			case DATELITERAL:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2416; Match(DATELITERAL);
+				State = 2544; Match(DATELITERAL);
 				}
 				break;
 			case STRINGLITERAL:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2417; Match(STRINGLITERAL);
+				State = 2545; Match(STRINGLITERAL);
 				}
 				break;
 			case TRUE:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2418; Match(TRUE);
+				State = 2546; Match(TRUE);
 				}
 				break;
 			case FALSE:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 2419; Match(FALSE);
+				State = 2547; Match(FALSE);
 				}
 				break;
 			case NOTHING:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 2420; Match(NOTHING);
+				State = 2548; Match(NOTHING);
 				}
 				break;
 			case NULL:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 2421; Match(NULL);
+				State = 2549; Match(NULL);
 				}
 				break;
 			case EMPTY:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 2422; Match(EMPTY);
+				State = 2550; Match(EMPTY);
 				}
 				break;
 			default:
@@ -14262,12 +15939,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public NumberLiteralContext numberLiteral() {
 		NumberLiteralContext _localctx = new NumberLiteralContext(_ctx, State);
-		EnterRule(_localctx, 272, RULE_numberLiteral);
+		EnterRule(_localctx, 334, RULE_numberLiteral);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2425;
+			State = 2553;
 			_la = _input.La(1);
 			if ( !(((((_la - 226)) & ~0x3f) == 0 && ((1L << (_la - 226)) & ((1L << (OCTLITERAL - 226)) | (1L << (HEXLITERAL - 226)) | (1L << (FLOATLITERAL - 226)) | (1L << (INTEGERLITERAL - 226)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -14324,47 +16001,47 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeContext type() {
 		TypeContext _localctx = new TypeContext(_ctx, State);
-		EnterRule(_localctx, 274, RULE_type);
+		EnterRule(_localctx, 336, RULE_type);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2429;
-			switch ( Interpreter.AdaptivePredict(_input,409,_ctx) ) {
+			State = 2557;
+			switch ( Interpreter.AdaptivePredict(_input,410,_ctx) ) {
 			case 1:
 				{
-				State = 2427; baseType();
+				State = 2555; baseType();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2428; complexType();
+				State = 2556; complexType();
 				}
 				break;
 			}
-			State = 2439;
-			switch ( Interpreter.AdaptivePredict(_input,412,_ctx) ) {
+			State = 2567;
+			switch ( Interpreter.AdaptivePredict(_input,413,_ctx) ) {
 			case 1:
 				{
-				State = 2432;
+				State = 2560;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2431; whiteSpace();
+					State = 2559; whiteSpace();
 					}
 				}
 
-				State = 2434; Match(LPAREN);
-				State = 2436;
+				State = 2562; Match(LPAREN);
+				State = 2564;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2435; whiteSpace();
+					State = 2563; whiteSpace();
 					}
 				}
 
-				State = 2438; Match(RPAREN);
+				State = 2566; Match(RPAREN);
 				}
 				break;
 			}
@@ -14412,12 +16089,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeHintContext typeHint() {
 		TypeHintContext _localctx = new TypeHintContext(_ctx, State);
-		EnterRule(_localctx, 276, RULE_typeHint);
+		EnterRule(_localctx, 338, RULE_typeHint);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2441;
+			State = 2569;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) ) {
 			_errHandler.RecoverInline(this);
@@ -14464,12 +16141,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VisibilityContext visibility() {
 		VisibilityContext _localctx = new VisibilityContext(_ctx, State);
-		EnterRule(_localctx, 278, RULE_visibility);
+		EnterRule(_localctx, 340, RULE_visibility);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2443;
+			State = 2571;
 			_la = _input.La(1);
 			if ( !(((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -14516,6 +16193,7 @@ public partial class VBAParser : Parser {
 		public ITerminalNode SENDKEYS() { return GetToken(VBAParser.SENDKEYS, 0); }
 		public ITerminalNode SGN() { return GetToken(VBAParser.SGN, 0); }
 		public ITerminalNode CBYTE() { return GetToken(VBAParser.CBYTE, 0); }
+		public ITerminalNode PUT() { return GetToken(VBAParser.PUT, 0); }
 		public ITerminalNode CVAR() { return GetToken(VBAParser.CVAR, 0); }
 		public ITerminalNode SINGLE() { return GetToken(VBAParser.SINGLE, 0); }
 		public ITerminalNode LONGLONG() { return GetToken(VBAParser.LONGLONG, 0); }
@@ -14547,12 +16225,16 @@ public partial class VBAParser : Parser {
 		public ITerminalNode ATTRIBUTE() { return GetToken(VBAParser.ATTRIBUTE, 0); }
 		public ITerminalNode TYPEOF() { return GetToken(VBAParser.TYPEOF, 0); }
 		public ITerminalNode PSET() { return GetToken(VBAParser.PSET, 0); }
+		public ITerminalNode UNLOCK() { return GetToken(VBAParser.UNLOCK, 0); }
 		public ITerminalNode CDBL() { return GetToken(VBAParser.CDBL, 0); }
 		public ITerminalNode CLNG() { return GetToken(VBAParser.CLNG, 0); }
 		public ITerminalNode LOCK_WRITE() { return GetToken(VBAParser.LOCK_WRITE, 0); }
 		public ITerminalNode INTEGER() { return GetToken(VBAParser.INTEGER, 0); }
 		public ITerminalNode END_SELECT() { return GetToken(VBAParser.END_SELECT, 0); }
 		public ITerminalNode ON_ERROR() { return GetToken(VBAParser.ON_ERROR, 0); }
+		public ITerminalNode WRITE(int i) {
+			return GetToken(VBAParser.WRITE, i);
+		}
 		public ITerminalNode FALSE() { return GetToken(VBAParser.FALSE, 0); }
 		public ITerminalNode PRESERVE() { return GetToken(VBAParser.PRESERVE, 0); }
 		public ITerminalNode SHARED() { return GetToken(VBAParser.SHARED, 0); }
@@ -14560,6 +16242,7 @@ public partial class VBAParser : Parser {
 		public ITerminalNode APPEND() { return GetToken(VBAParser.APPEND, 0); }
 		public ITerminalNode NULL() { return GetToken(VBAParser.NULL, 0); }
 		public ITerminalNode BEGIN() { return GetToken(VBAParser.BEGIN, 0); }
+		public ITerminalNode LOCK() { return GetToken(VBAParser.LOCK, 0); }
 		public ITerminalNode IMP() { return GetToken(VBAParser.IMP, 0); }
 		public ITerminalNode EXIT_DO() { return GetToken(VBAParser.EXIT_DO, 0); }
 		public ITerminalNode INPUTB() { return GetToken(VBAParser.INPUTB, 0); }
@@ -14568,6 +16251,8 @@ public partial class VBAParser : Parser {
 		public ITerminalNode DATABASE() { return GetToken(VBAParser.DATABASE, 0); }
 		public ITerminalNode BYTE() { return GetToken(VBAParser.BYTE, 0); }
 		public ITerminalNode STEP() { return GetToken(VBAParser.STEP, 0); }
+		public ITerminalNode INPUT() { return GetToken(VBAParser.INPUT, 0); }
+		public ITerminalNode SEEK() { return GetToken(VBAParser.SEEK, 0); }
 		public ITerminalNode CURRENCY() { return GetToken(VBAParser.CURRENCY, 0); }
 		public ITerminalNode CIRCLE() { return GetToken(VBAParser.CIRCLE, 0); }
 		public ITerminalNode LEN(int i) {
@@ -14587,19 +16272,22 @@ public partial class VBAParser : Parser {
 		public ITerminalNode EQV() { return GetToken(VBAParser.EQV, 0); }
 		public ITerminalNode TO() { return GetToken(VBAParser.TO, 0); }
 		public ITerminalNode READ() { return GetToken(VBAParser.READ, 0); }
+		public ITerminalNode OPEN() { return GetToken(VBAParser.OPEN, 0); }
 		public ITerminalNode LOCK_READ() { return GetToken(VBAParser.LOCK_READ, 0); }
 		public ITerminalNode DELETESETTING() { return GetToken(VBAParser.DELETESETTING, 0); }
 		public ITerminalNode DOEVENTS() { return GetToken(VBAParser.DOEVENTS, 0); }
+		public ITerminalNode CLOSE() { return GetToken(VBAParser.CLOSE, 0); }
 		public ITerminalNode AND() { return GetToken(VBAParser.AND, 0); }
 		public ITerminalNode MID() { return GetToken(VBAParser.MID, 0); }
 		public ITerminalNode EXIT_SUB() { return GetToken(VBAParser.EXIT_SUB, 0); }
 		public ITerminalNode LOCK_READ_WRITE() { return GetToken(VBAParser.LOCK_READ_WRITE, 0); }
 		public ITerminalNode SETATTR() { return GetToken(VBAParser.SETATTR, 0); }
-		public ITerminalNode WRITE() { return GetToken(VBAParser.WRITE, 0); }
+		public IReadOnlyList<ITerminalNode> WRITE() { return GetTokens(VBAParser.WRITE); }
 		public IReadOnlyList<ITerminalNode> LEN() { return GetTokens(VBAParser.LEN); }
 		public ITerminalNode ANY() { return GetToken(VBAParser.ANY, 0); }
 		public ITerminalNode CCUR() { return GetToken(VBAParser.CCUR, 0); }
 		public ITerminalNode NEW() { return GetToken(VBAParser.NEW, 0); }
+		public ITerminalNode GET() { return GetToken(VBAParser.GET, 0); }
 		public ITerminalNode LIB() { return GetToken(VBAParser.LIB, 0); }
 		public ITerminalNode OPTIONAL() { return GetToken(VBAParser.OPTIONAL, 0); }
 		public ITerminalNode EXIT_PROPERTY() { return GetToken(VBAParser.EXIT_PROPERTY, 0); }
@@ -14632,14 +16320,14 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public KeywordContext keyword() {
 		KeywordContext _localctx = new KeywordContext(_ctx, State);
-		EnterRule(_localctx, 280, RULE_keyword);
+		EnterRule(_localctx, 342, RULE_keyword);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2445;
+			State = 2573;
 			_la = _input.La(1);
-			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 193)) & ~0x3f) == 0 && ((1L << (_la - 193)) & ((1L << (UNTIL - 193)) | (1L << (VARIANT - 193)) | (1L << (VERSION - 193)) | (1L << (WIDTH - 193)) | (1L << (WITHEVENTS - 193)) | (1L << (WRITE - 193)) | (1L << (XOR - 193)) | (1L << (COLLECTION - 193)) | (1L << (DELETESETTING - 193)) | (1L << (LOAD - 193)) | (1L << (RMDIR - 193)) | (1L << (SENDKEYS - 193)) | (1L << (SETATTR - 193)) | (1L << (RESUME_NEXT - 193)))) != 0)) ) {
+			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
@@ -14681,11 +16369,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public MarkerKeywordContext markerKeyword() {
 		MarkerKeywordContext _localctx = new MarkerKeywordContext(_ctx, State);
-		EnterRule(_localctx, 282, RULE_markerKeyword);
+		EnterRule(_localctx, 344, RULE_markerKeyword);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2447; Match(AS);
+			State = 2575; Match(AS);
 			}
 		}
 		catch (RecognitionException re) {
@@ -14713,7 +16401,6 @@ public partial class VBAParser : Parser {
 		public ITerminalNode GOSUB() { return GetToken(VBAParser.GOSUB, 0); }
 		public ITerminalNode RETURN() { return GetToken(VBAParser.RETURN, 0); }
 		public ITerminalNode ENUM() { return GetToken(VBAParser.ENUM, 0); }
-		public ITerminalNode LOCK() { return GetToken(VBAParser.LOCK, 0); }
 		public ITerminalNode GLOBAL() { return GetToken(VBAParser.GLOBAL, 0); }
 		public ITerminalNode WEND() { return GetToken(VBAParser.WEND, 0); }
 		public ITerminalNode DEFSTR() { return GetToken(VBAParser.DEFSTR, 0); }
@@ -14727,35 +16414,28 @@ public partial class VBAParser : Parser {
 		public ITerminalNode SUB() { return GetToken(VBAParser.SUB, 0); }
 		public ITerminalNode FOR() { return GetToken(VBAParser.FOR, 0); }
 		public ITerminalNode LSET() { return GetToken(VBAParser.LSET, 0); }
-		public ITerminalNode INPUT() { return GetToken(VBAParser.INPUT, 0); }
-		public ITerminalNode SEEK() { return GetToken(VBAParser.SEEK, 0); }
 		public ITerminalNode LOOP() { return GetToken(VBAParser.LOOP, 0); }
 		public ITerminalNode DEFCUR() { return GetToken(VBAParser.DEFCUR, 0); }
 		public ITerminalNode PUBLIC() { return GetToken(VBAParser.PUBLIC, 0); }
 		public ITerminalNode DEFDATE() { return GetToken(VBAParser.DEFDATE, 0); }
-		public ITerminalNode PUT() { return GetToken(VBAParser.PUT, 0); }
 		public ITerminalNode LET() { return GetToken(VBAParser.LET, 0); }
 		public ITerminalNode FRIEND() { return GetToken(VBAParser.FRIEND, 0); }
 		public ITerminalNode TYPE() { return GetToken(VBAParser.TYPE, 0); }
 		public ITerminalNode CALL() { return GetToken(VBAParser.CALL, 0); }
 		public ITerminalNode DEFBOOL() { return GetToken(VBAParser.DEFBOOL, 0); }
-		public ITerminalNode OPEN() { return GetToken(VBAParser.OPEN, 0); }
 		public ITerminalNode STATIC() { return GetToken(VBAParser.STATIC, 0); }
 		public ITerminalNode DO() { return GetToken(VBAParser.DO, 0); }
 		public ITerminalNode DIM() { return GetToken(VBAParser.DIM, 0); }
 		public ITerminalNode OPTION() { return GetToken(VBAParser.OPTION, 0); }
-		public ITerminalNode CLOSE() { return GetToken(VBAParser.CLOSE, 0); }
 		public ITerminalNode DEFLNG() { return GetToken(VBAParser.DEFLNG, 0); }
 		public ITerminalNode IMPLEMENTS() { return GetToken(VBAParser.IMPLEMENTS, 0); }
 		public ITerminalNode ON() { return GetToken(VBAParser.ON, 0); }
 		public ITerminalNode WITH() { return GetToken(VBAParser.WITH, 0); }
 		public ITerminalNode DECLARE() { return GetToken(VBAParser.DECLARE, 0); }
 		public ITerminalNode RESUME() { return GetToken(VBAParser.RESUME, 0); }
-		public ITerminalNode WRITE() { return GetToken(VBAParser.WRITE, 0); }
 		public ITerminalNode DEFLNGPTR() { return GetToken(VBAParser.DEFLNGPTR, 0); }
 		public ITerminalNode WHILE() { return GetToken(VBAParser.WHILE, 0); }
 		public ITerminalNode EXIT() { return GetToken(VBAParser.EXIT, 0); }
-		public ITerminalNode GET() { return GetToken(VBAParser.GET, 0); }
 		public ITerminalNode DEFDBL() { return GetToken(VBAParser.DEFDBL, 0); }
 		public ITerminalNode NEXT() { return GetToken(VBAParser.NEXT, 0); }
 		public ITerminalNode FUNCTION() { return GetToken(VBAParser.FUNCTION, 0); }
@@ -14763,7 +16443,6 @@ public partial class VBAParser : Parser {
 		public ITerminalNode GOTO() { return GetToken(VBAParser.GOTO, 0); }
 		public ITerminalNode REDIM() { return GetToken(VBAParser.REDIM, 0); }
 		public ITerminalNode SELECT() { return GetToken(VBAParser.SELECT, 0); }
-		public ITerminalNode UNLOCK() { return GetToken(VBAParser.UNLOCK, 0); }
 		public ITerminalNode SET() { return GetToken(VBAParser.SET, 0); }
 		public StatementKeywordContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
@@ -14788,14 +16467,14 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementKeywordContext statementKeyword() {
 		StatementKeywordContext _localctx = new StatementKeywordContext(_ctx, State);
-		EnterRule(_localctx, 284, RULE_statementKeyword);
+		EnterRule(_localctx, 346, RULE_statementKeyword);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2449;
+			State = 2577;
 			_la = _input.La(1);
-			if ( !(((((_la - 22)) & ~0x3f) == 0 && ((1L << (_la - 22)) & ((1L << (EXIT - 22)) | (1L << (OPTION - 22)) | (1L << (CALL - 22)) | (1L << (CASE - 22)) | (1L << (CLOSE - 22)) | (1L << (CONST - 22)) | (1L << (DECLARE - 22)) | (1L << (DEFBOOL - 22)) | (1L << (DEFBYTE - 22)) | (1L << (DEFDATE - 22)) | (1L << (DEFDBL - 22)) | (1L << (DEFCUR - 22)) | (1L << (DEFINT - 22)) | (1L << (DEFLNG - 22)) | (1L << (DEFLNGLNG - 22)) | (1L << (DEFLNGPTR - 22)) | (1L << (DEFOBJ - 22)) | (1L << (DEFSNG - 22)) | (1L << (DEFSTR - 22)) | (1L << (DEFVAR - 22)) | (1L << (DIM - 22)) | (1L << (DO - 22)))) != 0) || ((((_la - 87)) & ~0x3f) == 0 && ((1L << (_la - 87)) & ((1L << (ELSE - 87)) | (1L << (ELSEIF - 87)) | (1L << (ENUM - 87)) | (1L << (ERASE - 87)) | (1L << (EVENT - 87)) | (1L << (FRIEND - 87)) | (1L << (FOR - 87)) | (1L << (FUNCTION - 87)) | (1L << (GET - 87)) | (1L << (GLOBAL - 87)) | (1L << (GOSUB - 87)) | (1L << (GOTO - 87)) | (1L << (IF - 87)) | (1L << (IMPLEMENTS - 87)) | (1L << (INPUT - 87)) | (1L << (LOCK - 87)) | (1L << (LOOP - 87)) | (1L << (LET - 87)) | (1L << (LSET - 87)) | (1L << (NEXT - 87)) | (1L << (ON - 87)) | (1L << (OPEN - 87)))) != 0) || ((((_la - 156)) & ~0x3f) == 0 && ((1L << (_la - 156)) & ((1L << (PRINT - 156)) | (1L << (PRIVATE - 156)) | (1L << (PUBLIC - 156)) | (1L << (PUT - 156)) | (1L << (RAISEEVENT - 156)) | (1L << (REDIM - 156)) | (1L << (RESUME - 156)) | (1L << (RETURN - 156)) | (1L << (RSET - 156)) | (1L << (SEEK - 156)) | (1L << (SELECT - 156)) | (1L << (SET - 156)) | (1L << (STATIC - 156)) | (1L << (STOP - 156)) | (1L << (SUB - 156)) | (1L << (TYPE - 156)) | (1L << (UNLOCK - 156)) | (1L << (WEND - 156)) | (1L << (WHILE - 156)) | (1L << (WITH - 156)) | (1L << (WRITE - 156)))) != 0)) ) {
+			if ( !(((((_la - 22)) & ~0x3f) == 0 && ((1L << (_la - 22)) & ((1L << (EXIT - 22)) | (1L << (OPTION - 22)) | (1L << (CALL - 22)) | (1L << (CASE - 22)) | (1L << (CONST - 22)) | (1L << (DECLARE - 22)) | (1L << (DEFBOOL - 22)) | (1L << (DEFBYTE - 22)) | (1L << (DEFDATE - 22)) | (1L << (DEFDBL - 22)) | (1L << (DEFCUR - 22)) | (1L << (DEFINT - 22)) | (1L << (DEFLNG - 22)) | (1L << (DEFLNGLNG - 22)) | (1L << (DEFLNGPTR - 22)) | (1L << (DEFOBJ - 22)) | (1L << (DEFSNG - 22)) | (1L << (DEFSTR - 22)) | (1L << (DEFVAR - 22)) | (1L << (DIM - 22)) | (1L << (DO - 22)))) != 0) || ((((_la - 87)) & ~0x3f) == 0 && ((1L << (_la - 87)) & ((1L << (ELSE - 87)) | (1L << (ELSEIF - 87)) | (1L << (ENUM - 87)) | (1L << (ERASE - 87)) | (1L << (EVENT - 87)) | (1L << (FRIEND - 87)) | (1L << (FOR - 87)) | (1L << (FUNCTION - 87)) | (1L << (GLOBAL - 87)) | (1L << (GOSUB - 87)) | (1L << (GOTO - 87)) | (1L << (IF - 87)) | (1L << (IMPLEMENTS - 87)) | (1L << (LOOP - 87)) | (1L << (LET - 87)) | (1L << (LSET - 87)) | (1L << (NEXT - 87)) | (1L << (ON - 87)))) != 0) || ((((_la - 156)) & ~0x3f) == 0 && ((1L << (_la - 156)) & ((1L << (PRINT - 156)) | (1L << (PRIVATE - 156)) | (1L << (PUBLIC - 156)) | (1L << (RAISEEVENT - 156)) | (1L << (REDIM - 156)) | (1L << (RESUME - 156)) | (1L << (RETURN - 156)) | (1L << (RSET - 156)) | (1L << (SELECT - 156)) | (1L << (SET - 156)) | (1L << (STATIC - 156)) | (1L << (STOP - 156)) | (1L << (SUB - 156)) | (1L << (TYPE - 156)) | (1L << (WEND - 156)) | (1L << (WHILE - 156)) | (1L << (WITH - 156)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
@@ -14842,24 +16521,24 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EndOfLineContext endOfLine() {
 		EndOfLineContext _localctx = new EndOfLineContext(_ctx, State);
-		EnterRule(_localctx, 286, RULE_endOfLine);
+		EnterRule(_localctx, 348, RULE_endOfLine);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2452;
+			State = 2580;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2451; whiteSpace();
+				State = 2579; whiteSpace();
 				}
 			}
 
-			State = 2455;
+			State = 2583;
 			_la = _input.La(1);
 			if (_la==REM || _la==SINGLEQUOTE) {
 				{
-				State = 2454; commentOrAnnotation();
+				State = 2582; commentOrAnnotation();
 				}
 			}
 
@@ -14921,34 +16600,34 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EndOfStatementContext endOfStatement() {
 		EndOfStatementContext _localctx = new EndOfStatementContext(_ctx, State);
-		EnterRule(_localctx, 288, RULE_endOfStatement);
+		EnterRule(_localctx, 350, RULE_endOfStatement);
 		int _la;
 		try {
 			int _alt;
-			State = 2479;
-			switch ( Interpreter.AdaptivePredict(_input,420,_ctx) ) {
+			State = 2607;
+			switch ( Interpreter.AdaptivePredict(_input,421,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2473;
+				State = 2601;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,419,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,420,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2469;
-						switch ( Interpreter.AdaptivePredict(_input,418,_ctx) ) {
+						State = 2597;
+						switch ( Interpreter.AdaptivePredict(_input,419,_ctx) ) {
 						case 1:
 							{
 							{
-							State = 2457; endOfLine();
-							State = 2458; Match(NEWLINE);
-							State = 2460;
-							switch ( Interpreter.AdaptivePredict(_input,415,_ctx) ) {
+							State = 2585; endOfLine();
+							State = 2586; Match(NEWLINE);
+							State = 2588;
+							switch ( Interpreter.AdaptivePredict(_input,416,_ctx) ) {
 							case 1:
 								{
-								State = 2459; whiteSpace();
+								State = 2587; whiteSpace();
 								}
 								break;
 							}
@@ -14959,20 +16638,20 @@ public partial class VBAParser : Parser {
 						case 2:
 							{
 							{
-							State = 2463;
+							State = 2591;
 							_la = _input.La(1);
 							if (_la==WS || _la==LINE_CONTINUATION) {
 								{
-								State = 2462; whiteSpace();
+								State = 2590; whiteSpace();
 								}
 							}
 
-							State = 2465; Match(COLON);
-							State = 2467;
-							switch ( Interpreter.AdaptivePredict(_input,417,_ctx) ) {
+							State = 2593; Match(COLON);
+							State = 2595;
+							switch ( Interpreter.AdaptivePredict(_input,418,_ctx) ) {
 							case 1:
 								{
-								State = 2466; whiteSpace();
+								State = 2594; whiteSpace();
 								}
 								break;
 							}
@@ -14983,9 +16662,9 @@ public partial class VBAParser : Parser {
 						}
 						} 
 					}
-					State = 2475;
+					State = 2603;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,419,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,420,_ctx);
 				}
 				}
 				break;
@@ -14993,8 +16672,8 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2476; endOfLine();
-				State = 2477; Match(Eof);
+				State = 2604; endOfLine();
+				State = 2605; Match(Eof);
 				}
 				break;
 			}
@@ -15043,28 +16722,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentOrAnnotationContext commentOrAnnotation() {
 		CommentOrAnnotationContext _localctx = new CommentOrAnnotationContext(_ctx, State);
-		EnterRule(_localctx, 290, RULE_commentOrAnnotation);
+		EnterRule(_localctx, 352, RULE_commentOrAnnotation);
 		try {
-			State = 2484;
-			switch ( Interpreter.AdaptivePredict(_input,421,_ctx) ) {
+			State = 2612;
+			switch ( Interpreter.AdaptivePredict(_input,422,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2481; annotationList();
+				State = 2609; annotationList();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2482; comment();
+				State = 2610; comment();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2483; remComment();
+				State = 2611; remComment();
 				}
 				break;
 			}
@@ -15111,20 +16790,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RemCommentContext remComment() {
 		RemCommentContext _localctx = new RemCommentContext(_ctx, State);
-		EnterRule(_localctx, 292, RULE_remComment);
+		EnterRule(_localctx, 354, RULE_remComment);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2486; Match(REM);
-			State = 2488;
-			switch ( Interpreter.AdaptivePredict(_input,422,_ctx) ) {
+			State = 2614; Match(REM);
+			State = 2616;
+			switch ( Interpreter.AdaptivePredict(_input,423,_ctx) ) {
 			case 1:
 				{
-				State = 2487; whiteSpace();
+				State = 2615; whiteSpace();
 				}
 				break;
 			}
-			State = 2490; commentBody();
+			State = 2618; commentBody();
 			}
 		}
 		catch (RecognitionException re) {
@@ -15166,12 +16845,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentContext comment() {
 		CommentContext _localctx = new CommentContext(_ctx, State);
-		EnterRule(_localctx, 294, RULE_comment);
+		EnterRule(_localctx, 356, RULE_comment);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2492; Match(SINGLEQUOTE);
-			State = 2493; commentBody();
+			State = 2620; Match(SINGLEQUOTE);
+			State = 2621; commentBody();
 			}
 		}
 		catch (RecognitionException re) {
@@ -15217,27 +16896,27 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentBodyContext commentBody() {
 		CommentBodyContext _localctx = new CommentBodyContext(_ctx, State);
-		EnterRule(_localctx, 296, RULE_commentBody);
+		EnterRule(_localctx, 358, RULE_commentBody);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2499;
+			State = 2627;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << COMMA) | (1L << COLON) | (1L << SEMICOLON) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (EACH - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_ENUM - 64)) | (1L << (END_FUNCTION - 64)) | (1L << (END_IF - 64)) | (1L << (END_PROPERTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_SUB - 64)) | (1L << (END_TYPE - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OPTION_BASE - 128)) | (1L << (OPTION_EXPLICIT - 128)) | (1L << (OPTION_COMPARE - 128)) | (1L << (OPTION_PRIVATE_MODULE - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PROPERTY_GET - 128)) | (1L << (PROPERTY_LET - 128)) | (1L << (PROPERTY_SET - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (ASSIGN - 192)) | (1L << (DIV - 192)) | (1L << (INTDIV - 192)) | (1L << (EQ - 192)) | (1L << (GEQ - 192)) | (1L << (GT - 192)) | (1L << (LEQ - 192)) | (1L << (LPAREN - 192)) | (1L << (LT - 192)) | (1L << (MINUS - 192)) | (1L << (MULT - 192)) | (1L << (NEQ - 192)) | (1L << (PLUS - 192)) | (1L << (POW - 192)) | (1L << (RPAREN - 192)) | (1L << (HASHCONST - 192)) | (1L << (HASHIF - 192)) | (1L << (HASHELSEIF - 192)) | (1L << (HASHELSE - 192)) | (1L << (HASHENDIF - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (R_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (SINGLEQUOTE - 192)) | (1L << (UNDERSCORE - 192)) | (1L << (WS - 192)) | (1L << (GUIDLITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (ERRORCHAR - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 2497;
-				switch ( Interpreter.AdaptivePredict(_input,423,_ctx) ) {
+				State = 2625;
+				switch ( Interpreter.AdaptivePredict(_input,424,_ctx) ) {
 				case 1:
 					{
-					State = 2495; Match(LINE_CONTINUATION);
+					State = 2623; Match(LINE_CONTINUATION);
 					}
 					break;
 
 				case 2:
 					{
-					State = 2496;
+					State = 2624;
 					_la = _input.La(1);
 					if ( _la <= 0 || (_la==NEWLINE) ) {
 					_errHandler.RecoverInline(this);
@@ -15247,7 +16926,7 @@ public partial class VBAParser : Parser {
 					break;
 				}
 				}
-				State = 2501;
+				State = 2629;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
@@ -15305,31 +16984,31 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationListContext annotationList() {
 		AnnotationListContext _localctx = new AnnotationListContext(_ctx, State);
-		EnterRule(_localctx, 298, RULE_annotationList);
+		EnterRule(_localctx, 360, RULE_annotationList);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2502; Match(SINGLEQUOTE);
-			State = 2508;
+			State = 2630; Match(SINGLEQUOTE);
+			State = 2636;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			do {
 				{
 				{
-				State = 2503; Match(AT);
-				State = 2504; annotation();
-				State = 2506;
+				State = 2631; Match(AT);
+				State = 2632; annotation();
+				State = 2634;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2505; whiteSpace();
+					State = 2633; whiteSpace();
 					}
 				}
 
 				}
 				}
-				State = 2510;
+				State = 2638;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			} while ( _la==AT );
@@ -15376,16 +17055,16 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationContext annotation() {
 		AnnotationContext _localctx = new AnnotationContext(_ctx, State);
-		EnterRule(_localctx, 300, RULE_annotation);
+		EnterRule(_localctx, 362, RULE_annotation);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2512; annotationName();
-			State = 2514;
-			switch ( Interpreter.AdaptivePredict(_input,427,_ctx) ) {
+			State = 2640; annotationName();
+			State = 2642;
+			switch ( Interpreter.AdaptivePredict(_input,428,_ctx) ) {
 			case 1:
 				{
-				State = 2513; annotationArgList();
+				State = 2641; annotationArgList();
 				}
 				break;
 			}
@@ -15429,11 +17108,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationNameContext annotationName() {
 		AnnotationNameContext _localctx = new AnnotationNameContext(_ctx, State);
-		EnterRule(_localctx, 302, RULE_annotationName);
+		EnterRule(_localctx, 364, RULE_annotationName);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2516; unrestrictedIdentifier();
+			State = 2644; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -15489,26 +17168,26 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationArgListContext annotationArgList() {
 		AnnotationArgListContext _localctx = new AnnotationArgListContext(_ctx, State);
-		EnterRule(_localctx, 304, RULE_annotationArgList);
+		EnterRule(_localctx, 366, RULE_annotationArgList);
 		int _la;
 		try {
 			int _alt;
-			State = 2578;
-			switch ( Interpreter.AdaptivePredict(_input,441,_ctx) ) {
+			State = 2706;
+			switch ( Interpreter.AdaptivePredict(_input,442,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2518; whiteSpace();
-				State = 2519; annotationArg();
+				State = 2646; whiteSpace();
+				State = 2647; annotationArg();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2521; whiteSpace();
-				State = 2522; annotationArg();
-				State = 2531;
+				State = 2649; whiteSpace();
+				State = 2650; annotationArg();
+				State = 2659;
 				_errHandler.Sync(this);
 				_alt = 1;
 				do {
@@ -15516,33 +17195,33 @@ public partial class VBAParser : Parser {
 					case 1:
 						{
 						{
-						State = 2524;
+						State = 2652;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2523; whiteSpace();
+							State = 2651; whiteSpace();
 							}
 						}
 
-						State = 2526; Match(COMMA);
-						State = 2528;
-						switch ( Interpreter.AdaptivePredict(_input,429,_ctx) ) {
+						State = 2654; Match(COMMA);
+						State = 2656;
+						switch ( Interpreter.AdaptivePredict(_input,430,_ctx) ) {
 						case 1:
 							{
-							State = 2527; whiteSpace();
+							State = 2655; whiteSpace();
 							}
 							break;
 						}
-						State = 2530; annotationArg();
+						State = 2658; annotationArg();
 						}
 						}
 						break;
 					default:
 						throw new NoViableAltException(this);
 					}
-					State = 2533;
+					State = 2661;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,430,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,431,_ctx);
 				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
 				}
 				break;
@@ -15550,74 +17229,74 @@ public partial class VBAParser : Parser {
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2536;
+				State = 2664;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2535; whiteSpace();
+					State = 2663; whiteSpace();
 					}
 				}
 
-				State = 2538; Match(LPAREN);
-				State = 2540;
+				State = 2666; Match(LPAREN);
+				State = 2668;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2539; whiteSpace();
+					State = 2667; whiteSpace();
 					}
 				}
 
-				State = 2542; Match(RPAREN);
+				State = 2670; Match(RPAREN);
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2544;
+				State = 2672;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2543; whiteSpace();
+					State = 2671; whiteSpace();
 					}
 				}
 
-				State = 2546; Match(LPAREN);
-				State = 2548;
-				switch ( Interpreter.AdaptivePredict(_input,434,_ctx) ) {
+				State = 2674; Match(LPAREN);
+				State = 2676;
+				switch ( Interpreter.AdaptivePredict(_input,435,_ctx) ) {
 				case 1:
 					{
-					State = 2547; whiteSpace();
+					State = 2675; whiteSpace();
 					}
 					break;
 				}
-				State = 2550; annotationArg();
-				State = 2552;
+				State = 2678; annotationArg();
+				State = 2680;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2551; whiteSpace();
+					State = 2679; whiteSpace();
 					}
 				}
 
-				State = 2554; Match(RPAREN);
+				State = 2682; Match(RPAREN);
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 2557;
+				State = 2685;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2556; whiteSpace();
+					State = 2684; whiteSpace();
 					}
 				}
 
-				State = 2559; Match(LPAREN);
-				State = 2560; annotationArg();
-				State = 2569;
+				State = 2687; Match(LPAREN);
+				State = 2688; annotationArg();
+				State = 2697;
 				_errHandler.Sync(this);
 				_alt = 1;
 				do {
@@ -15625,43 +17304,43 @@ public partial class VBAParser : Parser {
 					case 1:
 						{
 						{
-						State = 2562;
+						State = 2690;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2561; whiteSpace();
+							State = 2689; whiteSpace();
 							}
 						}
 
-						State = 2564; Match(COMMA);
-						State = 2566;
-						switch ( Interpreter.AdaptivePredict(_input,438,_ctx) ) {
+						State = 2692; Match(COMMA);
+						State = 2694;
+						switch ( Interpreter.AdaptivePredict(_input,439,_ctx) ) {
 						case 1:
 							{
-							State = 2565; whiteSpace();
+							State = 2693; whiteSpace();
 							}
 							break;
 						}
-						State = 2568; annotationArg();
+						State = 2696; annotationArg();
 						}
 						}
 						break;
 					default:
 						throw new NoViableAltException(this);
 					}
-					State = 2571;
+					State = 2699;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,439,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,440,_ctx);
 				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-				State = 2574;
+				State = 2702;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2573; whiteSpace();
+					State = 2701; whiteSpace();
 					}
 				}
 
-				State = 2576; Match(RPAREN);
+				State = 2704; Match(RPAREN);
 				}
 				break;
 			}
@@ -15704,11 +17383,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationArgContext annotationArg() {
 		AnnotationArgContext _localctx = new AnnotationArgContext(_ctx, State);
-		EnterRule(_localctx, 306, RULE_annotationArg);
+		EnterRule(_localctx, 368, RULE_annotationArg);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2580; valueStmt(0);
+			State = 2708; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -15754,13 +17433,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WhiteSpaceContext whiteSpace() {
 		WhiteSpaceContext _localctx = new WhiteSpaceContext(_ctx, State);
-		EnterRule(_localctx, 308, RULE_whiteSpace);
+		EnterRule(_localctx, 370, RULE_whiteSpace);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2583;
+			State = 2711;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -15768,7 +17447,7 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 2582;
+					State = 2710;
 					_la = _input.La(1);
 					if ( !(_la==WS || _la==LINE_CONTINUATION) ) {
 					_errHandler.RecoverInline(this);
@@ -15780,9 +17459,9 @@ public partial class VBAParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 2585;
+				State = 2713;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,442,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,443,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
 			}
 		}
@@ -15799,39 +17478,39 @@ public partial class VBAParser : Parser {
 
 	public override bool Sempred(RuleContext _localctx, int ruleIndex, int predIndex) {
 		switch (ruleIndex) {
-		case 25: return upperCaseA_sempred((UpperCaseAContext)_localctx, predIndex);
+		case 71: return upperCaseA_sempred((UpperCaseAContext)_localctx, predIndex);
 
-		case 26: return upperCaseZ_sempred((UpperCaseZContext)_localctx, predIndex);
+		case 72: return upperCaseZ_sempred((UpperCaseZContext)_localctx, predIndex);
 
-		case 92: return valueStmt_sempred((ValueStmtContext)_localctx, predIndex);
+		case 126: return valueStmt_sempred((ValueStmtContext)_localctx, predIndex);
 		}
 		return true;
 	}
 	private bool valueStmt_sempred(ValueStmtContext _localctx, int predIndex) {
 		switch (predIndex) {
-		case 2: return Precpred(_ctx, 14);
+		case 2: return Precpred(_ctx, 15);
 
-		case 3: return Precpred(_ctx, 12);
+		case 3: return Precpred(_ctx, 13);
 
-		case 4: return Precpred(_ctx, 11);
+		case 4: return Precpred(_ctx, 12);
 
-		case 5: return Precpred(_ctx, 10);
+		case 5: return Precpred(_ctx, 11);
 
-		case 6: return Precpred(_ctx, 9);
+		case 6: return Precpred(_ctx, 10);
 
-		case 7: return Precpred(_ctx, 8);
+		case 7: return Precpred(_ctx, 9);
 
-		case 8: return Precpred(_ctx, 7);
+		case 8: return Precpred(_ctx, 8);
 
-		case 9: return Precpred(_ctx, 5);
+		case 9: return Precpred(_ctx, 6);
 
-		case 10: return Precpred(_ctx, 4);
+		case 10: return Precpred(_ctx, 5);
 
-		case 11: return Precpred(_ctx, 3);
+		case 11: return Precpred(_ctx, 4);
 
-		case 12: return Precpred(_ctx, 2);
+		case 12: return Precpred(_ctx, 3);
 
-		case 13: return Precpred(_ctx, 1);
+		case 13: return Precpred(_ctx, 2);
 		}
 		return true;
 	}
@@ -15849,7 +17528,7 @@ public partial class VBAParser : Parser {
 	}
 
 	public static readonly string _serializedATN =
-		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xF7\xA1E\x4\x2"+
+		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xF7\xA9E\x4\x2"+
 		"\t\x2\x4\x3\t\x3\x4\x4\t\x4\x4\x5\t\x5\x4\x6\t\x6\x4\a\t\a\x4\b\t\b\x4"+
 		"\t\t\t\x4\n\t\n\x4\v\t\v\x4\f\t\f\x4\r\t\r\x4\xE\t\xE\x4\xF\t\xF\x4\x10"+
 		"\t\x10\x4\x11\t\x11\x4\x12\t\x12\x4\x13\t\x13\x4\x14\t\x14\x4\x15\t\x15"+
@@ -15871,201 +17550,233 @@ public partial class VBAParser : Parser {
 		"\x4\x88\t\x88\x4\x89\t\x89\x4\x8A\t\x8A\x4\x8B\t\x8B\x4\x8C\t\x8C\x4\x8D"+
 		"\t\x8D\x4\x8E\t\x8E\x4\x8F\t\x8F\x4\x90\t\x90\x4\x91\t\x91\x4\x92\t\x92"+
 		"\x4\x93\t\x93\x4\x94\t\x94\x4\x95\t\x95\x4\x96\t\x96\x4\x97\t\x97\x4\x98"+
-		"\t\x98\x4\x99\t\x99\x4\x9A\t\x9A\x4\x9B\t\x9B\x4\x9C\t\x9C\x3\x2\x3\x2"+
-		"\x3\x3\x5\x3\x13C\n\x3\x3\x3\x3\x3\x3\x3\x3\x3\x5\x3\x142\n\x3\x3\x3\x5"+
-		"\x3\x145\n\x3\x3\x3\x3\x3\x5\x3\x149\n\x3\x3\x3\x3\x3\x5\x3\x14D\n\x3"+
-		"\x3\x3\x3\x3\x5\x3\x151\n\x3\x3\x3\x3\x3\x3\x4\x3\x4\x3\x4\x3\x4\x5\x4"+
-		"\x159\n\x4\x3\x4\x5\x4\x15C\n\x4\x3\x4\x3\x4\x3\x5\x3\x5\x3\x5\x3\x5\x3"+
-		"\x5\x3\x5\x5\x5\x166\n\x5\x5\x5\x168\n\x5\x3\x5\x3\x5\x6\x5\x16C\n\x5"+
-		"\r\x5\xE\x5\x16D\x3\x5\x3\x5\x3\x6\x3\x6\a\x6\x174\n\x6\f\x6\xE\x6\x177"+
-		"\v\x6\x3\x6\x3\x6\a\x6\x17B\n\x6\f\x6\xE\x6\x17E\v\x6\x3\x6\x3\x6\x3\x6"+
-		"\x5\x6\x183\n\x6\x3\x6\x3\x6\x3\a\x3\a\x3\a\x6\a\x18A\n\a\r\a\xE\a\x18B"+
-		"\x3\b\x3\b\x3\b\x3\b\a\b\x192\n\b\f\b\xE\b\x195\v\b\x3\b\x3\b\x3\t\x3"+
-		"\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x5\t\x1A3\n\t\x3\n\x3\n\x3"+
-		"\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x5\n\x1AE\n\n\x3\v\x3\v\x3\v\x3\v\a\v"+
-		"\x1B4\n\v\f\v\xE\v\x1B7\v\v\x3\v\x3\v\x3\f\x3\f\x3\f\x3\f\x3\f\x5\f\x1C0"+
-		"\n\f\x3\r\x3\r\x3\r\x3\r\x5\r\x1C6\n\r\x3\r\x3\r\x5\r\x1CA\n\r\x3\r\x3"+
-		"\r\x5\r\x1CE\n\r\x3\r\x3\r\x5\r\x1D2\n\r\x3\r\a\r\x1D5\n\r\f\r\xE\r\x1D8"+
-		"\v\r\x3\xE\x3\xE\x3\xF\x3\xF\x3\x10\x3\x10\x3\x10\x3\x10\a\x10\x1E2\n"+
-		"\x10\f\x10\xE\x10\x1E5\v\x10\x3\x10\x3\x10\x3\x11\x3\x11\x3\x11\x3\x11"+
+		"\t\x98\x4\x99\t\x99\x4\x9A\t\x9A\x4\x9B\t\x9B\x4\x9C\t\x9C\x4\x9D\t\x9D"+
+		"\x4\x9E\t\x9E\x4\x9F\t\x9F\x4\xA0\t\xA0\x4\xA1\t\xA1\x4\xA2\t\xA2\x4\xA3"+
+		"\t\xA3\x4\xA4\t\xA4\x4\xA5\t\xA5\x4\xA6\t\xA6\x4\xA7\t\xA7\x4\xA8\t\xA8"+
+		"\x4\xA9\t\xA9\x4\xAA\t\xAA\x4\xAB\t\xAB\x4\xAC\t\xAC\x4\xAD\t\xAD\x4\xAE"+
+		"\t\xAE\x4\xAF\t\xAF\x4\xB0\t\xB0\x4\xB1\t\xB1\x4\xB2\t\xB2\x4\xB3\t\xB3"+
+		"\x4\xB4\t\xB4\x4\xB5\t\xB5\x4\xB6\t\xB6\x4\xB7\t\xB7\x4\xB8\t\xB8\x4\xB9"+
+		"\t\xB9\x4\xBA\t\xBA\x4\xBB\t\xBB\x3\x2\x3\x2\x3\x3\x5\x3\x17A\n\x3\x3"+
+		"\x3\x3\x3\x3\x3\x3\x3\x5\x3\x180\n\x3\x3\x3\x5\x3\x183\n\x3\x3\x3\x3\x3"+
+		"\x5\x3\x187\n\x3\x3\x3\x3\x3\x5\x3\x18B\n\x3\x3\x3\x3\x3\x5\x3\x18F\n"+
+		"\x3\x3\x3\x3\x3\x3\x4\x3\x4\x3\x4\x3\x4\x5\x4\x197\n\x4\x3\x4\x5\x4\x19A"+
+		"\n\x4\x3\x4\x3\x4\x3\x5\x3\x5\x3\x5\x3\x5\x3\x5\x3\x5\x5\x5\x1A4\n\x5"+
+		"\x5\x5\x1A6\n\x5\x3\x5\x3\x5\x6\x5\x1AA\n\x5\r\x5\xE\x5\x1AB\x3\x5\x3"+
+		"\x5\x3\x6\x3\x6\a\x6\x1B2\n\x6\f\x6\xE\x6\x1B5\v\x6\x3\x6\x3\x6\a\x6\x1B9"+
+		"\n\x6\f\x6\xE\x6\x1BC\v\x6\x3\x6\x3\x6\x3\x6\x5\x6\x1C1\n\x6\x3\x6\x3"+
+		"\x6\x3\a\x3\a\x3\a\x6\a\x1C8\n\a\r\a\xE\a\x1C9\x3\b\x3\b\x3\b\x3\b\a\b"+
+		"\x1D0\n\b\f\b\xE\b\x1D3\v\b\x3\b\x3\b\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3"+
+		"\t\x3\t\x3\t\x3\t\x5\t\x1E1\n\t\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3"+
+		"\n\x3\n\x5\n\x1EC\n\n\x3\v\x3\v\x3\v\x3\v\a\v\x1F2\n\v\f\v\xE\v\x1F5\v"+
+		"\v\x3\v\x3\v\x3\f\x3\f\x3\f\x3\f\x3\f\x5\f\x1FE\n\f\x3\r\x3\r\x3\r\x3"+
+		"\r\x5\r\x204\n\r\x3\r\x3\r\x5\r\x208\n\r\x3\r\x3\r\x5\r\x20C\n\r\x3\r"+
+		"\x3\r\x5\r\x210\n\r\x3\r\a\r\x213\n\r\f\r\xE\r\x216\v\r\x3\xE\x3\xE\x3"+
+		"\xF\x3\xF\x3\x10\x3\x10\x3\x10\x3\x10\a\x10\x220\n\x10\f\x10\xE\x10\x223"+
+		"\v\x10\x3\x10\x3\x10\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
 		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
 		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x5\x11\x218\n\x11\x3\x12\x3\x12\x3\x12\x3\x12\x5"+
-		"\x12\x21E\n\x12\x3\x12\x3\x12\x5\x12\x222\n\x12\x3\x12\a\x12\x225\n\x12"+
-		"\f\x12\xE\x12\x228\v\x12\x5\x12\x22A\n\x12\x3\x13\x3\x13\x3\x13\x5\x13"+
-		"\x22F\n\x13\x3\x13\x3\x13\x3\x13\x3\x13\x5\x13\x235\n\x13\x3\x13\x3\x13"+
-		"\x5\x13\x239\n\x13\x3\x13\a\x13\x23C\n\x13\f\x13\xE\x13\x23F\v\x13\x3"+
-		"\x14\x3\x14\x5\x14\x243\n\x14\x3\x14\x3\x14\x3\x14\x5\x14\x248\n\x14\x3"+
-		"\x14\x5\x14\x24B\n\x14\x3\x14\x3\x14\x5\x14\x24F\n\x14\x3\x14\x3\x14\x3"+
-		"\x15\x3\x15\x3\x15\x5\x15\x256\n\x15\x3\x15\x3\x15\x3\x15\x3\x15\x5\x15"+
-		"\x25C\n\x15\x3\x15\x3\x15\x3\x15\x3\x15\x5\x15\x262\n\x15\x3\x15\x3\x15"+
-		"\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x3\x15\x5\x15\x26D\n\x15\x3"+
-		"\x15\x5\x15\x270\n\x15\x3\x15\x5\x15\x273\n\x15\x3\x15\x3\x15\x3\x15\x5"+
-		"\x15\x278\n\x15\x3\x16\x3\x16\x3\x16\x3\x16\x5\x16\x27E\n\x16\x3\x16\x3"+
-		"\x16\x5\x16\x282\n\x16\x3\x16\a\x16\x285\n\x16\f\x16\xE\x16\x288\v\x16"+
-		"\x3\x17\x3\x17\x3\x18\x3\x18\x3\x18\x5\x18\x28F\n\x18\x3\x19\x3\x19\x3"+
-		"\x1A\x3\x1A\x5\x1A\x295\n\x1A\x3\x1A\x3\x1A\x5\x1A\x299\n\x1A\x3\x1A\x3"+
-		"\x1A\x3\x1B\x3\x1B\x3\x1B\x3\x1C\x3\x1C\x3\x1C\x3\x1D\x3\x1D\x5\x1D\x2A5"+
-		"\n\x1D\x3\x1D\x3\x1D\x5\x1D\x2A9\n\x1D\x3\x1D\x3\x1D\x3\x1E\x3\x1E\x3"+
-		"\x1F\x3\x1F\x3 \x3 \x3 \x5 \x2B4\n \x3 \x3 \x3 \x3 \x3 \x3 \x3 \x3 \x3"+
-		" \x5 \x2BF\n \x3 \x3 \x3 \x3 \x3 \x5 \x2C6\n \x3 \x3 \x3 \x3 \x3 \x3 "+
-		"\x5 \x2CE\n \x3!\x3!\x3!\x5!\x2D3\n!\x3!\x3!\x3!\x3!\x3!\a!\x2DA\n!\f"+
-		"!\xE!\x2DD\v!\x3!\x3!\x3\"\x3\"\x5\"\x2E3\n\"\x3\"\x3\"\x5\"\x2E7\n\""+
-		"\x3\"\x5\"\x2EA\n\"\x3\"\x3\"\x3#\x3#\x3$\x3$\x3$\x3$\x5$\x2F4\n$\x3$"+
-		"\x3$\x5$\x2F8\n$\x3$\a$\x2FB\n$\f$\xE$\x2FE\v$\x3%\x3%\x3%\x3%\x3&\x3"+
-		"&\x3&\x5&\x307\n&\x3&\x3&\x3&\x3&\x5&\x30D\n&\x3&\x3&\x3\'\x3\'\x3(\x3"+
-		"(\x3(\x3(\x3(\x3(\x3(\x3(\x3(\x3(\x3(\x5(\x31E\n(\x3(\x3(\x3(\x3(\x5("+
-		"\x324\n(\x3)\x3)\x3)\x3)\x5)\x32A\n)\x3)\x3)\x5)\x32E\n)\x3)\x3)\x3)\x3"+
-		")\x3)\x3)\x3)\x3)\x3)\x3)\x5)\x33A\n)\x3)\x3)\x5)\x33E\n)\x3)\x3)\x3)"+
-		"\x3)\x5)\x344\n)\x3*\x3*\x3*\x5*\x349\n*\x3*\x3*\x5*\x34D\n*\x3*\x3*\x5"+
-		"*\x351\n*\x3*\x3*\x5*\x355\n*\x3*\x5*\x358\n*\x3*\x5*\x35B\n*\x3*\x5*"+
-		"\x35E\n*\x3*\x5*\x361\n*\x3*\x3*\x5*\x365\n*\x3*\x3*\x3+\x3+\x3,\x3,\x3"+
-		",\x3,\x5,\x36F\n,\x3,\x3,\x5,\x373\n,\x3,\x5,\x376\n,\x3,\x5,\x379\n,"+
-		"\x3,\x3,\x5,\x37D\n,\x3,\x3,\x3-\x3-\x3-\x3-\x3.\x3.\x3.\x3.\x3/\x3/\x3"+
-		"/\x3/\x3/\x3/\x3/\x5/\x390\n/\x3/\a/\x393\n/\f/\xE/\x396\v/\x3/\x5/\x399"+
-		"\n/\x3/\x3/\x3\x30\x3\x30\x3\x30\x3\x30\x3\x30\x3\x30\x3\x30\x5\x30\x3A4"+
-		"\n\x30\x3\x30\x3\x30\x3\x30\x3\x30\x3\x30\x3\x30\x5\x30\x3AC\n\x30\x3"+
-		"\x30\x5\x30\x3AF\n\x30\x5\x30\x3B1\n\x30\x3\x31\x3\x31\x3\x31\x5\x31\x3B6"+
-		"\n\x31\x3\x32\x3\x32\x5\x32\x3BA\n\x32\x3\x33\x3\x33\x5\x33\x3BE\n\x33"+
-		"\x3\x33\x3\x33\x5\x33\x3C2\n\x33\x3\x33\x3\x33\x5\x33\x3C6\n\x33\x3\x33"+
-		"\x3\x33\x3\x33\x3\x33\x5\x33\x3CC\n\x33\x3\x34\x3\x34\x5\x34\x3D0\n\x34"+
-		"\x3\x34\x3\x34\x5\x34\x3D4\n\x34\x3\x34\x3\x34\x3\x34\x5\x34\x3D9\n\x34"+
-		"\x3\x34\x3\x34\x3\x35\x3\x35\x5\x35\x3DF\n\x35\x3\x35\x5\x35\x3E2\n\x35"+
-		"\x3\x36\x3\x36\x5\x36\x3E6\n\x36\x3\x36\x3\x36\x5\x36\x3EA\n\x36\x3\x36"+
-		"\x5\x36\x3ED\n\x36\a\x36\x3EF\n\x36\f\x36\xE\x36\x3F2\v\x36\x3\x36\x3"+
-		"\x36\x5\x36\x3F6\n\x36\x5\x36\x3F8\n\x36\x3\x36\x3\x36\x5\x36\x3FC\n\x36"+
-		"\x3\x36\x3\x36\x5\x36\x400\n\x36\x3\x36\x5\x36\x403\n\x36\a\x36\x405\n"+
-		"\x36\f\x36\xE\x36\x408\v\x36\x5\x36\x40A\n\x36\x3\x37\x3\x37\x3\x38\x3"+
-		"\x38\x3\x39\x3\x39\x3\x39\x3\x39\x3:\x3:\x3:\x3:\x5:\x418\n:\x3:\x3:\x5"+
-		":\x41C\n:\x3:\x6:\x41F\n:\r:\xE:\x420\x3;\x3;\x5;\x425\n;\x3;\x3;\x5;"+
-		"\x429\n;\x3;\x3;\x5;\x42D\n;\x3;\x3;\x3<\x3<\x3<\x3<\x5<\x435\n<\x3<\x3"+
-		"<\x5<\x439\n<\x3<\x3<\x3=\x3=\x3=\x3=\x5=\x441\n=\x3=\x3=\x5=\x445\n="+
-		"\x3=\x3=\x3=\x3=\x3=\x3=\x5=\x44D\n=\x5=\x44F\n=\x3>\x3>\x3>\x3>\x5>\x455"+
-		"\n>\x3>\x3>\x5>\x459\n>\x3>\x3>\x3?\x3?\x5?\x45F\n?\x3?\x3?\x5?\x463\n"+
-		"?\x3?\x3?\x5?\x467\n?\x3?\x3?\x3@\x3@\x3@\x3@\x3@\x3@\x3@\x3@\x3@\x3@"+
-		"\x5@\x475\n@\x3\x41\x3\x41\x3\x41\x3\x41\x3\x41\x3\x41\x3\x41\x3\x41\x5"+
-		"\x41\x47F\n\x41\x3\x41\x3\x41\x5\x41\x483\n\x41\x3\x41\a\x41\x486\n\x41"+
-		"\f\x41\xE\x41\x489\v\x41\x3\x42\x3\x42\x3\x42\x3\x42\x3\x42\x3\x42\x3"+
-		"\x42\x3\x42\x5\x42\x493\n\x42\x3\x42\x3\x42\x5\x42\x497\n\x42\x3\x42\a"+
-		"\x42\x49A\n\x42\f\x42\xE\x42\x49D\v\x42\x3\x43\x3\x43\x3\x43\x3\x43\x3"+
-		"\x43\x3\x43\x3\x43\x3\x43\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x4AB\n\x43"+
-		"\x3\x43\x3\x43\x3\x43\x5\x43\x4B0\n\x43\x3\x43\x3\x43\x3\x43\x3\x43\x3"+
-		"\x43\x3\x43\x3\x43\x5\x43\x4B9\n\x43\x3\x43\x3\x43\x5\x43\x4BD\n\x43\x3"+
-		"\x43\x3\x43\x5\x43\x4C1\n\x43\x3\x44\x3\x44\x5\x44\x4C5\n\x44\x3\x44\x3"+
-		"\x44\x5\x44\x4C9\n\x44\x3\x44\x5\x44\x4CC\n\x44\a\x44\x4CE\n\x44\f\x44"+
-		"\xE\x44\x4D1\v\x44\x3\x44\x5\x44\x4D4\n\x44\x3\x44\x5\x44\x4D7\n\x44\x3"+
-		"\x44\x3\x44\x5\x44\x4DB\n\x44\x3\x44\x5\x44\x4DE\n\x44\x6\x44\x4E0\n\x44"+
-		"\r\x44\xE\x44\x4E1\x5\x44\x4E4\n\x44\x3\x45\x3\x45\x3\x45\x5\x45\x4E9"+
-		"\n\x45\x3\x45\x3\x45\x5\x45\x4ED\n\x45\x3\x45\x3\x45\x5\x45\x4F1\n\x45"+
-		"\x3\x45\x3\x45\x5\x45\x4F5\n\x45\x5\x45\x4F7\n\x45\x3\x46\x3\x46\x3\x46"+
-		"\x3\x46\x5\x46\x4FD\n\x46\x3\x46\x3\x46\x5\x46\x501\n\x46\x3\x46\x5\x46"+
-		"\x504\n\x46\x3G\x3G\x3G\x5G\x509\nG\x3G\x3G\x5G\x50D\nG\x3G\x3G\x3G\x3"+
-		"G\x5G\x513\nG\x3G\x5G\x516\nG\x3G\x5G\x519\nG\x3G\x3G\x3G\x5G\x51E\nG"+
-		"\x3G\x3G\x5G\x522\nG\x3G\x3G\x3H\x3H\x3H\x5H\x529\nH\x3H\x3H\x5H\x52D"+
-		"\nH\x3H\x3H\x3H\x3H\x5H\x533\nH\x3H\x5H\x536\nH\x3H\x3H\x5H\x53A\nH\x3"+
-		"H\x3H\x3I\x3I\x3I\x5I\x541\nI\x3I\x3I\x5I\x545\nI\x3I\x3I\x3I\x3I\x5I"+
-		"\x54B\nI\x3I\x5I\x54E\nI\x3I\x3I\x5I\x552\nI\x3I\x3I\x3J\x3J\x3J\x3J\x5"+
-		"J\x55A\nJ\x3J\x3J\x5J\x55E\nJ\x3J\x5J\x561\nJ\x3J\x5J\x564\nJ\x3J\x3J"+
-		"\x5J\x568\nJ\x3J\x3J\x3K\x3K\x3K\x3K\x5K\x570\nK\x3K\x3K\x5K\x574\nK\x3"+
-		"K\x3K\x5K\x578\nK\x5K\x57A\nK\x3K\x5K\x57D\nK\x3L\x3L\x3L\x3L\x5L\x583"+
-		"\nL\x3L\x3L\x5L\x587\nL\x3L\x3L\x5L\x58B\nL\x3L\aL\x58E\nL\fL\xEL\x591"+
-		"\vL\x3M\x3M\x5M\x595\nM\x3M\x3M\x5M\x599\nM\x3M\x3M\x5M\x59D\nM\x3M\x3"+
-		"M\x3M\x3M\x5M\x5A3\nM\x3N\x3N\x3O\x3O\x3O\x3O\x5O\x5AB\nO\x5O\x5AD\nO"+
-		"\x3P\x3P\x3Q\x3Q\x3Q\x3Q\x5Q\x5B5\nQ\x3Q\x3Q\x5Q\x5B9\nQ\x3Q\x3Q\x3R\x3"+
-		"R\x3S\x3S\x3S\x3S\x5S\x5C3\nS\x3S\x3S\x5S\x5C7\nS\x3S\x3S\x3T\x3T\x3T"+
-		"\x3T\x3T\x3T\x3T\aT\x5D2\nT\fT\xET\x5D5\vT\x3T\x3T\x3U\x3U\x5U\x5DB\n"+
-		"U\x3U\x3U\x5U\x5DF\nU\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x5U\x5EA\nU"+
-		"\x3V\x3V\x3V\x3V\x3V\x5V\x5F1\nV\x3W\x3W\x3W\x5W\x5F6\nW\x3W\x3W\x5W\x5FA"+
-		"\nW\x3W\aW\x5FD\nW\fW\xEW\x600\vW\x5W\x602\nW\x3X\x3X\x3X\x3X\x5X\x608"+
-		"\nX\x3X\x3X\x5X\x60C\nX\x3X\x3X\x3Y\x3Y\x3Y\x5Y\x613\nY\x3Y\x3Y\x5Y\x617"+
-		"\nY\x3Y\x3Y\x5Y\x61B\nY\x3Y\x3Y\x5Y\x61F\nY\x3Y\x5Y\x622\nY\x3Y\x3Y\x5"+
-		"Y\x626\nY\x3Y\x3Y\x3Z\x3Z\x3[\x3[\x3[\x5[\x62F\n[\x3[\x3[\x3[\x3[\x3["+
-		"\a[\x636\n[\f[\xE[\x639\v[\x3[\x3[\x3\\\x3\\\x5\\\x63F\n\\\x3\\\x3\\\x5"+
-		"\\\x643\n\\\x3\\\x5\\\x646\n\\\x3\\\x5\\\x649\n\\\x3\\\x5\\\x64C\n\\\x3"+
-		"\\\x3\\\x3\\\x5\\\x651\n\\\x3\\\x3\\\x3]\x3]\x3]\x3]\x5]\x659\n]\x3]\x3"+
-		"]\x5]\x65D\n]\x3]\x3]\x3]\x3]\x3]\x3]\x5]\x665\n]\x5]\x667\n]\x3^\x3^"+
-		"\x3^\x5^\x66C\n^\x3^\x3^\x3^\x5^\x671\n^\x3^\x3^\x3^\x5^\x676\n^\x3^\x3"+
-		"^\x5^\x67A\n^\x3^\x3^\x3^\x3^\x5^\x680\n^\x3^\x3^\x3^\x5^\x685\n^\x3^"+
-		"\x3^\x3^\x3^\x3^\x5^\x68C\n^\x3^\x3^\x5^\x690\n^\x3^\x3^\x3^\x3^\x5^\x696"+
-		"\n^\x3^\x3^\x5^\x69A\n^\x3^\x3^\x5^\x69E\n^\x3^\x3^\x3^\x5^\x6A3\n^\x3"+
-		"^\x3^\x5^\x6A7\n^\x3^\x3^\x3^\x5^\x6AC\n^\x3^\x3^\x5^\x6B0\n^\x3^\x3^"+
-		"\x3^\x5^\x6B5\n^\x3^\x3^\x5^\x6B9\n^\x3^\x3^\x3^\x5^\x6BE\n^\x3^\x3^\x5"+
-		"^\x6C2\n^\x3^\x3^\x3^\x5^\x6C7\n^\x3^\x3^\x5^\x6CB\n^\x3^\x3^\x3^\x5^"+
-		"\x6D0\n^\x3^\x3^\x5^\x6D4\n^\x3^\x3^\x3^\x5^\x6D9\n^\x3^\x3^\x5^\x6DD"+
-		"\n^\x3^\x3^\x3^\x5^\x6E2\n^\x3^\x3^\x5^\x6E6\n^\x3^\x3^\x3^\x5^\x6EB\n"+
-		"^\x3^\x3^\x5^\x6EF\n^\x3^\x3^\x3^\x5^\x6F4\n^\x3^\x3^\x5^\x6F8\n^\x3^"+
-		"\x3^\x3^\x5^\x6FD\n^\x3^\x3^\x5^\x701\n^\x3^\a^\x704\n^\f^\xE^\x707\v"+
-		"^\x3_\x3_\x3_\x3_\x3_\x3_\x3_\x3_\x5_\x711\n_\x3`\x3`\x3`\x5`\x716\n`"+
-		"\x3`\x3`\x3`\x5`\x71B\n`\x3`\x3`\x3\x61\x3\x61\x5\x61\x721\n\x61\x3\x61"+
-		"\x3\x61\x5\x61\x725\n\x61\x3\x61\a\x61\x728\n\x61\f\x61\xE\x61\x72B\v"+
-		"\x61\x3\x62\x3\x62\x5\x62\x72F\n\x62\x3\x62\x5\x62\x732\n\x62\x3\x62\x3"+
-		"\x62\x5\x62\x736\n\x62\x3\x62\x3\x62\x5\x62\x73A\n\x62\x5\x62\x73C\n\x62"+
-		"\x3\x62\x3\x62\x5\x62\x740\n\x62\x5\x62\x742\n\x62\x3\x62\x3\x62\x3\x62"+
-		"\x5\x62\x747\n\x62\x3\x63\x3\x63\x3\x63\x3\x63\x3\x63\x5\x63\x74E\n\x63"+
-		"\x3\x63\x3\x63\x3\x64\x3\x64\x3\x64\x3\x64\x5\x64\x756\n\x64\x3\x64\x3"+
-		"\x64\x5\x64\x75A\n\x64\x3\x64\x3\x64\x3\x65\x3\x65\x3\x65\x3\x65\x3\x65"+
-		"\x5\x65\x763\n\x65\x3\x65\x3\x65\x3\x66\x3\x66\x3g\x3g\x3g\x3g\x5g\x76D"+
-		"\ng\x3g\x3g\x5g\x771\ng\x3g\x5g\x774\ng\x3h\x5h\x777\nh\x3h\x3h\x3i\x3"+
-		"i\x3i\x3i\x3j\x5j\x780\nj\x3j\x3j\x3j\x5j\x785\nj\x3j\x5j\x788\nj\x3j"+
-		"\x3j\x5j\x78C\nj\x3j\x3j\x5j\x790\nj\x3j\x3j\x5j\x794\nj\x3j\x5j\x797"+
-		"\nj\x3j\x3j\x3j\x3j\aj\x79D\nj\fj\xEj\x7A0\vj\x3j\x3j\x5j\x7A4\nj\x3j"+
-		"\x5j\x7A7\nj\x3j\x3j\x5j\x7AB\nj\x3j\x3j\x5j\x7AF\nj\x3j\x3j\x5j\x7B3"+
-		"\nj\x3j\x5j\x7B6\nj\x3j\x3j\x3j\x3j\aj\x7BC\nj\fj\xEj\x7BF\vj\x5j\x7C1"+
-		"\nj\x3k\x3k\x5k\x7C5\nk\x3l\x5l\x7C8\nl\x3l\x5l\x7CB\nl\x3l\x3l\x5l\x7CF"+
-		"\nl\x3l\x3l\x5l\x7D3\nl\x3l\x3l\x3l\x5l\x7D8\nl\x3l\x5l\x7DB\nl\x3l\x5"+
-		"l\x7DE\nl\x3l\x5l\x7E1\nl\x3l\x3l\x3l\x3l\al\x7E7\nl\fl\xEl\x7EA\vl\x3"+
-		"m\x3m\x3m\x3m\x5m\x7F0\nm\x3m\x5m\x7F3\nm\x3m\x3m\x3m\x3m\am\x7F9\nm\f"+
-		"m\xEm\x7FC\vm\x3n\x3n\x3n\x3n\x5n\x802\nn\x3o\x3o\x5o\x806\no\x3o\x5o"+
-		"\x809\no\x3o\x5o\x80C\no\x3o\x5o\x80F\no\x3o\x3o\x3o\x3o\ao\x815\no\f"+
-		"o\xEo\x818\vo\x3p\x3p\x5p\x81C\np\x3p\x5p\x81F\np\x3p\x5p\x822\np\x3p"+
-		"\x3p\x5p\x826\np\x3p\x3p\x5p\x82A\np\x5p\x82C\np\x3p\x3p\x5p\x830\np\x3"+
-		"p\x5p\x833\np\x3p\x5p\x836\np\x3p\x3p\x3p\x3p\ap\x83C\np\fp\xEp\x83F\v"+
-		"p\x3q\x3q\x5q\x843\nq\x3q\x5q\x846\nq\x3q\x5q\x849\nq\x3q\x5q\x84C\nq"+
-		"\x3q\x3q\x3q\x3q\aq\x852\nq\fq\xEq\x855\vq\x3r\x3r\x5r\x859\nr\x3r\x5"+
-		"r\x85C\nr\x3r\x5r\x85F\nr\x3r\x3r\x5r\x863\nr\x3r\x3r\x5r\x867\nr\x5r"+
-		"\x869\nr\x3r\x3r\x5r\x86D\nr\x3r\x5r\x870\nr\x3r\x5r\x873\nr\x3r\x3r\x3"+
-		"r\x3r\ar\x879\nr\fr\xEr\x87C\vr\x3s\x3s\x5s\x880\ns\x3s\x3s\x5s\x884\n"+
-		"s\x6s\x886\ns\rs\xEs\x887\x3s\x5s\x88B\ns\x3s\x5s\x88E\ns\x3s\x5s\x891"+
-		"\ns\x3s\x3s\x3s\x3s\as\x897\ns\fs\xEs\x89A\vs\x3t\x3t\x5t\x89E\nt\x3t"+
-		"\x3t\x5t\x8A2\nt\x3u\x5u\x8A5\nu\x3u\x3u\x3v\x5v\x8AA\nv\x3v\x5v\x8AD"+
-		"\nv\x3v\x3v\x5v\x8B1\nv\av\x8B3\nv\fv\xEv\x8B6\vv\x3v\x3v\x5v\x8BA\nv"+
-		"\x3v\x3v\x5v\x8BE\nv\x3v\x5v\x8C1\nv\av\x8C3\nv\fv\xEv\x8C6\vv\x3w\x5"+
-		"w\x8C9\nw\x3w\x3w\x5w\x8CD\nw\x3w\x5w\x8D0\nw\x3w\x3w\x3x\x3x\x5x\x8D6"+
-		"\nx\x3x\x3x\x5x\x8DA\nx\x3y\x3y\x5y\x8DE\ny\x3y\x3y\x5y\x8E2\ny\x3y\x3"+
-		"y\x5y\x8E6\ny\x3y\ay\x8E9\ny\fy\xEy\x8EC\vy\x5y\x8EE\ny\x3y\x5y\x8F1\n"+
-		"y\x3y\x3y\x3z\x3z\x5z\x8F7\nz\x3z\x3z\x5z\x8FB\nz\x3z\x3z\x5z\x8FF\nz"+
-		"\x3z\x3z\x5z\x903\nz\x3z\x5z\x906\nz\x3z\x3z\x5z\x90A\nz\x3z\x5z\x90D"+
-		"\nz\x3z\x5z\x910\nz\x3z\x5z\x913\nz\x3z\x5z\x916\nz\x3z\x5z\x919\nz\x3"+
-		"{\x3{\x5{\x91D\n{\x3{\x3{\x3|\x3|\x5|\x923\n|\x3|\x3|\x5|\x927\n|\x3|"+
-		"\a|\x92A\n|\f|\xE|\x92D\v|\x3}\x3}\x3}\x3}\x3}\x5}\x934\n}\x3}\x3}\x3"+
-		"~\x3~\x3~\x5~\x93B\n~\x3\x7F\x3\x7F\x5\x7F\x93F\n\x7F\x3\x80\x3\x80\x5"+
-		"\x80\x943\n\x80\x3\x80\x3\x80\x5\x80\x947\n\x80\x3\x80\x3\x80\x5\x80\x94B"+
-		"\n\x80\x3\x80\x5\x80\x94E\n\x80\x3\x81\x3\x81\x3\x82\x3\x82\x3\x83\x3"+
-		"\x83\x3\x83\a\x83\x957\n\x83\f\x83\xE\x83\x95A\v\x83\x3\x84\x3\x84\x5"+
-		"\x84\x95E\n\x84\x3\x84\x3\x84\x5\x84\x962\n\x84\x3\x85\x3\x85\x5\x85\x966"+
-		"\n\x85\x3\x85\x3\x85\x3\x86\x3\x86\x5\x86\x96C\n\x86\x3\x87\x3\x87\x3"+
-		"\x88\x3\x88\x3\x89\x3\x89\x3\x89\x3\x89\x3\x89\x3\x89\x3\x89\x3\x89\x5"+
-		"\x89\x97A\n\x89\x3\x8A\x3\x8A\x3\x8B\x3\x8B\x5\x8B\x980\n\x8B\x3\x8B\x5"+
-		"\x8B\x983\n\x8B\x3\x8B\x3\x8B\x5\x8B\x987\n\x8B\x3\x8B\x5\x8B\x98A\n\x8B"+
-		"\x3\x8C\x3\x8C\x3\x8D\x3\x8D\x3\x8E\x3\x8E\x3\x8F\x3\x8F\x3\x90\x3\x90"+
-		"\x3\x91\x5\x91\x997\n\x91\x3\x91\x5\x91\x99A\n\x91\x3\x92\x3\x92\x3\x92"+
-		"\x5\x92\x99F\n\x92\x3\x92\x5\x92\x9A2\n\x92\x3\x92\x3\x92\x5\x92\x9A6"+
-		"\n\x92\x5\x92\x9A8\n\x92\a\x92\x9AA\n\x92\f\x92\xE\x92\x9AD\v\x92\x3\x92"+
-		"\x3\x92\x3\x92\x5\x92\x9B2\n\x92\x3\x93\x3\x93\x3\x93\x5\x93\x9B7\n\x93"+
-		"\x3\x94\x3\x94\x5\x94\x9BB\n\x94\x3\x94\x3\x94\x3\x95\x3\x95\x3\x95\x3"+
-		"\x96\x3\x96\a\x96\x9C4\n\x96\f\x96\xE\x96\x9C7\v\x96\x3\x97\x3\x97\x3"+
-		"\x97\x3\x97\x5\x97\x9CD\n\x97\x6\x97\x9CF\n\x97\r\x97\xE\x97\x9D0\x3\x98"+
-		"\x3\x98\x5\x98\x9D5\n\x98\x3\x99\x3\x99\x3\x9A\x3\x9A\x3\x9A\x3\x9A\x3"+
-		"\x9A\x3\x9A\x5\x9A\x9DF\n\x9A\x3\x9A\x3\x9A\x5\x9A\x9E3\n\x9A\x3\x9A\x6"+
-		"\x9A\x9E6\n\x9A\r\x9A\xE\x9A\x9E7\x3\x9A\x5\x9A\x9EB\n\x9A\x3\x9A\x3\x9A"+
-		"\x5\x9A\x9EF\n\x9A\x3\x9A\x3\x9A\x5\x9A\x9F3\n\x9A\x3\x9A\x3\x9A\x5\x9A"+
-		"\x9F7\n\x9A\x3\x9A\x3\x9A\x5\x9A\x9FB\n\x9A\x3\x9A\x3\x9A\x3\x9A\x5\x9A"+
-		"\xA00\n\x9A\x3\x9A\x3\x9A\x3\x9A\x5\x9A\xA05\n\x9A\x3\x9A\x3\x9A\x5\x9A"+
-		"\xA09\n\x9A\x3\x9A\x6\x9A\xA0C\n\x9A\r\x9A\xE\x9A\xA0D\x3\x9A\x5\x9A\xA11"+
-		"\n\x9A\x3\x9A\x3\x9A\x5\x9A\xA15\n\x9A\x3\x9B\x3\x9B\x3\x9C\x6\x9C\xA1A"+
-		"\n\x9C\r\x9C\xE\x9C\xA1B\x3\x9C\x2\x2\x3\xBA\x9D\x2\x2\x4\x2\x6\x2\b\x2"+
+		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x5\x11\x24A\n"+
+		"\x11\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3"+
+		"\x12\x3\x12\x3\x12\x3\x12\x5\x12\x259\n\x12\x3\x13\x3\x13\x3\x13\x3\x13"+
+		"\x3\x13\x3\x13\x5\x13\x261\n\x13\x3\x13\x3\x13\x3\x13\x5\x13\x266\n\x13"+
+		"\x3\x13\x3\x13\x3\x13\x5\x13\x26B\n\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3"+
+		"\x13\x3\x13\x3\x13\x5\x13\x274\n\x13\x3\x14\x3\x14\x3\x15\x3\x15\x3\x15"+
+		"\x3\x15\x3\x16\x3\x16\x3\x17\x3\x17\x3\x17\x3\x17\x3\x18\x3\x18\x3\x19"+
+		"\x3\x19\x3\x1A\x3\x1A\x5\x1A\x288\n\x1A\x3\x1A\x3\x1A\x5\x1A\x28C\n\x1A"+
+		"\x3\x1A\x3\x1A\x3\x1B\x3\x1B\x3\x1C\x3\x1C\x5\x1C\x294\n\x1C\x3\x1D\x3"+
+		"\x1D\x3\x1D\x3\x1E\x3\x1E\x3\x1F\x3\x1F\x3\x1F\x3\x1F\x5\x1F\x29F\n\x1F"+
+		"\x3 \x3 \x3!\x3!\x5!\x2A5\n!\x3!\x3!\x5!\x2A9\n!\x3!\a!\x2AC\n!\f!\xE"+
+		"!\x2AF\v!\x3\"\x3\"\x3\"\x3\"\x5\"\x2B5\n\"\x3\"\x3\"\x5\"\x2B9\n\"\x3"+
+		"\"\x3\"\x3#\x3#\x3$\x3$\x3$\x3$\x5$\x2C3\n$\x3$\x3$\x5$\x2C7\n$\x3$\x5"+
+		"$\x2CA\n$\x3%\x3%\x3%\x3%\x5%\x2D0\n%\x3%\x3%\x3%\x3%\x5%\x2D6\n%\x3&"+
+		"\x3&\x3\'\x3\'\x3(\x3(\x3(\x3(\x5(\x2E0\n(\x3(\x3(\x5(\x2E4\n(\x3(\x5"+
+		"(\x2E7\n(\x3)\x3)\x3)\x3)\x5)\x2ED\n)\x3)\x3)\x5)\x2F1\n)\x3)\x3)\x3*"+
+		"\x3*\x3+\x3+\x3+\x3+\x5+\x2FB\n+\x3+\x3+\x5+\x2FF\n+\x3+\x3+\x3,\x3,\x3"+
+		"-\x3-\x3-\x3-\x5-\x309\n-\x3-\x3-\x5-\x30D\n-\x3-\x5-\x310\n-\x3.\x3."+
+		"\x5.\x314\n.\x3.\a.\x317\n.\f.\xE.\x31A\v.\x3/\x3/\x3/\x3/\x5/\x320\n"+
+		"/\x3/\x3/\x5/\x324\n/\x3\x30\x3\x30\x3\x30\x5\x30\x329\n\x30\x3\x31\x3"+
+		"\x31\x3\x32\x3\x32\x3\x33\x3\x33\x5\x33\x331\n\x33\x3\x33\x3\x33\x5\x33"+
+		"\x335\n\x33\x3\x33\x3\x33\x5\x33\x339\n\x33\x3\x33\x3\x33\x3\x34\x3\x34"+
+		"\x3\x35\x3\x35\x5\x35\x341\n\x35\x3\x35\x5\x35\x344\n\x35\x3\x36\x3\x36"+
+		"\x5\x36\x348\n\x36\x3\x36\x3\x36\x5\x36\x34C\n\x36\x3\x36\x3\x36\x3\x37"+
+		"\x3\x37\x3\x38\x3\x38\x3\x38\x3\x38\x5\x38\x356\n\x38\x3\x38\x3\x38\x5"+
+		"\x38\x35A\n\x38\x3\x38\x5\x38\x35D\n\x38\x3\x39\x3\x39\x3\x39\x3\x39\x5"+
+		"\x39\x363\n\x39\x3\x39\x3\x39\x5\x39\x367\n\x39\x3\x39\x3\x39\x3:\x3:"+
+		"\x5:\x36D\n:\x3:\x3:\x5:\x371\n:\x3:\a:\x374\n:\f:\xE:\x377\v:\x3;\x3"+
+		";\x3<\x3<\x3<\x3<\x5<\x37F\n<\x3<\x3<\x5<\x383\n<\x3<\x5<\x386\n<\x3<"+
+		"\x5<\x389\n<\x3<\x3<\x5<\x38D\n<\x3<\x3<\x3=\x3=\x3>\x3>\x3?\x3?\x3?\x3"+
+		"?\x5?\x399\n?\x3?\x3?\x5?\x39D\n?\x3?\x5?\x3A0\n?\x3?\x5?\x3A3\n?\x3?"+
+		"\x3?\x5?\x3A7\n?\x3?\x3?\x3@\x3@\x3\x41\x3\x41\x3\x41\x5\x41\x3B0\n\x41"+
+		"\x3\x41\x3\x41\x3\x41\x3\x41\x5\x41\x3B6\n\x41\x3\x41\x3\x41\x5\x41\x3BA"+
+		"\n\x41\x3\x41\a\x41\x3BD\n\x41\f\x41\xE\x41\x3C0\v\x41\x3\x42\x3\x42\x5"+
+		"\x42\x3C4\n\x42\x3\x42\x3\x42\x3\x42\x5\x42\x3C9\n\x42\x3\x42\x5\x42\x3CC"+
+		"\n\x42\x3\x42\x3\x42\x5\x42\x3D0\n\x42\x3\x42\x3\x42\x3\x43\x3\x43\x3"+
+		"\x43\x5\x43\x3D7\n\x43\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3DD\n\x43\x3"+
+		"\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3E3\n\x43\x3\x43\x3\x43\x3\x43\x3\x43"+
+		"\x3\x43\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3EE\n\x43\x3\x43\x5\x43\x3F1"+
+		"\n\x43\x3\x43\x5\x43\x3F4\n\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3F9\n\x43"+
+		"\x3\x44\x3\x44\x3\x44\x3\x44\x5\x44\x3FF\n\x44\x3\x44\x3\x44\x5\x44\x403"+
+		"\n\x44\x3\x44\a\x44\x406\n\x44\f\x44\xE\x44\x409\v\x44\x3\x45\x3\x45\x3"+
+		"\x46\x3\x46\x3\x46\x5\x46\x410\n\x46\x3G\x3G\x3H\x3H\x5H\x416\nH\x3H\x3"+
+		"H\x5H\x41A\nH\x3H\x3H\x3I\x3I\x3I\x3J\x3J\x3J\x3K\x3K\x5K\x426\nK\x3K"+
+		"\x3K\x5K\x42A\nK\x3K\x3K\x3L\x3L\x3M\x3M\x3N\x3N\x3N\x5N\x435\nN\x3N\x3"+
+		"N\x3N\x3N\x3N\x3N\x3N\x3N\x3N\x5N\x440\nN\x3N\x3N\x3N\x3N\x3N\x5N\x447"+
+		"\nN\x3N\x3N\x3N\x3N\x3N\x3N\x5N\x44F\nN\x3O\x3O\x3O\x5O\x454\nO\x3O\x3"+
+		"O\x3O\x3O\x3O\aO\x45B\nO\fO\xEO\x45E\vO\x3O\x3O\x3P\x3P\x5P\x464\nP\x3"+
+		"P\x3P\x5P\x468\nP\x3P\x5P\x46B\nP\x3P\x3P\x3Q\x3Q\x3R\x3R\x3R\x3R\x5R"+
+		"\x475\nR\x3R\x3R\x5R\x479\nR\x3R\aR\x47C\nR\fR\xER\x47F\vR\x3S\x3S\x3"+
+		"S\x3S\x3T\x3T\x3T\x5T\x488\nT\x3T\x3T\x3T\x3T\x5T\x48E\nT\x3T\x3T\x3U"+
+		"\x3U\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x5V\x49F\nV\x3V\x3V\x3"+
+		"V\x3V\x5V\x4A5\nV\x3W\x3W\x3W\x3W\x5W\x4AB\nW\x3W\x3W\x5W\x4AF\nW\x3W"+
+		"\x3W\x3W\x3W\x3W\x3W\x3W\x3W\x3W\x3W\x5W\x4BB\nW\x3W\x3W\x5W\x4BF\nW\x3"+
+		"W\x3W\x3W\x3W\x5W\x4C5\nW\x3X\x3X\x3X\x5X\x4CA\nX\x3X\x3X\x5X\x4CE\nX"+
+		"\x3X\x3X\x5X\x4D2\nX\x3X\x3X\x5X\x4D6\nX\x3X\x5X\x4D9\nX\x3X\x5X\x4DC"+
+		"\nX\x3X\x5X\x4DF\nX\x3X\x5X\x4E2\nX\x3X\x3X\x5X\x4E6\nX\x3X\x3X\x3Y\x3"+
+		"Y\x3Z\x3Z\x3Z\x3Z\x3[\x3[\x3[\x3[\x3\\\x3\\\x3\\\x3\\\x3\\\x3\\\x3\\\x5"+
+		"\\\x4FB\n\\\x3\\\a\\\x4FE\n\\\f\\\xE\\\x501\v\\\x3\\\x5\\\x504\n\\\x3"+
+		"\\\x3\\\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x5]\x50F\n]\x3]\x3]\x3]\x3]\x3]\x3"+
+		"]\x5]\x517\n]\x3]\x5]\x51A\n]\x5]\x51C\n]\x3^\x3^\x3^\x5^\x521\n^\x3_"+
+		"\x3_\x5_\x525\n_\x3`\x3`\x5`\x529\n`\x3`\x3`\x5`\x52D\n`\x3`\x3`\x5`\x531"+
+		"\n`\x3`\x3`\x3`\x3`\x5`\x537\n`\x3\x61\x3\x61\x5\x61\x53B\n\x61\x3\x61"+
+		"\x3\x61\x5\x61\x53F\n\x61\x3\x61\x3\x61\x3\x61\x5\x61\x544\n\x61\x3\x61"+
+		"\x3\x61\x3\x62\x3\x62\x5\x62\x54A\n\x62\x3\x62\x5\x62\x54D\n\x62\x3\x63"+
+		"\x3\x63\x5\x63\x551\n\x63\x3\x63\x3\x63\x5\x63\x555\n\x63\x3\x63\x5\x63"+
+		"\x558\n\x63\a\x63\x55A\n\x63\f\x63\xE\x63\x55D\v\x63\x3\x63\x3\x63\x5"+
+		"\x63\x561\n\x63\x5\x63\x563\n\x63\x3\x63\x3\x63\x5\x63\x567\n\x63\x3\x63"+
+		"\x3\x63\x5\x63\x56B\n\x63\x3\x63\x5\x63\x56E\n\x63\a\x63\x570\n\x63\f"+
+		"\x63\xE\x63\x573\v\x63\x5\x63\x575\n\x63\x3\x64\x3\x64\x3\x65\x3\x65\x3"+
+		"\x66\x3\x66\x3\x66\x3\x66\x3g\x3g\x5g\x581\ng\x3g\x3g\x5g\x585\ng\x3g"+
+		"\x3g\x5g\x589\ng\x3g\x3g\x3h\x3h\x3h\x3h\x5h\x591\nh\x3h\x3h\x5h\x595"+
+		"\nh\x3h\x3h\x3i\x3i\x5i\x59B\ni\x3i\x3i\x5i\x59F\ni\x3i\x3i\x5i\x5A3\n"+
+		"i\x3i\x3i\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x5j\x5B1\nj\x3k\x3k"+
+		"\x3k\x3k\x3k\x3k\x3k\x3k\x5k\x5BB\nk\x3k\x3k\x5k\x5BF\nk\x3k\ak\x5C2\n"+
+		"k\fk\xEk\x5C5\vk\x3l\x3l\x3l\x3l\x3l\x3l\x3l\x3l\x5l\x5CF\nl\x3l\x3l\x5"+
+		"l\x5D3\nl\x3l\al\x5D6\nl\fl\xEl\x5D9\vl\x3m\x3m\x3m\x5m\x5DE\nm\x3m\x3"+
+		"m\x5m\x5E2\nm\x3m\x3m\x3m\x3m\x5m\x5E8\nm\x3m\x5m\x5EB\nm\x3m\x5m\x5EE"+
+		"\nm\x3m\x3m\x3m\x5m\x5F3\nm\x3m\x3m\x5m\x5F7\nm\x3m\x3m\x3n\x3n\x3n\x5"+
+		"n\x5FE\nn\x3n\x3n\x5n\x602\nn\x3n\x3n\x3n\x3n\x5n\x608\nn\x3n\x5n\x60B"+
+		"\nn\x3n\x3n\x5n\x60F\nn\x3n\x3n\x3o\x3o\x3o\x5o\x616\no\x3o\x3o\x5o\x61A"+
+		"\no\x3o\x3o\x3o\x3o\x5o\x620\no\x3o\x5o\x623\no\x3o\x3o\x5o\x627\no\x3"+
+		"o\x3o\x3p\x3p\x3p\x3p\x5p\x62F\np\x3p\x3p\x5p\x633\np\x3p\x3p\x5p\x637"+
+		"\np\x5p\x639\np\x3p\x5p\x63C\np\x3q\x3q\x3q\x3q\x5q\x642\nq\x3q\x3q\x5"+
+		"q\x646\nq\x3q\x3q\x5q\x64A\nq\x3q\aq\x64D\nq\fq\xEq\x650\vq\x3r\x3r\x5"+
+		"r\x654\nr\x3r\x3r\x5r\x658\nr\x3r\x3r\x5r\x65C\nr\x3r\x3r\x3r\x3r\x5r"+
+		"\x662\nr\x3s\x3s\x3s\x3s\x5s\x668\ns\x5s\x66A\ns\x3t\x3t\x3u\x3u\x3u\x3"+
+		"u\x5u\x672\nu\x3u\x3u\x5u\x676\nu\x3u\x3u\x3v\x3v\x3w\x3w\x3w\x3w\x3w"+
+		"\x3w\x3w\aw\x683\nw\fw\xEw\x686\vw\x3w\x3w\x3x\x3x\x5x\x68C\nx\x3x\x3"+
+		"x\x5x\x690\nx\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x5x\x69B\nx\x3y\x3y"+
+		"\x3y\x3y\x3y\x5y\x6A2\ny\x3z\x3z\x3z\x5z\x6A7\nz\x3z\x3z\x5z\x6AB\nz\x3"+
+		"z\az\x6AE\nz\fz\xEz\x6B1\vz\x5z\x6B3\nz\x3{\x3{\x3{\x3{\x5{\x6B9\n{\x3"+
+		"{\x3{\x5{\x6BD\n{\x3{\x3{\x3|\x3|\x3|\x5|\x6C4\n|\x3|\x3|\x5|\x6C8\n|"+
+		"\x3|\x3|\x5|\x6CC\n|\x3|\x3|\x5|\x6D0\n|\x3|\x5|\x6D3\n|\x3|\x3|\x5|\x6D7"+
+		"\n|\x3|\x3|\x3}\x3}\x3~\x3~\x3~\x5~\x6E0\n~\x3~\x3~\x3~\x3~\x3~\a~\x6E7"+
+		"\n~\f~\xE~\x6EA\v~\x3~\x3~\x3\x7F\x3\x7F\x5\x7F\x6F0\n\x7F\x3\x7F\x3\x7F"+
+		"\x5\x7F\x6F4\n\x7F\x3\x7F\x5\x7F\x6F7\n\x7F\x3\x7F\x5\x7F\x6FA\n\x7F\x3"+
+		"\x7F\x5\x7F\x6FD\n\x7F\x3\x7F\x3\x7F\x3\x7F\x5\x7F\x702\n\x7F\x3\x7F\x3"+
+		"\x7F\x3\x80\x3\x80\x3\x80\x5\x80\x709\n\x80\x3\x80\x3\x80\x3\x80\x5\x80"+
+		"\x70E\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x713\n\x80\x3\x80\x3\x80\x5\x80"+
+		"\x717\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x71D\n\x80\x3\x80\x3\x80"+
+		"\x3\x80\x5\x80\x722\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x729"+
+		"\n\x80\x3\x80\x3\x80\x5\x80\x72D\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x3"+
+		"\x80\x5\x80\x734\n\x80\x3\x80\x3\x80\x5\x80\x738\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x73C\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x741\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x745\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x74A\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x74E\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x753\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x757\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x75C\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x760\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x765\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x769\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x76E\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x772\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x777\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x77B\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x780\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x784\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x789\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x78D\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x792\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x796\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x79B\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x79F\n\x80\x3\x80\a\x80\x7A2\n\x80\f\x80\xE\x80\x7A5\v\x80\x3\x81"+
+		"\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x5\x81\x7AF\n\x81\x3"+
+		"\x82\x3\x82\x3\x82\x5\x82\x7B4\n\x82\x3\x82\x3\x82\x3\x82\x5\x82\x7B9"+
+		"\n\x82\x3\x82\x3\x82\x3\x83\x3\x83\x5\x83\x7BF\n\x83\x3\x83\x3\x83\x5"+
+		"\x83\x7C3\n\x83\x3\x83\a\x83\x7C6\n\x83\f\x83\xE\x83\x7C9\v\x83\x3\x84"+
+		"\x3\x84\x5\x84\x7CD\n\x84\x3\x84\x5\x84\x7D0\n\x84\x3\x84\x3\x84\x5\x84"+
+		"\x7D4\n\x84\x3\x84\x3\x84\x5\x84\x7D8\n\x84\x5\x84\x7DA\n\x84\x3\x84\x3"+
+		"\x84\x5\x84\x7DE\n\x84\x5\x84\x7E0\n\x84\x3\x84\x3\x84\x3\x84\x5\x84\x7E5"+
+		"\n\x84\x3\x85\x3\x85\x3\x85\x3\x85\x3\x85\x5\x85\x7EC\n\x85\x3\x85\x3"+
+		"\x85\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x5\x86\x7F5\n\x86\x3\x86\x3\x86"+
+		"\x3\x87\x3\x87\x3\x88\x3\x88\x3\x88\x3\x88\x3\x89\x5\x89\x800\n\x89\x3"+
+		"\x89\x3\x89\x3\x89\x5\x89\x805\n\x89\x3\x89\x5\x89\x808\n\x89\x3\x89\x3"+
+		"\x89\x5\x89\x80C\n\x89\x3\x89\x3\x89\x5\x89\x810\n\x89\x3\x89\x3\x89\x5"+
+		"\x89\x814\n\x89\x3\x89\x5\x89\x817\n\x89\x3\x89\x3\x89\x3\x89\x3\x89\a"+
+		"\x89\x81D\n\x89\f\x89\xE\x89\x820\v\x89\x3\x89\x3\x89\x5\x89\x824\n\x89"+
+		"\x3\x89\x5\x89\x827\n\x89\x3\x89\x3\x89\x5\x89\x82B\n\x89\x3\x89\x3\x89"+
+		"\x5\x89\x82F\n\x89\x3\x89\x3\x89\x5\x89\x833\n\x89\x3\x89\x5\x89\x836"+
+		"\n\x89\x3\x89\x3\x89\x3\x89\x3\x89\a\x89\x83C\n\x89\f\x89\xE\x89\x83F"+
+		"\v\x89\x5\x89\x841\n\x89\x3\x8A\x3\x8A\x5\x8A\x845\n\x8A\x3\x8B\x5\x8B"+
+		"\x848\n\x8B\x3\x8B\x5\x8B\x84B\n\x8B\x3\x8B\x3\x8B\x5\x8B\x84F\n\x8B\x3"+
+		"\x8B\x3\x8B\x5\x8B\x853\n\x8B\x3\x8B\x3\x8B\x3\x8B\x5\x8B\x858\n\x8B\x3"+
+		"\x8B\x5\x8B\x85B\n\x8B\x3\x8B\x5\x8B\x85E\n\x8B\x3\x8B\x5\x8B\x861\n\x8B"+
+		"\x3\x8B\x3\x8B\x3\x8B\x3\x8B\a\x8B\x867\n\x8B\f\x8B\xE\x8B\x86A\v\x8B"+
+		"\x3\x8C\x3\x8C\x3\x8C\x3\x8C\x5\x8C\x870\n\x8C\x3\x8C\x5\x8C\x873\n\x8C"+
+		"\x3\x8C\x3\x8C\x3\x8C\x3\x8C\a\x8C\x879\n\x8C\f\x8C\xE\x8C\x87C\v\x8C"+
+		"\x3\x8D\x3\x8D\x3\x8D\x3\x8D\x5\x8D\x882\n\x8D\x3\x8E\x3\x8E\x5\x8E\x886"+
+		"\n\x8E\x3\x8E\x5\x8E\x889\n\x8E\x3\x8E\x5\x8E\x88C\n\x8E\x3\x8E\x5\x8E"+
+		"\x88F\n\x8E\x3\x8E\x3\x8E\x3\x8E\x3\x8E\a\x8E\x895\n\x8E\f\x8E\xE\x8E"+
+		"\x898\v\x8E\x3\x8F\x3\x8F\x5\x8F\x89C\n\x8F\x3\x8F\x5\x8F\x89F\n\x8F\x3"+
+		"\x8F\x5\x8F\x8A2\n\x8F\x3\x8F\x3\x8F\x5\x8F\x8A6\n\x8F\x3\x8F\x3\x8F\x5"+
+		"\x8F\x8AA\n\x8F\x5\x8F\x8AC\n\x8F\x3\x8F\x3\x8F\x5\x8F\x8B0\n\x8F\x3\x8F"+
+		"\x5\x8F\x8B3\n\x8F\x3\x8F\x5\x8F\x8B6\n\x8F\x3\x8F\x3\x8F\x3\x8F\x3\x8F"+
+		"\a\x8F\x8BC\n\x8F\f\x8F\xE\x8F\x8BF\v\x8F\x3\x90\x3\x90\x5\x90\x8C3\n"+
+		"\x90\x3\x90\x5\x90\x8C6\n\x90\x3\x90\x5\x90\x8C9\n\x90\x3\x90\x5\x90\x8CC"+
+		"\n\x90\x3\x90\x3\x90\x3\x90\x3\x90\a\x90\x8D2\n\x90\f\x90\xE\x90\x8D5"+
+		"\v\x90\x3\x91\x3\x91\x5\x91\x8D9\n\x91\x3\x91\x5\x91\x8DC\n\x91\x3\x91"+
+		"\x5\x91\x8DF\n\x91\x3\x91\x3\x91\x5\x91\x8E3\n\x91\x3\x91\x3\x91\x5\x91"+
+		"\x8E7\n\x91\x5\x91\x8E9\n\x91\x3\x91\x3\x91\x5\x91\x8ED\n\x91\x3\x91\x5"+
+		"\x91\x8F0\n\x91\x3\x91\x5\x91\x8F3\n\x91\x3\x91\x3\x91\x3\x91\x3\x91\a"+
+		"\x91\x8F9\n\x91\f\x91\xE\x91\x8FC\v\x91\x3\x92\x3\x92\x5\x92\x900\n\x92"+
+		"\x3\x92\x3\x92\x5\x92\x904\n\x92\x6\x92\x906\n\x92\r\x92\xE\x92\x907\x3"+
+		"\x92\x5\x92\x90B\n\x92\x3\x92\x5\x92\x90E\n\x92\x3\x92\x5\x92\x911\n\x92"+
+		"\x3\x92\x3\x92\x3\x92\x3\x92\a\x92\x917\n\x92\f\x92\xE\x92\x91A\v\x92"+
+		"\x3\x93\x3\x93\x5\x93\x91E\n\x93\x3\x93\x3\x93\x5\x93\x922\n\x93\x3\x94"+
+		"\x5\x94\x925\n\x94\x3\x94\x3\x94\x3\x95\x5\x95\x92A\n\x95\x3\x95\x5\x95"+
+		"\x92D\n\x95\x3\x95\x3\x95\x5\x95\x931\n\x95\a\x95\x933\n\x95\f\x95\xE"+
+		"\x95\x936\v\x95\x3\x95\x3\x95\x5\x95\x93A\n\x95\x3\x95\x3\x95\x5\x95\x93E"+
+		"\n\x95\x3\x95\x5\x95\x941\n\x95\a\x95\x943\n\x95\f\x95\xE\x95\x946\v\x95"+
+		"\x3\x96\x5\x96\x949\n\x96\x3\x96\x3\x96\x5\x96\x94D\n\x96\x3\x96\x5\x96"+
+		"\x950\n\x96\x3\x96\x3\x96\x3\x97\x3\x97\x5\x97\x956\n\x97\x3\x97\x3\x97"+
+		"\x5\x97\x95A\n\x97\x3\x98\x3\x98\x5\x98\x95E\n\x98\x3\x98\x3\x98\x5\x98"+
+		"\x962\n\x98\x3\x98\x3\x98\x5\x98\x966\n\x98\x3\x98\a\x98\x969\n\x98\f"+
+		"\x98\xE\x98\x96C\v\x98\x5\x98\x96E\n\x98\x3\x98\x5\x98\x971\n\x98\x3\x98"+
+		"\x3\x98\x3\x99\x3\x99\x5\x99\x977\n\x99\x3\x99\x3\x99\x5\x99\x97B\n\x99"+
+		"\x3\x99\x3\x99\x5\x99\x97F\n\x99\x3\x99\x3\x99\x5\x99\x983\n\x99\x3\x99"+
+		"\x5\x99\x986\n\x99\x3\x99\x3\x99\x5\x99\x98A\n\x99\x3\x99\x5\x99\x98D"+
+		"\n\x99\x3\x99\x5\x99\x990\n\x99\x3\x99\x5\x99\x993\n\x99\x3\x99\x5\x99"+
+		"\x996\n\x99\x3\x99\x5\x99\x999\n\x99\x3\x9A\x3\x9A\x5\x9A\x99D\n\x9A\x3"+
+		"\x9A\x3\x9A\x3\x9B\x3\x9B\x5\x9B\x9A3\n\x9B\x3\x9B\x3\x9B\x5\x9B\x9A7"+
+		"\n\x9B\x3\x9B\a\x9B\x9AA\n\x9B\f\x9B\xE\x9B\x9AD\v\x9B\x3\x9C\x3\x9C\x3"+
+		"\x9C\x3\x9C\x3\x9C\x5\x9C\x9B4\n\x9C\x3\x9C\x3\x9C\x3\x9D\x3\x9D\x3\x9D"+
+		"\x5\x9D\x9BB\n\x9D\x3\x9E\x3\x9E\x5\x9E\x9BF\n\x9E\x3\x9F\x3\x9F\x5\x9F"+
+		"\x9C3\n\x9F\x3\x9F\x3\x9F\x5\x9F\x9C7\n\x9F\x3\x9F\x3\x9F\x5\x9F\x9CB"+
+		"\n\x9F\x3\x9F\x5\x9F\x9CE\n\x9F\x3\xA0\x3\xA0\x3\xA1\x3\xA1\x3\xA2\x3"+
+		"\xA2\x3\xA2\a\xA2\x9D7\n\xA2\f\xA2\xE\xA2\x9DA\v\xA2\x3\xA3\x3\xA3\x5"+
+		"\xA3\x9DE\n\xA3\x3\xA3\x3\xA3\x5\xA3\x9E2\n\xA3\x3\xA4\x3\xA4\x5\xA4\x9E6"+
+		"\n\xA4\x3\xA4\x3\xA4\x3\xA5\x3\xA5\x5\xA5\x9EC\n\xA5\x3\xA6\x3\xA6\x3"+
+		"\xA7\x3\xA7\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x5"+
+		"\xA8\x9FA\n\xA8\x3\xA9\x3\xA9\x3\xAA\x3\xAA\x5\xAA\xA00\n\xAA\x3\xAA\x5"+
+		"\xAA\xA03\n\xAA\x3\xAA\x3\xAA\x5\xAA\xA07\n\xAA\x3\xAA\x5\xAA\xA0A\n\xAA"+
+		"\x3\xAB\x3\xAB\x3\xAC\x3\xAC\x3\xAD\x3\xAD\x3\xAE\x3\xAE\x3\xAF\x3\xAF"+
+		"\x3\xB0\x5\xB0\xA17\n\xB0\x3\xB0\x5\xB0\xA1A\n\xB0\x3\xB1\x3\xB1\x3\xB1"+
+		"\x5\xB1\xA1F\n\xB1\x3\xB1\x5\xB1\xA22\n\xB1\x3\xB1\x3\xB1\x5\xB1\xA26"+
+		"\n\xB1\x5\xB1\xA28\n\xB1\a\xB1\xA2A\n\xB1\f\xB1\xE\xB1\xA2D\v\xB1\x3\xB1"+
+		"\x3\xB1\x3\xB1\x5\xB1\xA32\n\xB1\x3\xB2\x3\xB2\x3\xB2\x5\xB2\xA37\n\xB2"+
+		"\x3\xB3\x3\xB3\x5\xB3\xA3B\n\xB3\x3\xB3\x3\xB3\x3\xB4\x3\xB4\x3\xB4\x3"+
+		"\xB5\x3\xB5\a\xB5\xA44\n\xB5\f\xB5\xE\xB5\xA47\v\xB5\x3\xB6\x3\xB6\x3"+
+		"\xB6\x3\xB6\x5\xB6\xA4D\n\xB6\x6\xB6\xA4F\n\xB6\r\xB6\xE\xB6\xA50\x3\xB7"+
+		"\x3\xB7\x5\xB7\xA55\n\xB7\x3\xB8\x3\xB8\x3\xB9\x3\xB9\x3\xB9\x3\xB9\x3"+
+		"\xB9\x3\xB9\x5\xB9\xA5F\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA63\n\xB9\x3\xB9\x6"+
+		"\xB9\xA66\n\xB9\r\xB9\xE\xB9\xA67\x3\xB9\x5\xB9\xA6B\n\xB9\x3\xB9\x3\xB9"+
+		"\x5\xB9\xA6F\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA73\n\xB9\x3\xB9\x3\xB9\x5\xB9"+
+		"\xA77\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA7B\n\xB9\x3\xB9\x3\xB9\x3\xB9\x5\xB9"+
+		"\xA80\n\xB9\x3\xB9\x3\xB9\x3\xB9\x5\xB9\xA85\n\xB9\x3\xB9\x3\xB9\x5\xB9"+
+		"\xA89\n\xB9\x3\xB9\x6\xB9\xA8C\n\xB9\r\xB9\xE\xB9\xA8D\x3\xB9\x5\xB9\xA91"+
+		"\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA95\n\xB9\x3\xBA\x3\xBA\x3\xBB\x6\xBB\xA9A"+
+		"\n\xBB\r\xBB\xE\xBB\xA9B\x3\xBB\x2\x2\x3\xFE\xBC\x2\x2\x4\x2\x6\x2\b\x2"+
 		"\n\x2\f\x2\xE\x2\x10\x2\x12\x2\x14\x2\x16\x2\x18\x2\x1A\x2\x1C\x2\x1E"+
 		"\x2 \x2\"\x2$\x2&\x2(\x2*\x2,\x2.\x2\x30\x2\x32\x2\x34\x2\x36\x2\x38\x2"+
 		":\x2<\x2>\x2@\x2\x42\x2\x44\x2\x46\x2H\x2J\x2L\x2N\x2P\x2R\x2T\x2V\x2"+
@@ -16079,988 +17790,1033 @@ public partial class VBAParser : Parser {
 		"\xF2\x2\xF4\x2\xF6\x2\xF8\x2\xFA\x2\xFC\x2\xFE\x2\x100\x2\x102\x2\x104"+
 		"\x2\x106\x2\x108\x2\x10A\x2\x10C\x2\x10E\x2\x110\x2\x112\x2\x114\x2\x116"+
 		"\x2\x118\x2\x11A\x2\x11C\x2\x11E\x2\x120\x2\x122\x2\x124\x2\x126\x2\x128"+
-		"\x2\x12A\x2\x12C\x2\x12E\x2\x130\x2\x132\x2\x134\x2\x136\x2\x2\x1B\x5"+
-		"\x2;;\x45\x45\xBC\xBC\x4\x2rr\xBA\xBA\x3\x2HT\x4\x2\xC3\xC3\xC7\xC7\x3"+
-		"\x2jn\x3\x2\x92\x93\a\x2\x38\x38;;{{\x9B\x9B\xA6\xA6\x4\x2\xA8\xA9\xCB"+
-		"\xCB\x4\x2\x85\x87\xB3\xB3\x4\x2))++\x4\x2\xB5\xB5\xBB\xBB\x4\x2\xCE\xCE"+
-		"\xD7\xD7\x4\x2\xD6\xD6\xD9\xD9\a\x2||\x83\x83\xD0\xD3\xD5\xD5\xD8\xD8"+
-		"\x3\x2,-\x4\x2=>\x9C\x9C\x3\x2=>\r\x2\x13\x13\x1F <<??\x46\x46WW}}\x7F"+
-		"\x7F\xB4\xB4\xB9\xB9\xC4\xC4\x3\x2\xE4\xE7\x5\x2,,.\x32\xDA\xDA\x6\x2"+
-		"pptt\x9F\x9F\xA4\xA4%\x2\x3\x17\x19#%(\x33\x38:?\x42\x42\x45\x46WW``\x63"+
-		"\x64\x66\x66hhjoxxzz|}\x7F\x7F\x82\x87\x89\x8B\x8D\x90\x92\x92\x95\x95"+
-		"\x9A\x9D\xA6\xA6\xA8\xA9\xAB\xAC\xB3\xB5\xB7\xB7\xB9\xB9\xBB\xBF\xC1\xC1"+
-		"\xC3\xC5\xC8\xC8\xCA\xCC\xF1\xF7!\x2\x18\x18$$@\x41\x43\x44GVYZ\x65\x65"+
-		"ggiipwyy{{~~\x80\x81\x88\x88\x8C\x8C\x91\x91\x94\x94\x9E\x9F\xA4\xA5\xA7"+
-		"\xA7\xAA\xAA\xAD\xB2\xB6\xB6\xB8\xB8\xBA\xBA\xC0\xC0\xC2\xC2\xC6\xC7\xC9"+
-		"\xC9\xCB\xCB\x3\x2\xE9\xE9\x4\x2\xEC\xEC\xEF\xEF\xB9A\x2\x138\x3\x2\x2"+
-		"\x2\x4\x13B\x3\x2\x2\x2\x6\x154\x3\x2\x2\x2\b\x15F\x3\x2\x2\x2\n\x171"+
-		"\x3\x2\x2\x2\f\x189\x3\x2\x2\x2\xE\x18D\x3\x2\x2\x2\x10\x1A2\x3\x2\x2"+
-		"\x2\x12\x1AD\x3\x2\x2\x2\x14\x1AF\x3\x2\x2\x2\x16\x1BF\x3\x2\x2\x2\x18"+
-		"\x1C1\x3\x2\x2\x2\x1A\x1D9\x3\x2\x2\x2\x1C\x1DB\x3\x2\x2\x2\x1E\x1DD\x3"+
-		"\x2\x2\x2 \x217\x3\x2\x2\x2\"\x219\x3\x2\x2\x2$\x22E\x3\x2\x2\x2&\x240"+
-		"\x3\x2\x2\x2(\x255\x3\x2\x2\x2*\x279\x3\x2\x2\x2,\x289\x3\x2\x2\x2.\x28E"+
-		"\x3\x2\x2\x2\x30\x290\x3\x2\x2\x2\x32\x292\x3\x2\x2\x2\x34\x29C\x3\x2"+
-		"\x2\x2\x36\x29F\x3\x2\x2\x2\x38\x2A2\x3\x2\x2\x2:\x2AC\x3\x2\x2\x2<\x2AE"+
-		"\x3\x2\x2\x2>\x2CD\x3\x2\x2\x2@\x2D2\x3\x2\x2\x2\x42\x2E0\x3\x2\x2\x2"+
-		"\x44\x2ED\x3\x2\x2\x2\x46\x2EF\x3\x2\x2\x2H\x2FF\x3\x2\x2\x2J\x306\x3"+
-		"\x2\x2\x2L\x310\x3\x2\x2\x2N\x312\x3\x2\x2\x2P\x325\x3\x2\x2\x2R\x348"+
-		"\x3\x2\x2\x2T\x368\x3\x2\x2\x2V\x36A\x3\x2\x2\x2X\x380\x3\x2\x2\x2Z\x384"+
-		"\x3\x2\x2\x2\\\x388\x3\x2\x2\x2^\x3B0\x3\x2\x2\x2`\x3B2\x3\x2\x2\x2\x62"+
-		"\x3B9\x3\x2\x2\x2\x64\x3BB\x3\x2\x2\x2\x66\x3CD\x3\x2\x2\x2h\x3DC\x3\x2"+
-		"\x2\x2j\x409\x3\x2\x2\x2l\x40B\x3\x2\x2\x2n\x40D\x3\x2\x2\x2p\x40F\x3"+
-		"\x2\x2\x2r\x413\x3\x2\x2\x2t\x424\x3\x2\x2\x2v\x430\x3\x2\x2\x2x\x43C"+
-		"\x3\x2\x2\x2z\x450\x3\x2\x2\x2|\x45C\x3\x2\x2\x2~\x46A\x3\x2\x2\x2\x80"+
-		"\x476\x3\x2\x2\x2\x82\x48A\x3\x2\x2\x2\x84\x49E\x3\x2\x2\x2\x86\x4E3\x3"+
-		"\x2\x2\x2\x88\x4F6\x3\x2\x2\x2\x8A\x4F8\x3\x2\x2\x2\x8C\x508\x3\x2\x2"+
-		"\x2\x8E\x528\x3\x2\x2\x2\x90\x540\x3\x2\x2\x2\x92\x555\x3\x2\x2\x2\x94"+
-		"\x56B\x3\x2\x2\x2\x96\x57E\x3\x2\x2\x2\x98\x592\x3\x2\x2\x2\x9A\x5A4\x3"+
-		"\x2\x2\x2\x9C\x5A6\x3\x2\x2\x2\x9E\x5AE\x3\x2\x2\x2\xA0\x5B0\x3\x2\x2"+
-		"\x2\xA2\x5BC\x3\x2\x2\x2\xA4\x5BE\x3\x2\x2\x2\xA6\x5CA\x3\x2\x2\x2\xA8"+
-		"\x5E9\x3\x2\x2\x2\xAA\x5EB\x3\x2\x2\x2\xAC\x601\x3\x2\x2\x2\xAE\x603\x3"+
-		"\x2\x2\x2\xB0\x612\x3\x2\x2\x2\xB2\x629\x3\x2\x2\x2\xB4\x62E\x3\x2\x2"+
-		"\x2\xB6\x63C\x3\x2\x2\x2\xB8\x654\x3\x2\x2\x2\xBA\x695\x3\x2\x2\x2\xBC"+
-		"\x708\x3\x2\x2\x2\xBE\x715\x3\x2\x2\x2\xC0\x71E\x3\x2\x2\x2\xC2\x72C\x3"+
-		"\x2\x2\x2\xC4\x748\x3\x2\x2\x2\xC6\x751\x3\x2\x2\x2\xC8\x75D\x3\x2\x2"+
-		"\x2\xCA\x766\x3\x2\x2\x2\xCC\x768\x3\x2\x2\x2\xCE\x776\x3\x2\x2\x2\xD0"+
-		"\x77A\x3\x2\x2\x2\xD2\x7C0\x3\x2\x2\x2\xD4\x7C4\x3\x2\x2\x2\xD6\x7C7\x3"+
-		"\x2\x2\x2\xD8\x7EB\x3\x2\x2\x2\xDA\x801\x3\x2\x2\x2\xDC\x803\x3\x2\x2"+
-		"\x2\xDE\x81B\x3\x2\x2\x2\xE0\x840\x3\x2\x2\x2\xE2\x858\x3\x2\x2\x2\xE4"+
-		"\x87F\x3\x2\x2\x2\xE6\x89B\x3\x2\x2\x2\xE8\x8A4\x3\x2\x2\x2\xEA\x8B4\x3"+
-		"\x2\x2\x2\xEC\x8C8\x3\x2\x2\x2\xEE\x8D3\x3\x2\x2\x2\xF0\x8DB\x3\x2\x2"+
-		"\x2\xF2\x8F6\x3\x2\x2\x2\xF4\x91A\x3\x2\x2\x2\xF6\x920\x3\x2\x2\x2\xF8"+
-		"\x933\x3\x2\x2\x2\xFA\x93A\x3\x2\x2\x2\xFC\x93E\x3\x2\x2\x2\xFE\x940\x3"+
-		"\x2\x2\x2\x100\x94F\x3\x2\x2\x2\x102\x951\x3\x2\x2\x2\x104\x953\x3\x2"+
-		"\x2\x2\x106\x95B\x3\x2\x2\x2\x108\x963\x3\x2\x2\x2\x10A\x96B\x3\x2\x2"+
-		"\x2\x10C\x96D\x3\x2\x2\x2\x10E\x96F\x3\x2\x2\x2\x110\x979\x3\x2\x2\x2"+
-		"\x112\x97B\x3\x2\x2\x2\x114\x97F\x3\x2\x2\x2\x116\x98B\x3\x2\x2\x2\x118"+
-		"\x98D\x3\x2\x2\x2\x11A\x98F\x3\x2\x2\x2\x11C\x991\x3\x2\x2\x2\x11E\x993"+
-		"\x3\x2\x2\x2\x120\x996\x3\x2\x2\x2\x122\x9B1\x3\x2\x2\x2\x124\x9B6\x3"+
-		"\x2\x2\x2\x126\x9B8\x3\x2\x2\x2\x128\x9BE\x3\x2\x2\x2\x12A\x9C5\x3\x2"+
-		"\x2\x2\x12C\x9C8\x3\x2\x2\x2\x12E\x9D2\x3\x2\x2\x2\x130\x9D6\x3\x2\x2"+
-		"\x2\x132\xA14\x3\x2\x2\x2\x134\xA16\x3\x2\x2\x2\x136\xA19\x3\x2\x2\x2"+
-		"\x138\x139\x5\x4\x3\x2\x139\x3\x3\x2\x2\x2\x13A\x13C\x5\x136\x9C\x2\x13B"+
-		"\x13A\x3\x2\x2\x2\x13B\x13C\x3\x2\x2\x2\x13C\x13D\x3\x2\x2\x2\x13D\x141"+
-		"\x5\x122\x92\x2\x13E\x13F\x5\x6\x4\x2\x13F\x140\x5\x122\x92\x2\x140\x142"+
-		"\x3\x2\x2\x2\x141\x13E\x3\x2\x2\x2\x141\x142\x3\x2\x2\x2\x142\x144\x3"+
-		"\x2\x2\x2\x143\x145\x5\b\x5\x2\x144\x143\x3\x2\x2\x2\x144\x145\x3\x2\x2"+
-		"\x2\x145\x146\x3\x2\x2\x2\x146\x148\x5\x122\x92\x2\x147\x149\x5\f\a\x2"+
-		"\x148\x147\x3\x2\x2\x2\x148\x149\x3\x2\x2\x2\x149\x14A\x3\x2\x2\x2\x14A"+
-		"\x14C\x5\x122\x92\x2\x14B\x14D\x5\xE\b\x2\x14C\x14B\x3\x2\x2\x2\x14C\x14D"+
-		"\x3\x2\x2\x2\x14D\x14E\x3\x2\x2\x2\x14E\x150\x5\x122\x92\x2\x14F\x151"+
-		"\x5\x14\v\x2\x150\x14F\x3\x2\x2\x2\x150\x151\x3\x2\x2\x2\x151\x152\x3"+
-		"\x2\x2\x2\x152\x153\x5\x122\x92\x2\x153\x5\x3\x2\x2\x2\x154\x155\a\xC5"+
-		"\x2\x2\x155\x156\x5\x136\x9C\x2\x156\x158\x5\x112\x8A\x2\x157\x159\x5"+
-		"\x136\x9C\x2\x158\x157\x3\x2\x2\x2\x158\x159\x3\x2\x2\x2\x159\x15B\x3"+
-		"\x2\x2\x2\x15A\x15C\a\x42\x2\x2\x15B\x15A\x3\x2\x2\x2\x15B\x15C\x3\x2"+
-		"\x2\x2\x15C\x15D\x3\x2\x2\x2\x15D\x15E\x5\x122\x92\x2\x15E\a\x3\x2\x2"+
-		"\x2\x15F\x167\a:\x2\x2\x160\x161\x5\x136\x9C\x2\x161\x162\a\xED\x2\x2"+
-		"\x162\x163\x5\x136\x9C\x2\x163\x165\x5\xFA~\x2\x164\x166\x5\x136\x9C\x2"+
-		"\x165\x164\x3\x2\x2\x2\x165\x166\x3\x2\x2\x2\x166\x168\x3\x2\x2\x2\x167"+
-		"\x160\x3\x2\x2\x2\x167\x168\x3\x2\x2\x2\x168\x169\x3\x2\x2\x2\x169\x16B"+
-		"\x5\x122\x92\x2\x16A\x16C\x5\n\x6\x2\x16B\x16A\x3\x2\x2\x2\x16C\x16D\x3"+
-		"\x2\x2\x2\x16D\x16B\x3\x2\x2\x2\x16D\x16E\x3\x2\x2\x2\x16E\x16F\x3\x2"+
-		"\x2\x2\x16F\x170\a\x64\x2\x2\x170\t\x3\x2\x2\x2\x171\x175\x5\xFA~\x2\x172"+
-		"\x174\x5\x136\x9C\x2\x173\x172\x3\x2\x2\x2\x174\x177\x3\x2\x2\x2\x175"+
-		"\x173\x3\x2\x2\x2\x175\x176\x3\x2\x2\x2\x176\x178\x3\x2\x2\x2\x177\x175"+
-		"\x3\x2\x2\x2\x178\x17C\a\xD0\x2\x2\x179\x17B\x5\x136\x9C\x2\x17A\x179"+
-		"\x3\x2\x2\x2\x17B\x17E\x3\x2\x2\x2\x17C\x17A\x3\x2\x2\x2\x17C\x17D\x3"+
-		"\x2\x2\x2\x17D\x17F\x3\x2\x2\x2\x17E\x17C\x3\x2\x2\x2\x17F\x182\x5\xBA"+
-		"^\x2\x180\x181\a*\x2\x2\x181\x183\x5\x112\x8A\x2\x182\x180\x3\x2\x2\x2"+
-		"\x182\x183\x3\x2\x2\x2\x183\x184\x3\x2\x2\x2\x184\x185\x5\x122\x92\x2"+
-		"\x185\v\x3\x2\x2\x2\x186\x187\x5\x18\r\x2\x187\x188\x5\x122\x92\x2\x188"+
-		"\x18A\x3\x2\x2\x2\x189\x186\x3\x2\x2\x2\x18A\x18B\x3\x2\x2\x2\x18B\x189"+
-		"\x3\x2\x2\x2\x18B\x18C\x3\x2\x2\x2\x18C\r\x3\x2\x2\x2\x18D\x193\x5\x12"+
-		"\n\x2\x18E\x18F\x5\x122\x92\x2\x18F\x190\x5\x12\n\x2\x190\x192\x3\x2\x2"+
-		"\x2\x191\x18E\x3\x2\x2\x2\x192\x195\x3\x2\x2\x2\x193\x191\x3\x2\x2\x2"+
-		"\x193\x194\x3\x2\x2\x2\x194\x196\x3\x2\x2\x2\x195\x193\x3\x2\x2\x2\x196"+
-		"\x197\x5\x122\x92\x2\x197\xF\x3\x2\x2\x2\x198\x199\a\x96\x2\x2\x199\x19A"+
-		"\x5\x136\x9C\x2\x19A\x19B\x5\x112\x8A\x2\x19B\x1A3\x3\x2\x2\x2\x19C\x19D"+
-		"\a\x98\x2\x2\x19D\x19E\x5\x136\x9C\x2\x19E\x19F\t\x2\x2\x2\x19F\x1A3\x3"+
-		"\x2\x2\x2\x1A0\x1A3\a\x97\x2\x2\x1A1\x1A3\a\x99\x2\x2\x1A2\x198\x3\x2"+
-		"\x2\x2\x1A2\x19C\x3\x2\x2\x2\x1A2\x1A0\x3\x2\x2\x2\x1A2\x1A1\x3\x2\x2"+
-		"\x2\x1A3\x11\x3\x2\x2\x2\x1A4\x1AE\x5(\x15\x2\x1A5\x1AE\x5*\x16\x2\x1A6"+
-		"\x1AE\x5@!\x2\x1A7\x1AE\x5J&\x2\x1A8\x1AE\x5$\x13\x2\x1A9\x1AE\x5p\x39"+
-		"\x2\x1AA\x1AE\x5\xBE`\x2\x1AB\x1AE\x5\x10\t\x2\x1AC\x1AE\x5\xB4[\x2\x1AD"+
-		"\x1A4\x3\x2\x2\x2\x1AD\x1A5\x3\x2\x2\x2\x1AD\x1A6\x3\x2\x2\x2\x1AD\x1A7"+
-		"\x3\x2\x2\x2\x1AD\x1A8\x3\x2\x2\x2\x1AD\x1A9\x3\x2\x2\x2\x1AD\x1AA\x3"+
-		"\x2\x2\x2\x1AD\x1AB\x3\x2\x2\x2\x1AD\x1AC\x3\x2\x2\x2\x1AE\x13\x3\x2\x2"+
-		"\x2\x1AF\x1B5\x5\x16\f\x2\x1B0\x1B1\x5\x122\x92\x2\x1B1\x1B2\x5\x16\f"+
-		"\x2\x1B2\x1B4\x3\x2\x2\x2\x1B3\x1B0\x3\x2\x2\x2\x1B4\x1B7\x3\x2\x2\x2"+
-		"\x1B5\x1B3\x3\x2\x2\x2\x1B5\x1B6\x3\x2\x2\x2\x1B6\x1B8\x3\x2\x2\x2\x1B7"+
-		"\x1B5\x3\x2\x2\x2\x1B8\x1B9\x5\x122\x92\x2\x1B9\x15\x3\x2\x2\x2\x1BA\x1C0"+
-		"\x5R*\x2\x1BB\x1C0\x5\x8CG\x2\x1BC\x1C0\x5\x8EH\x2\x1BD\x1C0\x5\x90I\x2"+
-		"\x1BE\x1C0\x5\xB0Y\x2\x1BF\x1BA\x3\x2\x2\x2\x1BF\x1BB\x3\x2\x2\x2\x1BF"+
-		"\x1BC\x3\x2\x2\x2\x1BF\x1BD\x3\x2\x2\x2\x1BF\x1BE\x3\x2\x2\x2\x1C0\x17"+
-		"\x3\x2\x2\x2\x1C1\x1C2\a\x37\x2\x2\x1C2\x1C3\x5\x136\x9C\x2\x1C3\x1C5"+
-		"\x5\x1A\xE\x2\x1C4\x1C6\x5\x136\x9C\x2\x1C5\x1C4\x3\x2\x2\x2\x1C5\x1C6"+
-		"\x3\x2\x2\x2\x1C6\x1C7\x3\x2\x2\x2\x1C7\x1C9\a\xD0\x2\x2\x1C8\x1CA\x5"+
-		"\x136\x9C\x2\x1C9\x1C8\x3\x2\x2\x2\x1C9\x1CA\x3\x2\x2\x2\x1CA\x1CB\x3"+
-		"\x2\x2\x2\x1CB\x1D6\x5\x1C\xF\x2\x1CC\x1CE\x5\x136\x9C\x2\x1CD\x1CC\x3"+
-		"\x2\x2\x2\x1CD\x1CE\x3\x2\x2\x2\x1CE\x1CF\x3\x2\x2\x2\x1CF\x1D1\a)\x2"+
-		"\x2\x1D0\x1D2\x5\x136\x9C\x2\x1D1\x1D0\x3\x2\x2\x2\x1D1\x1D2\x3\x2\x2"+
-		"\x2\x1D2\x1D3\x3\x2\x2\x2\x1D3\x1D5\x5\x1C\xF\x2\x1D4\x1CD\x3\x2\x2\x2"+
-		"\x1D5\x1D8\x3\x2\x2\x2\x1D6\x1D4\x3\x2\x2\x2\x1D6\x1D7\x3\x2\x2\x2\x1D7"+
-		"\x19\x3\x2\x2\x2\x1D8\x1D6\x3\x2\x2\x2\x1D9\x1DA\x5\xDAn\x2\x1DA\x1B\x3"+
-		"\x2\x2\x2\x1DB\x1DC\x5\xBA^\x2\x1DC\x1D\x3\x2\x2\x2\x1DD\x1E3\x5 \x11"+
-		"\x2\x1DE\x1DF\x5\x122\x92\x2\x1DF\x1E0\x5 \x11\x2\x1E0\x1E2\x3\x2\x2\x2"+
-		"\x1E1\x1DE\x3\x2\x2\x2\x1E2\x1E5\x3\x2\x2\x2\x1E3\x1E1\x3\x2\x2\x2\x1E3"+
-		"\x1E4\x3\x2\x2\x2\x1E4\x1E6\x3\x2\x2\x2\x1E5\x1E3\x3\x2\x2\x2\x1E6\x1E7"+
-		"\x5\x122\x92\x2\x1E7\x1F\x3\x2\x2\x2\x1E8\x218\x5\x108\x85\x2\x1E9\x218"+
-		"\x5\x18\r\x2\x1EA\x218\x5\"\x12\x2\x1EB\x218\x5$\x13\x2\x1EC\x218\x5>"+
-		" \x2\x1ED\x218\x5\x44#\x2\x1EE\x218\x5\x46$\x2\x1EF\x218\x5H%\x2\x1F0"+
-		"\x218\x5L\'\x2\x1F1\x218\x5\xD0i\x2\x1F2\x218\x5N(\x2\x1F3\x218\x5P)\x2"+
-		"\x1F4\x218\x5V,\x2\x1F5\x218\x5X-\x2\x1F6\x218\x5Z.\x2\x1F7\x218\x5\\"+
-		"/\x2\x1F8\x218\x5\x62\x32\x2\x1F9\x218\x5p\x39\x2\x1FA\x218\x5r:\x2\x1FB"+
-		"\x218\x5t;\x2\x1FC\x218\x5v<\x2\x1FD\x218\x5x=\x2\x1FE\x218\x5z>\x2\x1FF"+
-		"\x218\x5|?\x2\x200\x218\x5~@\x2\x201\x218\x5\x80\x41\x2\x202\x218\x5\x82"+
-		"\x42\x2\x203\x218\x5\x84\x43\x2\x204\x218\x5\x8A\x46\x2\x205\x218\x5\x92"+
-		"J\x2\x206\x218\x5\x94K\x2\x207\x218\x5\x96L\x2\x208\x218\x5\x9AN\x2\x209"+
-		"\x218\x5\x9CO\x2\x20A\x218\x5\x9EP\x2\x20B\x218\x5\xA0Q\x2\x20C\x218\x5"+
-		"\xA4S\x2\x20D\x218\x5\xA6T\x2\x20E\x218\x5\xAEX\x2\x20F\x218\x5\xA2R\x2"+
-		"\x210\x218\x5\xB8]\x2\x211\x218\x5\xBE`\x2\x212\x218\x5\xC4\x63\x2\x213"+
-		"\x218\x5\xC6\x64\x2\x214\x218\x5\xC8\x65\x2\x215\x218\x5\xCCg\x2\x216"+
-		"\x218\x5\xD4k\x2\x217\x1E8\x3\x2\x2\x2\x217\x1E9\x3\x2\x2\x2\x217\x1EA"+
-		"\x3\x2\x2\x2\x217\x1EB\x3\x2\x2\x2\x217\x1EC\x3\x2\x2\x2\x217\x1ED\x3"+
-		"\x2\x2\x2\x217\x1EE\x3\x2\x2\x2\x217\x1EF\x3\x2\x2\x2\x217\x1F0\x3\x2"+
-		"\x2\x2\x217\x1F1\x3\x2\x2\x2\x217\x1F2\x3\x2\x2\x2\x217\x1F3\x3\x2\x2"+
-		"\x2\x217\x1F4\x3\x2\x2\x2\x217\x1F5\x3\x2\x2\x2\x217\x1F6\x3\x2\x2\x2"+
-		"\x217\x1F7\x3\x2\x2\x2\x217\x1F8\x3\x2\x2\x2\x217\x1F9\x3\x2\x2\x2\x217"+
-		"\x1FA\x3\x2\x2\x2\x217\x1FB\x3\x2\x2\x2\x217\x1FC\x3\x2\x2\x2\x217\x1FD"+
-		"\x3\x2\x2\x2\x217\x1FE\x3\x2\x2\x2\x217\x1FF\x3\x2\x2\x2\x217\x200\x3"+
-		"\x2\x2\x2\x217\x201\x3\x2\x2\x2\x217\x202\x3\x2\x2\x2\x217\x203\x3\x2"+
-		"\x2\x2\x217\x204\x3\x2\x2\x2\x217\x205\x3\x2\x2\x2\x217\x206\x3\x2\x2"+
-		"\x2\x217\x207\x3\x2\x2\x2\x217\x208\x3\x2\x2\x2\x217\x209\x3\x2\x2\x2"+
-		"\x217\x20A\x3\x2\x2\x2\x217\x20B\x3\x2\x2\x2\x217\x20C\x3\x2\x2\x2\x217"+
-		"\x20D\x3\x2\x2\x2\x217\x20E\x3\x2\x2\x2\x217\x20F\x3\x2\x2\x2\x217\x210"+
-		"\x3\x2\x2\x2\x217\x211\x3\x2\x2\x2\x217\x212\x3\x2\x2\x2\x217\x213\x3"+
-		"\x2\x2\x2\x217\x214\x3\x2\x2\x2\x217\x215\x3\x2\x2\x2\x217\x216\x3\x2"+
-		"\x2\x2\x218!\x3\x2\x2\x2\x219\x229\a\x43\x2\x2\x21A\x21B\x5\x136\x9C\x2"+
-		"\x21B\x226\x5\xCEh\x2\x21C\x21E\x5\x136\x9C\x2\x21D\x21C\x3\x2\x2\x2\x21D"+
-		"\x21E\x3\x2\x2\x2\x21E\x21F\x3\x2\x2\x2\x21F\x221\a)\x2\x2\x220\x222\x5"+
-		"\x136\x9C\x2\x221\x220\x3\x2\x2\x2\x221\x222\x3\x2\x2\x2\x222\x223\x3"+
-		"\x2\x2\x2\x223\x225\x5\xCEh\x2\x224\x21D\x3\x2\x2\x2\x225\x228\x3\x2\x2"+
-		"\x2\x226\x224\x3\x2\x2\x2\x226\x227\x3\x2\x2\x2\x227\x22A\x3\x2\x2\x2"+
-		"\x228\x226\x3\x2\x2\x2\x229\x21A\x3\x2\x2\x2\x229\x22A\x3\x2\x2\x2\x22A"+
-		"#\x3\x2\x2\x2\x22B\x22C\x5\x118\x8D\x2\x22C\x22D\x5\x136\x9C\x2\x22D\x22F"+
-		"\x3\x2\x2\x2\x22E\x22B\x3\x2\x2\x2\x22E\x22F\x3\x2\x2\x2\x22F\x230\x3"+
-		"\x2\x2\x2\x230\x231\a\x44\x2\x2\x231\x232\x5\x136\x9C\x2\x232\x23D\x5"+
-		"&\x14\x2\x233\x235\x5\x136\x9C\x2\x234\x233\x3\x2\x2\x2\x234\x235\x3\x2"+
-		"\x2\x2\x235\x236\x3\x2\x2\x2\x236\x238\a)\x2\x2\x237\x239\x5\x136\x9C"+
-		"\x2\x238\x237\x3\x2\x2\x2\x238\x239\x3\x2\x2\x2\x239\x23A\x3\x2\x2\x2"+
-		"\x23A\x23C\x5&\x14\x2\x23B\x234\x3\x2\x2\x2\x23C\x23F\x3\x2\x2\x2\x23D"+
-		"\x23B\x3\x2\x2\x2\x23D\x23E\x3\x2\x2\x2\x23E%\x3\x2\x2\x2\x23F\x23D\x3"+
-		"\x2\x2\x2\x240\x242\x5\xFC\x7F\x2\x241\x243\x5\x116\x8C\x2\x242\x241\x3"+
-		"\x2\x2\x2\x242\x243\x3\x2\x2\x2\x243\x247\x3\x2\x2\x2\x244\x245\x5\x136"+
-		"\x9C\x2\x245\x246\x5\xFE\x80\x2\x246\x248\x3\x2\x2\x2\x247\x244\x3\x2"+
-		"\x2\x2\x247\x248\x3\x2\x2\x2\x248\x24A\x3\x2\x2\x2\x249\x24B\x5\x136\x9C"+
-		"\x2\x24A\x249\x3\x2\x2\x2\x24A\x24B\x3\x2\x2\x2\x24B\x24C\x3\x2\x2\x2"+
-		"\x24C\x24E\a\xD0\x2\x2\x24D\x24F\x5\x136\x9C\x2\x24E\x24D\x3\x2\x2\x2"+
-		"\x24E\x24F\x3\x2\x2\x2\x24F\x250\x3\x2\x2\x2\x250\x251\x5\xBA^\x2\x251"+
-		"\'\x3\x2\x2\x2\x252\x253\x5\x118\x8D\x2\x253\x254\x5\x136\x9C\x2\x254"+
-		"\x256\x3\x2\x2\x2\x255\x252\x3\x2\x2\x2\x255\x256\x3\x2\x2\x2\x256\x257"+
-		"\x3\x2\x2\x2\x257\x258\aG\x2\x2\x258\x25B\x5\x136\x9C\x2\x259\x25A\a\xA3"+
-		"\x2\x2\x25A\x25C\x5\x136\x9C\x2\x25B\x259\x3\x2\x2\x2\x25B\x25C\x3\x2"+
-		"\x2\x2\x25C\x25D\x3\x2\x2\x2\x25D\x25E\t\x3\x2\x2\x25E\x25F\x5\x136\x9C"+
-		"\x2\x25F\x261\x5\xFC\x7F\x2\x260\x262\x5\x116\x8C\x2\x261\x260\x3\x2\x2"+
-		"\x2\x261\x262\x3\x2\x2\x2\x262\x263\x3\x2\x2\x2\x263\x264\x5\x136\x9C"+
-		"\x2\x264\x265\a\x82\x2\x2\x265\x266\x5\x136\x9C\x2\x266\x26C\a\xE3\x2"+
-		"\x2\x267\x268\x5\x136\x9C\x2\x268\x269\a\x35\x2\x2\x269\x26A\x5\x136\x9C"+
-		"\x2\x26A\x26B\a\xE3\x2\x2\x26B\x26D\x3\x2\x2\x2\x26C\x267\x3\x2\x2\x2"+
-		"\x26C\x26D\x3\x2\x2\x2\x26D\x272\x3\x2\x2\x2\x26E\x270\x5\x136\x9C\x2"+
-		"\x26F\x26E\x3\x2\x2\x2\x26F\x270\x3\x2\x2\x2\x270\x271\x3\x2\x2\x2\x271"+
-		"\x273\x5\xF0y\x2\x272\x26F\x3\x2\x2\x2\x272\x273\x3\x2\x2\x2\x273\x277"+
-		"\x3\x2\x2\x2\x274\x275\x5\x136\x9C\x2\x275\x276\x5\xFE\x80\x2\x276\x278"+
-		"\x3\x2\x2\x2\x277\x274\x3\x2\x2\x2\x277\x278\x3\x2\x2\x2\x278)\x3\x2\x2"+
-		"\x2\x279\x27A\x5,\x17\x2\x27A\x27B\x5\x136\x9C\x2\x27B\x286\x5.\x18\x2"+
-		"\x27C\x27E\x5\x136\x9C\x2\x27D\x27C\x3\x2\x2\x2\x27D\x27E\x3\x2\x2\x2"+
-		"\x27E\x27F\x3\x2\x2\x2\x27F\x281\a)\x2\x2\x280\x282\x5\x136\x9C\x2\x281"+
-		"\x280\x3\x2\x2\x2\x281\x282\x3\x2\x2\x2\x282\x283\x3\x2\x2\x2\x283\x285"+
-		"\x5.\x18\x2\x284\x27D\x3\x2\x2\x2\x285\x288\x3\x2\x2\x2\x286\x284\x3\x2"+
-		"\x2\x2\x286\x287\x3\x2\x2\x2\x287+\x3\x2\x2\x2\x288\x286\x3\x2\x2\x2\x289"+
-		"\x28A\t\x4\x2\x2\x28A-\x3\x2\x2\x2\x28B\x28F\x5\x30\x19\x2\x28C\x28F\x5"+
-		"\x32\x1A\x2\x28D\x28F\x5\x38\x1D\x2\x28E\x28B\x3\x2\x2\x2\x28E\x28C\x3"+
-		"\x2\x2\x2\x28E\x28D\x3\x2\x2\x2\x28F/\x3\x2\x2\x2\x290\x291\x5\xFA~\x2"+
-		"\x291\x31\x3\x2\x2\x2\x292\x294\x5\x34\x1B\x2\x293\x295\x5\x136\x9C\x2"+
-		"\x294\x293\x3\x2\x2\x2\x294\x295\x3\x2\x2\x2\x295\x296\x3\x2\x2\x2\x296"+
-		"\x298\a\xD6\x2\x2\x297\x299\x5\x136\x9C\x2\x298\x297\x3\x2\x2\x2\x298"+
-		"\x299\x3\x2\x2\x2\x299\x29A\x3\x2\x2\x2\x29A\x29B\x5\x36\x1C\x2\x29B\x33"+
-		"\x3\x2\x2\x2\x29C\x29D\x6\x1B\x2\x2\x29D\x29E\x5\xFA~\x2\x29E\x35\x3\x2"+
-		"\x2\x2\x29F\x2A0\x6\x1C\x3\x2\x2A0\x2A1\x5\xFA~\x2\x2A1\x37\x3\x2\x2\x2"+
-		"\x2A2\x2A4\x5:\x1E\x2\x2A3\x2A5\x5\x136\x9C\x2\x2A4\x2A3\x3\x2\x2\x2\x2A4"+
-		"\x2A5\x3\x2\x2\x2\x2A5\x2A6\x3\x2\x2\x2\x2A6\x2A8\a\xD6\x2\x2\x2A7\x2A9"+
-		"\x5\x136\x9C\x2\x2A8\x2A7\x3\x2\x2\x2\x2A8\x2A9\x3\x2\x2\x2\x2A9\x2AA"+
-		"\x3\x2\x2\x2\x2AA\x2AB\x5<\x1F\x2\x2AB\x39\x3\x2\x2\x2\x2AC\x2AD\x5\xFA"+
-		"~\x2\x2AD;\x3\x2\x2\x2\x2AE\x2AF\x5\xFA~\x2\x2AF=\x3\x2\x2\x2\x2B0\x2B1"+
-		"\aV\x2\x2\x2B1\x2B3\x5\x122\x92\x2\x2B2\x2B4\x5\x1E\x10\x2\x2B3\x2B2\x3"+
-		"\x2\x2\x2\x2B3\x2B4\x3\x2\x2\x2\x2B4\x2B5\x3\x2\x2\x2\x2B5\x2B6\a\x80"+
-		"\x2\x2\x2B6\x2CE\x3\x2\x2\x2\x2B7\x2B8\aV\x2\x2\x2B8\x2B9\x5\x136\x9C"+
-		"\x2\x2B9\x2BA\t\x5\x2\x2\x2BA\x2BB\x5\x136\x9C\x2\x2BB\x2BC\x5\xBA^\x2"+
-		"\x2BC\x2BE\x5\x122\x92\x2\x2BD\x2BF\x5\x1E\x10\x2\x2BE\x2BD\x3\x2\x2\x2"+
-		"\x2BE\x2BF\x3\x2\x2\x2\x2BF\x2C0\x3\x2\x2\x2\x2C0\x2C1\a\x80\x2\x2\x2C1"+
-		"\x2CE\x3\x2\x2\x2\x2C2\x2C3\aV\x2\x2\x2C3\x2C5\x5\x122\x92\x2\x2C4\x2C6"+
-		"\x5\x1E\x10\x2\x2C5\x2C4\x3\x2\x2\x2\x2C5\x2C6\x3\x2\x2\x2\x2C6\x2C7\x3"+
-		"\x2\x2\x2\x2C7\x2C8\a\x80\x2\x2\x2C8\x2C9\x5\x136\x9C\x2\x2C9\x2CA\t\x5"+
-		"\x2\x2\x2CA\x2CB\x5\x136\x9C\x2\x2CB\x2CC\x5\xBA^\x2\x2CC\x2CE\x3\x2\x2"+
-		"\x2\x2CD\x2B0\x3\x2\x2\x2\x2CD\x2B7\x3\x2\x2\x2\x2CD\x2C2\x3\x2\x2\x2"+
-		"\x2CE?\x3\x2\x2\x2\x2CF\x2D0\x5\x118\x8D\x2\x2D0\x2D1\x5\x136\x9C\x2\x2D1"+
-		"\x2D3\x3\x2\x2\x2\x2D2\x2CF\x3\x2\x2\x2\x2D2\x2D3\x3\x2\x2\x2\x2D3\x2D4"+
-		"\x3\x2\x2\x2\x2D4\x2D5\a\x65\x2\x2\x2D5\x2D6\x5\x136\x9C\x2\x2D6\x2D7"+
-		"\x5\xFC\x7F\x2\x2D7\x2DB\x5\x122\x92\x2\x2D8\x2DA\x5\x42\"\x2\x2D9\x2D8"+
-		"\x3\x2\x2\x2\x2DA\x2DD\x3\x2\x2\x2\x2DB\x2D9\x3\x2\x2\x2\x2DB\x2DC\x3"+
-		"\x2\x2\x2\x2DC\x2DE\x3\x2\x2\x2\x2DD\x2DB\x3\x2\x2\x2\x2DE\x2DF\a\\\x2"+
-		"\x2\x2DF\x41\x3\x2\x2\x2\x2E0\x2E9\x5\xFC\x7F\x2\x2E1\x2E3\x5\x136\x9C"+
-		"\x2\x2E2\x2E1\x3\x2\x2\x2\x2E2\x2E3\x3\x2\x2\x2\x2E3\x2E4\x3\x2\x2\x2"+
-		"\x2E4\x2E6\a\xD0\x2\x2\x2E5\x2E7\x5\x136\x9C\x2\x2E6\x2E5\x3\x2\x2\x2"+
-		"\x2E6\x2E7\x3\x2\x2\x2\x2E7\x2E8\x3\x2\x2\x2\x2E8\x2EA\x5\xBA^\x2\x2E9"+
-		"\x2E2\x3\x2\x2\x2\x2E9\x2EA\x3\x2\x2\x2\x2EA\x2EB\x3\x2\x2\x2\x2EB\x2EC"+
-		"\x5\x122\x92\x2\x2EC\x43\x3\x2\x2\x2\x2ED\x2EE\a\x64\x2\x2\x2EE\x45\x3"+
-		"\x2\x2\x2\x2EF\x2F0\ag\x2\x2\x2F0\x2F1\x5\x136\x9C\x2\x2F1\x2FC\x5\xBA"+
-		"^\x2\x2F2\x2F4\x5\x136\x9C\x2\x2F3\x2F2\x3\x2\x2\x2\x2F3\x2F4\x3\x2\x2"+
-		"\x2\x2F4\x2F5\x3\x2\x2\x2\x2F5\x2F7\a)\x2\x2\x2F6\x2F8\x5\x136\x9C\x2"+
-		"\x2F7\x2F6\x3\x2\x2\x2\x2F7\x2F8\x3\x2\x2\x2\x2F8\x2F9\x3\x2\x2\x2\x2F9"+
-		"\x2FB\x5\xBA^\x2\x2FA\x2F3\x3\x2\x2\x2\x2FB\x2FE\x3\x2\x2\x2\x2FC\x2FA"+
-		"\x3\x2\x2\x2\x2FC\x2FD\x3\x2\x2\x2\x2FDG\x3\x2\x2\x2\x2FE\x2FC\x3\x2\x2"+
-		"\x2\x2FF\x300\ah\x2\x2\x300\x301\x5\x136\x9C\x2\x301\x302\x5\xBA^\x2\x302"+
-		"I\x3\x2\x2\x2\x303\x304\x5\x118\x8D\x2\x304\x305\x5\x136\x9C\x2\x305\x307"+
-		"\x3\x2\x2\x2\x306\x303\x3\x2\x2\x2\x306\x307\x3\x2\x2\x2\x307\x308\x3"+
-		"\x2\x2\x2\x308\x309\ai\x2\x2\x309\x30A\x5\x136\x9C\x2\x30A\x30C\x5\xFC"+
-		"\x7F\x2\x30B\x30D\x5\x136\x9C\x2\x30C\x30B\x3\x2\x2\x2\x30C\x30D\x3\x2"+
-		"\x2\x2\x30D\x30E\x3\x2\x2\x2\x30E\x30F\x5\xF0y\x2\x30FK\x3\x2\x2\x2\x310"+
-		"\x311\t\x6\x2\x2\x311M\x3\x2\x2\x2\x312\x313\aq\x2\x2\x313\x314\x5\x136"+
-		"\x9C\x2\x314\x315\aX\x2\x2\x315\x316\x5\x136\x9C\x2\x316\x317\x5\xBA^"+
-		"\x2\x317\x318\x5\x136\x9C\x2\x318\x319\az\x2\x2\x319\x31A\x5\x136\x9C"+
-		"\x2\x31A\x31B\x5\xBA^\x2\x31B\x31D\x5\x122\x92\x2\x31C\x31E\x5\x1E\x10"+
-		"\x2\x31D\x31C\x3\x2\x2\x2\x31D\x31E\x3\x2\x2\x2\x31E\x31F\x3\x2\x2\x2"+
-		"\x31F\x323\a\x8C\x2\x2\x320\x321\x5\x136\x9C\x2\x321\x322\x5\xBA^\x2\x322"+
-		"\x324\x3\x2\x2\x2\x323\x320\x3\x2\x2\x2\x323\x324\x3\x2\x2\x2\x324O\x3"+
-		"\x2\x2\x2\x325\x326\aq\x2\x2\x326\x327\x5\x136\x9C\x2\x327\x329\x5\xBA"+
-		"^\x2\x328\x32A\x5\x136\x9C\x2\x329\x328\x3\x2\x2\x2\x329\x32A\x3\x2\x2"+
-		"\x2\x32A\x32B\x3\x2\x2\x2\x32B\x32D\a\xD0\x2\x2\x32C\x32E\x5\x136\x9C"+
-		"\x2\x32D\x32C\x3\x2\x2\x2\x32D\x32E\x3\x2\x2\x2\x32E\x32F\x3\x2\x2\x2"+
-		"\x32F\x330\x5\xBA^\x2\x330\x331\x5\x136\x9C\x2\x331\x332\a\xBE\x2\x2\x332"+
-		"\x333\x5\x136\x9C\x2\x333\x339\x5\xBA^\x2\x334\x335\x5\x136\x9C\x2\x335"+
-		"\x336\a\xB7\x2\x2\x336\x337\x5\x136\x9C\x2\x337\x338\x5\xBA^\x2\x338\x33A"+
-		"\x3\x2\x2\x2\x339\x334\x3\x2\x2\x2\x339\x33A\x3\x2\x2\x2\x33A\x33B\x3"+
-		"\x2\x2\x2\x33B\x33D\x5\x122\x92\x2\x33C\x33E\x5\x1E\x10\x2\x33D\x33C\x3"+
-		"\x2\x2\x2\x33D\x33E\x3\x2\x2\x2\x33E\x33F\x3\x2\x2\x2\x33F\x343\a\x8C"+
-		"\x2\x2\x340\x341\x5\x136\x9C\x2\x341\x342\x5\xBA^\x2\x342\x344\x3\x2\x2"+
-		"\x2\x343\x340\x3\x2\x2\x2\x343\x344\x3\x2\x2\x2\x344Q\x3\x2\x2\x2\x345"+
-		"\x346\x5\x118\x8D\x2\x346\x347\x5\x136\x9C\x2\x347\x349\x3\x2\x2\x2\x348"+
-		"\x345\x3\x2\x2\x2\x348\x349\x3\x2\x2\x2\x349\x34C\x3\x2\x2\x2\x34A\x34B"+
-		"\a\xB6\x2\x2\x34B\x34D\x5\x136\x9C\x2\x34C\x34A\x3\x2\x2\x2\x34C\x34D"+
-		"\x3\x2\x2\x2\x34D\x34E\x3\x2\x2\x2\x34E\x350\ar\x2\x2\x34F\x351\x5\x136"+
-		"\x9C\x2\x350\x34F\x3\x2\x2\x2\x350\x351\x3\x2\x2\x2\x351\x352\x3\x2\x2"+
-		"\x2\x352\x354\x5T+\x2\x353\x355\x5\x116\x8C\x2\x354\x353\x3\x2\x2\x2\x354"+
-		"\x355\x3\x2\x2\x2\x355\x35A\x3\x2\x2\x2\x356\x358\x5\x136\x9C\x2\x357"+
-		"\x356\x3\x2\x2\x2\x357\x358\x3\x2\x2\x2\x358\x359\x3\x2\x2\x2\x359\x35B"+
-		"\x5\xF0y\x2\x35A\x357\x3\x2\x2\x2\x35A\x35B\x3\x2\x2\x2\x35B\x360\x3\x2"+
-		"\x2\x2\x35C\x35E\x5\x136\x9C\x2\x35D\x35C\x3\x2\x2\x2\x35D\x35E\x3\x2"+
-		"\x2\x2\x35E\x35F\x3\x2\x2\x2\x35F\x361\x5\xFE\x80\x2\x360\x35D\x3\x2\x2"+
-		"\x2\x360\x361\x3\x2\x2\x2\x361\x362\x3\x2\x2\x2\x362\x364\x5\x122\x92"+
-		"\x2\x363\x365\x5\x1E\x10\x2\x364\x363\x3\x2\x2\x2\x364\x365\x3\x2\x2\x2"+
-		"\x365\x366\x3\x2\x2\x2\x366\x367\a]\x2\x2\x367S\x3\x2\x2\x2\x368\x369"+
-		"\x5\xFC\x7F\x2\x369U\x3\x2\x2\x2\x36A\x36B\as\x2\x2\x36B\x36C\x5\x136"+
-		"\x9C\x2\x36C\x36E\x5\xCEh\x2\x36D\x36F\x5\x136\x9C\x2\x36E\x36D\x3\x2"+
-		"\x2\x2\x36E\x36F\x3\x2\x2\x2\x36F\x370\x3\x2\x2\x2\x370\x372\a)\x2\x2"+
-		"\x371\x373\x5\x136\x9C\x2\x372\x371\x3\x2\x2\x2\x372\x373\x3\x2\x2\x2"+
-		"\x373\x375\x3\x2\x2\x2\x374\x376\x5\xBA^\x2\x375\x374\x3\x2\x2\x2\x375"+
-		"\x376\x3\x2\x2\x2\x376\x378\x3\x2\x2\x2\x377\x379\x5\x136\x9C\x2\x378"+
-		"\x377\x3\x2\x2\x2\x378\x379\x3\x2\x2\x2\x379\x37A\x3\x2\x2\x2\x37A\x37C"+
-		"\a)\x2\x2\x37B\x37D\x5\x136\x9C\x2\x37C\x37B\x3\x2\x2\x2\x37C\x37D\x3"+
-		"\x2\x2\x2\x37D\x37E\x3\x2\x2\x2\x37E\x37F\x5\xBA^\x2\x37FW\x3\x2\x2\x2"+
-		"\x380\x381\au\x2\x2\x381\x382\x5\x136\x9C\x2\x382\x383\x5\xBA^\x2\x383"+
-		"Y\x3\x2\x2\x2\x384\x385\av\x2\x2\x385\x386\x5\x136\x9C\x2\x386\x387\x5"+
-		"\xBA^\x2\x387[\x3\x2\x2\x2\x388\x389\aw\x2\x2\x389\x38A\x5\x136\x9C\x2"+
-		"\x38A\x38B\x5n\x38\x2\x38B\x38C\x5\x136\x9C\x2\x38C\x38D\a\xBD\x2\x2\x38D"+
-		"\x38F\x5\x122\x92\x2\x38E\x390\x5\x1E\x10\x2\x38F\x38E\x3\x2\x2\x2\x38F"+
-		"\x390\x3\x2\x2\x2\x390\x394\x3\x2\x2\x2\x391\x393\x5^\x30\x2\x392\x391"+
-		"\x3\x2\x2\x2\x393\x396\x3\x2\x2\x2\x394\x392\x3\x2\x2\x2\x394\x395\x3"+
-		"\x2\x2\x2\x395\x398\x3\x2\x2\x2\x396\x394\x3\x2\x2\x2\x397\x399\x5`\x31"+
+		"\x2\x12A\x2\x12C\x2\x12E\x2\x130\x2\x132\x2\x134\x2\x136\x2\x138\x2\x13A"+
+		"\x2\x13C\x2\x13E\x2\x140\x2\x142\x2\x144\x2\x146\x2\x148\x2\x14A\x2\x14C"+
+		"\x2\x14E\x2\x150\x2\x152\x2\x154\x2\x156\x2\x158\x2\x15A\x2\x15C\x2\x15E"+
+		"\x2\x160\x2\x162\x2\x164\x2\x166\x2\x168\x2\x16A\x2\x16C\x2\x16E\x2\x170"+
+		"\x2\x172\x2\x174\x2\x2\x1A\x5\x2;;\x45\x45\xBC\xBC\a\x2\x38\x38;;{{\x9B"+
+		"\x9B\xA6\xA6\x4\x2\xA8\xA9\xCB\xCB\x4\x2\x85\x87\xB3\xB3\x4\x2))++\x4"+
+		"\x2rr\xBA\xBA\x3\x2HT\x4\x2\xC3\xC3\xC7\xC7\x3\x2jn\x3\x2\x92\x93\x4\x2"+
+		"\xCE\xCE\xD7\xD7\x4\x2\xD6\xD6\xD9\xD9\a\x2||\x83\x83\xD0\xD3\xD5\xD5"+
+		"\xD8\xD8\x3\x2,-\x4\x2=>\x9C\x9C\x3\x2=>\r\x2\x13\x13\x1F <<??\x46\x46"+
+		"WW}}\x7F\x7F\xB4\xB4\xB9\xB9\xC4\xC4\x3\x2\xE4\xE7\x5\x2,,.\x32\xDA\xDA"+
+		"\x6\x2pptt\x9F\x9F\xA4\xA4$\x2\x3\x17\x19#%(\x33\x38:?\x42\x43\x45\x46"+
+		"WW``\x63\x64\x66\x66hhjossxxz\x7F\x82\x87\x89\x8B\x8D\x90\x92\x92\x94"+
+		"\x95\x9A\x9D\xA5\xA6\xA8\xA9\xAB\xAC\xB0\xB0\xB3\xB5\xB7\xB7\xB9\xB9\xBB"+
+		"\xBF\xC1\xC5\xC8\xC8\xCA\xCC\xF1\xF7\x1E\x2\x18\x18$$@\x41\x44\x44GVY"+
+		"Z\x65\x65ggiiprtwyy\x80\x81\x88\x88\x8C\x8C\x91\x91\x9E\x9F\xA4\xA4\xA7"+
+		"\xA7\xAA\xAA\xAD\xAF\xB1\xB2\xB6\xB6\xB8\xB8\xBA\xBA\xC0\xC0\xC6\xC7\xC9"+
+		"\xC9\x3\x2\xE9\xE9\x4\x2\xEC\xEC\xEF\xEF\xBFE\x2\x176\x3\x2\x2\x2\x4\x179"+
+		"\x3\x2\x2\x2\x6\x192\x3\x2\x2\x2\b\x19D\x3\x2\x2\x2\n\x1AF\x3\x2\x2\x2"+
+		"\f\x1C7\x3\x2\x2\x2\xE\x1CB\x3\x2\x2\x2\x10\x1E0\x3\x2\x2\x2\x12\x1EB"+
+		"\x3\x2\x2\x2\x14\x1ED\x3\x2\x2\x2\x16\x1FD\x3\x2\x2\x2\x18\x1FF\x3\x2"+
+		"\x2\x2\x1A\x217\x3\x2\x2\x2\x1C\x219\x3\x2\x2\x2\x1E\x21B\x3\x2\x2\x2"+
+		" \x249\x3\x2\x2\x2\"\x258\x3\x2\x2\x2$\x25A\x3\x2\x2\x2&\x275\x3\x2\x2"+
+		"\x2(\x277\x3\x2\x2\x2*\x27B\x3\x2\x2\x2,\x27D\x3\x2\x2\x2.\x281\x3\x2"+
+		"\x2\x2\x30\x283\x3\x2\x2\x2\x32\x285\x3\x2\x2\x2\x34\x28F\x3\x2\x2\x2"+
+		"\x36\x293\x3\x2\x2\x2\x38\x295\x3\x2\x2\x2:\x298\x3\x2\x2\x2<\x29A\x3"+
+		"\x2\x2\x2>\x2A0\x3\x2\x2\x2@\x2A2\x3\x2\x2\x2\x42\x2B0\x3\x2\x2\x2\x44"+
+		"\x2BC\x3\x2\x2\x2\x46\x2BE\x3\x2\x2\x2H\x2D5\x3\x2\x2\x2J\x2D7\x3\x2\x2"+
+		"\x2L\x2D9\x3\x2\x2\x2N\x2DB\x3\x2\x2\x2P\x2E8\x3\x2\x2\x2R\x2F4\x3\x2"+
+		"\x2\x2T\x2F6\x3\x2\x2\x2V\x302\x3\x2\x2\x2X\x304\x3\x2\x2\x2Z\x311\x3"+
+		"\x2\x2\x2\\\x323\x3\x2\x2\x2^\x328\x3\x2\x2\x2`\x32A\x3\x2\x2\x2\x62\x32C"+
+		"\x3\x2\x2\x2\x64\x32E\x3\x2\x2\x2\x66\x33C\x3\x2\x2\x2h\x33E\x3\x2\x2"+
+		"\x2j\x345\x3\x2\x2\x2l\x34F\x3\x2\x2\x2n\x351\x3\x2\x2\x2p\x35E\x3\x2"+
+		"\x2\x2r\x36A\x3\x2\x2\x2t\x378\x3\x2\x2\x2v\x37A\x3\x2\x2\x2x\x390\x3"+
+		"\x2\x2\x2z\x392\x3\x2\x2\x2|\x394\x3\x2\x2\x2~\x3AA\x3\x2\x2\x2\x80\x3AF"+
+		"\x3\x2\x2\x2\x82\x3C1\x3\x2\x2\x2\x84\x3D6\x3\x2\x2\x2\x86\x3FA\x3\x2"+
+		"\x2\x2\x88\x40A\x3\x2\x2\x2\x8A\x40F\x3\x2\x2\x2\x8C\x411\x3\x2\x2\x2"+
+		"\x8E\x413\x3\x2\x2\x2\x90\x41D\x3\x2\x2\x2\x92\x420\x3\x2\x2\x2\x94\x423"+
+		"\x3\x2\x2\x2\x96\x42D\x3\x2\x2\x2\x98\x42F\x3\x2\x2\x2\x9A\x44E\x3\x2"+
+		"\x2\x2\x9C\x453\x3\x2\x2\x2\x9E\x461\x3\x2\x2\x2\xA0\x46E\x3\x2\x2\x2"+
+		"\xA2\x470\x3\x2\x2\x2\xA4\x480\x3\x2\x2\x2\xA6\x487\x3\x2\x2\x2\xA8\x491"+
+		"\x3\x2\x2\x2\xAA\x493\x3\x2\x2\x2\xAC\x4A6\x3\x2\x2\x2\xAE\x4C9\x3\x2"+
+		"\x2\x2\xB0\x4E9\x3\x2\x2\x2\xB2\x4EB\x3\x2\x2\x2\xB4\x4EF\x3\x2\x2\x2"+
+		"\xB6\x4F3\x3\x2\x2\x2\xB8\x51B\x3\x2\x2\x2\xBA\x51D\x3\x2\x2\x2\xBC\x524"+
+		"\x3\x2\x2\x2\xBE\x526\x3\x2\x2\x2\xC0\x538\x3\x2\x2\x2\xC2\x547\x3\x2"+
+		"\x2\x2\xC4\x574\x3\x2\x2\x2\xC6\x576\x3\x2\x2\x2\xC8\x578\x3\x2\x2\x2"+
+		"\xCA\x57A\x3\x2\x2\x2\xCC\x580\x3\x2\x2\x2\xCE\x58C\x3\x2\x2\x2\xD0\x598"+
+		"\x3\x2\x2\x2\xD2\x5A6\x3\x2\x2\x2\xD4\x5B2\x3\x2\x2\x2\xD6\x5C6\x3\x2"+
+		"\x2\x2\xD8\x5DD\x3\x2\x2\x2\xDA\x5FD\x3\x2\x2\x2\xDC\x615\x3\x2\x2\x2"+
+		"\xDE\x62A\x3\x2\x2\x2\xE0\x63D\x3\x2\x2\x2\xE2\x651\x3\x2\x2\x2\xE4\x663"+
+		"\x3\x2\x2\x2\xE6\x66B\x3\x2\x2\x2\xE8\x66D\x3\x2\x2\x2\xEA\x679\x3\x2"+
+		"\x2\x2\xEC\x67B\x3\x2\x2\x2\xEE\x69A\x3\x2\x2\x2\xF0\x69C\x3\x2\x2\x2"+
+		"\xF2\x6B2\x3\x2\x2\x2\xF4\x6B4\x3\x2\x2\x2\xF6\x6C3\x3\x2\x2\x2\xF8\x6DA"+
+		"\x3\x2\x2\x2\xFA\x6DF\x3\x2\x2\x2\xFC\x6ED\x3\x2\x2\x2\xFE\x733\x3\x2"+
+		"\x2\x2\x100\x7A6\x3\x2\x2\x2\x102\x7B3\x3\x2\x2\x2\x104\x7BC\x3\x2\x2"+
+		"\x2\x106\x7CA\x3\x2\x2\x2\x108\x7E6\x3\x2\x2\x2\x10A\x7EF\x3\x2\x2\x2"+
+		"\x10C\x7F8\x3\x2\x2\x2\x10E\x7FA\x3\x2\x2\x2\x110\x840\x3\x2\x2\x2\x112"+
+		"\x844\x3\x2\x2\x2\x114\x847\x3\x2\x2\x2\x116\x86B\x3\x2\x2\x2\x118\x881"+
+		"\x3\x2\x2\x2\x11A\x883\x3\x2\x2\x2\x11C\x89B\x3\x2\x2\x2\x11E\x8C0\x3"+
+		"\x2\x2\x2\x120\x8D8\x3\x2\x2\x2\x122\x8FF\x3\x2\x2\x2\x124\x91B\x3\x2"+
+		"\x2\x2\x126\x924\x3\x2\x2\x2\x128\x934\x3\x2\x2\x2\x12A\x948\x3\x2\x2"+
+		"\x2\x12C\x953\x3\x2\x2\x2\x12E\x95B\x3\x2\x2\x2\x130\x976\x3\x2\x2\x2"+
+		"\x132\x99A\x3\x2\x2\x2\x134\x9A0\x3\x2\x2\x2\x136\x9B3\x3\x2\x2\x2\x138"+
+		"\x9BA\x3\x2\x2\x2\x13A\x9BE\x3\x2\x2\x2\x13C\x9C0\x3\x2\x2\x2\x13E\x9CF"+
+		"\x3\x2\x2\x2\x140\x9D1\x3\x2\x2\x2\x142\x9D3\x3\x2\x2\x2\x144\x9DB\x3"+
+		"\x2\x2\x2\x146\x9E3\x3\x2\x2\x2\x148\x9EB\x3\x2\x2\x2\x14A\x9ED\x3\x2"+
+		"\x2\x2\x14C\x9EF\x3\x2\x2\x2\x14E\x9F9\x3\x2\x2\x2\x150\x9FB\x3\x2\x2"+
+		"\x2\x152\x9FF\x3\x2\x2\x2\x154\xA0B\x3\x2\x2\x2\x156\xA0D\x3\x2\x2\x2"+
+		"\x158\xA0F\x3\x2\x2\x2\x15A\xA11\x3\x2\x2\x2\x15C\xA13\x3\x2\x2\x2\x15E"+
+		"\xA16\x3\x2\x2\x2\x160\xA31\x3\x2\x2\x2\x162\xA36\x3\x2\x2\x2\x164\xA38"+
+		"\x3\x2\x2\x2\x166\xA3E\x3\x2\x2\x2\x168\xA45\x3\x2\x2\x2\x16A\xA48\x3"+
+		"\x2\x2\x2\x16C\xA52\x3\x2\x2\x2\x16E\xA56\x3\x2\x2\x2\x170\xA94\x3\x2"+
+		"\x2\x2\x172\xA96\x3\x2\x2\x2\x174\xA99\x3\x2\x2\x2\x176\x177\x5\x4\x3"+
+		"\x2\x177\x3\x3\x2\x2\x2\x178\x17A\x5\x174\xBB\x2\x179\x178\x3\x2\x2\x2"+
+		"\x179\x17A\x3\x2\x2\x2\x17A\x17B\x3\x2\x2\x2\x17B\x17F\x5\x160\xB1\x2"+
+		"\x17C\x17D\x5\x6\x4\x2\x17D\x17E\x5\x160\xB1\x2\x17E\x180\x3\x2\x2\x2"+
+		"\x17F\x17C\x3\x2\x2\x2\x17F\x180\x3\x2\x2\x2\x180\x182\x3\x2\x2\x2\x181"+
+		"\x183\x5\b\x5\x2\x182\x181\x3\x2\x2\x2\x182\x183\x3\x2\x2\x2\x183\x184"+
+		"\x3\x2\x2\x2\x184\x186\x5\x160\xB1\x2\x185\x187\x5\f\a\x2\x186\x185\x3"+
+		"\x2\x2\x2\x186\x187\x3\x2\x2\x2\x187\x188\x3\x2\x2\x2\x188\x18A\x5\x160"+
+		"\xB1\x2\x189\x18B\x5\xE\b\x2\x18A\x189\x3\x2\x2\x2\x18A\x18B\x3\x2\x2"+
+		"\x2\x18B\x18C\x3\x2\x2\x2\x18C\x18E\x5\x160\xB1\x2\x18D\x18F\x5\x14\v"+
+		"\x2\x18E\x18D\x3\x2\x2\x2\x18E\x18F\x3\x2\x2\x2\x18F\x190\x3\x2\x2\x2"+
+		"\x190\x191\x5\x160\xB1\x2\x191\x5\x3\x2\x2\x2\x192\x193\a\xC5\x2\x2\x193"+
+		"\x194\x5\x174\xBB\x2\x194\x196\x5\x150\xA9\x2\x195\x197\x5\x174\xBB\x2"+
+		"\x196\x195\x3\x2\x2\x2\x196\x197\x3\x2\x2\x2\x197\x199\x3\x2\x2\x2\x198"+
+		"\x19A\a\x42\x2\x2\x199\x198\x3\x2\x2\x2\x199\x19A\x3\x2\x2\x2\x19A\x19B"+
+		"\x3\x2\x2\x2\x19B\x19C\x5\x160\xB1\x2\x19C\a\x3\x2\x2\x2\x19D\x1A5\a:"+
+		"\x2\x2\x19E\x19F\x5\x174\xBB\x2\x19F\x1A0\a\xED\x2\x2\x1A0\x1A1\x5\x174"+
+		"\xBB\x2\x1A1\x1A3\x5\x138\x9D\x2\x1A2\x1A4\x5\x174\xBB\x2\x1A3\x1A2\x3"+
+		"\x2\x2\x2\x1A3\x1A4\x3\x2\x2\x2\x1A4\x1A6\x3\x2\x2\x2\x1A5\x19E\x3\x2"+
+		"\x2\x2\x1A5\x1A6\x3\x2\x2\x2\x1A6\x1A7\x3\x2\x2\x2\x1A7\x1A9\x5\x160\xB1"+
+		"\x2\x1A8\x1AA\x5\n\x6\x2\x1A9\x1A8\x3\x2\x2\x2\x1AA\x1AB\x3\x2\x2\x2\x1AB"+
+		"\x1A9\x3\x2\x2\x2\x1AB\x1AC\x3\x2\x2\x2\x1AC\x1AD\x3\x2\x2\x2\x1AD\x1AE"+
+		"\a\x64\x2\x2\x1AE\t\x3\x2\x2\x2\x1AF\x1B3\x5\x138\x9D\x2\x1B0\x1B2\x5"+
+		"\x174\xBB\x2\x1B1\x1B0\x3\x2\x2\x2\x1B2\x1B5\x3\x2\x2\x2\x1B3\x1B1\x3"+
+		"\x2\x2\x2\x1B3\x1B4\x3\x2\x2\x2\x1B4\x1B6\x3\x2\x2\x2\x1B5\x1B3\x3\x2"+
+		"\x2\x2\x1B6\x1BA\a\xD0\x2\x2\x1B7\x1B9\x5\x174\xBB\x2\x1B8\x1B7\x3\x2"+
+		"\x2\x2\x1B9\x1BC\x3\x2\x2\x2\x1BA\x1B8\x3\x2\x2\x2\x1BA\x1BB\x3\x2\x2"+
+		"\x2\x1BB\x1BD\x3\x2\x2\x2\x1BC\x1BA\x3\x2\x2\x2\x1BD\x1C0\x5\xFE\x80\x2"+
+		"\x1BE\x1BF\a*\x2\x2\x1BF\x1C1\x5\x150\xA9\x2\x1C0\x1BE\x3\x2\x2\x2\x1C0"+
+		"\x1C1\x3\x2\x2\x2\x1C1\x1C2\x3\x2\x2\x2\x1C2\x1C3\x5\x160\xB1\x2\x1C3"+
+		"\v\x3\x2\x2\x2\x1C4\x1C5\x5\x18\r\x2\x1C5\x1C6\x5\x160\xB1\x2\x1C6\x1C8"+
+		"\x3\x2\x2\x2\x1C7\x1C4\x3\x2\x2\x2\x1C8\x1C9\x3\x2\x2\x2\x1C9\x1C7\x3"+
+		"\x2\x2\x2\x1C9\x1CA\x3\x2\x2\x2\x1CA\r\x3\x2\x2\x2\x1CB\x1D1\x5\x12\n"+
+		"\x2\x1CC\x1CD\x5\x160\xB1\x2\x1CD\x1CE\x5\x12\n\x2\x1CE\x1D0\x3\x2\x2"+
+		"\x2\x1CF\x1CC\x3\x2\x2\x2\x1D0\x1D3\x3\x2\x2\x2\x1D1\x1CF\x3\x2\x2\x2"+
+		"\x1D1\x1D2\x3\x2\x2\x2\x1D2\x1D4\x3\x2\x2\x2\x1D3\x1D1\x3\x2\x2\x2\x1D4"+
+		"\x1D5\x5\x160\xB1\x2\x1D5\xF\x3\x2\x2\x2\x1D6\x1D7\a\x96\x2\x2\x1D7\x1D8"+
+		"\x5\x174\xBB\x2\x1D8\x1D9\x5\x150\xA9\x2\x1D9\x1E1\x3\x2\x2\x2\x1DA\x1DB"+
+		"\a\x98\x2\x2\x1DB\x1DC\x5\x174\xBB\x2\x1DC\x1DD\t\x2\x2\x2\x1DD\x1E1\x3"+
+		"\x2\x2\x2\x1DE\x1E1\a\x97\x2\x2\x1DF\x1E1\a\x99\x2\x2\x1E0\x1D6\x3\x2"+
+		"\x2\x2\x1E0\x1DA\x3\x2\x2\x2\x1E0\x1DE\x3\x2\x2\x2\x1E0\x1DF\x3\x2\x2"+
+		"\x2\x1E1\x11\x3\x2\x2\x2\x1E2\x1EC\x5\x84\x43\x2\x1E3\x1EC\x5\x86\x44"+
+		"\x2\x1E4\x1EC\x5\x9CO\x2\x1E5\x1EC\x5\xA6T\x2\x1E6\x1EC\x5\x80\x41\x2"+
+		"\x1E7\x1EC\x5\xCA\x66\x2\x1E8\x1EC\x5\x102\x82\x2\x1E9\x1EC\x5\x10\t\x2"+
+		"\x1EA\x1EC\x5\xFA~\x2\x1EB\x1E2\x3\x2\x2\x2\x1EB\x1E3\x3\x2\x2\x2\x1EB"+
+		"\x1E4\x3\x2\x2\x2\x1EB\x1E5\x3\x2\x2\x2\x1EB\x1E6\x3\x2\x2\x2\x1EB\x1E7"+
+		"\x3\x2\x2\x2\x1EB\x1E8\x3\x2\x2\x2\x1EB\x1E9\x3\x2\x2\x2\x1EB\x1EA\x3"+
+		"\x2\x2\x2\x1EC\x13\x3\x2\x2\x2\x1ED\x1F3\x5\x16\f\x2\x1EE\x1EF\x5\x160"+
+		"\xB1\x2\x1EF\x1F0\x5\x16\f\x2\x1F0\x1F2\x3\x2\x2\x2\x1F1\x1EE\x3\x2\x2"+
+		"\x2\x1F2\x1F5\x3\x2\x2\x2\x1F3\x1F1\x3\x2\x2\x2\x1F3\x1F4\x3\x2\x2\x2"+
+		"\x1F4\x1F6\x3\x2\x2\x2\x1F5\x1F3\x3\x2\x2\x2\x1F6\x1F7\x5\x160\xB1\x2"+
+		"\x1F7\x15\x3\x2\x2\x2\x1F8\x1FE\x5\xAEX\x2\x1F9\x1FE\x5\xD8m\x2\x1FA\x1FE"+
+		"\x5\xDAn\x2\x1FB\x1FE\x5\xDCo\x2\x1FC\x1FE\x5\xF6|\x2\x1FD\x1F8\x3\x2"+
+		"\x2\x2\x1FD\x1F9\x3\x2\x2\x2\x1FD\x1FA\x3\x2\x2\x2\x1FD\x1FB\x3\x2\x2"+
+		"\x2\x1FD\x1FC\x3\x2\x2\x2\x1FE\x17\x3\x2\x2\x2\x1FF\x200\a\x37\x2\x2\x200"+
+		"\x201\x5\x174\xBB\x2\x201\x203\x5\x1A\xE\x2\x202\x204\x5\x174\xBB\x2\x203"+
+		"\x202\x3\x2\x2\x2\x203\x204\x3\x2\x2\x2\x204\x205\x3\x2\x2\x2\x205\x207"+
+		"\a\xD0\x2\x2\x206\x208\x5\x174\xBB\x2\x207\x206\x3\x2\x2\x2\x207\x208"+
+		"\x3\x2\x2\x2\x208\x209\x3\x2\x2\x2\x209\x214\x5\x1C\xF\x2\x20A\x20C\x5"+
+		"\x174\xBB\x2\x20B\x20A\x3\x2\x2\x2\x20B\x20C\x3\x2\x2\x2\x20C\x20D\x3"+
+		"\x2\x2\x2\x20D\x20F\a)\x2\x2\x20E\x210\x5\x174\xBB\x2\x20F\x20E\x3\x2"+
+		"\x2\x2\x20F\x210\x3\x2\x2\x2\x210\x211\x3\x2\x2\x2\x211\x213\x5\x1C\xF"+
+		"\x2\x212\x20B\x3\x2\x2\x2\x213\x216\x3\x2\x2\x2\x214\x212\x3\x2\x2\x2"+
+		"\x214\x215\x3\x2\x2\x2\x215\x19\x3\x2\x2\x2\x216\x214\x3\x2\x2\x2\x217"+
+		"\x218\x5\x118\x8D\x2\x218\x1B\x3\x2\x2\x2\x219\x21A\x5\xFE\x80\x2\x21A"+
+		"\x1D\x3\x2\x2\x2\x21B\x221\x5 \x11\x2\x21C\x21D\x5\x160\xB1\x2\x21D\x21E"+
+		"\x5 \x11\x2\x21E\x220\x3\x2\x2\x2\x21F\x21C\x3\x2\x2\x2\x220\x223\x3\x2"+
+		"\x2\x2\x221\x21F\x3\x2\x2\x2\x221\x222\x3\x2\x2\x2\x222\x224\x3\x2\x2"+
+		"\x2\x223\x221\x3\x2\x2\x2\x224\x225\x5\x160\xB1\x2\x225\x1F\x3\x2\x2\x2"+
+		"\x226\x24A\x5\x146\xA4\x2\x227\x24A\x5\"\x12\x2\x228\x24A\x5\x18\r\x2"+
+		"\x229\x24A\x5\x80\x41\x2\x22A\x24A\x5\x9AN\x2\x22B\x24A\x5\xA0Q\x2\x22C"+
+		"\x24A\x5\xA2R\x2\x22D\x24A\x5\xA4S\x2\x22E\x24A\x5\xA8U\x2\x22F\x24A\x5"+
+		"\x10E\x88\x2\x230\x24A\x5\xAAV\x2\x231\x24A\x5\xACW\x2\x232\x24A\x5\xB2"+
+		"Z\x2\x233\x24A\x5\xB4[\x2\x234\x24A\x5\xB6\\\x2\x235\x24A\x5\xBC_\x2\x236"+
+		"\x24A\x5\xCA\x66\x2\x237\x24A\x5\xCCg\x2\x238\x24A\x5\xCEh\x2\x239\x24A"+
+		"\x5\xD0i\x2\x23A\x24A\x5\xD2j\x2\x23B\x24A\x5\xD4k\x2\x23C\x24A\x5\xD6"+
+		"l\x2\x23D\x24A\x5\xDEp\x2\x23E\x24A\x5\xE0q\x2\x23F\x24A\x5\xE4s\x2\x240"+
+		"\x24A\x5\xE6t\x2\x241\x24A\x5\xE8u\x2\x242\x24A\x5\xECw\x2\x243\x24A\x5"+
+		"\xF4{\x2\x244\x24A\x5\xEAv\x2\x245\x24A\x5\x102\x82\x2\x246\x24A\x5\x108"+
+		"\x85\x2\x247\x24A\x5\x10A\x86\x2\x248\x24A\x5\x112\x8A\x2\x249\x226\x3"+
+		"\x2\x2\x2\x249\x227\x3\x2\x2\x2\x249\x228\x3\x2\x2\x2\x249\x229\x3\x2"+
+		"\x2\x2\x249\x22A\x3\x2\x2\x2\x249\x22B\x3\x2\x2\x2\x249\x22C\x3\x2\x2"+
+		"\x2\x249\x22D\x3\x2\x2\x2\x249\x22E\x3\x2\x2\x2\x249\x22F\x3\x2\x2\x2"+
+		"\x249\x230\x3\x2\x2\x2\x249\x231\x3\x2\x2\x2\x249\x232\x3\x2\x2\x2\x249"+
+		"\x233\x3\x2\x2\x2\x249\x234\x3\x2\x2\x2\x249\x235\x3\x2\x2\x2\x249\x236"+
+		"\x3\x2\x2\x2\x249\x237\x3\x2\x2\x2\x249\x238\x3\x2\x2\x2\x249\x239\x3"+
+		"\x2\x2\x2\x249\x23A\x3\x2\x2\x2\x249\x23B\x3\x2\x2\x2\x249\x23C\x3\x2"+
+		"\x2\x2\x249\x23D\x3\x2\x2\x2\x249\x23E\x3\x2\x2\x2\x249\x23F\x3\x2\x2"+
+		"\x2\x249\x240\x3\x2\x2\x2\x249\x241\x3\x2\x2\x2\x249\x242\x3\x2\x2\x2"+
+		"\x249\x243\x3\x2\x2\x2\x249\x244\x3\x2\x2\x2\x249\x245\x3\x2\x2\x2\x249"+
+		"\x246\x3\x2\x2\x2\x249\x247\x3\x2\x2\x2\x249\x248\x3\x2\x2\x2\x24A!\x3"+
+		"\x2\x2\x2\x24B\x259\x5$\x13\x2\x24C\x259\x5> \x2\x24D\x259\x5<\x1F\x2"+
+		"\x24E\x259\x5\x42\"\x2\x24F\x259\x5\x46$\x2\x250\x259\x5N(\x2\x251\x259"+
+		"\x5P)\x2\x252\x259\x5T+\x2\x253\x259\x5X-\x2\x254\x259\x5n\x38\x2\x255"+
+		"\x259\x5p\x39\x2\x256\x259\x5v<\x2\x257\x259\x5|?\x2\x258\x24B\x3\x2\x2"+
+		"\x2\x258\x24C\x3\x2\x2\x2\x258\x24D\x3\x2\x2\x2\x258\x24E\x3\x2\x2\x2"+
+		"\x258\x24F\x3\x2\x2\x2\x258\x250\x3\x2\x2\x2\x258\x251\x3\x2\x2\x2\x258"+
+		"\x252\x3\x2\x2\x2\x258\x253\x3\x2\x2\x2\x258\x254\x3\x2\x2\x2\x258\x255"+
+		"\x3\x2\x2\x2\x258\x256\x3\x2\x2\x2\x258\x257\x3\x2\x2\x2\x259#\x3\x2\x2"+
+		"\x2\x25A\x25B\a\x94\x2\x2\x25B\x25C\x5\x174\xBB\x2\x25C\x260\x5&\x14\x2"+
+		"\x25D\x25E\x5\x174\xBB\x2\x25E\x25F\x5(\x15\x2\x25F\x261\x3\x2\x2\x2\x260"+
+		"\x25D\x3\x2\x2\x2\x260\x261\x3\x2\x2\x2\x261\x265\x3\x2\x2\x2\x262\x263"+
+		"\x5\x174\xBB\x2\x263\x264\x5,\x17\x2\x264\x266\x3\x2\x2\x2\x265\x262\x3"+
+		"\x2\x2\x2\x265\x266\x3\x2\x2\x2\x266\x26A\x3\x2\x2\x2\x267\x268\x5\x174"+
+		"\xBB\x2\x268\x269\x5\x30\x19\x2\x269\x26B\x3\x2\x2\x2\x26A\x267\x3\x2"+
+		"\x2\x2\x26A\x26B\x3\x2\x2\x2\x26B\x26C\x3\x2\x2\x2\x26C\x26D\x5\x174\xBB"+
+		"\x2\x26D\x26E\a\x39\x2\x2\x26E\x26F\x5\x174\xBB\x2\x26F\x273\x5\x36\x1C"+
+		"\x2\x270\x271\x5\x174\xBB\x2\x271\x272\x5\x32\x1A\x2\x272\x274\x3\x2\x2"+
+		"\x2\x273\x270\x3\x2\x2\x2\x273\x274\x3\x2\x2\x2\x274%\x3\x2\x2\x2\x275"+
+		"\x276\x5\xFE\x80\x2\x276\'\x3\x2\x2\x2\x277\x278\aq\x2\x2\x278\x279\x5"+
+		"\x174\xBB\x2\x279\x27A\x5*\x16\x2\x27A)\x3\x2\x2\x2\x27B\x27C\t\x3\x2"+
+		"\x2\x27C+\x3\x2\x2\x2\x27D\x27E\a\x33\x2\x2\x27E\x27F\x5\x174\xBB\x2\x27F"+
+		"\x280\x5.\x18\x2\x280-\x3\x2\x2\x2\x281\x282\t\x4\x2\x2\x282/\x3\x2\x2"+
+		"\x2\x283\x284\t\x5\x2\x2\x284\x31\x3\x2\x2\x2\x285\x287\a\x1D\x2\x2\x286"+
+		"\x288\x5\x174\xBB\x2\x287\x286\x3\x2\x2\x2\x287\x288\x3\x2\x2\x2\x288"+
+		"\x289\x3\x2\x2\x2\x289\x28B\a\xD0\x2\x2\x28A\x28C\x5\x174\xBB\x2\x28B"+
+		"\x28A\x3\x2\x2\x2\x28B\x28C\x3\x2\x2\x2\x28C\x28D\x3\x2\x2\x2\x28D\x28E"+
+		"\x5\x34\x1B\x2\x28E\x33\x3\x2\x2\x2\x28F\x290\x5\xFE\x80\x2\x290\x35\x3"+
+		"\x2\x2\x2\x291\x294\x5\x38\x1D\x2\x292\x294\x5:\x1E\x2\x293\x291\x3\x2"+
+		"\x2\x2\x293\x292\x3\x2\x2\x2\x294\x37\x3\x2\x2\x2\x295\x296\a.\x2\x2\x296"+
+		"\x297\x5\xFE\x80\x2\x297\x39\x3\x2\x2\x2\x298\x299\x5\xFE\x80\x2\x299"+
+		";\x3\x2\x2\x2\x29A\x29E\a\x43\x2\x2\x29B\x29C\x5\x174\xBB\x2\x29C\x29D"+
+		"\x5@!\x2\x29D\x29F\x3\x2\x2\x2\x29E\x29B\x3\x2\x2\x2\x29E\x29F\x3\x2\x2"+
+		"\x2\x29F=\x3\x2\x2\x2\x2A0\x2A1\a\xAC\x2\x2\x2A1?\x3\x2\x2\x2\x2A2\x2AD"+
+		"\x5\x36\x1C\x2\x2A3\x2A5\x5\x174\xBB\x2\x2A4\x2A3\x3\x2\x2\x2\x2A4\x2A5"+
+		"\x3\x2\x2\x2\x2A5\x2A6\x3\x2\x2\x2\x2A6\x2A8\a)\x2\x2\x2A7\x2A9\x5\x174"+
+		"\xBB\x2\x2A8\x2A7\x3\x2\x2\x2\x2A8\x2A9\x3\x2\x2\x2\x2A9\x2AA\x3\x2\x2"+
+		"\x2\x2AA\x2AC\x5\x36\x1C\x2\x2AB\x2A4\x3\x2\x2\x2\x2AC\x2AF\x3\x2\x2\x2"+
+		"\x2AD\x2AB\x3\x2\x2\x2\x2AD\x2AE\x3\x2\x2\x2\x2AE\x41\x3\x2\x2\x2\x2AF"+
+		"\x2AD\x3\x2\x2\x2\x2B0\x2B1\a\xB0\x2\x2\x2B1\x2B2\x5\x174\xBB\x2\x2B2"+
+		"\x2B4\x5\x36\x1C\x2\x2B3\x2B5\x5\x174\xBB\x2\x2B4\x2B3\x3\x2\x2\x2\x2B4"+
+		"\x2B5\x3\x2\x2\x2\x2B5\x2B6\x3\x2\x2\x2\x2B6\x2B8\a)\x2\x2\x2B7\x2B9\x5"+
+		"\x174\xBB\x2\x2B8\x2B7\x3\x2\x2\x2\x2B8\x2B9\x3\x2\x2\x2\x2B9\x2BA\x3"+
+		"\x2\x2\x2\x2BA\x2BB\x5\x44#\x2\x2BB\x43\x3\x2\x2\x2\x2BC\x2BD\x5\xFE\x80"+
+		"\x2\x2BD\x45\x3\x2\x2\x2\x2BE\x2BF\a~\x2\x2\x2BF\x2C0\x5\x174\xBB\x2\x2C0"+
+		"\x2C9\x5\x36\x1C\x2\x2C1\x2C3\x5\x174\xBB\x2\x2C2\x2C1\x3\x2\x2\x2\x2C2"+
+		"\x2C3\x3\x2\x2\x2\x2C3\x2C4\x3\x2\x2\x2\x2C4\x2C6\a)\x2\x2\x2C5\x2C7\x5"+
+		"\x174\xBB\x2\x2C6\x2C5\x3\x2\x2\x2\x2C6\x2C7\x3\x2\x2\x2\x2C7\x2C8\x3"+
+		"\x2\x2\x2\x2C8\x2CA\x5H%\x2\x2C9\x2C2\x3\x2\x2\x2\x2C9\x2CA\x3\x2\x2\x2"+
+		"\x2CAG\x3\x2\x2\x2\x2CB\x2D6\x5J&\x2\x2CC\x2CD\x5J&\x2\x2CD\x2CE\x5\x174"+
+		"\xBB\x2\x2CE\x2D0\x3\x2\x2\x2\x2CF\x2CC\x3\x2\x2\x2\x2CF\x2D0\x3\x2\x2"+
+		"\x2\x2D0\x2D1\x3\x2\x2\x2\x2D1\x2D2\a\xBE\x2\x2\x2D2\x2D3\x5\x174\xBB"+
+		"\x2\x2D3\x2D4\x5L\'\x2\x2D4\x2D6\x3\x2\x2\x2\x2D5\x2CB\x3\x2\x2\x2\x2D5"+
+		"\x2CF\x3\x2\x2\x2\x2D6I\x3\x2\x2\x2\x2D7\x2D8\x5\xFE\x80\x2\x2D8K\x3\x2"+
+		"\x2\x2\x2D9\x2DA\x5\xFE\x80\x2\x2DAM\x3\x2\x2\x2\x2DB\x2DC\a\xC2\x2\x2"+
+		"\x2DC\x2DD\x5\x174\xBB\x2\x2DD\x2E6\x5\x36\x1C\x2\x2DE\x2E0\x5\x174\xBB"+
+		"\x2\x2DF\x2DE\x3\x2\x2\x2\x2DF\x2E0\x3\x2\x2\x2\x2E0\x2E1\x3\x2\x2\x2"+
+		"\x2E1\x2E3\a)\x2\x2\x2E2\x2E4\x5\x174\xBB\x2\x2E3\x2E2\x3\x2\x2\x2\x2E3"+
+		"\x2E4\x3\x2\x2\x2\x2E4\x2E5\x3\x2\x2\x2\x2E5\x2E7\x5H%\x2\x2E6\x2DF\x3"+
+		"\x2\x2\x2\x2E6\x2E7\x3\x2\x2\x2\x2E7O\x3\x2\x2\x2\x2E8\x2E9\a\x84\x2\x2"+
+		"\x2E9\x2EA\x5\x174\xBB\x2\x2EA\x2EC\x5\x38\x1D\x2\x2EB\x2ED\x5\x174\xBB"+
+		"\x2\x2EC\x2EB\x3\x2\x2\x2\x2EC\x2ED\x3\x2\x2\x2\x2ED\x2EE\x3\x2\x2\x2"+
+		"\x2EE\x2F0\a)\x2\x2\x2EF\x2F1\x5\x174\xBB\x2\x2F0\x2EF\x3\x2\x2\x2\x2F0"+
+		"\x2F1\x3\x2\x2\x2\x2F1\x2F2\x3\x2\x2\x2\x2F2\x2F3\x5R*\x2\x2F3Q\x3\x2"+
+		"\x2\x2\x2F4\x2F5\x5\xFE\x80\x2\x2F5S\x3\x2\x2\x2\x2F6\x2F7\a\xC8\x2\x2"+
+		"\x2F7\x2F8\x5\x174\xBB\x2\x2F8\x2FA\x5\x38\x1D\x2\x2F9\x2FB\x5\x174\xBB"+
+		"\x2\x2FA\x2F9\x3\x2\x2\x2\x2FA\x2FB\x3\x2\x2\x2\x2FB\x2FC\x3\x2\x2\x2"+
+		"\x2FC\x2FE\a)\x2\x2\x2FD\x2FF\x5\x174\xBB\x2\x2FE\x2FD\x3\x2\x2\x2\x2FE"+
+		"\x2FF\x3\x2\x2\x2\x2FF\x300\x3\x2\x2\x2\x300\x301\x5V,\x2\x301U\x3\x2"+
+		"\x2\x2\x302\x303\x5\xFE\x80\x2\x303W\x3\x2\x2\x2\x304\x305\a\x9E\x2\x2"+
+		"\x305\x306\x5\x174\xBB\x2\x306\x308\x5\x38\x1D\x2\x307\x309\x5\x174\xBB"+
+		"\x2\x308\x307\x3\x2\x2\x2\x308\x309\x3\x2\x2\x2\x309\x30A\x3\x2\x2\x2"+
+		"\x30A\x30F\a)\x2\x2\x30B\x30D\x5\x174\xBB\x2\x30C\x30B\x3\x2\x2\x2\x30C"+
+		"\x30D\x3\x2\x2\x2\x30D\x30E\x3\x2\x2\x2\x30E\x310\x5Z.\x2\x30F\x30C\x3"+
+		"\x2\x2\x2\x30F\x310\x3\x2\x2\x2\x310Y\x3\x2\x2\x2\x311\x318\x5\\/\x2\x312"+
+		"\x314\x5\x174\xBB\x2\x313\x312\x3\x2\x2\x2\x313\x314\x3\x2\x2\x2\x314"+
+		"\x315\x3\x2\x2\x2\x315\x317\x5\\/\x2\x316\x313\x3\x2\x2\x2\x317\x31A\x3"+
+		"\x2\x2\x2\x318\x316\x3\x2\x2\x2\x318\x319\x3\x2\x2\x2\x319[\x3\x2\x2\x2"+
+		"\x31A\x318\x3\x2\x2\x2\x31B\x324\x5^\x30\x2\x31C\x324\x5`\x31\x2\x31D"+
+		"\x31F\x5^\x30\x2\x31E\x320\x5\x174\xBB\x2\x31F\x31E\x3\x2\x2\x2\x31F\x320"+
+		"\x3\x2\x2\x2\x320\x321\x3\x2\x2\x2\x321\x322\x5`\x31\x2\x322\x324\x3\x2"+
+		"\x2\x2\x323\x31B\x3\x2\x2\x2\x323\x31C\x3\x2\x2\x2\x323\x31D\x3\x2\x2"+
+		"\x2\x324]\x3\x2\x2\x2\x325\x329\x5\x64\x33\x2\x326\x329\x5h\x35\x2\x327"+
+		"\x329\x5\x62\x32\x2\x328\x325\x3\x2\x2\x2\x328\x326\x3\x2\x2\x2\x328\x327"+
+		"\x3\x2\x2\x2\x329_\x3\x2\x2\x2\x32A\x32B\t\x6\x2\x2\x32B\x61\x3\x2\x2"+
+		"\x2\x32C\x32D\x5\xFE\x80\x2\x32D\x63\x3\x2\x2\x2\x32E\x330\a\xB5\x2\x2"+
+		"\x32F\x331\x5\x174\xBB\x2\x330\x32F\x3\x2\x2\x2\x330\x331\x3\x2\x2\x2"+
+		"\x331\x332\x3\x2\x2\x2\x332\x334\a\xD4\x2\x2\x333\x335\x5\x174\xBB\x2"+
+		"\x334\x333\x3\x2\x2\x2\x334\x335\x3\x2\x2\x2\x335\x336\x3\x2\x2\x2\x336"+
+		"\x338\x5\x66\x34\x2\x337\x339\x5\x174\xBB\x2\x338\x337\x3\x2\x2\x2\x338"+
+		"\x339\x3\x2\x2\x2\x339\x33A\x3\x2\x2\x2\x33A\x33B\a\xDB\x2\x2\x33B\x65"+
+		"\x3\x2\x2\x2\x33C\x33D\x5\xFE\x80\x2\x33Dg\x3\x2\x2\x2\x33E\x343\a\xBB"+
+		"\x2\x2\x33F\x341\x5\x174\xBB\x2\x340\x33F\x3\x2\x2\x2\x340\x341\x3\x2"+
+		"\x2\x2\x341\x342\x3\x2\x2\x2\x342\x344\x5j\x36\x2\x343\x340\x3\x2\x2\x2"+
+		"\x343\x344\x3\x2\x2\x2\x344i\x3\x2\x2\x2\x345\x347\a\xD4\x2\x2\x346\x348"+
+		"\x5\x174\xBB\x2\x347\x346\x3\x2\x2\x2\x347\x348\x3\x2\x2\x2\x348\x349"+
+		"\x3\x2\x2\x2\x349\x34B\x5l\x37\x2\x34A\x34C\x5\x174\xBB\x2\x34B\x34A\x3"+
+		"\x2\x2\x2\x34B\x34C\x3\x2\x2\x2\x34C\x34D\x3\x2\x2\x2\x34D\x34E\a\xDB"+
+		"\x2\x2\x34Ek\x3\x2\x2\x2\x34F\x350\x5\xFE\x80\x2\x350m\x3\x2\x2\x2\x351"+
+		"\x352\a\xCB\x2\x2\x352\x353\x5\x174\xBB\x2\x353\x355\x5\x38\x1D\x2\x354"+
+		"\x356\x5\x174\xBB\x2\x355\x354\x3\x2\x2\x2\x355\x356\x3\x2\x2\x2\x356"+
+		"\x357\x3\x2\x2\x2\x357\x35C\a)\x2\x2\x358\x35A\x5\x174\xBB\x2\x359\x358"+
+		"\x3\x2\x2\x2\x359\x35A\x3\x2\x2\x2\x35A\x35B\x3\x2\x2\x2\x35B\x35D\x5"+
+		"Z.\x2\x35C\x359\x3\x2\x2\x2\x35C\x35D\x3\x2\x2\x2\x35Do\x3\x2\x2\x2\x35E"+
+		"\x35F\a{\x2\x2\x35F\x360\x5\x174\xBB\x2\x360\x362\x5\x38\x1D\x2\x361\x363"+
+		"\x5\x174\xBB\x2\x362\x361\x3\x2\x2\x2\x362\x363\x3\x2\x2\x2\x363\x364"+
+		"\x3\x2\x2\x2\x364\x366\a)\x2\x2\x365\x367\x5\x174\xBB\x2\x366\x365\x3"+
+		"\x2\x2\x2\x366\x367\x3\x2\x2\x2\x367\x368\x3\x2\x2\x2\x368\x369\x5r:\x2"+
+		"\x369q\x3\x2\x2\x2\x36A\x375\x5t;\x2\x36B\x36D\x5\x174\xBB\x2\x36C\x36B"+
+		"\x3\x2\x2\x2\x36C\x36D\x3\x2\x2\x2\x36D\x36E\x3\x2\x2\x2\x36E\x370\a)"+
+		"\x2\x2\x36F\x371\x5\x174\xBB\x2\x370\x36F\x3\x2\x2\x2\x370\x371\x3\x2"+
+		"\x2\x2\x371\x372\x3\x2\x2\x2\x372\x374\x5t;\x2\x373\x36C\x3\x2\x2\x2\x374"+
+		"\x377\x3\x2\x2\x2\x375\x373\x3\x2\x2\x2\x375\x376\x3\x2\x2\x2\x376s\x3"+
+		"\x2\x2\x2\x377\x375\x3\x2\x2\x2\x378\x379\x5\xFE\x80\x2\x379u\x3\x2\x2"+
+		"\x2\x37A\x37B\a\xA5\x2\x2\x37B\x37C\x5\x174\xBB\x2\x37C\x37E\x5\x36\x1C"+
+		"\x2\x37D\x37F\x5\x174\xBB\x2\x37E\x37D\x3\x2\x2\x2\x37E\x37F\x3\x2\x2"+
+		"\x2\x37F\x380\x3\x2\x2\x2\x380\x382\a)\x2\x2\x381\x383\x5\x174\xBB\x2"+
+		"\x382\x381\x3\x2\x2\x2\x382\x383\x3\x2\x2\x2\x383\x385\x3\x2\x2\x2\x384"+
+		"\x386\x5x=\x2\x385\x384\x3\x2\x2\x2\x385\x386\x3\x2\x2\x2\x386\x388\x3"+
+		"\x2\x2\x2\x387\x389\x5\x174\xBB\x2\x388\x387\x3\x2\x2\x2\x388\x389\x3"+
+		"\x2\x2\x2\x389\x38A\x3\x2\x2\x2\x38A\x38C\a)\x2\x2\x38B\x38D\x5\x174\xBB"+
+		"\x2\x38C\x38B\x3\x2\x2\x2\x38C\x38D\x3\x2\x2\x2\x38D\x38E\x3\x2\x2\x2"+
+		"\x38E\x38F\x5z>\x2\x38Fw\x3\x2\x2\x2\x390\x391\x5\xFE\x80\x2\x391y\x3"+
+		"\x2\x2\x2\x392\x393\x5\xFE\x80\x2\x393{\x3\x2\x2\x2\x394\x395\as\x2\x2"+
+		"\x395\x396\x5\x174\xBB\x2\x396\x398\x5\x36\x1C\x2\x397\x399\x5\x174\xBB"+
 		"\x2\x398\x397\x3\x2\x2\x2\x398\x399\x3\x2\x2\x2\x399\x39A\x3\x2\x2\x2"+
-		"\x39A\x39B\a^\x2\x2\x39B]\x3\x2\x2\x2\x39C\x39D\aZ\x2\x2\x39D\x39E\x5"+
-		"\x136\x9C\x2\x39E\x39F\x5n\x38\x2\x39F\x3A0\x5\x136\x9C\x2\x3A0\x3A1\a"+
-		"\xBD\x2\x2\x3A1\x3A3\x5\x122\x92\x2\x3A2\x3A4\x5\x1E\x10\x2\x3A3\x3A2"+
-		"\x3\x2\x2\x2\x3A3\x3A4\x3\x2\x2\x2\x3A4\x3B1\x3\x2\x2\x2\x3A5\x3A6\aZ"+
-		"\x2\x2\x3A6\x3A7\x5\x136\x9C\x2\x3A7\x3A8\x5n\x38\x2\x3A8\x3A9\x5\x136"+
-		"\x9C\x2\x3A9\x3AB\a\xBD\x2\x2\x3AA\x3AC\x5\x136\x9C\x2\x3AB\x3AA\x3\x2"+
-		"\x2\x2\x3AB\x3AC\x3\x2\x2\x2\x3AC\x3AE\x3\x2\x2\x2\x3AD\x3AF\x5\x1E\x10"+
-		"\x2\x3AE\x3AD\x3\x2\x2\x2\x3AE\x3AF\x3\x2\x2\x2\x3AF\x3B1\x3\x2\x2\x2"+
-		"\x3B0\x39C\x3\x2\x2\x2\x3B0\x3A5\x3\x2\x2\x2\x3B1_\x3\x2\x2\x2\x3B2\x3B3"+
-		"\aY\x2\x2\x3B3\x3B5\x5\x122\x92\x2\x3B4\x3B6\x5\x1E\x10\x2\x3B5\x3B4\x3"+
-		"\x2\x2\x2\x3B5\x3B6\x3\x2\x2\x2\x3B6\x61\x3\x2\x2\x2\x3B7\x3BA\x5\x64"+
-		"\x33\x2\x3B8\x3BA\x5\x66\x34\x2\x3B9\x3B7\x3\x2\x2\x2\x3B9\x3B8\x3\x2"+
-		"\x2\x2\x3BA\x63\x3\x2\x2\x2\x3BB\x3BD\aw\x2\x2\x3BC\x3BE\x5\x136\x9C\x2"+
-		"\x3BD\x3BC\x3\x2\x2\x2\x3BD\x3BE\x3\x2\x2\x2\x3BE\x3BF\x3\x2\x2\x2\x3BF"+
-		"\x3C1\x5n\x38\x2\x3C0\x3C2\x5\x136\x9C\x2\x3C1\x3C0\x3\x2\x2\x2\x3C1\x3C2"+
-		"\x3\x2\x2\x2\x3C2\x3C3\x3\x2\x2\x2\x3C3\x3C5\a\xBD\x2\x2\x3C4\x3C6\x5"+
-		"\x136\x9C\x2\x3C5\x3C4\x3\x2\x2\x2\x3C5\x3C6\x3\x2\x2\x2\x3C6\x3C7\x3"+
-		"\x2\x2\x2\x3C7\x3CB\x5j\x36\x2\x3C8\x3C9\x5\x136\x9C\x2\x3C9\x3CA\x5h"+
-		"\x35\x2\x3CA\x3CC\x3\x2\x2\x2\x3CB\x3C8\x3\x2\x2\x2\x3CB\x3CC\x3\x2\x2"+
-		"\x2\x3CC\x65\x3\x2\x2\x2\x3CD\x3CF\aw\x2\x2\x3CE\x3D0\x5\x136\x9C\x2\x3CF"+
-		"\x3CE\x3\x2\x2\x2\x3CF\x3D0\x3\x2\x2\x2\x3D0\x3D1\x3\x2\x2\x2\x3D1\x3D3"+
-		"\x5n\x38\x2\x3D2\x3D4\x5\x136\x9C\x2\x3D3\x3D2\x3\x2\x2\x2\x3D3\x3D4\x3"+
-		"\x2\x2\x2\x3D4\x3D5\x3\x2\x2\x2\x3D5\x3D6\a\xBD\x2\x2\x3D6\x3D8\x5\x122"+
-		"\x92\x2\x3D7\x3D9\x5\x136\x9C\x2\x3D8\x3D7\x3\x2\x2\x2\x3D8\x3D9\x3\x2"+
-		"\x2\x2\x3D9\x3DA\x3\x2\x2\x2\x3DA\x3DB\x5h\x35\x2\x3DBg\x3\x2\x2\x2\x3DC"+
-		"\x3DE\aY\x2\x2\x3DD\x3DF\x5\x136\x9C\x2\x3DE\x3DD\x3\x2\x2\x2\x3DE\x3DF"+
-		"\x3\x2\x2\x2\x3DF\x3E1\x3\x2\x2\x2\x3E0\x3E2\x5j\x36\x2\x3E1\x3E0\x3\x2"+
-		"\x2\x2\x3E1\x3E2\x3\x2\x2\x2\x3E2i\x3\x2\x2\x2\x3E3\x3F0\x5\x10E\x88\x2"+
-		"\x3E4\x3E6\x5\x136\x9C\x2\x3E5\x3E4\x3\x2\x2\x2\x3E5\x3E6\x3\x2\x2\x2"+
-		"\x3E6\x3E7\x3\x2\x2\x2\x3E7\x3E9\a*\x2\x2\x3E8\x3EA\x5\x136\x9C\x2\x3E9"+
-		"\x3E8\x3\x2\x2\x2\x3E9\x3EA\x3\x2\x2\x2\x3EA\x3EC\x3\x2\x2\x2\x3EB\x3ED"+
-		"\x5l\x37\x2\x3EC\x3EB\x3\x2\x2\x2\x3EC\x3ED\x3\x2\x2\x2\x3ED\x3EF\x3\x2"+
-		"\x2\x2\x3EE\x3E5\x3\x2\x2\x2\x3EF\x3F2\x3\x2\x2\x2\x3F0\x3EE\x3\x2\x2"+
-		"\x2\x3F0\x3F1\x3\x2\x2\x2\x3F1\x40A\x3\x2\x2\x2\x3F2\x3F0\x3\x2\x2\x2"+
-		"\x3F3\x3F5\a*\x2\x2\x3F4\x3F6\x5\x136\x9C\x2\x3F5\x3F4\x3\x2\x2\x2\x3F5"+
-		"\x3F6\x3\x2\x2\x2\x3F6\x3F8\x3\x2\x2\x2\x3F7\x3F3\x3\x2\x2\x2\x3F7\x3F8"+
-		"\x3\x2\x2\x2\x3F8\x3F9\x3\x2\x2\x2\x3F9\x406\x5l\x37\x2\x3FA\x3FC\x5\x136"+
-		"\x9C\x2\x3FB\x3FA\x3\x2\x2\x2\x3FB\x3FC\x3\x2\x2\x2\x3FC\x3FD\x3\x2\x2"+
-		"\x2\x3FD\x3FF\a*\x2\x2\x3FE\x400\x5\x136\x9C\x2\x3FF\x3FE\x3\x2\x2\x2"+
-		"\x3FF\x400\x3\x2\x2\x2\x400\x402\x3\x2\x2\x2\x401\x403\x5l\x37\x2\x402"+
-		"\x401\x3\x2\x2\x2\x402\x403\x3\x2\x2\x2\x403\x405\x3\x2\x2\x2\x404\x3FB"+
-		"\x3\x2\x2\x2\x405\x408\x3\x2\x2\x2\x406\x404\x3\x2\x2\x2\x406\x407\x3"+
-		"\x2\x2\x2\x407\x40A\x3\x2\x2\x2\x408\x406\x3\x2\x2\x2\x409\x3E3\x3\x2"+
-		"\x2\x2\x409\x3F7\x3\x2\x2\x2\x40Ak\x3\x2\x2\x2\x40B\x40C\x5 \x11\x2\x40C"+
-		"m\x3\x2\x2\x2\x40D\x40E\x5\xBA^\x2\x40Eo\x3\x2\x2\x2\x40F\x410\ay\x2\x2"+
-		"\x410\x411\x5\x136\x9C\x2\x411\x412\x5\xBA^\x2\x412q\x3\x2\x2\x2\x413"+
-		"\x414\a{\x2\x2\x414\x415\x5\x136\x9C\x2\x415\x41E\x5\xCEh\x2\x416\x418"+
-		"\x5\x136\x9C\x2\x417\x416\x3\x2\x2\x2\x417\x418\x3\x2\x2\x2\x418\x419"+
-		"\x3\x2\x2\x2\x419\x41B\a)\x2\x2\x41A\x41C\x5\x136\x9C\x2\x41B\x41A\x3"+
-		"\x2\x2\x2\x41B\x41C\x3\x2\x2\x2\x41C\x41D\x3\x2\x2\x2\x41D\x41F\x5\xBA"+
-		"^\x2\x41E\x417\x3\x2\x2\x2\x41F\x420\x3\x2\x2\x2\x420\x41E\x3\x2\x2\x2"+
-		"\x420\x421\x3\x2\x2\x2\x421s\x3\x2\x2\x2\x422\x423\a\x81\x2\x2\x423\x425"+
-		"\x5\x136\x9C\x2\x424\x422\x3\x2\x2\x2\x424\x425\x3\x2\x2\x2\x425\x426"+
-		"\x3\x2\x2\x2\x426\x428\x5\xBA^\x2\x427\x429\x5\x136\x9C\x2\x428\x427\x3"+
-		"\x2\x2\x2\x428\x429\x3\x2\x2\x2\x429\x42A\x3\x2\x2\x2\x42A\x42C\a\xD0"+
-		"\x2\x2\x42B\x42D\x5\x136\x9C\x2\x42C\x42B\x3\x2\x2\x2\x42C\x42D\x3\x2"+
-		"\x2\x2\x42D\x42E\x3\x2\x2\x2\x42E\x42F\x5\xBA^\x2\x42Fu\x3\x2\x2\x2\x430"+
-		"\x431\a\x84\x2\x2\x431\x432\x5\x136\x9C\x2\x432\x434\x5\xCEh\x2\x433\x435"+
-		"\x5\x136\x9C\x2\x434\x433\x3\x2\x2\x2\x434\x435\x3\x2\x2\x2\x435\x436"+
-		"\x3\x2\x2\x2\x436\x438\a)\x2\x2\x437\x439\x5\x136\x9C\x2\x438\x437\x3"+
-		"\x2\x2\x2\x438\x439\x3\x2\x2\x2\x439\x43A\x3\x2\x2\x2\x43A\x43B\x5\xBA"+
-		"^\x2\x43Bw\x3\x2\x2\x2\x43C\x43D\a~\x2\x2\x43D\x43E\x5\x136\x9C\x2\x43E"+
-		"\x44E\x5\xBA^\x2\x43F\x441\x5\x136\x9C\x2\x440\x43F\x3\x2\x2\x2\x440\x441"+
-		"\x3\x2\x2\x2\x441\x442\x3\x2\x2\x2\x442\x444\a)\x2\x2\x443\x445\x5\x136"+
-		"\x9C\x2\x444\x443\x3\x2\x2\x2\x444\x445\x3\x2\x2\x2\x445\x446\x3\x2\x2"+
-		"\x2\x446\x44C\x5\xBA^\x2\x447\x448\x5\x136\x9C\x2\x448\x449\a\xBE\x2\x2"+
-		"\x449\x44A\x5\x136\x9C\x2\x44A\x44B\x5\xBA^\x2\x44B\x44D\x3\x2\x2\x2\x44C"+
-		"\x447\x3\x2\x2\x2\x44C\x44D\x3\x2\x2\x2\x44D\x44F\x3\x2\x2\x2\x44E\x440"+
-		"\x3\x2\x2\x2\x44E\x44F\x3\x2\x2\x2\x44Fy\x3\x2\x2\x2\x450\x451\a\x88\x2"+
-		"\x2\x451\x452\x5\x136\x9C\x2\x452\x454\x5\xBA^\x2\x453\x455\x5\x136\x9C"+
-		"\x2\x454\x453\x3\x2\x2\x2\x454\x455\x3\x2\x2\x2\x455\x456\x3\x2\x2\x2"+
-		"\x456\x458\a\xD0\x2\x2\x457\x459\x5\x136\x9C\x2\x458\x457\x3\x2\x2\x2"+
-		"\x458\x459\x3\x2\x2\x2\x459\x45A\x3\x2\x2\x2\x45A\x45B\x5\xBA^\x2\x45B"+
-		"{\x3\x2\x2\x2\x45C\x45E\a\x8A\x2\x2\x45D\x45F\x5\x136\x9C\x2\x45E\x45D"+
-		"\x3\x2\x2\x2\x45E\x45F\x3\x2\x2\x2\x45F\x460\x3\x2\x2\x2\x460\x462\a\xD4"+
-		"\x2\x2\x461\x463\x5\x136\x9C\x2\x462\x461\x3\x2\x2\x2\x462\x463\x3\x2"+
-		"\x2\x2\x463\x464\x3\x2\x2\x2\x464\x466\x5\xEAv\x2\x465\x467\x5\x136\x9C"+
-		"\x2\x466\x465\x3\x2\x2\x2\x466\x467\x3\x2\x2\x2\x467\x468\x3\x2\x2\x2"+
-		"\x468\x469\a\xDB\x2\x2\x469}\x3\x2\x2\x2\x46A\x46B\t\a\x2\x2\x46B\x474"+
-		"\x5\x136\x9C\x2\x46C\x46D\av\x2\x2\x46D\x46E\x5\x136\x9C\x2\x46E\x46F"+
-		"\x5\xBA^\x2\x46F\x475\x3\x2\x2\x2\x470\x471\a\xAD\x2\x2\x471\x472\x5\x136"+
-		"\x9C\x2\x472\x473\a\x8C\x2\x2\x473\x475\x3\x2\x2\x2\x474\x46C\x3\x2\x2"+
-		"\x2\x474\x470\x3\x2\x2\x2\x475\x7F\x3\x2\x2\x2\x476\x477\a\x91\x2\x2\x477"+
-		"\x478\x5\x136\x9C\x2\x478\x479\x5\xBA^\x2\x479\x47A\x5\x136\x9C\x2\x47A"+
-		"\x47B\av\x2\x2\x47B\x47C\x5\x136\x9C\x2\x47C\x487\x5\xBA^\x2\x47D\x47F"+
-		"\x5\x136\x9C\x2\x47E\x47D\x3\x2\x2\x2\x47E\x47F\x3\x2\x2\x2\x47F\x480"+
-		"\x3\x2\x2\x2\x480\x482\a)\x2\x2\x481\x483\x5\x136\x9C\x2\x482\x481\x3"+
-		"\x2\x2\x2\x482\x483\x3\x2\x2\x2\x483\x484\x3\x2\x2\x2\x484\x486\x5\xBA"+
-		"^\x2\x485\x47E\x3\x2\x2\x2\x486\x489\x3\x2\x2\x2\x487\x485\x3\x2\x2\x2"+
-		"\x487\x488\x3\x2\x2\x2\x488\x81\x3\x2\x2\x2\x489\x487\x3\x2\x2\x2\x48A"+
-		"\x48B\a\x91\x2\x2\x48B\x48C\x5\x136\x9C\x2\x48C\x48D\x5\xBA^\x2\x48D\x48E"+
-		"\x5\x136\x9C\x2\x48E\x48F\au\x2\x2\x48F\x490\x5\x136\x9C\x2\x490\x49B"+
-		"\x5\xBA^\x2\x491\x493\x5\x136\x9C\x2\x492\x491\x3\x2\x2\x2\x492\x493\x3"+
-		"\x2\x2\x2\x493\x494\x3\x2\x2\x2\x494\x496\a)\x2\x2\x495\x497\x5\x136\x9C"+
-		"\x2\x496\x495\x3\x2\x2\x2\x496\x497\x3\x2\x2\x2\x497\x498\x3\x2\x2\x2"+
-		"\x498\x49A\x5\xBA^\x2\x499\x492\x3\x2\x2\x2\x49A\x49D\x3\x2\x2\x2\x49B"+
-		"\x499\x3\x2\x2\x2\x49B\x49C\x3\x2\x2\x2\x49C\x83\x3\x2\x2\x2\x49D\x49B"+
-		"\x3\x2\x2\x2\x49E\x49F\a\x94\x2\x2\x49F\x4A0\x5\x136\x9C\x2\x4A0\x4A1"+
-		"\x5\xBA^\x2\x4A1\x4A2\x5\x136\x9C\x2\x4A2\x4A3\aq\x2\x2\x4A3\x4A4\x5\x136"+
-		"\x9C\x2\x4A4\x4AA\t\b\x2\x2\x4A5\x4A6\x5\x136\x9C\x2\x4A6\x4A7\a\x33\x2"+
-		"\x2\x4A7\x4A8\x5\x136\x9C\x2\x4A8\x4A9\t\t\x2\x2\x4A9\x4AB\x3\x2\x2\x2"+
-		"\x4AA\x4A5\x3\x2\x2\x2\x4AA\x4AB\x3\x2\x2\x2\x4AB\x4AF\x3\x2\x2\x2\x4AC"+
-		"\x4AD\x5\x136\x9C\x2\x4AD\x4AE\t\n\x2\x2\x4AE\x4B0\x3\x2\x2\x2\x4AF\x4AC"+
-		"\x3\x2\x2\x2\x4AF\x4B0\x3\x2\x2\x2\x4B0\x4B1\x3\x2\x2\x2\x4B1\x4B2\x5"+
-		"\x136\x9C\x2\x4B2\x4B3\a\x39\x2\x2\x4B3\x4B4\x5\x136\x9C\x2\x4B4\x4C0"+
-		"\x5\xCEh\x2\x4B5\x4B6\x5\x136\x9C\x2\x4B6\x4B8\a\x1D\x2\x2\x4B7\x4B9\x5"+
-		"\x136\x9C\x2\x4B8\x4B7\x3\x2\x2\x2\x4B8\x4B9\x3\x2\x2\x2\x4B9\x4BA\x3"+
-		"\x2\x2\x2\x4BA\x4BC\a\xD0\x2\x2\x4BB\x4BD\x5\x136\x9C\x2\x4BC\x4BB\x3"+
-		"\x2\x2\x2\x4BC\x4BD\x3\x2\x2\x2\x4BD\x4BE\x3\x2\x2\x2\x4BE\x4BF\x5\xBA"+
-		"^\x2\x4BF\x4C1\x3\x2\x2\x2\x4C0\x4B5\x3\x2\x2\x2\x4C0\x4C1\x3\x2\x2\x2"+
-		"\x4C1\x85\x3\x2\x2\x2\x4C2\x4CF\x5\x88\x45\x2\x4C3\x4C5\x5\x136\x9C\x2"+
-		"\x4C4\x4C3\x3\x2\x2\x2\x4C4\x4C5\x3\x2\x2\x2\x4C5\x4C6\x3\x2\x2\x2\x4C6"+
-		"\x4C8\t\v\x2\x2\x4C7\x4C9\x5\x136\x9C\x2\x4C8\x4C7\x3\x2\x2\x2\x4C8\x4C9"+
-		"\x3\x2\x2\x2\x4C9\x4CB\x3\x2\x2\x2\x4CA\x4CC\x5\x88\x45\x2\x4CB\x4CA\x3"+
-		"\x2\x2\x2\x4CB\x4CC\x3\x2\x2\x2\x4CC\x4CE\x3\x2\x2\x2\x4CD\x4C4\x3\x2"+
-		"\x2\x2\x4CE\x4D1\x3\x2\x2\x2\x4CF\x4CD\x3\x2\x2\x2\x4CF\x4D0\x3\x2\x2"+
-		"\x2\x4D0\x4E4\x3\x2\x2\x2\x4D1\x4CF\x3\x2\x2\x2\x4D2\x4D4\x5\x88\x45\x2"+
-		"\x4D3\x4D2\x3\x2\x2\x2\x4D3\x4D4\x3\x2\x2\x2\x4D4\x4DF\x3\x2\x2\x2\x4D5"+
-		"\x4D7\x5\x136\x9C\x2\x4D6\x4D5\x3\x2\x2\x2\x4D6\x4D7\x3\x2\x2\x2\x4D7"+
-		"\x4D8\x3\x2\x2\x2\x4D8\x4DA\t\v\x2\x2\x4D9\x4DB\x5\x136\x9C\x2\x4DA\x4D9"+
-		"\x3\x2\x2\x2\x4DA\x4DB\x3\x2\x2\x2\x4DB\x4DD\x3\x2\x2\x2\x4DC\x4DE\x5"+
-		"\x88\x45\x2\x4DD\x4DC\x3\x2\x2\x2\x4DD\x4DE\x3\x2\x2\x2\x4DE\x4E0\x3\x2"+
-		"\x2\x2\x4DF\x4D6\x3\x2\x2\x2\x4E0\x4E1\x3\x2\x2\x2\x4E1\x4DF\x3\x2\x2"+
-		"\x2\x4E1\x4E2\x3\x2\x2\x2\x4E2\x4E4\x3\x2\x2\x2\x4E3\x4C2\x3\x2\x2\x2"+
-		"\x4E3\x4D3\x3\x2\x2\x2\x4E4\x87\x3\x2\x2\x2\x4E5\x4F7\x5\xBA^\x2\x4E6"+
-		"\x4F4\t\f\x2\x2\x4E7\x4E9\x5\x136\x9C\x2\x4E8\x4E7\x3\x2\x2\x2\x4E8\x4E9"+
-		"\x3\x2\x2\x2\x4E9\x4EA\x3\x2\x2\x2\x4EA\x4EC\a\xD4\x2\x2\x4EB\x4ED\x5"+
-		"\x136\x9C\x2\x4EC\x4EB\x3\x2\x2\x2\x4EC\x4ED\x3\x2\x2\x2\x4ED\x4EE\x3"+
-		"\x2\x2\x2\x4EE\x4F0\x5\xEAv\x2\x4EF\x4F1\x5\x136\x9C\x2\x4F0\x4EF\x3\x2"+
-		"\x2\x2\x4F0\x4F1\x3\x2\x2\x2\x4F1\x4F2\x3\x2\x2\x2\x4F2\x4F3\a\xDB\x2"+
-		"\x2\x4F3\x4F5\x3\x2\x2\x2\x4F4\x4E8\x3\x2\x2\x2\x4F4\x4F5\x3\x2\x2\x2"+
-		"\x4F5\x4F7\x3\x2\x2\x2\x4F6\x4E5\x3\x2\x2\x2\x4F6\x4E6\x3\x2\x2\x2\x4F7"+
-		"\x89\x3\x2\x2\x2\x4F8\x4F9\a\x9E\x2\x2\x4F9\x4FA\x5\x136\x9C\x2\x4FA\x4FC"+
-		"\x5\xCEh\x2\x4FB\x4FD\x5\x136\x9C\x2\x4FC\x4FB\x3\x2\x2\x2\x4FC\x4FD\x3"+
-		"\x2\x2\x2\x4FD\x4FE\x3\x2\x2\x2\x4FE\x503\a)\x2\x2\x4FF\x501\x5\x136\x9C"+
-		"\x2\x500\x4FF\x3\x2\x2\x2\x500\x501\x3\x2\x2\x2\x501\x502\x3\x2\x2\x2"+
-		"\x502\x504\x5\x86\x44\x2\x503\x500\x3\x2\x2\x2\x503\x504\x3\x2\x2\x2\x504"+
-		"\x8B\x3\x2\x2\x2\x505\x506\x5\x118\x8D\x2\x506\x507\x5\x136\x9C\x2\x507"+
-		"\x509\x3\x2\x2\x2\x508\x505\x3\x2\x2\x2\x508\x509\x3\x2\x2\x2\x509\x50C"+
-		"\x3\x2\x2\x2\x50A\x50B\a\xB6\x2\x2\x50B\x50D\x5\x136\x9C\x2\x50C\x50A"+
-		"\x3\x2\x2\x2\x50C\x50D\x3\x2\x2\x2\x50D\x50E\x3\x2\x2\x2\x50E\x50F\a\xA0"+
-		"\x2\x2\x50F\x510\x5\x136\x9C\x2\x510\x512\x5T+\x2\x511\x513\x5\x116\x8C"+
-		"\x2\x512\x511\x3\x2\x2\x2\x512\x513\x3\x2\x2\x2\x513\x518\x3\x2\x2\x2"+
-		"\x514\x516\x5\x136\x9C\x2\x515\x514\x3\x2\x2\x2\x515\x516\x3\x2\x2\x2"+
-		"\x516\x517\x3\x2\x2\x2\x517\x519\x5\xF0y\x2\x518\x515\x3\x2\x2\x2\x518"+
-		"\x519\x3\x2\x2\x2\x519\x51D\x3\x2\x2\x2\x51A\x51B\x5\x136\x9C\x2\x51B"+
-		"\x51C\x5\xFE\x80\x2\x51C\x51E\x3\x2\x2\x2\x51D\x51A\x3\x2\x2\x2\x51D\x51E"+
-		"\x3\x2\x2\x2\x51E\x51F\x3\x2\x2\x2\x51F\x521\x5\x122\x92\x2\x520\x522"+
-		"\x5\x1E\x10\x2\x521\x520\x3\x2\x2\x2\x521\x522\x3\x2\x2\x2\x522\x523\x3"+
-		"\x2\x2\x2\x523\x524\a_\x2\x2\x524\x8D\x3\x2\x2\x2\x525\x526\x5\x118\x8D"+
-		"\x2\x526\x527\x5\x136\x9C\x2\x527\x529\x3\x2\x2\x2\x528\x525\x3\x2\x2"+
-		"\x2\x528\x529\x3\x2\x2\x2\x529\x52C\x3\x2\x2\x2\x52A\x52B\a\xB6\x2\x2"+
-		"\x52B\x52D\x5\x136\x9C\x2\x52C\x52A\x3\x2\x2\x2\x52C\x52D\x3\x2\x2\x2"+
-		"\x52D\x52E\x3\x2\x2\x2\x52E\x52F\a\xA2\x2\x2\x52F\x530\x5\x136\x9C\x2"+
-		"\x530\x535\x5\xB2Z\x2\x531\x533\x5\x136\x9C\x2\x532\x531\x3\x2\x2\x2\x532"+
-		"\x533\x3\x2\x2\x2\x533\x534\x3\x2\x2\x2\x534\x536\x5\xF0y\x2\x535\x532"+
-		"\x3\x2\x2\x2\x535\x536\x3\x2\x2\x2\x536\x537\x3\x2\x2\x2\x537\x539\x5"+
-		"\x122\x92\x2\x538\x53A\x5\x1E\x10\x2\x539\x538\x3\x2\x2\x2\x539\x53A\x3"+
-		"\x2\x2\x2\x53A\x53B\x3\x2\x2\x2\x53B\x53C\a_\x2\x2\x53C\x8F\x3\x2\x2\x2"+
-		"\x53D\x53E\x5\x118\x8D\x2\x53E\x53F\x5\x136\x9C\x2\x53F\x541\x3\x2\x2"+
-		"\x2\x540\x53D\x3\x2\x2\x2\x540\x541\x3\x2\x2\x2\x541\x544\x3\x2\x2\x2"+
-		"\x542\x543\a\xB6\x2\x2\x543\x545\x5\x136\x9C\x2\x544\x542\x3\x2\x2\x2"+
-		"\x544\x545\x3\x2\x2\x2\x545\x546\x3\x2\x2\x2\x546\x547\a\xA1\x2\x2\x547"+
-		"\x548\x5\x136\x9C\x2\x548\x54D\x5\xB2Z\x2\x549\x54B\x5\x136\x9C\x2\x54A"+
-		"\x549\x3\x2\x2\x2\x54A\x54B\x3\x2\x2\x2\x54B\x54C\x3\x2\x2\x2\x54C\x54E"+
-		"\x5\xF0y\x2\x54D\x54A\x3\x2\x2\x2\x54D\x54E\x3\x2\x2\x2\x54E\x54F\x3\x2"+
-		"\x2\x2\x54F\x551\x5\x122\x92\x2\x550\x552\x5\x1E\x10\x2\x551\x550\x3\x2"+
-		"\x2\x2\x551\x552\x3\x2\x2\x2\x552\x553\x3\x2\x2\x2\x553\x554\a_\x2\x2"+
-		"\x554\x91\x3\x2\x2\x2\x555\x556\a\xA5\x2\x2\x556\x557\x5\x136\x9C\x2\x557"+
-		"\x559\x5\xCEh\x2\x558\x55A\x5\x136\x9C\x2\x559\x558\x3\x2\x2\x2\x559\x55A"+
-		"\x3\x2\x2\x2\x55A\x55B\x3\x2\x2\x2\x55B\x55D\a)\x2\x2\x55C\x55E\x5\x136"+
-		"\x9C\x2\x55D\x55C\x3\x2\x2\x2\x55D\x55E\x3\x2\x2\x2\x55E\x560\x3\x2\x2"+
-		"\x2\x55F\x561\x5\xBA^\x2\x560\x55F\x3\x2\x2\x2\x560\x561\x3\x2\x2\x2\x561"+
-		"\x563\x3\x2\x2\x2\x562\x564\x5\x136\x9C\x2\x563\x562\x3\x2\x2\x2\x563"+
-		"\x564\x3\x2\x2\x2\x564\x565\x3\x2\x2\x2\x565\x567\a)\x2\x2\x566\x568\x5"+
-		"\x136\x9C\x2\x567\x566\x3\x2\x2\x2\x567\x568\x3\x2\x2\x2\x568\x569\x3"+
-		"\x2\x2\x2\x569\x56A\x5\xBA^\x2\x56A\x93\x3\x2\x2\x2\x56B\x56C\a\xA7\x2"+
-		"\x2\x56C\x56D\x5\x136\x9C\x2\x56D\x57C\x5\xFC\x7F\x2\x56E\x570\x5\x136"+
-		"\x9C\x2\x56F\x56E\x3\x2\x2\x2\x56F\x570\x3\x2\x2\x2\x570\x571\x3\x2\x2"+
-		"\x2\x571\x573\a\xD4\x2\x2\x572\x574\x5\x136\x9C\x2\x573\x572\x3\x2\x2"+
-		"\x2\x573\x574\x3\x2\x2\x2\x574\x579\x3\x2\x2\x2\x575\x577\x5\xEAv\x2\x576"+
-		"\x578\x5\x136\x9C\x2\x577\x576\x3\x2\x2\x2\x577\x578\x3\x2\x2\x2\x578"+
-		"\x57A\x3\x2\x2\x2\x579\x575\x3\x2\x2\x2\x579\x57A\x3\x2\x2\x2\x57A\x57B"+
-		"\x3\x2\x2\x2\x57B\x57D\a\xDB\x2\x2\x57C\x56F\x3\x2\x2\x2\x57C\x57D\x3"+
-		"\x2\x2\x2\x57D\x95\x3\x2\x2\x2\x57E\x57F\a\xAA\x2\x2\x57F\x582\x5\x136"+
-		"\x9C\x2\x580\x581\a\x9D\x2\x2\x581\x583\x5\x136\x9C\x2\x582\x580\x3\x2"+
-		"\x2\x2\x582\x583\x3\x2\x2\x2\x583\x584\x3\x2\x2\x2\x584\x58F\x5\x98M\x2"+
-		"\x585\x587\x5\x136\x9C\x2\x586\x585\x3\x2\x2\x2\x586\x587\x3\x2\x2\x2"+
-		"\x587\x588\x3\x2\x2\x2\x588\x58A\a)\x2\x2\x589\x58B\x5\x136\x9C\x2\x58A"+
-		"\x589\x3\x2\x2\x2\x58A\x58B\x3\x2\x2\x2\x58B\x58C\x3\x2\x2\x2\x58C\x58E"+
-		"\x5\x98M\x2\x58D\x586\x3\x2\x2\x2\x58E\x591\x3\x2\x2\x2\x58F\x58D\x3\x2"+
-		"\x2\x2\x58F\x590\x3\x2\x2\x2\x590\x97\x3\x2\x2\x2\x591\x58F\x3\x2\x2\x2"+
-		"\x592\x594\x5\xDAn\x2\x593\x595\x5\x136\x9C\x2\x594\x593\x3\x2\x2\x2\x594"+
-		"\x595\x3\x2\x2\x2\x595\x596\x3\x2\x2\x2\x596\x598\a\xD4\x2\x2\x597\x599"+
-		"\x5\x136\x9C\x2\x598\x597\x3\x2\x2\x2\x598\x599\x3\x2\x2\x2\x599\x59A"+
-		"\x3\x2\x2\x2\x59A\x59C\x5\xF6|\x2\x59B\x59D\x5\x136\x9C\x2\x59C\x59B\x3"+
-		"\x2\x2\x2\x59C\x59D\x3\x2\x2\x2\x59D\x59E\x3\x2\x2\x2\x59E\x5A2\a\xDB"+
-		"\x2\x2\x59F\x5A0\x5\x136\x9C\x2\x5A0\x5A1\x5\xFE\x80\x2\x5A1\x5A3\x3\x2"+
-		"\x2\x2\x5A2\x59F\x3\x2\x2\x2\x5A2\x5A3\x3\x2\x2\x2\x5A3\x99\x3\x2\x2\x2"+
-		"\x5A4\x5A5\a\xAC\x2\x2\x5A5\x9B\x3\x2\x2\x2\x5A6\x5AC\a\xAD\x2\x2\x5A7"+
-		"\x5AA\x5\x136\x9C\x2\x5A8\x5AB\a\x8C\x2\x2\x5A9\x5AB\x5\xBA^\x2\x5AA\x5A8"+
-		"\x3\x2\x2\x2\x5AA\x5A9\x3\x2\x2\x2\x5AB\x5AD\x3\x2\x2\x2\x5AC\x5A7\x3"+
-		"\x2\x2\x2\x5AC\x5AD\x3\x2\x2\x2\x5AD\x9D\x3\x2\x2\x2\x5AE\x5AF\a\xAE\x2"+
-		"\x2\x5AF\x9F\x3\x2\x2\x2\x5B0\x5B1\a\xAF\x2\x2\x5B1\x5B2\x5\x136\x9C\x2"+
-		"\x5B2\x5B4\x5\xBA^\x2\x5B3\x5B5\x5\x136\x9C\x2\x5B4\x5B3\x3\x2\x2\x2\x5B4"+
-		"\x5B5\x3\x2\x2\x2\x5B5\x5B6\x3\x2\x2\x2\x5B6\x5B8\a\xD0\x2\x2\x5B7\x5B9"+
-		"\x5\x136\x9C\x2\x5B8\x5B7\x3\x2\x2\x2\x5B8\x5B9\x3\x2\x2\x2\x5B9\x5BA"+
-		"\x3\x2\x2\x2\x5BA\x5BB\x5\xBA^\x2\x5BB\xA1\x3\x2\x2\x2\x5BC\x5BD\a\xB8"+
-		"\x2\x2\x5BD\xA3\x3\x2\x2\x2\x5BE\x5BF\a\xB0\x2\x2\x5BF\x5C0\x5\x136\x9C"+
-		"\x2\x5C0\x5C2\x5\xCEh\x2\x5C1\x5C3\x5\x136\x9C\x2\x5C2\x5C1\x3\x2\x2\x2"+
-		"\x5C2\x5C3\x3\x2\x2\x2\x5C3\x5C4\x3\x2\x2\x2\x5C4\x5C6\a)\x2\x2\x5C5\x5C7"+
-		"\x5\x136\x9C\x2\x5C6\x5C5\x3\x2\x2\x2\x5C6\x5C7\x3\x2\x2\x2\x5C7\x5C8"+
-		"\x3\x2\x2\x2\x5C8\x5C9\x5\xBA^\x2\x5C9\xA5\x3\x2\x2\x2\x5CA\x5CB\a\xB1"+
-		"\x2\x2\x5CB\x5CC\x5\x136\x9C\x2\x5CC\x5CD\a\x41\x2\x2\x5CD\x5CE\x5\x136"+
-		"\x9C\x2\x5CE\x5CF\x5\xBA^\x2\x5CF\x5D3\x5\x122\x92\x2\x5D0\x5D2\x5\xAA"+
-		"V\x2\x5D1\x5D0\x3\x2\x2\x2\x5D2\x5D5\x3\x2\x2\x2\x5D3\x5D1\x3\x2\x2\x2"+
-		"\x5D3\x5D4\x3\x2\x2\x2\x5D4\x5D6\x3\x2\x2\x2\x5D5\x5D3\x3\x2\x2\x2\x5D6"+
-		"\x5D7\a`\x2\x2\x5D7\xA7\x3\x2\x2\x2\x5D8\x5DA\a|\x2\x2\x5D9\x5DB\x5\x136"+
-		"\x9C\x2\x5DA\x5D9\x3\x2\x2\x2\x5DA\x5DB\x3\x2\x2\x2\x5DB\x5DC\x3\x2\x2"+
-		"\x2\x5DC\x5DE\x5\x102\x82\x2\x5DD\x5DF\x5\x136\x9C\x2\x5DE\x5DD\x3\x2"+
-		"\x2\x2\x5DE\x5DF\x3\x2\x2\x2\x5DF\x5E0\x3\x2\x2\x2\x5E0\x5E1\x5\xBA^\x2"+
-		"\x5E1\x5EA\x3\x2\x2\x2\x5E2\x5E3\x5\xBA^\x2\x5E3\x5E4\x5\x136\x9C\x2\x5E4"+
-		"\x5E5\a\xBE\x2\x2\x5E5\x5E6\x5\x136\x9C\x2\x5E6\x5E7\x5\xBA^\x2\x5E7\x5EA"+
-		"\x3\x2\x2\x2\x5E8\x5EA\x5\xBA^\x2\x5E9\x5D8\x3\x2\x2\x2\x5E9\x5E2\x3\x2"+
-		"\x2\x2\x5E9\x5E8\x3\x2\x2\x2\x5EA\xA9\x3\x2\x2\x2\x5EB\x5EC\a\x41\x2\x2"+
-		"\x5EC\x5ED\x5\x136\x9C\x2\x5ED\x5EE\x5\xACW\x2\x5EE\x5F0\x5\x122\x92\x2"+
-		"\x5EF\x5F1\x5\x1E\x10\x2\x5F0\x5EF\x3\x2\x2\x2\x5F0\x5F1\x3\x2\x2\x2\x5F1"+
-		"\xAB\x3\x2\x2\x2\x5F2\x602\aY\x2\x2\x5F3\x5FE\x5\xA8U\x2\x5F4\x5F6\x5"+
-		"\x136\x9C\x2\x5F5\x5F4\x3\x2\x2\x2\x5F5\x5F6\x3\x2\x2\x2\x5F6\x5F7\x3"+
-		"\x2\x2\x2\x5F7\x5F9\a)\x2\x2\x5F8\x5FA\x5\x136\x9C\x2\x5F9\x5F8\x3\x2"+
-		"\x2\x2\x5F9\x5FA\x3\x2\x2\x2\x5FA\x5FB\x3\x2\x2\x2\x5FB\x5FD\x5\xA8U\x2"+
-		"\x5FC\x5F5\x3\x2\x2\x2\x5FD\x600\x3\x2\x2\x2\x5FE\x5FC\x3\x2\x2\x2\x5FE"+
-		"\x5FF\x3\x2\x2\x2\x5FF\x602\x3\x2\x2\x2\x600\x5FE\x3\x2\x2\x2\x601\x5F2"+
-		"\x3\x2\x2\x2\x601\x5F3\x3\x2\x2\x2\x602\xAD\x3\x2\x2\x2\x603\x604\a\xB2"+
-		"\x2\x2\x604\x605\x5\x136\x9C\x2\x605\x607\x5\xBA^\x2\x606\x608\x5\x136"+
-		"\x9C\x2\x607\x606\x3\x2\x2\x2\x607\x608\x3\x2\x2\x2\x608\x609\x3\x2\x2"+
-		"\x2\x609\x60B\a\xD0\x2\x2\x60A\x60C\x5\x136\x9C\x2\x60B\x60A\x3\x2\x2"+
-		"\x2\x60B\x60C\x3\x2\x2\x2\x60C\x60D\x3\x2\x2\x2\x60D\x60E\x5\xBA^\x2\x60E"+
-		"\xAF\x3\x2\x2\x2\x60F\x610\x5\x118\x8D\x2\x610\x611\x5\x136\x9C\x2\x611"+
-		"\x613\x3\x2\x2\x2\x612\x60F\x3\x2\x2\x2\x612\x613\x3\x2\x2\x2\x613\x616"+
-		"\x3\x2\x2\x2\x614\x615\a\xB6\x2\x2\x615\x617\x5\x136\x9C\x2\x616\x614"+
-		"\x3\x2\x2\x2\x616\x617\x3\x2\x2\x2\x617\x618\x3\x2\x2\x2\x618\x61A\a\xBA"+
-		"\x2\x2\x619\x61B\x5\x136\x9C\x2\x61A\x619\x3\x2\x2\x2\x61A\x61B\x3\x2"+
-		"\x2\x2\x61B\x61C\x3\x2\x2\x2\x61C\x621\x5\xB2Z\x2\x61D\x61F\x5\x136\x9C"+
-		"\x2\x61E\x61D\x3\x2\x2\x2\x61E\x61F\x3\x2\x2\x2\x61F\x620\x3\x2\x2\x2"+
-		"\x620\x622\x5\xF0y\x2\x621\x61E\x3\x2\x2\x2\x621\x622\x3\x2\x2\x2\x622"+
-		"\x623\x3\x2\x2\x2\x623\x625\x5\x122\x92\x2\x624\x626\x5\x1E\x10\x2\x625"+
-		"\x624\x3\x2\x2\x2\x625\x626\x3\x2\x2\x2\x626\x627\x3\x2\x2\x2\x627\x628"+
-		"\a\x61\x2\x2\x628\xB1\x3\x2\x2\x2\x629\x62A\x5\xFC\x7F\x2\x62A\xB3\x3"+
-		"\x2\x2\x2\x62B\x62C\x5\x118\x8D\x2\x62C\x62D\x5\x136\x9C\x2\x62D\x62F"+
-		"\x3\x2\x2\x2\x62E\x62B\x3\x2\x2\x2\x62E\x62F\x3\x2\x2\x2\x62F\x630\x3"+
-		"\x2\x2\x2\x630\x631\a\xC0\x2\x2\x631\x632\x5\x136\x9C\x2\x632\x633\x5"+
-		"\xFC\x7F\x2\x633\x637\x5\x122\x92\x2\x634\x636\x5\xB6\\\x2\x635\x634\x3"+
-		"\x2\x2\x2\x636\x639\x3\x2\x2\x2\x637\x635\x3\x2\x2\x2\x637\x638\x3\x2"+
-		"\x2\x2\x638\x63A\x3\x2\x2\x2\x639\x637\x3\x2\x2\x2\x63A\x63B\a\x62\x2"+
-		"\x2\x63B\xB5\x3\x2\x2\x2\x63C\x64B\x5\xFC\x7F\x2\x63D\x63F\x5\x136\x9C"+
-		"\x2\x63E\x63D\x3\x2\x2\x2\x63E\x63F\x3\x2\x2\x2\x63F\x640\x3\x2\x2\x2"+
-		"\x640\x645\a\xD4\x2\x2\x641\x643\x5\x136\x9C\x2\x642\x641\x3\x2\x2\x2"+
-		"\x642\x643\x3\x2\x2\x2\x643\x644\x3\x2\x2\x2\x644\x646\x5\xF6|\x2\x645"+
-		"\x642\x3\x2\x2\x2\x645\x646\x3\x2\x2\x2\x646\x648\x3\x2\x2\x2\x647\x649"+
-		"\x5\x136\x9C\x2\x648\x647\x3\x2\x2\x2\x648\x649\x3\x2\x2\x2\x649\x64A"+
-		"\x3\x2\x2\x2\x64A\x64C\a\xDB\x2\x2\x64B\x63E\x3\x2\x2\x2\x64B\x64C\x3"+
-		"\x2\x2\x2\x64C\x650\x3\x2\x2\x2\x64D\x64E\x5\x136\x9C\x2\x64E\x64F\x5"+
-		"\xFE\x80\x2\x64F\x651\x3\x2\x2\x2\x650\x64D\x3\x2\x2\x2\x650\x651\x3\x2"+
-		"\x2\x2\x651\x652\x3\x2\x2\x2\x652\x653\x5\x122\x92\x2\x653\xB7\x3\x2\x2"+
-		"\x2\x654\x655\a\xC2\x2\x2\x655\x656\x5\x136\x9C\x2\x656\x666\x5\xCEh\x2"+
-		"\x657\x659\x5\x136\x9C\x2\x658\x657\x3\x2\x2\x2\x658\x659\x3\x2\x2\x2"+
-		"\x659\x65A\x3\x2\x2\x2\x65A\x65C\a)\x2\x2\x65B\x65D\x5\x136\x9C\x2\x65C"+
-		"\x65B\x3\x2\x2\x2\x65C\x65D\x3\x2\x2\x2\x65D\x65E\x3\x2\x2\x2\x65E\x664"+
-		"\x5\xBA^\x2\x65F\x660\x5\x136\x9C\x2\x660\x661\a\xBE\x2\x2\x661\x662\x5"+
-		"\x136\x9C\x2\x662\x663\x5\xBA^\x2\x663\x665\x3\x2\x2\x2\x664\x65F\x3\x2"+
-		"\x2\x2\x664\x665\x3\x2\x2\x2\x665\x667\x3\x2\x2\x2\x666\x658\x3\x2\x2"+
-		"\x2\x666\x667\x3\x2\x2\x2\x667\xB9\x3\x2\x2\x2\x668\x669\b^\x1\x2\x669"+
-		"\x66B\a\x8D\x2\x2\x66A\x66C\x5\x136\x9C\x2\x66B\x66A\x3\x2\x2\x2\x66B"+
-		"\x66C\x3\x2\x2\x2\x66C\x66D\x3\x2\x2\x2\x66D\x696\x5\xBA^\x15\x66E\x670"+
-		"\a\x34\x2\x2\x66F\x671\x5\x136\x9C\x2\x670\x66F\x3\x2\x2\x2\x670\x671"+
-		"\x3\x2\x2\x2\x671\x672\x3\x2\x2\x2\x672\x696\x5\xBA^\x12\x673\x675\x5"+
-		"\xFA~\x2\x674\x676\x5\x136\x9C\x2\x675\x674\x3\x2\x2\x2\x675\x676\x3\x2"+
-		"\x2\x2\x676\x677\x3\x2\x2\x2\x677\x679\a\xCD\x2\x2\x678\x67A\x5\x136\x9C"+
-		"\x2\x679\x678\x3\x2\x2\x2\x679\x67A\x3\x2\x2\x2\x67A\x67B\x3\x2\x2\x2"+
-		"\x67B\x67C\x5\xBA^\x11\x67C\x696\x3\x2\x2\x2\x67D\x67F\a\xD6\x2\x2\x67E"+
-		"\x680\x5\x136\x9C\x2\x67F\x67E\x3\x2\x2\x2\x67F\x680\x3\x2\x2\x2\x680"+
-		"\x681\x3\x2\x2\x2\x681\x696\x5\xBA^\xF\x682\x684\a\x8E\x2\x2\x683\x685"+
-		"\x5\x136\x9C\x2\x684\x683\x3\x2\x2\x2\x684\x685\x3\x2\x2\x2\x685\x686"+
-		"\x3\x2\x2\x2\x686\x696\x5\xBA^\b\x687\x696\x5\x110\x89\x2\x688\x696\x5"+
-		"\xDAn\x2\x689\x68B\a\xD4\x2\x2\x68A\x68C\x5\x136\x9C\x2\x68B\x68A\x3\x2"+
-		"\x2\x2\x68B\x68C\x3\x2\x2\x2\x68C\x68D\x3\x2\x2\x2\x68D\x68F\x5\xBA^\x2"+
-		"\x68E\x690\x5\x136\x9C\x2\x68F\x68E\x3\x2\x2\x2\x68F\x690\x3\x2\x2\x2"+
-		"\x690\x691\x3\x2\x2\x2\x691\x692\a\xDB\x2\x2\x692\x696\x3\x2\x2\x2\x693"+
-		"\x696\x5\xBC_\x2\x694\x696\x5|?\x2\x695\x668\x3\x2\x2\x2\x695\x66E\x3"+
-		"\x2\x2\x2\x695\x673\x3\x2\x2\x2\x695\x67D\x3\x2\x2\x2\x695\x682\x3\x2"+
-		"\x2\x2\x695\x687\x3\x2\x2\x2\x695\x688\x3\x2\x2\x2\x695\x689\x3\x2\x2"+
-		"\x2\x695\x693\x3\x2\x2\x2\x695\x694\x3\x2\x2\x2\x696\x705\x3\x2\x2\x2"+
-		"\x697\x699\f\x10\x2\x2\x698\x69A\x5\x136\x9C\x2\x699\x698\x3\x2\x2\x2"+
-		"\x699\x69A\x3\x2\x2\x2\x69A\x69B\x3\x2\x2\x2\x69B\x69D\a\xDA\x2\x2\x69C"+
-		"\x69E\x5\x136\x9C\x2\x69D\x69C\x3\x2\x2\x2\x69D\x69E\x3\x2\x2\x2\x69E"+
-		"\x69F\x3\x2\x2\x2\x69F\x704\x5\xBA^\x11\x6A0\x6A2\f\xE\x2\x2\x6A1\x6A3"+
-		"\x5\x136\x9C\x2\x6A2\x6A1\x3\x2\x2\x2\x6A2\x6A3\x3\x2\x2\x2\x6A3\x6A4"+
-		"\x3\x2\x2\x2\x6A4\x6A6\t\r\x2\x2\x6A5\x6A7\x5\x136\x9C\x2\x6A6\x6A5\x3"+
-		"\x2\x2\x2\x6A6\x6A7\x3\x2\x2\x2\x6A7\x6A8\x3\x2\x2\x2\x6A8\x704\x5\xBA"+
-		"^\xF\x6A9\x6AB\f\r\x2\x2\x6AA\x6AC\x5\x136\x9C\x2\x6AB\x6AA\x3\x2\x2\x2"+
-		"\x6AB\x6AC\x3\x2\x2\x2\x6AC\x6AD\x3\x2\x2\x2\x6AD\x6AF\a\xCF\x2\x2\x6AE"+
-		"\x6B0\x5\x136\x9C\x2\x6AF\x6AE\x3\x2\x2\x2\x6AF\x6B0\x3\x2\x2\x2\x6B0"+
-		"\x6B1\x3\x2\x2\x2\x6B1\x704\x5\xBA^\xE\x6B2\x6B4\f\f\x2\x2\x6B3\x6B5\x5"+
-		"\x136\x9C\x2\x6B4\x6B3\x3\x2\x2\x2\x6B4\x6B5\x3\x2\x2\x2\x6B5\x6B6\x3"+
-		"\x2\x2\x2\x6B6\x6B8\a\x8B\x2\x2\x6B7\x6B9\x5\x136\x9C\x2\x6B8\x6B7\x3"+
-		"\x2\x2\x2\x6B8\x6B9\x3\x2\x2\x2\x6B9\x6BA\x3\x2\x2\x2\x6BA\x704\x5\xBA"+
-		"^\r\x6BB\x6BD\f\v\x2\x2\x6BC\x6BE\x5\x136\x9C\x2\x6BD\x6BC\x3\x2\x2\x2"+
-		"\x6BD\x6BE\x3\x2\x2\x2\x6BE\x6BF\x3\x2\x2\x2\x6BF\x6C1\t\xE\x2\x2\x6C0"+
-		"\x6C2\x5\x136\x9C\x2\x6C1\x6C0\x3\x2\x2\x2\x6C1\x6C2\x3\x2\x2\x2\x6C2"+
-		"\x6C3\x3\x2\x2\x2\x6C3\x704\x5\xBA^\f\x6C4\x6C6\f\n\x2\x2\x6C5\x6C7\x5"+
-		"\x136\x9C\x2\x6C6\x6C5\x3\x2\x2\x2\x6C6\x6C7\x3\x2\x2\x2\x6C7\x6C8\x3"+
-		"\x2\x2\x2\x6C8\x6CA\a\x32\x2\x2\x6C9\x6CB\x5\x136\x9C\x2\x6CA\x6C9\x3"+
-		"\x2\x2\x2\x6CA\x6CB\x3\x2\x2\x2\x6CB\x6CC\x3\x2\x2\x2\x6CC\x704\x5\xBA"+
-		"^\v\x6CD\x6CF\f\t\x2\x2\x6CE\x6D0\x5\x136\x9C\x2\x6CF\x6CE\x3\x2\x2\x2"+
-		"\x6CF\x6D0\x3\x2\x2\x2\x6D0\x6D1\x3\x2\x2\x2\x6D1\x6D3\t\xF\x2\x2\x6D2"+
-		"\x6D4\x5\x136\x9C\x2\x6D3\x6D2\x3\x2\x2\x2\x6D3\x6D4\x3\x2\x2\x2\x6D4"+
-		"\x6D5\x3\x2\x2\x2\x6D5\x704\x5\xBA^\n\x6D6\x6D8\f\a\x2\x2\x6D7\x6D9\x5"+
-		"\x136\x9C\x2\x6D8\x6D7\x3\x2\x2\x2\x6D8\x6D9\x3\x2\x2\x2\x6D9\x6DA\x3"+
-		"\x2\x2\x2\x6DA\x6DC\a\x36\x2\x2\x6DB\x6DD\x5\x136\x9C\x2\x6DC\x6DB\x3"+
-		"\x2\x2\x2\x6DC\x6DD\x3\x2\x2\x2\x6DD\x6DE\x3\x2\x2\x2\x6DE\x704\x5\xBA"+
-		"^\b\x6DF\x6E1\f\x6\x2\x2\x6E0\x6E2\x5\x136\x9C\x2\x6E1\x6E0\x3\x2\x2\x2"+
-		"\x6E1\x6E2\x3\x2\x2\x2\x6E2\x6E3\x3\x2\x2\x2\x6E3\x6E5\a\x9A\x2\x2\x6E4"+
-		"\x6E6\x5\x136\x9C\x2\x6E5\x6E4\x3\x2\x2\x2\x6E5\x6E6\x3\x2\x2\x2\x6E6"+
-		"\x6E7\x3\x2\x2\x2\x6E7\x704\x5\xBA^\a\x6E8\x6EA\f\x5\x2\x2\x6E9\x6EB\x5"+
-		"\x136\x9C\x2\x6EA\x6E9\x3\x2\x2\x2\x6EA\x6EB\x3\x2\x2\x2\x6EB\x6EC\x3"+
-		"\x2\x2\x2\x6EC\x6EE\a\xCC\x2\x2\x6ED\x6EF\x5\x136\x9C\x2\x6EE\x6ED\x3"+
-		"\x2\x2\x2\x6EE\x6EF\x3\x2\x2\x2\x6EF\x6F0\x3\x2\x2\x2\x6F0\x704\x5\xBA"+
-		"^\x6\x6F1\x6F3\f\x4\x2\x2\x6F2\x6F4\x5\x136\x9C\x2\x6F3\x6F2\x3\x2\x2"+
-		"\x2\x6F3\x6F4\x3\x2\x2\x2\x6F4\x6F5\x3\x2\x2\x2\x6F5\x6F7\a\x66\x2\x2"+
-		"\x6F6\x6F8\x5\x136\x9C\x2\x6F7\x6F6\x3\x2\x2\x2\x6F7\x6F8\x3\x2\x2\x2"+
-		"\x6F8\x6F9\x3\x2\x2\x2\x6F9\x704\x5\xBA^\x5\x6FA\x6FC\f\x3\x2\x2\x6FB"+
-		"\x6FD\x5\x136\x9C\x2\x6FC\x6FB\x3\x2\x2\x2\x6FC\x6FD\x3\x2\x2\x2\x6FD"+
-		"\x6FE\x3\x2\x2\x2\x6FE\x700\ax\x2\x2\x6FF\x701\x5\x136\x9C\x2\x700\x6FF"+
-		"\x3\x2\x2\x2\x700\x701\x3\x2\x2\x2\x701\x702\x3\x2\x2\x2\x702\x704\x5"+
-		"\xBA^\x4\x703\x697\x3\x2\x2\x2\x703\x6A0\x3\x2\x2\x2\x703\x6A9\x3\x2\x2"+
-		"\x2\x703\x6B2\x3\x2\x2\x2\x703\x6BB\x3\x2\x2\x2\x703\x6C4\x3\x2\x2\x2"+
-		"\x703\x6CD\x3\x2\x2\x2\x703\x6D6\x3\x2\x2\x2\x703\x6DF\x3\x2\x2\x2\x703"+
-		"\x6E8\x3\x2\x2\x2\x703\x6F1\x3\x2\x2\x2\x703\x6FA\x3\x2\x2\x2\x704\x707"+
-		"\x3\x2\x2\x2\x705\x703\x3\x2\x2\x2\x705\x706\x3\x2\x2\x2\x706\xBB\x3\x2"+
-		"\x2\x2\x707\x705\x3\x2\x2\x2\x708\x709\a\xC1\x2\x2\x709\x70A\x5\x136\x9C"+
-		"\x2\x70A\x710\x5\xBA^\x2\x70B\x70C\x5\x136\x9C\x2\x70C\x70D\a|\x2\x2\x70D"+
-		"\x70E\x5\x136\x9C\x2\x70E\x70F\x5\x114\x8B\x2\x70F\x711\x3\x2\x2\x2\x710"+
-		"\x70B\x3\x2\x2\x2\x710\x711\x3\x2\x2\x2\x711\xBD\x3\x2\x2\x2\x712\x716"+
-		"\aU\x2\x2\x713\x716\a\xB6\x2\x2\x714\x716\x5\x118\x8D\x2\x715\x712\x3"+
-		"\x2\x2\x2\x715\x713\x3\x2\x2\x2\x715\x714\x3\x2\x2\x2\x716\x717\x3\x2"+
-		"\x2\x2\x717\x71A\x5\x136\x9C\x2\x718\x719\a\xCA\x2\x2\x719\x71B\x5\x136"+
-		"\x9C\x2\x71A\x718\x3\x2\x2\x2\x71A\x71B\x3\x2\x2\x2\x71B\x71C\x3\x2\x2"+
-		"\x2\x71C\x71D\x5\xC0\x61\x2\x71D\xBF\x3\x2\x2\x2\x71E\x729\x5\xC2\x62"+
-		"\x2\x71F\x721\x5\x136\x9C\x2\x720\x71F\x3\x2\x2\x2\x720\x721\x3\x2\x2"+
-		"\x2\x721\x722\x3\x2\x2\x2\x722\x724\a)\x2\x2\x723\x725\x5\x136\x9C\x2"+
-		"\x724\x723\x3\x2\x2\x2\x724\x725\x3\x2\x2\x2\x725\x726\x3\x2\x2\x2\x726"+
-		"\x728\x5\xC2\x62\x2\x727\x720\x3\x2\x2\x2\x728\x72B\x3\x2\x2\x2\x729\x727"+
-		"\x3\x2\x2\x2\x729\x72A\x3\x2\x2\x2\x72A\xC1\x3\x2\x2\x2\x72B\x729\x3\x2"+
-		"\x2\x2\x72C\x72E\x5\xFC\x7F\x2\x72D\x72F\x5\x116\x8C\x2\x72E\x72D\x3\x2"+
-		"\x2\x2\x72E\x72F\x3\x2\x2\x2\x72F\x741\x3\x2\x2\x2\x730\x732\x5\x136\x9C"+
-		"\x2\x731\x730\x3\x2\x2\x2\x731\x732\x3\x2\x2\x2\x732\x733\x3\x2\x2\x2"+
-		"\x733\x735\a\xD4\x2\x2\x734\x736\x5\x136\x9C\x2\x735\x734\x3\x2\x2\x2"+
-		"\x735\x736\x3\x2\x2\x2\x736\x73B\x3\x2\x2\x2\x737\x739\x5\xF6|\x2\x738"+
-		"\x73A\x5\x136\x9C\x2\x739\x738\x3\x2\x2\x2\x739\x73A\x3\x2\x2\x2\x73A"+
-		"\x73C\x3\x2\x2\x2\x73B\x737\x3\x2\x2\x2\x73B\x73C\x3\x2\x2\x2\x73C\x73D"+
-		"\x3\x2\x2\x2\x73D\x73F\a\xDB\x2\x2\x73E\x740\x5\x136\x9C\x2\x73F\x73E"+
-		"\x3\x2\x2\x2\x73F\x740\x3\x2\x2\x2\x740\x742\x3\x2\x2\x2\x741\x731\x3"+
-		"\x2\x2\x2\x741\x742\x3\x2\x2\x2\x742\x746\x3\x2\x2\x2\x743\x744\x5\x136"+
-		"\x9C\x2\x744\x745\x5\xFE\x80\x2\x745\x747\x3\x2\x2\x2\x746\x743\x3\x2"+
-		"\x2\x2\x746\x747\x3\x2\x2\x2\x747\xC3\x3\x2\x2\x2\x748\x749\a\xC7\x2\x2"+
-		"\x749\x74A\x5\x136\x9C\x2\x74A\x74B\x5\xBA^\x2\x74B\x74D\x5\x122\x92\x2"+
-		"\x74C\x74E\x5\x1E\x10\x2\x74D\x74C\x3\x2\x2\x2\x74D\x74E\x3\x2\x2\x2\x74E"+
-		"\x74F\x3\x2\x2\x2\x74F\x750\a\xC6\x2\x2\x750\xC5\x3\x2\x2\x2\x751\x752"+
-		"\a\xC8\x2\x2\x752\x753\x5\x136\x9C\x2\x753\x755\x5\xCEh\x2\x754\x756\x5"+
-		"\x136\x9C\x2\x755\x754\x3\x2\x2\x2\x755\x756\x3\x2\x2\x2\x756\x757\x3"+
-		"\x2\x2\x2\x757\x759\a)\x2\x2\x758\x75A\x5\x136\x9C\x2\x759\x758\x3\x2"+
-		"\x2\x2\x759\x75A\x3\x2\x2\x2\x75A\x75B\x3\x2\x2\x2\x75B\x75C\x5\xBA^\x2"+
-		"\x75C\xC7\x3\x2\x2\x2\x75D\x75E\a\xC9\x2\x2\x75E\x75F\x5\x136\x9C\x2\x75F"+
-		"\x760\x5\xCA\x66\x2\x760\x762\x5\x122\x92\x2\x761\x763\x5\x1E\x10\x2\x762"+
-		"\x761\x3\x2\x2\x2\x762\x763\x3\x2\x2\x2\x763\x764\x3\x2\x2\x2\x764\x765"+
-		"\a\x63\x2\x2\x765\xC9\x3\x2\x2\x2\x766\x767\x5\xBA^\x2\x767\xCB\x3\x2"+
-		"\x2\x2\x768\x769\a\xCB\x2\x2\x769\x76A\x5\x136\x9C\x2\x76A\x76C\x5\xCE"+
-		"h\x2\x76B\x76D\x5\x136\x9C\x2\x76C\x76B\x3\x2\x2\x2\x76C\x76D\x3\x2\x2"+
-		"\x2\x76D\x76E\x3\x2\x2\x2\x76E\x773\a)\x2\x2\x76F\x771\x5\x136\x9C\x2"+
-		"\x770\x76F\x3\x2\x2\x2\x770\x771\x3\x2\x2\x2\x771\x772\x3\x2\x2\x2\x772"+
-		"\x774\x5\x86\x44\x2\x773\x770\x3\x2\x2\x2\x773\x774\x3\x2\x2\x2\x774\xCD"+
-		"\x3\x2\x2\x2\x775\x777\a.\x2\x2\x776\x775\x3\x2\x2\x2\x776\x777\x3\x2"+
-		"\x2\x2\x777\x778\x3\x2\x2\x2\x778\x779\x5\xBA^\x2\x779\xCF\x3\x2\x2\x2"+
-		"\x77A\x77B\a@\x2\x2\x77B\x77C\x5\x136\x9C\x2\x77C\x77D\x5\xD2j\x2\x77D"+
-		"\xD1\x3\x2\x2\x2\x77E\x780\x5\xDAn\x2\x77F\x77E\x3\x2\x2\x2\x77F\x780"+
-		"\x3\x2\x2\x2\x780\x781\x3\x2\x2\x2\x781\x782\a-\x2\x2\x782\x784\x5\xFC"+
-		"\x7F\x2\x783\x785\x5\x116\x8C\x2\x784\x783\x3\x2\x2\x2\x784\x785\x3\x2"+
-		"\x2\x2\x785\x793\x3\x2\x2\x2\x786\x788\x5\x136\x9C\x2\x787\x786\x3\x2"+
-		"\x2\x2\x787\x788\x3\x2\x2\x2\x788\x789\x3\x2\x2\x2\x789\x78B\a\xD4\x2"+
-		"\x2\x78A\x78C\x5\x136\x9C\x2\x78B\x78A\x3\x2\x2\x2\x78B\x78C\x3\x2\x2"+
-		"\x2\x78C\x78D\x3\x2\x2\x2\x78D\x78F\x5\xEAv\x2\x78E\x790\x5\x136\x9C\x2"+
-		"\x78F\x78E\x3\x2\x2\x2\x78F\x790\x3\x2\x2\x2\x790\x791\x3\x2\x2\x2\x791"+
-		"\x792\a\xDB\x2\x2\x792\x794\x3\x2\x2\x2\x793\x787\x3\x2\x2\x2\x793\x794"+
-		"\x3\x2\x2\x2\x794\x79E\x3\x2\x2\x2\x795\x797\x5\x136\x9C\x2\x796\x795"+
-		"\x3\x2\x2\x2\x796\x797\x3\x2\x2\x2\x797\x798\x3\x2\x2\x2\x798\x799\a\xD4"+
-		"\x2\x2\x799\x79A\x5\xF6|\x2\x79A\x79B\a\xDB\x2\x2\x79B\x79D\x3\x2\x2\x2"+
-		"\x79C\x796\x3\x2\x2\x2\x79D\x7A0\x3\x2\x2\x2\x79E\x79C\x3\x2\x2\x2\x79E"+
-		"\x79F\x3\x2\x2\x2\x79F\x7C1\x3\x2\x2\x2\x7A0\x79E\x3\x2\x2\x2\x7A1\x7A3"+
-		"\x5\xFC\x7F\x2\x7A2\x7A4\x5\x116\x8C\x2\x7A3\x7A2\x3\x2\x2\x2\x7A3\x7A4"+
-		"\x3\x2\x2\x2\x7A4\x7B2\x3\x2\x2\x2\x7A5\x7A7\x5\x136\x9C\x2\x7A6\x7A5"+
-		"\x3\x2\x2\x2\x7A6\x7A7\x3\x2\x2\x2\x7A7\x7A8\x3\x2\x2\x2\x7A8\x7AA\a\xD4"+
-		"\x2\x2\x7A9\x7AB\x5\x136\x9C\x2\x7AA\x7A9\x3\x2\x2\x2\x7AA\x7AB\x3\x2"+
-		"\x2\x2\x7AB\x7AC\x3\x2\x2\x2\x7AC\x7AE\x5\xEAv\x2\x7AD\x7AF\x5\x136\x9C"+
-		"\x2\x7AE\x7AD\x3\x2\x2\x2\x7AE\x7AF\x3\x2\x2\x2\x7AF\x7B0\x3\x2\x2\x2"+
-		"\x7B0\x7B1\a\xDB\x2\x2\x7B1\x7B3\x3\x2\x2\x2\x7B2\x7A6\x3\x2\x2\x2\x7B2"+
-		"\x7B3\x3\x2\x2\x2\x7B3\x7BD\x3\x2\x2\x2\x7B4\x7B6\x5\x136\x9C\x2\x7B5"+
-		"\x7B4\x3\x2\x2\x2\x7B5\x7B6\x3\x2\x2\x2\x7B6\x7B7\x3\x2\x2\x2\x7B7\x7B8"+
-		"\a\xD4\x2\x2\x7B8\x7B9\x5\xF6|\x2\x7B9\x7BA\a\xDB\x2\x2\x7BA\x7BC\x3\x2"+
-		"\x2\x2\x7BB\x7B5\x3\x2\x2\x2\x7BC\x7BF\x3\x2\x2\x2\x7BD\x7BB\x3\x2\x2"+
-		"\x2\x7BD\x7BE\x3\x2\x2\x2\x7BE\x7C1\x3\x2\x2\x2\x7BF\x7BD\x3\x2\x2\x2"+
-		"\x7C0\x77F\x3\x2\x2\x2\x7C0\x7A1\x3\x2\x2\x2\x7C1\xD3\x3\x2\x2\x2\x7C2"+
-		"\x7C5\x5\xD6l\x2\x7C3\x7C5\x5\xD8m\x2\x7C4\x7C2\x3\x2\x2\x2\x7C4\x7C3"+
-		"\x3\x2\x2\x2\x7C5\xD5\x3\x2\x2\x2\x7C6\x7C8\x5\xDAn\x2\x7C7\x7C6\x3\x2"+
-		"\x2\x2\x7C7\x7C8\x3\x2\x2\x2\x7C8\x7CA\x3\x2\x2\x2\x7C9\x7CB\x5\x136\x9C"+
-		"\x2\x7CA\x7C9\x3\x2\x2\x2\x7CA\x7CB\x3\x2\x2\x2\x7CB\x7CC\x3\x2\x2\x2"+
-		"\x7CC\x7CE\a-\x2\x2\x7CD\x7CF\x5\x136\x9C\x2\x7CE\x7CD\x3\x2\x2\x2\x7CE"+
-		"\x7CF\x3\x2\x2\x2\x7CF\x7D0\x3\x2\x2\x2\x7D0\x7D2\x5\xFA~\x2\x7D1\x7D3"+
-		"\x5\x116\x8C\x2\x7D2\x7D1\x3\x2\x2\x2\x7D2\x7D3\x3\x2\x2\x2\x7D3\x7D7"+
-		"\x3\x2\x2\x2\x7D4\x7D5\x5\x136\x9C\x2\x7D5\x7D6\x5\xEAv\x2\x7D6\x7D8\x3"+
-		"\x2\x2\x2\x7D7\x7D4\x3\x2\x2\x2\x7D7\x7D8\x3\x2\x2\x2\x7D8\x7DD\x3\x2"+
-		"\x2\x2\x7D9\x7DB\x5\x136\x9C\x2\x7DA\x7D9\x3\x2\x2\x2\x7DA\x7DB\x3\x2"+
-		"\x2\x2\x7DB\x7DC\x3\x2\x2\x2\x7DC\x7DE\x5\xEEx\x2\x7DD\x7DA\x3\x2\x2\x2"+
-		"\x7DD\x7DE\x3\x2\x2\x2\x7DE\x7E8\x3\x2\x2\x2\x7DF\x7E1\x5\x136\x9C\x2"+
-		"\x7E0\x7DF\x3\x2\x2\x2\x7E0\x7E1\x3\x2\x2\x2\x7E1\x7E2\x3\x2\x2\x2\x7E2"+
-		"\x7E3\a\xD4\x2\x2\x7E3\x7E4\x5\xF6|\x2\x7E4\x7E5\a\xDB\x2\x2\x7E5\x7E7"+
-		"\x3\x2\x2\x2\x7E6\x7E0\x3\x2\x2\x2\x7E7\x7EA\x3\x2\x2\x2\x7E8\x7E6\x3"+
-		"\x2\x2\x2\x7E8\x7E9\x3\x2\x2\x2\x7E9\xD7\x3\x2\x2\x2\x7EA\x7E8\x3\x2\x2"+
-		"\x2\x7EB\x7EF\x5\xFC\x7F\x2\x7EC\x7ED\x5\x136\x9C\x2\x7ED\x7EE\x5\xEA"+
-		"v\x2\x7EE\x7F0\x3\x2\x2\x2\x7EF\x7EC\x3\x2\x2\x2\x7EF\x7F0\x3\x2\x2\x2"+
-		"\x7F0\x7FA\x3\x2\x2\x2\x7F1\x7F3\x5\x136\x9C\x2\x7F2\x7F1\x3\x2\x2\x2"+
-		"\x7F2\x7F3\x3\x2\x2\x2\x7F3\x7F4\x3\x2\x2\x2\x7F4\x7F5\a\xD4\x2\x2\x7F5"+
-		"\x7F6\x5\xF6|\x2\x7F6\x7F7\a\xDB\x2\x2\x7F7\x7F9\x3\x2\x2\x2\x7F8\x7F2"+
-		"\x3\x2\x2\x2\x7F9\x7FC\x3\x2\x2\x2\x7FA\x7F8\x3\x2\x2\x2\x7FA\x7FB\x3"+
-		"\x2\x2\x2\x7FB\xD9\x3\x2\x2\x2\x7FC\x7FA\x3\x2\x2\x2\x7FD\x802\x5\xE4"+
-		"s\x2\x7FE\x802\x5\xDCo\x2\x7FF\x802\x5\xDEp\x2\x800\x802\x5\xE8u\x2\x801"+
-		"\x7FD\x3\x2\x2\x2\x801\x7FE\x3\x2\x2\x2\x801\x7FF\x3\x2\x2\x2\x801\x800"+
-		"\x3\x2\x2\x2\x802\xDB\x3\x2\x2\x2\x803\x805\x5\xFC\x7F\x2\x804\x806\x5"+
-		"\x116\x8C\x2\x805\x804\x3\x2\x2\x2\x805\x806\x3\x2\x2\x2\x806\x80B\x3"+
-		"\x2\x2\x2\x807\x809\x5\x136\x9C\x2\x808\x807\x3\x2\x2\x2\x808\x809\x3"+
-		"\x2\x2\x2\x809\x80A\x3\x2\x2\x2\x80A\x80C\x5\xEEx\x2\x80B\x808\x3\x2\x2"+
-		"\x2\x80B\x80C\x3\x2\x2\x2\x80C\x816\x3\x2\x2\x2\x80D\x80F\x5\x136\x9C"+
-		"\x2\x80E\x80D\x3\x2\x2\x2\x80E\x80F\x3\x2\x2\x2\x80F\x810\x3\x2\x2\x2"+
-		"\x810\x811\a\xD4\x2\x2\x811\x812\x5\xF6|\x2\x812\x813\a\xDB\x2\x2\x813"+
-		"\x815\x3\x2\x2\x2\x814\x80E\x3\x2\x2\x2\x815\x818\x3\x2\x2\x2\x816\x814"+
-		"\x3\x2\x2\x2\x816\x817\x3\x2\x2\x2\x817\xDD\x3\x2\x2\x2\x818\x816\x3\x2"+
-		"\x2\x2\x819\x81C\x5\xFC\x7F\x2\x81A\x81C\x5\x100\x81\x2\x81B\x819\x3\x2"+
-		"\x2\x2\x81B\x81A\x3\x2\x2\x2\x81C\x81E\x3\x2\x2\x2\x81D\x81F\x5\x116\x8C"+
-		"\x2\x81E\x81D\x3\x2\x2\x2\x81E\x81F\x3\x2\x2\x2\x81F\x821\x3\x2\x2\x2"+
-		"\x820\x822\x5\x136\x9C\x2\x821\x820\x3\x2\x2\x2\x821\x822\x3\x2\x2\x2"+
-		"\x822\x823\x3\x2\x2\x2\x823\x825\a\xD4\x2\x2\x824\x826\x5\x136\x9C\x2"+
-		"\x825\x824\x3\x2\x2\x2\x825\x826\x3\x2\x2\x2\x826\x82B\x3\x2\x2\x2\x827"+
-		"\x829\x5\xEAv\x2\x828\x82A\x5\x136\x9C\x2\x829\x828\x3\x2\x2\x2\x829\x82A"+
-		"\x3\x2\x2\x2\x82A\x82C\x3\x2\x2\x2\x82B\x827\x3\x2\x2\x2\x82B\x82C\x3"+
-		"\x2\x2\x2\x82C\x82D\x3\x2\x2\x2\x82D\x832\a\xDB\x2\x2\x82E\x830\x5\x136"+
-		"\x9C\x2\x82F\x82E\x3\x2\x2\x2\x82F\x830\x3\x2\x2\x2\x830\x831\x3\x2\x2"+
-		"\x2\x831\x833\x5\xEEx\x2\x832\x82F\x3\x2\x2\x2\x832\x833\x3\x2\x2\x2\x833"+
-		"\x83D\x3\x2\x2\x2\x834\x836\x5\x136\x9C\x2\x835\x834\x3\x2\x2\x2\x835"+
-		"\x836\x3\x2\x2\x2\x836\x837\x3\x2\x2\x2\x837\x838\a\xD4\x2\x2\x838\x839"+
-		"\x5\xF6|\x2\x839\x83A\a\xDB\x2\x2\x83A\x83C\x3\x2\x2\x2\x83B\x835\x3\x2"+
-		"\x2\x2\x83C\x83F\x3\x2\x2\x2\x83D\x83B\x3\x2\x2\x2\x83D\x83E\x3\x2\x2"+
-		"\x2\x83E\xDF\x3\x2\x2\x2\x83F\x83D\x3\x2\x2\x2\x840\x842\x5\xFA~\x2\x841"+
-		"\x843\x5\x116\x8C\x2\x842\x841\x3\x2\x2\x2\x842\x843\x3\x2\x2\x2\x843"+
-		"\x848\x3\x2\x2\x2\x844\x846\x5\x136\x9C\x2\x845\x844\x3\x2\x2\x2\x845"+
-		"\x846\x3\x2\x2\x2\x846\x847\x3\x2\x2\x2\x847\x849\x5\xEEx\x2\x848\x845"+
-		"\x3\x2\x2\x2\x848\x849\x3\x2\x2\x2\x849\x853\x3\x2\x2\x2\x84A\x84C\x5"+
-		"\x136\x9C\x2\x84B\x84A\x3\x2\x2\x2\x84B\x84C\x3\x2\x2\x2\x84C\x84D\x3"+
-		"\x2\x2\x2\x84D\x84E\a\xD4\x2\x2\x84E\x84F\x5\xF6|\x2\x84F\x850\a\xDB\x2"+
-		"\x2\x850\x852\x3\x2\x2\x2\x851\x84B\x3\x2\x2\x2\x852\x855\x3\x2\x2\x2"+
-		"\x853\x851\x3\x2\x2\x2\x853\x854\x3\x2\x2\x2\x854\xE1\x3\x2\x2\x2\x855"+
-		"\x853\x3\x2\x2\x2\x856\x859\x5\xFA~\x2\x857\x859\x5\x100\x81\x2\x858\x856"+
-		"\x3\x2\x2\x2\x858\x857\x3\x2\x2\x2\x859\x85B\x3\x2\x2\x2\x85A\x85C\x5"+
-		"\x116\x8C\x2\x85B\x85A\x3\x2\x2\x2\x85B\x85C\x3\x2\x2\x2\x85C\x85E\x3"+
-		"\x2\x2\x2\x85D\x85F\x5\x136\x9C\x2\x85E\x85D\x3\x2\x2\x2\x85E\x85F\x3"+
-		"\x2\x2\x2\x85F\x860\x3\x2\x2\x2\x860\x862\a\xD4\x2\x2\x861\x863\x5\x136"+
-		"\x9C\x2\x862\x861\x3\x2\x2\x2\x862\x863\x3\x2\x2\x2\x863\x868\x3\x2\x2"+
-		"\x2\x864\x866\x5\xEAv\x2\x865\x867\x5\x136\x9C\x2\x866\x865\x3\x2\x2\x2"+
-		"\x866\x867\x3\x2\x2\x2\x867\x869\x3\x2\x2\x2\x868\x864\x3\x2\x2\x2\x868"+
-		"\x869\x3\x2\x2\x2\x869\x86A\x3\x2\x2\x2\x86A\x86F\a\xDB\x2\x2\x86B\x86D"+
-		"\x5\x136\x9C\x2\x86C\x86B\x3\x2\x2\x2\x86C\x86D\x3\x2\x2\x2\x86D\x86E"+
-		"\x3\x2\x2\x2\x86E\x870\x5\xEEx\x2\x86F\x86C\x3\x2\x2\x2\x86F\x870\x3\x2"+
-		"\x2\x2\x870\x87A\x3\x2\x2\x2\x871\x873\x5\x136\x9C\x2\x872\x871\x3\x2"+
-		"\x2\x2\x872\x873\x3\x2\x2\x2\x873\x874\x3\x2\x2\x2\x874\x875\a\xD4\x2"+
-		"\x2\x875\x876\x5\xF6|\x2\x876\x877\a\xDB\x2\x2\x877\x879\x3\x2\x2\x2\x878"+
-		"\x872\x3\x2\x2\x2\x879\x87C\x3\x2\x2\x2\x87A\x878\x3\x2\x2\x2\x87A\x87B"+
-		"\x3\x2\x2\x2\x87B\xE3\x3\x2\x2\x2\x87C\x87A\x3\x2\x2\x2\x87D\x880\x5\xDC"+
-		"o\x2\x87E\x880\x5\xDEp\x2\x87F\x87D\x3\x2\x2\x2\x87F\x87E\x3\x2\x2\x2"+
-		"\x87F\x880\x3\x2\x2\x2\x880\x885\x3\x2\x2\x2\x881\x883\x5\xE6t\x2\x882"+
-		"\x884\x5\x136\x9C\x2\x883\x882\x3\x2\x2\x2\x883\x884\x3\x2\x2\x2\x884"+
-		"\x886\x3\x2\x2\x2\x885\x881\x3\x2\x2\x2\x886\x887\x3\x2\x2\x2\x887\x885"+
-		"\x3\x2\x2\x2\x887\x888\x3\x2\x2\x2\x888\x88D\x3\x2\x2\x2\x889\x88B\x5"+
-		"\x136\x9C\x2\x88A\x889\x3\x2\x2\x2\x88A\x88B\x3\x2\x2\x2\x88B\x88C\x3"+
-		"\x2\x2\x2\x88C\x88E\x5\xEEx\x2\x88D\x88A\x3\x2\x2\x2\x88D\x88E\x3\x2\x2"+
-		"\x2\x88E\x898\x3\x2\x2\x2\x88F\x891\x5\x136\x9C\x2\x890\x88F\x3\x2\x2"+
-		"\x2\x890\x891\x3\x2\x2\x2\x891\x892\x3\x2\x2\x2\x892\x893\a\xD4\x2\x2"+
-		"\x893\x894\x5\xF6|\x2\x894\x895\a\xDB\x2\x2\x895\x897\x3\x2\x2\x2\x896"+
-		"\x890\x3\x2\x2\x2\x897\x89A\x3\x2\x2\x2\x898\x896\x3\x2\x2\x2\x898\x899"+
-		"\x3\x2\x2\x2\x899\xE5\x3\x2\x2\x2\x89A\x898\x3\x2\x2\x2\x89B\x89D\t\x10"+
-		"\x2\x2\x89C\x89E\x5\x136\x9C\x2\x89D\x89C\x3\x2\x2\x2\x89D\x89E\x3\x2"+
-		"\x2\x2\x89E\x8A1\x3\x2\x2\x2\x89F\x8A2\x5\xE0q\x2\x8A0\x8A2\x5\xE2r\x2"+
-		"\x8A1\x89F\x3\x2\x2\x2\x8A1\x8A0\x3\x2\x2\x2\x8A2\xE7\x3\x2\x2\x2\x8A3"+
-		"\x8A5\x5\x136\x9C\x2\x8A4\x8A3\x3\x2\x2\x2\x8A4\x8A5\x3\x2\x2\x2\x8A5"+
-		"\x8A6\x3\x2\x2\x2\x8A6\x8A7\x5\xEEx\x2\x8A7\xE9\x3\x2\x2\x2\x8A8\x8AA"+
-		"\x5\xECw\x2\x8A9\x8A8\x3\x2\x2\x2\x8A9\x8AA\x3\x2\x2\x2\x8AA\x8AC\x3\x2"+
-		"\x2\x2\x8AB\x8AD\x5\x136\x9C\x2\x8AC\x8AB\x3\x2\x2\x2\x8AC\x8AD\x3\x2"+
-		"\x2\x2\x8AD\x8AE\x3\x2\x2\x2\x8AE\x8B0\t\v\x2\x2\x8AF\x8B1\x5\x136\x9C"+
-		"\x2\x8B0\x8AF\x3\x2\x2\x2\x8B0\x8B1\x3\x2\x2\x2\x8B1\x8B3\x3\x2\x2\x2"+
-		"\x8B2\x8A9\x3\x2\x2\x2\x8B3\x8B6\x3\x2\x2\x2\x8B4\x8B2\x3\x2\x2\x2\x8B4"+
-		"\x8B5\x3\x2\x2\x2\x8B5\x8B7\x3\x2\x2\x2\x8B6\x8B4\x3\x2\x2\x2\x8B7\x8C4"+
-		"\x5\xECw\x2\x8B8\x8BA\x5\x136\x9C\x2\x8B9\x8B8\x3\x2\x2\x2\x8B9\x8BA\x3"+
-		"\x2\x2\x2\x8BA\x8BB\x3\x2\x2\x2\x8BB\x8BD\t\v\x2\x2\x8BC\x8BE\x5\x136"+
-		"\x9C\x2\x8BD\x8BC\x3\x2\x2\x2\x8BD\x8BE\x3\x2\x2\x2\x8BE\x8C0\x3\x2\x2"+
-		"\x2\x8BF\x8C1\x5\xECw\x2\x8C0\x8BF\x3\x2\x2\x2\x8C0\x8C1\x3\x2\x2\x2\x8C1"+
-		"\x8C3\x3\x2\x2\x2\x8C2\x8B9\x3\x2\x2\x2\x8C3\x8C6\x3\x2\x2\x2\x8C4\x8C2"+
-		"\x3\x2\x2\x2\x8C4\x8C5\x3\x2\x2\x2\x8C5\xEB\x3\x2\x2\x2\x8C6\x8C4\x3\x2"+
-		"\x2\x2\x8C7\x8C9\a\xD4\x2\x2\x8C8\x8C7\x3\x2\x2\x2\x8C8\x8C9\x3\x2\x2"+
-		"\x2\x8C9\x8CC\x3\x2\x2\x2\x8CA\x8CB\t\x11\x2\x2\x8CB\x8CD\x5\x136\x9C"+
-		"\x2\x8CC\x8CA\x3\x2\x2\x2\x8CC\x8CD\x3\x2\x2\x2\x8CD\x8CF\x3\x2\x2\x2"+
-		"\x8CE\x8D0\a\xDB\x2\x2\x8CF\x8CE\x3\x2\x2\x2\x8CF\x8D0\x3\x2\x2\x2\x8D0"+
-		"\x8D1\x3\x2\x2\x2\x8D1\x8D2\x5\xBA^\x2\x8D2\xED\x3\x2\x2\x2\x8D3\x8D5"+
-		"\a,\x2\x2\x8D4\x8D6\x5\x136\x9C\x2\x8D5\x8D4\x3\x2\x2\x2\x8D5\x8D6\x3"+
-		"\x2\x2\x2\x8D6\x8D7\x3\x2\x2\x2\x8D7\x8D9\x5\xFA~\x2\x8D8\x8DA\x5\x116"+
-		"\x8C\x2\x8D9\x8D8\x3\x2\x2\x2\x8D9\x8DA\x3\x2\x2\x2\x8DA\xEF\x3\x2\x2"+
-		"\x2\x8DB\x8ED\a\xD4\x2\x2\x8DC\x8DE\x5\x136\x9C\x2\x8DD\x8DC\x3\x2\x2"+
-		"\x2\x8DD\x8DE\x3\x2\x2\x2\x8DE\x8DF\x3\x2\x2\x2\x8DF\x8EA\x5\xF2z\x2\x8E0"+
-		"\x8E2\x5\x136\x9C\x2\x8E1\x8E0\x3\x2\x2\x2\x8E1\x8E2\x3\x2\x2\x2\x8E2"+
-		"\x8E3\x3\x2\x2\x2\x8E3\x8E5\a)\x2\x2\x8E4\x8E6\x5\x136\x9C\x2\x8E5\x8E4"+
-		"\x3\x2\x2\x2\x8E5\x8E6\x3\x2\x2\x2\x8E6\x8E7\x3\x2\x2\x2\x8E7\x8E9\x5"+
-		"\xF2z\x2\x8E8\x8E1\x3\x2\x2\x2\x8E9\x8EC\x3\x2\x2\x2\x8EA\x8E8\x3\x2\x2"+
-		"\x2\x8EA\x8EB\x3\x2\x2\x2\x8EB\x8EE\x3\x2\x2\x2\x8EC\x8EA\x3\x2\x2\x2"+
-		"\x8ED\x8DD\x3\x2\x2\x2\x8ED\x8EE\x3\x2\x2\x2\x8EE\x8F0\x3\x2\x2\x2\x8EF"+
-		"\x8F1\x5\x136\x9C\x2\x8F0\x8EF\x3\x2\x2\x2\x8F0\x8F1\x3\x2\x2\x2\x8F1"+
-		"\x8F2\x3\x2\x2\x2\x8F2\x8F3\a\xDB\x2\x2\x8F3\xF1\x3\x2\x2\x2\x8F4\x8F5"+
-		"\a\x95\x2\x2\x8F5\x8F7\x5\x136\x9C\x2\x8F6\x8F4\x3\x2\x2\x2\x8F6\x8F7"+
-		"\x3\x2\x2\x2\x8F7\x8FA\x3\x2\x2\x2\x8F8\x8F9\t\x12\x2\x2\x8F9\x8FB\x5"+
-		"\x136\x9C\x2\x8FA\x8F8\x3\x2\x2\x2\x8FA\x8FB\x3\x2\x2\x2\x8FB\x8FE\x3"+
-		"\x2\x2\x2\x8FC\x8FD\a\x9C\x2\x2\x8FD\x8FF\x5\x136\x9C\x2\x8FE\x8FC\x3"+
-		"\x2\x2\x2\x8FE\x8FF\x3\x2\x2\x2\x8FF\x900\x3\x2\x2\x2\x900\x902\x5\xFA"+
-		"~\x2\x901\x903\x5\x116\x8C\x2\x902\x901\x3\x2\x2\x2\x902\x903\x3\x2\x2"+
-		"\x2\x903\x90C\x3\x2\x2\x2\x904\x906\x5\x136\x9C\x2\x905\x904\x3\x2\x2"+
-		"\x2\x905\x906\x3\x2\x2\x2\x906\x907\x3\x2\x2\x2\x907\x909\a\xD4\x2\x2"+
-		"\x908\x90A\x5\x136\x9C\x2\x909\x908\x3\x2\x2\x2\x909\x90A\x3\x2\x2\x2"+
-		"\x90A\x90B\x3\x2\x2\x2\x90B\x90D\a\xDB\x2\x2\x90C\x905\x3\x2\x2\x2\x90C"+
-		"\x90D\x3\x2\x2\x2\x90D\x912\x3\x2\x2\x2\x90E\x910\x5\x136\x9C\x2\x90F"+
-		"\x90E\x3\x2\x2\x2\x90F\x910\x3\x2\x2\x2\x910\x911\x3\x2\x2\x2\x911\x913"+
-		"\x5\xFE\x80\x2\x912\x90F\x3\x2\x2\x2\x912\x913\x3\x2\x2\x2\x913\x918\x3"+
-		"\x2\x2\x2\x914\x916\x5\x136\x9C\x2\x915\x914\x3\x2\x2\x2\x915\x916\x3"+
-		"\x2\x2\x2\x916\x917\x3\x2\x2\x2\x917\x919\x5\xF4{\x2\x918\x915\x3\x2\x2"+
-		"\x2\x918\x919\x3\x2\x2\x2\x919\xF3\x3\x2\x2\x2\x91A\x91C\a\xD0\x2\x2\x91B"+
-		"\x91D\x5\x136\x9C\x2\x91C\x91B\x3\x2\x2\x2\x91C\x91D\x3\x2\x2\x2\x91D"+
-		"\x91E\x3\x2\x2\x2\x91E\x91F\x5\xBA^\x2\x91F\xF5\x3\x2\x2\x2\x920\x92B"+
-		"\x5\xF8}\x2\x921\x923\x5\x136\x9C\x2\x922\x921\x3\x2\x2\x2\x922\x923\x3"+
-		"\x2\x2\x2\x923\x924\x3\x2\x2\x2\x924\x926\a)\x2\x2\x925\x927\x5\x136\x9C"+
-		"\x2\x926\x925\x3\x2\x2\x2\x926\x927\x3\x2\x2\x2\x927\x928\x3\x2\x2\x2"+
-		"\x928\x92A\x5\xF8}\x2\x929\x922\x3\x2\x2\x2\x92A\x92D\x3\x2\x2\x2\x92B"+
-		"\x929\x3\x2\x2\x2\x92B\x92C\x3\x2\x2\x2\x92C\xF7\x3\x2\x2\x2\x92D\x92B"+
-		"\x3\x2\x2\x2\x92E\x92F\x5\xBA^\x2\x92F\x930\x5\x136\x9C\x2\x930\x931\a"+
-		"\xBE\x2\x2\x931\x932\x5\x136\x9C\x2\x932\x934\x3\x2\x2\x2\x933\x92E\x3"+
-		"\x2\x2\x2\x933\x934\x3\x2\x2\x2\x934\x935\x3\x2\x2\x2\x935\x936\x5\xBA"+
-		"^\x2\x936\xF9\x3\x2\x2\x2\x937\x93B\x5\xFC\x7F\x2\x938\x93B\x5\x11E\x90"+
-		"\x2\x939\x93B\x5\x11C\x8F\x2\x93A\x937\x3\x2\x2\x2\x93A\x938\x3\x2\x2"+
-		"\x2\x93A\x939\x3\x2\x2\x2\x93B\xFB\x3\x2\x2\x2\x93C\x93F\a\xEE\x2\x2\x93D"+
-		"\x93F\x5\x11A\x8E\x2\x93E\x93C\x3\x2\x2\x2\x93E\x93D\x3\x2\x2\x2\x93F"+
-		"\xFD\x3\x2\x2\x2\x940\x942\a\x39\x2\x2\x941\x943\x5\x136\x9C\x2\x942\x941"+
-		"\x3\x2\x2\x2\x942\x943\x3\x2\x2\x2\x943\x946\x3\x2\x2\x2\x944\x945\a\x8D"+
-		"\x2\x2\x945\x947\x5\x136\x9C\x2\x946\x944\x3\x2\x2\x2\x946\x947\x3\x2"+
-		"\x2\x2\x947\x948\x3\x2\x2\x2\x948\x94D\x5\x114\x8B\x2\x949\x94B\x5\x136"+
-		"\x9C\x2\x94A\x949\x3\x2\x2\x2\x94A\x94B\x3\x2\x2\x2\x94B\x94C\x3\x2\x2"+
-		"\x2\x94C\x94E\x5\x106\x84\x2\x94D\x94A\x3\x2\x2\x2\x94D\x94E\x3\x2\x2"+
-		"\x2\x94E\xFF\x3\x2\x2\x2\x94F\x950\t\x13\x2\x2\x950\x101\x3\x2\x2\x2\x951"+
-		"\x952\t\xF\x2\x2\x952\x103\x3\x2\x2\x2\x953\x958\x5\xFC\x7F\x2\x954\x955"+
-		"\t\x10\x2\x2\x955\x957\x5\xFC\x7F\x2\x956\x954\x3\x2\x2\x2\x957\x95A\x3"+
-		"\x2\x2\x2\x958\x956\x3\x2\x2\x2\x958\x959\x3\x2\x2\x2\x959\x105\x3\x2"+
-		"\x2\x2\x95A\x958\x3\x2\x2\x2\x95B\x95D\a\xD7\x2\x2\x95C\x95E\x5\x136\x9C"+
-		"\x2\x95D\x95C\x3\x2\x2\x2\x95D\x95E\x3\x2\x2\x2\x95E\x961\x3\x2\x2\x2"+
-		"\x95F\x962\x5\x112\x8A\x2\x960\x962\x5\xFC\x7F\x2\x961\x95F\x3\x2\x2\x2"+
-		"\x961\x960\x3\x2\x2\x2\x962\x107\x3\x2\x2\x2\x963\x965\x5\x10A\x86\x2"+
-		"\x964\x966\x5\x136\x9C\x2\x965\x964\x3\x2\x2\x2\x965\x966\x3\x2\x2\x2"+
-		"\x966\x967\x3\x2\x2\x2\x967\x968\a*\x2\x2\x968\x109\x3\x2\x2\x2\x969\x96C"+
-		"\x5\x10C\x87\x2\x96A\x96C\x5\x10E\x88\x2\x96B\x969\x3\x2\x2\x2\x96B\x96A"+
-		"\x3\x2\x2\x2\x96C\x10B\x3\x2\x2\x2\x96D\x96E\x5\xFA~\x2\x96E\x10D\x3\x2"+
-		"\x2\x2\x96F\x970\x5\x112\x8A\x2\x970\x10F\x3\x2\x2\x2\x971\x97A\x5\x112"+
-		"\x8A\x2\x972\x97A\a\xE8\x2\x2\x973\x97A\a\xE3\x2\x2\x974\x97A\a\xBF\x2"+
-		"\x2\x975\x97A\ao\x2\x2\x976\x97A\a\x8F\x2\x2\x977\x97A\a\x90\x2\x2\x978"+
-		"\x97A\a[\x2\x2\x979\x971\x3\x2\x2\x2\x979\x972\x3\x2\x2\x2\x979\x973\x3"+
-		"\x2\x2\x2\x979\x974\x3\x2\x2\x2\x979\x975\x3\x2\x2\x2\x979\x976\x3\x2"+
-		"\x2\x2\x979\x977\x3\x2\x2\x2\x979\x978\x3\x2\x2\x2\x97A\x111\x3\x2\x2"+
-		"\x2\x97B\x97C\t\x14\x2\x2\x97C\x113\x3\x2\x2\x2\x97D\x980\x5\x100\x81"+
-		"\x2\x97E\x980\x5\x104\x83\x2\x97F\x97D\x3\x2\x2\x2\x97F\x97E\x3\x2\x2"+
-		"\x2\x980\x989\x3\x2\x2\x2\x981\x983\x5\x136\x9C\x2\x982\x981\x3\x2\x2"+
-		"\x2\x982\x983\x3\x2\x2\x2\x983\x984\x3\x2\x2\x2\x984\x986\a\xD4\x2\x2"+
-		"\x985\x987\x5\x136\x9C\x2\x986\x985\x3\x2\x2\x2\x986\x987\x3\x2\x2\x2"+
-		"\x987\x988\x3\x2\x2\x2\x988\x98A\a\xDB\x2\x2\x989\x982\x3\x2\x2\x2\x989"+
-		"\x98A\x3\x2\x2\x2\x98A\x115\x3\x2\x2\x2\x98B\x98C\t\x15\x2\x2\x98C\x117"+
-		"\x3\x2\x2\x2\x98D\x98E\t\x16\x2\x2\x98E\x119\x3\x2\x2\x2\x98F\x990\t\x17"+
-		"\x2\x2\x990\x11B\x3\x2\x2\x2\x991\x992\a\x39\x2\x2\x992\x11D\x3\x2\x2"+
-		"\x2\x993\x994\t\x18\x2\x2\x994\x11F\x3\x2\x2\x2\x995\x997\x5\x136\x9C"+
-		"\x2\x996\x995\x3\x2\x2\x2\x996\x997\x3\x2\x2\x2\x997\x999\x3\x2\x2\x2"+
-		"\x998\x99A\x5\x124\x93\x2\x999\x998\x3\x2\x2\x2\x999\x99A\x3\x2\x2\x2"+
-		"\x99A\x121\x3\x2\x2\x2\x99B\x99C\x5\x120\x91\x2\x99C\x99E\a\xE9\x2\x2"+
-		"\x99D\x99F\x5\x136\x9C\x2\x99E\x99D\x3\x2\x2\x2\x99E\x99F\x3\x2\x2\x2"+
-		"\x99F\x9A8\x3\x2\x2\x2\x9A0\x9A2\x5\x136\x9C\x2\x9A1\x9A0\x3\x2\x2\x2"+
-		"\x9A1\x9A2\x3\x2\x2\x2\x9A2\x9A3\x3\x2\x2\x2\x9A3\x9A5\a*\x2\x2\x9A4\x9A6"+
-		"\x5\x136\x9C\x2\x9A5\x9A4\x3\x2\x2\x2\x9A5\x9A6\x3\x2\x2\x2\x9A6\x9A8"+
-		"\x3\x2\x2\x2\x9A7\x99B\x3\x2\x2\x2\x9A7\x9A1\x3\x2\x2\x2\x9A8\x9AA\x3"+
-		"\x2\x2\x2\x9A9\x9A7\x3\x2\x2\x2\x9AA\x9AD\x3\x2\x2\x2\x9AB\x9A9\x3\x2"+
-		"\x2\x2\x9AB\x9AC\x3\x2\x2\x2\x9AC\x9B2\x3\x2\x2\x2\x9AD\x9AB\x3\x2\x2"+
-		"\x2\x9AE\x9AF\x5\x120\x91\x2\x9AF\x9B0\a\x2\x2\x3\x9B0\x9B2\x3\x2\x2\x2"+
-		"\x9B1\x9AB\x3\x2\x2\x2\x9B1\x9AE\x3\x2\x2\x2\x9B2\x123\x3\x2\x2\x2\x9B3"+
-		"\x9B7\x5\x12C\x97\x2\x9B4\x9B7\x5\x128\x95\x2\x9B5\x9B7\x5\x126\x94\x2"+
-		"\x9B6\x9B3\x3\x2\x2\x2\x9B6\x9B4\x3\x2\x2\x2\x9B6\x9B5\x3\x2\x2\x2\x9B7"+
-		"\x125\x3\x2\x2\x2\x9B8\x9BA\a\xAB\x2\x2\x9B9\x9BB\x5\x136\x9C\x2\x9BA"+
-		"\x9B9\x3\x2\x2\x2\x9BA\x9BB\x3\x2\x2\x2\x9BB\x9BC\x3\x2\x2\x2\x9BC\x9BD"+
-		"\x5\x12A\x96\x2\x9BD\x127\x3\x2\x2\x2\x9BE\x9BF\a\xEA\x2\x2\x9BF\x9C0"+
-		"\x5\x12A\x96\x2\x9C0\x129\x3\x2\x2\x2\x9C1\x9C4\a\xEF\x2\x2\x9C2\x9C4"+
-		"\n\x19\x2\x2\x9C3\x9C1\x3\x2\x2\x2\x9C3\x9C2\x3\x2\x2\x2\x9C4\x9C7\x3"+
-		"\x2\x2\x2\x9C5\x9C3\x3\x2\x2\x2\x9C5\x9C6\x3\x2\x2\x2\x9C6\x12B\x3\x2"+
-		"\x2\x2\x9C7\x9C5\x3\x2\x2\x2\x9C8\x9CE\a\xEA\x2\x2\x9C9\x9CA\a/\x2\x2"+
-		"\x9CA\x9CC\x5\x12E\x98\x2\x9CB\x9CD\x5\x136\x9C\x2\x9CC\x9CB\x3\x2\x2"+
-		"\x2\x9CC\x9CD\x3\x2\x2\x2\x9CD\x9CF\x3\x2\x2\x2\x9CE\x9C9\x3\x2\x2\x2"+
-		"\x9CF\x9D0\x3\x2\x2\x2\x9D0\x9CE\x3\x2\x2\x2\x9D0\x9D1\x3\x2\x2\x2\x9D1"+
-		"\x12D\x3\x2\x2\x2\x9D2\x9D4\x5\x130\x99\x2\x9D3\x9D5\x5\x132\x9A\x2\x9D4"+
-		"\x9D3\x3\x2\x2\x2\x9D4\x9D5\x3\x2\x2\x2\x9D5\x12F\x3\x2\x2\x2\x9D6\x9D7"+
-		"\x5\xFA~\x2\x9D7\x131\x3\x2\x2\x2\x9D8\x9D9\x5\x136\x9C\x2\x9D9\x9DA\x5"+
-		"\x134\x9B\x2\x9DA\xA15\x3\x2\x2\x2\x9DB\x9DC\x5\x136\x9C\x2\x9DC\x9E5"+
-		"\x5\x134\x9B\x2\x9DD\x9DF\x5\x136\x9C\x2\x9DE\x9DD\x3\x2\x2\x2\x9DE\x9DF"+
-		"\x3\x2\x2\x2\x9DF\x9E0\x3\x2\x2\x2\x9E0\x9E2\a)\x2\x2\x9E1\x9E3\x5\x136"+
-		"\x9C\x2\x9E2\x9E1\x3\x2\x2\x2\x9E2\x9E3\x3\x2\x2\x2\x9E3\x9E4\x3\x2\x2"+
-		"\x2\x9E4\x9E6\x5\x134\x9B\x2\x9E5\x9DE\x3\x2\x2\x2\x9E6\x9E7\x3\x2\x2"+
-		"\x2\x9E7\x9E5\x3\x2\x2\x2\x9E7\x9E8\x3\x2\x2\x2\x9E8\xA15\x3\x2\x2\x2"+
-		"\x9E9\x9EB\x5\x136\x9C\x2\x9EA\x9E9\x3\x2\x2\x2\x9EA\x9EB\x3\x2\x2\x2"+
-		"\x9EB\x9EC\x3\x2\x2\x2\x9EC\x9EE\a\xD4\x2\x2\x9ED\x9EF\x5\x136\x9C\x2"+
-		"\x9EE\x9ED\x3\x2\x2\x2\x9EE\x9EF\x3\x2\x2\x2\x9EF\x9F0\x3\x2\x2\x2\x9F0"+
-		"\xA15\a\xDB\x2\x2\x9F1\x9F3\x5\x136\x9C\x2\x9F2\x9F1\x3\x2\x2\x2\x9F2"+
-		"\x9F3\x3\x2\x2\x2\x9F3\x9F4\x3\x2\x2\x2\x9F4\x9F6\a\xD4\x2\x2\x9F5\x9F7"+
-		"\x5\x136\x9C\x2\x9F6\x9F5\x3\x2\x2\x2\x9F6\x9F7\x3\x2\x2\x2\x9F7\x9F8"+
-		"\x3\x2\x2\x2\x9F8\x9FA\x5\x134\x9B\x2\x9F9\x9FB\x5\x136\x9C\x2\x9FA\x9F9"+
-		"\x3\x2\x2\x2\x9FA\x9FB\x3\x2\x2\x2\x9FB\x9FC\x3\x2\x2\x2\x9FC\x9FD\a\xDB"+
-		"\x2\x2\x9FD\xA15\x3\x2\x2\x2\x9FE\xA00\x5\x136\x9C\x2\x9FF\x9FE\x3\x2"+
-		"\x2\x2\x9FF\xA00\x3\x2\x2\x2\xA00\xA01\x3\x2\x2\x2\xA01\xA02\a\xD4\x2"+
-		"\x2\xA02\xA0B\x5\x134\x9B\x2\xA03\xA05\x5\x136\x9C\x2\xA04\xA03\x3\x2"+
-		"\x2\x2\xA04\xA05\x3\x2\x2\x2\xA05\xA06\x3\x2\x2\x2\xA06\xA08\a)\x2\x2"+
-		"\xA07\xA09\x5\x136\x9C\x2\xA08\xA07\x3\x2\x2\x2\xA08\xA09\x3\x2\x2\x2"+
-		"\xA09\xA0A\x3\x2\x2\x2\xA0A\xA0C\x5\x134\x9B\x2\xA0B\xA04\x3\x2\x2\x2"+
-		"\xA0C\xA0D\x3\x2\x2\x2\xA0D\xA0B\x3\x2\x2\x2\xA0D\xA0E\x3\x2\x2\x2\xA0E"+
-		"\xA10\x3\x2\x2\x2\xA0F\xA11\x5\x136\x9C\x2\xA10\xA0F\x3\x2\x2\x2\xA10"+
-		"\xA11\x3\x2\x2\x2\xA11\xA12\x3\x2\x2\x2\xA12\xA13\a\xDB\x2\x2\xA13\xA15"+
-		"\x3\x2\x2\x2\xA14\x9D8\x3\x2\x2\x2\xA14\x9DB\x3\x2\x2\x2\xA14\x9EA\x3"+
-		"\x2\x2\x2\xA14\x9F2\x3\x2\x2\x2\xA14\x9FF\x3\x2\x2\x2\xA15\x133\x3\x2"+
-		"\x2\x2\xA16\xA17\x5\xBA^\x2\xA17\x135\x3\x2\x2\x2\xA18\xA1A\t\x1A\x2\x2"+
-		"\xA19\xA18\x3\x2\x2\x2\xA1A\xA1B\x3\x2\x2\x2\xA1B\xA19\x3\x2\x2\x2\xA1B"+
-		"\xA1C\x3\x2\x2\x2\xA1C\x137\x3\x2\x2\x2\x1BD\x13B\x141\x144\x148\x14C"+
-		"\x150\x158\x15B\x165\x167\x16D\x175\x17C\x182\x18B\x193\x1A2\x1AD\x1B5"+
-		"\x1BF\x1C5\x1C9\x1CD\x1D1\x1D6\x1E3\x217\x21D\x221\x226\x229\x22E\x234"+
-		"\x238\x23D\x242\x247\x24A\x24E\x255\x25B\x261\x26C\x26F\x272\x277\x27D"+
-		"\x281\x286\x28E\x294\x298\x2A4\x2A8\x2B3\x2BE\x2C5\x2CD\x2D2\x2DB\x2E2"+
-		"\x2E6\x2E9\x2F3\x2F7\x2FC\x306\x30C\x31D\x323\x329\x32D\x339\x33D\x343"+
-		"\x348\x34C\x350\x354\x357\x35A\x35D\x360\x364\x36E\x372\x375\x378\x37C"+
-		"\x38F\x394\x398\x3A3\x3AB\x3AE\x3B0\x3B5\x3B9\x3BD\x3C1\x3C5\x3CB\x3CF"+
-		"\x3D3\x3D8\x3DE\x3E1\x3E5\x3E9\x3EC\x3F0\x3F5\x3F7\x3FB\x3FF\x402\x406"+
-		"\x409\x417\x41B\x420\x424\x428\x42C\x434\x438\x440\x444\x44C\x44E\x454"+
-		"\x458\x45E\x462\x466\x474\x47E\x482\x487\x492\x496\x49B\x4AA\x4AF\x4B8"+
-		"\x4BC\x4C0\x4C4\x4C8\x4CB\x4CF\x4D3\x4D6\x4DA\x4DD\x4E1\x4E3\x4E8\x4EC"+
-		"\x4F0\x4F4\x4F6\x4FC\x500\x503\x508\x50C\x512\x515\x518\x51D\x521\x528"+
-		"\x52C\x532\x535\x539\x540\x544\x54A\x54D\x551\x559\x55D\x560\x563\x567"+
-		"\x56F\x573\x577\x579\x57C\x582\x586\x58A\x58F\x594\x598\x59C\x5A2\x5AA"+
-		"\x5AC\x5B4\x5B8\x5C2\x5C6\x5D3\x5DA\x5DE\x5E9\x5F0\x5F5\x5F9\x5FE\x601"+
-		"\x607\x60B\x612\x616\x61A\x61E\x621\x625\x62E\x637\x63E\x642\x645\x648"+
-		"\x64B\x650\x658\x65C\x664\x666\x66B\x670\x675\x679\x67F\x684\x68B\x68F"+
-		"\x695\x699\x69D\x6A2\x6A6\x6AB\x6AF\x6B4\x6B8\x6BD\x6C1\x6C6\x6CA\x6CF"+
-		"\x6D3\x6D8\x6DC\x6E1\x6E5\x6EA\x6EE\x6F3\x6F7\x6FC\x700\x703\x705\x710"+
-		"\x715\x71A\x720\x724\x729\x72E\x731\x735\x739\x73B\x73F\x741\x746\x74D"+
-		"\x755\x759\x762\x76C\x770\x773\x776\x77F\x784\x787\x78B\x78F\x793\x796"+
-		"\x79E\x7A3\x7A6\x7AA\x7AE\x7B2\x7B5\x7BD\x7C0\x7C4\x7C7\x7CA\x7CE\x7D2"+
-		"\x7D7\x7DA\x7DD\x7E0\x7E8\x7EF\x7F2\x7FA\x801\x805\x808\x80B\x80E\x816"+
-		"\x81B\x81E\x821\x825\x829\x82B\x82F\x832\x835\x83D\x842\x845\x848\x84B"+
-		"\x853\x858\x85B\x85E\x862\x866\x868\x86C\x86F\x872\x87A\x87F\x883\x887"+
-		"\x88A\x88D\x890\x898\x89D\x8A1\x8A4\x8A9\x8AC\x8B0\x8B4\x8B9\x8BD\x8C0"+
-		"\x8C4\x8C8\x8CC\x8CF\x8D5\x8D9\x8DD\x8E1\x8E5\x8EA\x8ED\x8F0\x8F6\x8FA"+
-		"\x8FE\x902\x905\x909\x90C\x90F\x912\x915\x918\x91C\x922\x926\x92B\x933"+
-		"\x93A\x93E\x942\x946\x94A\x94D\x958\x95D\x961\x965\x96B\x979\x97F\x982"+
-		"\x986\x989\x996\x999\x99E\x9A1\x9A5\x9A7\x9AB\x9B1\x9B6\x9BA\x9C3\x9C5"+
-		"\x9CC\x9D0\x9D4\x9DE\x9E2\x9E7\x9EA\x9EE\x9F2\x9F6\x9FA\x9FF\xA04\xA08"+
-		"\xA0D\xA10\xA14\xA1B";
+		"\x39A\x39C\a)\x2\x2\x39B\x39D\x5\x174\xBB\x2\x39C\x39B\x3\x2\x2\x2\x39C"+
+		"\x39D\x3\x2\x2\x2\x39D\x39F\x3\x2\x2\x2\x39E\x3A0\x5x=\x2\x39F\x39E\x3"+
+		"\x2\x2\x2\x39F\x3A0\x3\x2\x2\x2\x3A0\x3A2\x3\x2\x2\x2\x3A1\x3A3\x5\x174"+
+		"\xBB\x2\x3A2\x3A1\x3\x2\x2\x2\x3A2\x3A3\x3\x2\x2\x2\x3A3\x3A4\x3\x2\x2"+
+		"\x2\x3A4\x3A6\a)\x2\x2\x3A5\x3A7\x5\x174\xBB\x2\x3A6\x3A5\x3\x2\x2\x2"+
+		"\x3A6\x3A7\x3\x2\x2\x2\x3A7\x3A8\x3\x2\x2\x2\x3A8\x3A9\x5~@\x2\x3A9}\x3"+
+		"\x2\x2\x2\x3AA\x3AB\x5\xFE\x80\x2\x3AB\x7F\x3\x2\x2\x2\x3AC\x3AD\x5\x156"+
+		"\xAC\x2\x3AD\x3AE\x5\x174\xBB\x2\x3AE\x3B0\x3\x2\x2\x2\x3AF\x3AC\x3\x2"+
+		"\x2\x2\x3AF\x3B0\x3\x2\x2\x2\x3B0\x3B1\x3\x2\x2\x2\x3B1\x3B2\a\x44\x2"+
+		"\x2\x3B2\x3B3\x5\x174\xBB\x2\x3B3\x3BE\x5\x82\x42\x2\x3B4\x3B6\x5\x174"+
+		"\xBB\x2\x3B5\x3B4\x3\x2\x2\x2\x3B5\x3B6\x3\x2\x2\x2\x3B6\x3B7\x3\x2\x2"+
+		"\x2\x3B7\x3B9\a)\x2\x2\x3B8\x3BA\x5\x174\xBB\x2\x3B9\x3B8\x3\x2\x2\x2"+
+		"\x3B9\x3BA\x3\x2\x2\x2\x3BA\x3BB\x3\x2\x2\x2\x3BB\x3BD\x5\x82\x42\x2\x3BC"+
+		"\x3B5\x3\x2\x2\x2\x3BD\x3C0\x3\x2\x2\x2\x3BE\x3BC\x3\x2\x2\x2\x3BE\x3BF"+
+		"\x3\x2\x2\x2\x3BF\x81\x3\x2\x2\x2\x3C0\x3BE\x3\x2\x2\x2\x3C1\x3C3\x5\x13A"+
+		"\x9E\x2\x3C2\x3C4\x5\x154\xAB\x2\x3C3\x3C2\x3\x2\x2\x2\x3C3\x3C4\x3\x2"+
+		"\x2\x2\x3C4\x3C8\x3\x2\x2\x2\x3C5\x3C6\x5\x174\xBB\x2\x3C6\x3C7\x5\x13C"+
+		"\x9F\x2\x3C7\x3C9\x3\x2\x2\x2\x3C8\x3C5\x3\x2\x2\x2\x3C8\x3C9\x3\x2\x2"+
+		"\x2\x3C9\x3CB\x3\x2\x2\x2\x3CA\x3CC\x5\x174\xBB\x2\x3CB\x3CA\x3\x2\x2"+
+		"\x2\x3CB\x3CC\x3\x2\x2\x2\x3CC\x3CD\x3\x2\x2\x2\x3CD\x3CF\a\xD0\x2\x2"+
+		"\x3CE\x3D0\x5\x174\xBB\x2\x3CF\x3CE\x3\x2\x2\x2\x3CF\x3D0\x3\x2\x2\x2"+
+		"\x3D0\x3D1\x3\x2\x2\x2\x3D1\x3D2\x5\xFE\x80\x2\x3D2\x83\x3\x2\x2\x2\x3D3"+
+		"\x3D4\x5\x156\xAC\x2\x3D4\x3D5\x5\x174\xBB\x2\x3D5\x3D7\x3\x2\x2\x2\x3D6"+
+		"\x3D3\x3\x2\x2\x2\x3D6\x3D7\x3\x2\x2\x2\x3D7\x3D8\x3\x2\x2\x2\x3D8\x3D9"+
+		"\aG\x2\x2\x3D9\x3DC\x5\x174\xBB\x2\x3DA\x3DB\a\xA3\x2\x2\x3DB\x3DD\x5"+
+		"\x174\xBB\x2\x3DC\x3DA\x3\x2\x2\x2\x3DC\x3DD\x3\x2\x2\x2\x3DD\x3DE\x3"+
+		"\x2\x2\x2\x3DE\x3DF\t\a\x2\x2\x3DF\x3E0\x5\x174\xBB\x2\x3E0\x3E2\x5\x13A"+
+		"\x9E\x2\x3E1\x3E3\x5\x154\xAB\x2\x3E2\x3E1\x3\x2\x2\x2\x3E2\x3E3\x3\x2"+
+		"\x2\x2\x3E3\x3E4\x3\x2\x2\x2\x3E4\x3E5\x5\x174\xBB\x2\x3E5\x3E6\a\x82"+
+		"\x2\x2\x3E6\x3E7\x5\x174\xBB\x2\x3E7\x3ED\a\xE3\x2\x2\x3E8\x3E9\x5\x174"+
+		"\xBB\x2\x3E9\x3EA\a\x35\x2\x2\x3EA\x3EB\x5\x174\xBB\x2\x3EB\x3EC\a\xE3"+
+		"\x2\x2\x3EC\x3EE\x3\x2\x2\x2\x3ED\x3E8\x3\x2\x2\x2\x3ED\x3EE\x3\x2\x2"+
+		"\x2\x3EE\x3F3\x3\x2\x2\x2\x3EF\x3F1\x5\x174\xBB\x2\x3F0\x3EF\x3\x2\x2"+
+		"\x2\x3F0\x3F1\x3\x2\x2\x2\x3F1\x3F2\x3\x2\x2\x2\x3F2\x3F4\x5\x12E\x98"+
+		"\x2\x3F3\x3F0\x3\x2\x2\x2\x3F3\x3F4\x3\x2\x2\x2\x3F4\x3F8\x3\x2\x2\x2"+
+		"\x3F5\x3F6\x5\x174\xBB\x2\x3F6\x3F7\x5\x13C\x9F\x2\x3F7\x3F9\x3\x2\x2"+
+		"\x2\x3F8\x3F5\x3\x2\x2\x2\x3F8\x3F9\x3\x2\x2\x2\x3F9\x85\x3\x2\x2\x2\x3FA"+
+		"\x3FB\x5\x88\x45\x2\x3FB\x3FC\x5\x174\xBB\x2\x3FC\x407\x5\x8A\x46\x2\x3FD"+
+		"\x3FF\x5\x174\xBB\x2\x3FE\x3FD\x3\x2\x2\x2\x3FE\x3FF\x3\x2\x2\x2\x3FF"+
+		"\x400\x3\x2\x2\x2\x400\x402\a)\x2\x2\x401\x403\x5\x174\xBB\x2\x402\x401"+
+		"\x3\x2\x2\x2\x402\x403\x3\x2\x2\x2\x403\x404\x3\x2\x2\x2\x404\x406\x5"+
+		"\x8A\x46\x2\x405\x3FE\x3\x2\x2\x2\x406\x409\x3\x2\x2\x2\x407\x405\x3\x2"+
+		"\x2\x2\x407\x408\x3\x2\x2\x2\x408\x87\x3\x2\x2\x2\x409\x407\x3\x2\x2\x2"+
+		"\x40A\x40B\t\b\x2\x2\x40B\x89\x3\x2\x2\x2\x40C\x410\x5\x8CG\x2\x40D\x410"+
+		"\x5\x8EH\x2\x40E\x410\x5\x94K\x2\x40F\x40C\x3\x2\x2\x2\x40F\x40D\x3\x2"+
+		"\x2\x2\x40F\x40E\x3\x2\x2\x2\x410\x8B\x3\x2\x2\x2\x411\x412\x5\x138\x9D"+
+		"\x2\x412\x8D\x3\x2\x2\x2\x413\x415\x5\x90I\x2\x414\x416\x5\x174\xBB\x2"+
+		"\x415\x414\x3\x2\x2\x2\x415\x416\x3\x2\x2\x2\x416\x417\x3\x2\x2\x2\x417"+
+		"\x419\a\xD6\x2\x2\x418\x41A\x5\x174\xBB\x2\x419\x418\x3\x2\x2\x2\x419"+
+		"\x41A\x3\x2\x2\x2\x41A\x41B\x3\x2\x2\x2\x41B\x41C\x5\x92J\x2\x41C\x8F"+
+		"\x3\x2\x2\x2\x41D\x41E\x6I\x2\x2\x41E\x41F\x5\x138\x9D\x2\x41F\x91\x3"+
+		"\x2\x2\x2\x420\x421\x6J\x3\x2\x421\x422\x5\x138\x9D\x2\x422\x93\x3\x2"+
+		"\x2\x2\x423\x425\x5\x96L\x2\x424\x426\x5\x174\xBB\x2\x425\x424\x3\x2\x2"+
+		"\x2\x425\x426\x3\x2\x2\x2\x426\x427\x3\x2\x2\x2\x427\x429\a\xD6\x2\x2"+
+		"\x428\x42A\x5\x174\xBB\x2\x429\x428\x3\x2\x2\x2\x429\x42A\x3\x2\x2\x2"+
+		"\x42A\x42B\x3\x2\x2\x2\x42B\x42C\x5\x98M\x2\x42C\x95\x3\x2\x2\x2\x42D"+
+		"\x42E\x5\x138\x9D\x2\x42E\x97\x3\x2\x2\x2\x42F\x430\x5\x138\x9D\x2\x430"+
+		"\x99\x3\x2\x2\x2\x431\x432\aV\x2\x2\x432\x434\x5\x160\xB1\x2\x433\x435"+
+		"\x5\x1E\x10\x2\x434\x433\x3\x2\x2\x2\x434\x435\x3\x2\x2\x2\x435\x436\x3"+
+		"\x2\x2\x2\x436\x437\a\x80\x2\x2\x437\x44F\x3\x2\x2\x2\x438\x439\aV\x2"+
+		"\x2\x439\x43A\x5\x174\xBB\x2\x43A\x43B\t\t\x2\x2\x43B\x43C\x5\x174\xBB"+
+		"\x2\x43C\x43D\x5\xFE\x80\x2\x43D\x43F\x5\x160\xB1\x2\x43E\x440\x5\x1E"+
+		"\x10\x2\x43F\x43E\x3\x2\x2\x2\x43F\x440\x3\x2\x2\x2\x440\x441\x3\x2\x2"+
+		"\x2\x441\x442\a\x80\x2\x2\x442\x44F\x3\x2\x2\x2\x443\x444\aV\x2\x2\x444"+
+		"\x446\x5\x160\xB1\x2\x445\x447\x5\x1E\x10\x2\x446\x445\x3\x2\x2\x2\x446"+
+		"\x447\x3\x2\x2\x2\x447\x448\x3\x2\x2\x2\x448\x449\a\x80\x2\x2\x449\x44A"+
+		"\x5\x174\xBB\x2\x44A\x44B\t\t\x2\x2\x44B\x44C\x5\x174\xBB\x2\x44C\x44D"+
+		"\x5\xFE\x80\x2\x44D\x44F\x3\x2\x2\x2\x44E\x431\x3\x2\x2\x2\x44E\x438\x3"+
+		"\x2\x2\x2\x44E\x443\x3\x2\x2\x2\x44F\x9B\x3\x2\x2\x2\x450\x451\x5\x156"+
+		"\xAC\x2\x451\x452\x5\x174\xBB\x2\x452\x454\x3\x2\x2\x2\x453\x450\x3\x2"+
+		"\x2\x2\x453\x454\x3\x2\x2\x2\x454\x455\x3\x2\x2\x2\x455\x456\a\x65\x2"+
+		"\x2\x456\x457\x5\x174\xBB\x2\x457\x458\x5\x13A\x9E\x2\x458\x45C\x5\x160"+
+		"\xB1\x2\x459\x45B\x5\x9EP\x2\x45A\x459\x3\x2\x2\x2\x45B\x45E\x3\x2\x2"+
+		"\x2\x45C\x45A\x3\x2\x2\x2\x45C\x45D\x3\x2\x2\x2\x45D\x45F\x3\x2\x2\x2"+
+		"\x45E\x45C\x3\x2\x2\x2\x45F\x460\a\\\x2\x2\x460\x9D\x3\x2\x2\x2\x461\x46A"+
+		"\x5\x13A\x9E\x2\x462\x464\x5\x174\xBB\x2\x463\x462\x3\x2\x2\x2\x463\x464"+
+		"\x3\x2\x2\x2\x464\x465\x3\x2\x2\x2\x465\x467\a\xD0\x2\x2\x466\x468\x5"+
+		"\x174\xBB\x2\x467\x466\x3\x2\x2\x2\x467\x468\x3\x2\x2\x2\x468\x469\x3"+
+		"\x2\x2\x2\x469\x46B\x5\xFE\x80\x2\x46A\x463\x3\x2\x2\x2\x46A\x46B\x3\x2"+
+		"\x2\x2\x46B\x46C\x3\x2\x2\x2\x46C\x46D\x5\x160\xB1\x2\x46D\x9F\x3\x2\x2"+
+		"\x2\x46E\x46F\a\x64\x2\x2\x46F\xA1\x3\x2\x2\x2\x470\x471\ag\x2\x2\x471"+
+		"\x472\x5\x174\xBB\x2\x472\x47D\x5\xFE\x80\x2\x473\x475\x5\x174\xBB\x2"+
+		"\x474\x473\x3\x2\x2\x2\x474\x475\x3\x2\x2\x2\x475\x476\x3\x2\x2\x2\x476"+
+		"\x478\a)\x2\x2\x477\x479\x5\x174\xBB\x2\x478\x477\x3\x2\x2\x2\x478\x479"+
+		"\x3\x2\x2\x2\x479\x47A\x3\x2\x2\x2\x47A\x47C\x5\xFE\x80\x2\x47B\x474\x3"+
+		"\x2\x2\x2\x47C\x47F\x3\x2\x2\x2\x47D\x47B\x3\x2\x2\x2\x47D\x47E\x3\x2"+
+		"\x2\x2\x47E\xA3\x3\x2\x2\x2\x47F\x47D\x3\x2\x2\x2\x480\x481\ah\x2\x2\x481"+
+		"\x482\x5\x174\xBB\x2\x482\x483\x5\xFE\x80\x2\x483\xA5\x3\x2\x2\x2\x484"+
+		"\x485\x5\x156\xAC\x2\x485\x486\x5\x174\xBB\x2\x486\x488\x3\x2\x2\x2\x487"+
+		"\x484\x3\x2\x2\x2\x487\x488\x3\x2\x2\x2\x488\x489\x3\x2\x2\x2\x489\x48A"+
+		"\ai\x2\x2\x48A\x48B\x5\x174\xBB\x2\x48B\x48D\x5\x13A\x9E\x2\x48C\x48E"+
+		"\x5\x174\xBB\x2\x48D\x48C\x3\x2\x2\x2\x48D\x48E\x3\x2\x2\x2\x48E\x48F"+
+		"\x3\x2\x2\x2\x48F\x490\x5\x12E\x98\x2\x490\xA7\x3\x2\x2\x2\x491\x492\t"+
+		"\n\x2\x2\x492\xA9\x3\x2\x2\x2\x493\x494\aq\x2\x2\x494\x495\x5\x174\xBB"+
+		"\x2\x495\x496\aX\x2\x2\x496\x497\x5\x174\xBB\x2\x497\x498\x5\xFE\x80\x2"+
+		"\x498\x499\x5\x174\xBB\x2\x499\x49A\az\x2\x2\x49A\x49B\x5\x174\xBB\x2"+
+		"\x49B\x49C\x5\xFE\x80\x2\x49C\x49E\x5\x160\xB1\x2\x49D\x49F\x5\x1E\x10"+
+		"\x2\x49E\x49D\x3\x2\x2\x2\x49E\x49F\x3\x2\x2\x2\x49F\x4A0\x3\x2\x2\x2"+
+		"\x4A0\x4A4\a\x8C\x2\x2\x4A1\x4A2\x5\x174\xBB\x2\x4A2\x4A3\x5\xFE\x80\x2"+
+		"\x4A3\x4A5\x3\x2\x2\x2\x4A4\x4A1\x3\x2\x2\x2\x4A4\x4A5\x3\x2\x2\x2\x4A5"+
+		"\xAB\x3\x2\x2\x2\x4A6\x4A7\aq\x2\x2\x4A7\x4A8\x5\x174\xBB\x2\x4A8\x4AA"+
+		"\x5\xFE\x80\x2\x4A9\x4AB\x5\x174\xBB\x2\x4AA\x4A9\x3\x2\x2\x2\x4AA\x4AB"+
+		"\x3\x2\x2\x2\x4AB\x4AC\x3\x2\x2\x2\x4AC\x4AE\a\xD0\x2\x2\x4AD\x4AF\x5"+
+		"\x174\xBB\x2\x4AE\x4AD\x3\x2\x2\x2\x4AE\x4AF\x3\x2\x2\x2\x4AF\x4B0\x3"+
+		"\x2\x2\x2\x4B0\x4B1\x5\xFE\x80\x2\x4B1\x4B2\x5\x174\xBB\x2\x4B2\x4B3\a"+
+		"\xBE\x2\x2\x4B3\x4B4\x5\x174\xBB\x2\x4B4\x4BA\x5\xFE\x80\x2\x4B5\x4B6"+
+		"\x5\x174\xBB\x2\x4B6\x4B7\a\xB7\x2\x2\x4B7\x4B8\x5\x174\xBB\x2\x4B8\x4B9"+
+		"\x5\xFE\x80\x2\x4B9\x4BB\x3\x2\x2\x2\x4BA\x4B5\x3\x2\x2\x2\x4BA\x4BB\x3"+
+		"\x2\x2\x2\x4BB\x4BC\x3\x2\x2\x2\x4BC\x4BE\x5\x160\xB1\x2\x4BD\x4BF\x5"+
+		"\x1E\x10\x2\x4BE\x4BD\x3\x2\x2\x2\x4BE\x4BF\x3\x2\x2\x2\x4BF\x4C0\x3\x2"+
+		"\x2\x2\x4C0\x4C4\a\x8C\x2\x2\x4C1\x4C2\x5\x174\xBB\x2\x4C2\x4C3\x5\xFE"+
+		"\x80\x2\x4C3\x4C5\x3\x2\x2\x2\x4C4\x4C1\x3\x2\x2\x2\x4C4\x4C5\x3\x2\x2"+
+		"\x2\x4C5\xAD\x3\x2\x2\x2\x4C6\x4C7\x5\x156\xAC\x2\x4C7\x4C8\x5\x174\xBB"+
+		"\x2\x4C8\x4CA\x3\x2\x2\x2\x4C9\x4C6\x3\x2\x2\x2\x4C9\x4CA\x3\x2\x2\x2"+
+		"\x4CA\x4CD\x3\x2\x2\x2\x4CB\x4CC\a\xB6\x2\x2\x4CC\x4CE\x5\x174\xBB\x2"+
+		"\x4CD\x4CB\x3\x2\x2\x2\x4CD\x4CE\x3\x2\x2\x2\x4CE\x4CF\x3\x2\x2\x2\x4CF"+
+		"\x4D1\ar\x2\x2\x4D0\x4D2\x5\x174\xBB\x2\x4D1\x4D0\x3\x2\x2\x2\x4D1\x4D2"+
+		"\x3\x2\x2\x2\x4D2\x4D3\x3\x2\x2\x2\x4D3\x4D5\x5\xB0Y\x2\x4D4\x4D6\x5\x154"+
+		"\xAB\x2\x4D5\x4D4\x3\x2\x2\x2\x4D5\x4D6\x3\x2\x2\x2\x4D6\x4DB\x3\x2\x2"+
+		"\x2\x4D7\x4D9\x5\x174\xBB\x2\x4D8\x4D7\x3\x2\x2\x2\x4D8\x4D9\x3\x2\x2"+
+		"\x2\x4D9\x4DA\x3\x2\x2\x2\x4DA\x4DC\x5\x12E\x98\x2\x4DB\x4D8\x3\x2\x2"+
+		"\x2\x4DB\x4DC\x3\x2\x2\x2\x4DC\x4E1\x3\x2\x2\x2\x4DD\x4DF\x5\x174\xBB"+
+		"\x2\x4DE\x4DD\x3\x2\x2\x2\x4DE\x4DF\x3\x2\x2\x2\x4DF\x4E0\x3\x2\x2\x2"+
+		"\x4E0\x4E2\x5\x13C\x9F\x2\x4E1\x4DE\x3\x2\x2\x2\x4E1\x4E2\x3\x2\x2\x2"+
+		"\x4E2\x4E3\x3\x2\x2\x2\x4E3\x4E5\x5\x160\xB1\x2\x4E4\x4E6\x5\x1E\x10\x2"+
+		"\x4E5\x4E4\x3\x2\x2\x2\x4E5\x4E6\x3\x2\x2\x2\x4E6\x4E7\x3\x2\x2\x2\x4E7"+
+		"\x4E8\a]\x2\x2\x4E8\xAF\x3\x2\x2\x2\x4E9\x4EA\x5\x13A\x9E\x2\x4EA\xB1"+
+		"\x3\x2\x2\x2\x4EB\x4EC\au\x2\x2\x4EC\x4ED\x5\x174\xBB\x2\x4ED\x4EE\x5"+
+		"\xFE\x80\x2\x4EE\xB3\x3\x2\x2\x2\x4EF\x4F0\av\x2\x2\x4F0\x4F1\x5\x174"+
+		"\xBB\x2\x4F1\x4F2\x5\xFE\x80\x2\x4F2\xB5\x3\x2\x2\x2\x4F3\x4F4\aw\x2\x2"+
+		"\x4F4\x4F5\x5\x174\xBB\x2\x4F5\x4F6\x5\xC8\x65\x2\x4F6\x4F7\x5\x174\xBB"+
+		"\x2\x4F7\x4F8\a\xBD\x2\x2\x4F8\x4FA\x5\x160\xB1\x2\x4F9\x4FB\x5\x1E\x10"+
+		"\x2\x4FA\x4F9\x3\x2\x2\x2\x4FA\x4FB\x3\x2\x2\x2\x4FB\x4FF\x3\x2\x2\x2"+
+		"\x4FC\x4FE\x5\xB8]\x2\x4FD\x4FC\x3\x2\x2\x2\x4FE\x501\x3\x2\x2\x2\x4FF"+
+		"\x4FD\x3\x2\x2\x2\x4FF\x500\x3\x2\x2\x2\x500\x503\x3\x2\x2\x2\x501\x4FF"+
+		"\x3\x2\x2\x2\x502\x504\x5\xBA^\x2\x503\x502\x3\x2\x2\x2\x503\x504\x3\x2"+
+		"\x2\x2\x504\x505\x3\x2\x2\x2\x505\x506\a^\x2\x2\x506\xB7\x3\x2\x2\x2\x507"+
+		"\x508\aZ\x2\x2\x508\x509\x5\x174\xBB\x2\x509\x50A\x5\xC8\x65\x2\x50A\x50B"+
+		"\x5\x174\xBB\x2\x50B\x50C\a\xBD\x2\x2\x50C\x50E\x5\x160\xB1\x2\x50D\x50F"+
+		"\x5\x1E\x10\x2\x50E\x50D\x3\x2\x2\x2\x50E\x50F\x3\x2\x2\x2\x50F\x51C\x3"+
+		"\x2\x2\x2\x510\x511\aZ\x2\x2\x511\x512\x5\x174\xBB\x2\x512\x513\x5\xC8"+
+		"\x65\x2\x513\x514\x5\x174\xBB\x2\x514\x516\a\xBD\x2\x2\x515\x517\x5\x174"+
+		"\xBB\x2\x516\x515\x3\x2\x2\x2\x516\x517\x3\x2\x2\x2\x517\x519\x3\x2\x2"+
+		"\x2\x518\x51A\x5\x1E\x10\x2\x519\x518\x3\x2\x2\x2\x519\x51A\x3\x2\x2\x2"+
+		"\x51A\x51C\x3\x2\x2\x2\x51B\x507\x3\x2\x2\x2\x51B\x510\x3\x2\x2\x2\x51C"+
+		"\xB9\x3\x2\x2\x2\x51D\x51E\aY\x2\x2\x51E\x520\x5\x160\xB1\x2\x51F\x521"+
+		"\x5\x1E\x10\x2\x520\x51F\x3\x2\x2\x2\x520\x521\x3\x2\x2\x2\x521\xBB\x3"+
+		"\x2\x2\x2\x522\x525\x5\xBE`\x2\x523\x525\x5\xC0\x61\x2\x524\x522\x3\x2"+
+		"\x2\x2\x524\x523\x3\x2\x2\x2\x525\xBD\x3\x2\x2\x2\x526\x528\aw\x2\x2\x527"+
+		"\x529\x5\x174\xBB\x2\x528\x527\x3\x2\x2\x2\x528\x529\x3\x2\x2\x2\x529"+
+		"\x52A\x3\x2\x2\x2\x52A\x52C\x5\xC8\x65\x2\x52B\x52D\x5\x174\xBB\x2\x52C"+
+		"\x52B\x3\x2\x2\x2\x52C\x52D\x3\x2\x2\x2\x52D\x52E\x3\x2\x2\x2\x52E\x530"+
+		"\a\xBD\x2\x2\x52F\x531\x5\x174\xBB\x2\x530\x52F\x3\x2\x2\x2\x530\x531"+
+		"\x3\x2\x2\x2\x531\x532\x3\x2\x2\x2\x532\x536\x5\xC4\x63\x2\x533\x534\x5"+
+		"\x174\xBB\x2\x534\x535\x5\xC2\x62\x2\x535\x537\x3\x2\x2\x2\x536\x533\x3"+
+		"\x2\x2\x2\x536\x537\x3\x2\x2\x2\x537\xBF\x3\x2\x2\x2\x538\x53A\aw\x2\x2"+
+		"\x539\x53B\x5\x174\xBB\x2\x53A\x539\x3\x2\x2\x2\x53A\x53B\x3\x2\x2\x2"+
+		"\x53B\x53C\x3\x2\x2\x2\x53C\x53E\x5\xC8\x65\x2\x53D\x53F\x5\x174\xBB\x2"+
+		"\x53E\x53D\x3\x2\x2\x2\x53E\x53F\x3\x2\x2\x2\x53F\x540\x3\x2\x2\x2\x540"+
+		"\x541\a\xBD\x2\x2\x541\x543\x5\x160\xB1\x2\x542\x544\x5\x174\xBB\x2\x543"+
+		"\x542\x3\x2\x2\x2\x543\x544\x3\x2\x2\x2\x544\x545\x3\x2\x2\x2\x545\x546"+
+		"\x5\xC2\x62\x2\x546\xC1\x3\x2\x2\x2\x547\x549\aY\x2\x2\x548\x54A\x5\x174"+
+		"\xBB\x2\x549\x548\x3\x2\x2\x2\x549\x54A\x3\x2\x2\x2\x54A\x54C\x3\x2\x2"+
+		"\x2\x54B\x54D\x5\xC4\x63\x2\x54C\x54B\x3\x2\x2\x2\x54C\x54D\x3\x2\x2\x2"+
+		"\x54D\xC3\x3\x2\x2\x2\x54E\x55B\x5\x14C\xA7\x2\x54F\x551\x5\x174\xBB\x2"+
+		"\x550\x54F\x3\x2\x2\x2\x550\x551\x3\x2\x2\x2\x551\x552\x3\x2\x2\x2\x552"+
+		"\x554\a*\x2\x2\x553\x555\x5\x174\xBB\x2\x554\x553\x3\x2\x2\x2\x554\x555"+
+		"\x3\x2\x2\x2\x555\x557\x3\x2\x2\x2\x556\x558\x5\xC6\x64\x2\x557\x556\x3"+
+		"\x2\x2\x2\x557\x558\x3\x2\x2\x2\x558\x55A\x3\x2\x2\x2\x559\x550\x3\x2"+
+		"\x2\x2\x55A\x55D\x3\x2\x2\x2\x55B\x559\x3\x2\x2\x2\x55B\x55C\x3\x2\x2"+
+		"\x2\x55C\x575\x3\x2\x2\x2\x55D\x55B\x3\x2\x2\x2\x55E\x560\a*\x2\x2\x55F"+
+		"\x561\x5\x174\xBB\x2\x560\x55F\x3\x2\x2\x2\x560\x561\x3\x2\x2\x2\x561"+
+		"\x563\x3\x2\x2\x2\x562\x55E\x3\x2\x2\x2\x562\x563\x3\x2\x2\x2\x563\x564"+
+		"\x3\x2\x2\x2\x564\x571\x5\xC6\x64\x2\x565\x567\x5\x174\xBB\x2\x566\x565"+
+		"\x3\x2\x2\x2\x566\x567\x3\x2\x2\x2\x567\x568\x3\x2\x2\x2\x568\x56A\a*"+
+		"\x2\x2\x569\x56B\x5\x174\xBB\x2\x56A\x569\x3\x2\x2\x2\x56A\x56B\x3\x2"+
+		"\x2\x2\x56B\x56D\x3\x2\x2\x2\x56C\x56E\x5\xC6\x64\x2\x56D\x56C\x3\x2\x2"+
+		"\x2\x56D\x56E\x3\x2\x2\x2\x56E\x570\x3\x2\x2\x2\x56F\x566\x3\x2\x2\x2"+
+		"\x570\x573\x3\x2\x2\x2\x571\x56F\x3\x2\x2\x2\x571\x572\x3\x2\x2\x2\x572"+
+		"\x575\x3\x2\x2\x2\x573\x571\x3\x2\x2\x2\x574\x54E\x3\x2\x2\x2\x574\x562"+
+		"\x3\x2\x2\x2\x575\xC5\x3\x2\x2\x2\x576\x577\x5 \x11\x2\x577\xC7\x3\x2"+
+		"\x2\x2\x578\x579\x5\xFE\x80\x2\x579\xC9\x3\x2\x2\x2\x57A\x57B\ay\x2\x2"+
+		"\x57B\x57C\x5\x174\xBB\x2\x57C\x57D\x5\xFE\x80\x2\x57D\xCB\x3\x2\x2\x2"+
+		"\x57E\x57F\a\x81\x2\x2\x57F\x581\x5\x174\xBB\x2\x580\x57E\x3\x2\x2\x2"+
+		"\x580\x581\x3\x2\x2\x2\x581\x582\x3\x2\x2\x2\x582\x584\x5\xFE\x80\x2\x583"+
+		"\x585\x5\x174\xBB\x2\x584\x583\x3\x2\x2\x2\x584\x585\x3\x2\x2\x2\x585"+
+		"\x586\x3\x2\x2\x2\x586\x588\a\xD0\x2\x2\x587\x589\x5\x174\xBB\x2\x588"+
+		"\x587\x3\x2\x2\x2\x588\x589\x3\x2\x2\x2\x589\x58A\x3\x2\x2\x2\x58A\x58B"+
+		"\x5\xFE\x80\x2\x58B\xCD\x3\x2\x2\x2\x58C\x58D\a\x88\x2\x2\x58D\x58E\x5"+
+		"\x174\xBB\x2\x58E\x590\x5\xFE\x80\x2\x58F\x591\x5\x174\xBB\x2\x590\x58F"+
+		"\x3\x2\x2\x2\x590\x591\x3\x2\x2\x2\x591\x592\x3\x2\x2\x2\x592\x594\a\xD0"+
+		"\x2\x2\x593\x595\x5\x174\xBB\x2\x594\x593\x3\x2\x2\x2\x594\x595\x3\x2"+
+		"\x2\x2\x595\x596\x3\x2\x2\x2\x596\x597\x5\xFE\x80\x2\x597\xCF\x3\x2\x2"+
+		"\x2\x598\x59A\a\x8A\x2\x2\x599\x59B\x5\x174\xBB\x2\x59A\x599\x3\x2\x2"+
+		"\x2\x59A\x59B\x3\x2\x2\x2\x59B\x59C\x3\x2\x2\x2\x59C\x59E\a\xD4\x2\x2"+
+		"\x59D\x59F\x5\x174\xBB\x2\x59E\x59D\x3\x2\x2\x2\x59E\x59F\x3\x2\x2\x2"+
+		"\x59F\x5A0\x3\x2\x2\x2\x5A0\x5A2\x5\x128\x95\x2\x5A1\x5A3\x5\x174\xBB"+
+		"\x2\x5A2\x5A1\x3\x2\x2\x2\x5A2\x5A3\x3\x2\x2\x2\x5A3\x5A4\x3\x2\x2\x2"+
+		"\x5A4\x5A5\a\xDB\x2\x2\x5A5\xD1\x3\x2\x2\x2\x5A6\x5A7\t\v\x2\x2\x5A7\x5B0"+
+		"\x5\x174\xBB\x2\x5A8\x5A9\av\x2\x2\x5A9\x5AA\x5\x174\xBB\x2\x5AA\x5AB"+
+		"\x5\xFE\x80\x2\x5AB\x5B1\x3\x2\x2\x2\x5AC\x5AD\a\xAD\x2\x2\x5AD\x5AE\x5"+
+		"\x174\xBB\x2\x5AE\x5AF\a\x8C\x2\x2\x5AF\x5B1\x3\x2\x2\x2\x5B0\x5A8\x3"+
+		"\x2\x2\x2\x5B0\x5AC\x3\x2\x2\x2\x5B1\xD3\x3\x2\x2\x2\x5B2\x5B3\a\x91\x2"+
+		"\x2\x5B3\x5B4\x5\x174\xBB\x2\x5B4\x5B5\x5\xFE\x80\x2\x5B5\x5B6\x5\x174"+
+		"\xBB\x2\x5B6\x5B7\av\x2\x2\x5B7\x5B8\x5\x174\xBB\x2\x5B8\x5C3\x5\xFE\x80"+
+		"\x2\x5B9\x5BB\x5\x174\xBB\x2\x5BA\x5B9\x3\x2\x2\x2\x5BA\x5BB\x3\x2\x2"+
+		"\x2\x5BB\x5BC\x3\x2\x2\x2\x5BC\x5BE\a)\x2\x2\x5BD\x5BF\x5\x174\xBB\x2"+
+		"\x5BE\x5BD\x3\x2\x2\x2\x5BE\x5BF\x3\x2\x2\x2\x5BF\x5C0\x3\x2\x2\x2\x5C0"+
+		"\x5C2\x5\xFE\x80\x2\x5C1\x5BA\x3\x2\x2\x2\x5C2\x5C5\x3\x2\x2\x2\x5C3\x5C1"+
+		"\x3\x2\x2\x2\x5C3\x5C4\x3\x2\x2\x2\x5C4\xD5\x3\x2\x2\x2\x5C5\x5C3\x3\x2"+
+		"\x2\x2\x5C6\x5C7\a\x91\x2\x2\x5C7\x5C8\x5\x174\xBB\x2\x5C8\x5C9\x5\xFE"+
+		"\x80\x2\x5C9\x5CA\x5\x174\xBB\x2\x5CA\x5CB\au\x2\x2\x5CB\x5CC\x5\x174"+
+		"\xBB\x2\x5CC\x5D7\x5\xFE\x80\x2\x5CD\x5CF\x5\x174\xBB\x2\x5CE\x5CD\x3"+
+		"\x2\x2\x2\x5CE\x5CF\x3\x2\x2\x2\x5CF\x5D0\x3\x2\x2\x2\x5D0\x5D2\a)\x2"+
+		"\x2\x5D1\x5D3\x5\x174\xBB\x2\x5D2\x5D1\x3\x2\x2\x2\x5D2\x5D3\x3\x2\x2"+
+		"\x2\x5D3\x5D4\x3\x2\x2\x2\x5D4\x5D6\x5\xFE\x80\x2\x5D5\x5CE\x3\x2\x2\x2"+
+		"\x5D6\x5D9\x3\x2\x2\x2\x5D7\x5D5\x3\x2\x2\x2\x5D7\x5D8\x3\x2\x2\x2\x5D8"+
+		"\xD7\x3\x2\x2\x2\x5D9\x5D7\x3\x2\x2\x2\x5DA\x5DB\x5\x156\xAC\x2\x5DB\x5DC"+
+		"\x5\x174\xBB\x2\x5DC\x5DE\x3\x2\x2\x2\x5DD\x5DA\x3\x2\x2\x2\x5DD\x5DE"+
+		"\x3\x2\x2\x2\x5DE\x5E1\x3\x2\x2\x2\x5DF\x5E0\a\xB6\x2\x2\x5E0\x5E2\x5"+
+		"\x174\xBB\x2\x5E1\x5DF\x3\x2\x2\x2\x5E1\x5E2\x3\x2\x2\x2\x5E2\x5E3\x3"+
+		"\x2\x2\x2\x5E3\x5E4\a\xA0\x2\x2\x5E4\x5E5\x5\x174\xBB\x2\x5E5\x5E7\x5"+
+		"\xB0Y\x2\x5E6\x5E8\x5\x154\xAB\x2\x5E7\x5E6\x3\x2\x2\x2\x5E7\x5E8\x3\x2"+
+		"\x2\x2\x5E8\x5ED\x3\x2\x2\x2\x5E9\x5EB\x5\x174\xBB\x2\x5EA\x5E9\x3\x2"+
+		"\x2\x2\x5EA\x5EB\x3\x2\x2\x2\x5EB\x5EC\x3\x2\x2\x2\x5EC\x5EE\x5\x12E\x98"+
+		"\x2\x5ED\x5EA\x3\x2\x2\x2\x5ED\x5EE\x3\x2\x2\x2\x5EE\x5F2\x3\x2\x2\x2"+
+		"\x5EF\x5F0\x5\x174\xBB\x2\x5F0\x5F1\x5\x13C\x9F\x2\x5F1\x5F3\x3\x2\x2"+
+		"\x2\x5F2\x5EF\x3\x2\x2\x2\x5F2\x5F3\x3\x2\x2\x2\x5F3\x5F4\x3\x2\x2\x2"+
+		"\x5F4\x5F6\x5\x160\xB1\x2\x5F5\x5F7\x5\x1E\x10\x2\x5F6\x5F5\x3\x2\x2\x2"+
+		"\x5F6\x5F7\x3\x2\x2\x2\x5F7\x5F8\x3\x2\x2\x2\x5F8\x5F9\a_\x2\x2\x5F9\xD9"+
+		"\x3\x2\x2\x2\x5FA\x5FB\x5\x156\xAC\x2\x5FB\x5FC\x5\x174\xBB\x2\x5FC\x5FE"+
+		"\x3\x2\x2\x2\x5FD\x5FA\x3\x2\x2\x2\x5FD\x5FE\x3\x2\x2\x2\x5FE\x601\x3"+
+		"\x2\x2\x2\x5FF\x600\a\xB6\x2\x2\x600\x602\x5\x174\xBB\x2\x601\x5FF\x3"+
+		"\x2\x2\x2\x601\x602\x3\x2\x2\x2\x602\x603\x3\x2\x2\x2\x603\x604\a\xA2"+
+		"\x2\x2\x604\x605\x5\x174\xBB\x2\x605\x60A\x5\xF8}\x2\x606\x608\x5\x174"+
+		"\xBB\x2\x607\x606\x3\x2\x2\x2\x607\x608\x3\x2\x2\x2\x608\x609\x3\x2\x2"+
+		"\x2\x609\x60B\x5\x12E\x98\x2\x60A\x607\x3\x2\x2\x2\x60A\x60B\x3\x2\x2"+
+		"\x2\x60B\x60C\x3\x2\x2\x2\x60C\x60E\x5\x160\xB1\x2\x60D\x60F\x5\x1E\x10"+
+		"\x2\x60E\x60D\x3\x2\x2\x2\x60E\x60F\x3\x2\x2\x2\x60F\x610\x3\x2\x2\x2"+
+		"\x610\x611\a_\x2\x2\x611\xDB\x3\x2\x2\x2\x612\x613\x5\x156\xAC\x2\x613"+
+		"\x614\x5\x174\xBB\x2\x614\x616\x3\x2\x2\x2\x615\x612\x3\x2\x2\x2\x615"+
+		"\x616\x3\x2\x2\x2\x616\x619\x3\x2\x2\x2\x617\x618\a\xB6\x2\x2\x618\x61A"+
+		"\x5\x174\xBB\x2\x619\x617\x3\x2\x2\x2\x619\x61A\x3\x2\x2\x2\x61A\x61B"+
+		"\x3\x2\x2\x2\x61B\x61C\a\xA1\x2\x2\x61C\x61D\x5\x174\xBB\x2\x61D\x622"+
+		"\x5\xF8}\x2\x61E\x620\x5\x174\xBB\x2\x61F\x61E\x3\x2\x2\x2\x61F\x620\x3"+
+		"\x2\x2\x2\x620\x621\x3\x2\x2\x2\x621\x623\x5\x12E\x98\x2\x622\x61F\x3"+
+		"\x2\x2\x2\x622\x623\x3\x2\x2\x2\x623\x624\x3\x2\x2\x2\x624\x626\x5\x160"+
+		"\xB1\x2\x625\x627\x5\x1E\x10\x2\x626\x625\x3\x2\x2\x2\x626\x627\x3\x2"+
+		"\x2\x2\x627\x628\x3\x2\x2\x2\x628\x629\a_\x2\x2\x629\xDD\x3\x2\x2\x2\x62A"+
+		"\x62B\a\xA7\x2\x2\x62B\x62C\x5\x174\xBB\x2\x62C\x63B\x5\x13A\x9E\x2\x62D"+
+		"\x62F\x5\x174\xBB\x2\x62E\x62D\x3\x2\x2\x2\x62E\x62F\x3\x2\x2\x2\x62F"+
+		"\x630\x3\x2\x2\x2\x630\x632\a\xD4\x2\x2\x631\x633\x5\x174\xBB\x2\x632"+
+		"\x631\x3\x2\x2\x2\x632\x633\x3\x2\x2\x2\x633\x638\x3\x2\x2\x2\x634\x636"+
+		"\x5\x128\x95\x2\x635\x637\x5\x174\xBB\x2\x636\x635\x3\x2\x2\x2\x636\x637"+
+		"\x3\x2\x2\x2\x637\x639\x3\x2\x2\x2\x638\x634\x3\x2\x2\x2\x638\x639\x3"+
+		"\x2\x2\x2\x639\x63A\x3\x2\x2\x2\x63A\x63C\a\xDB\x2\x2\x63B\x62E\x3\x2"+
+		"\x2\x2\x63B\x63C\x3\x2\x2\x2\x63C\xDF\x3\x2\x2\x2\x63D\x63E\a\xAA\x2\x2"+
+		"\x63E\x641\x5\x174\xBB\x2\x63F\x640\a\x9D\x2\x2\x640\x642\x5\x174\xBB"+
+		"\x2\x641\x63F\x3\x2\x2\x2\x641\x642\x3\x2\x2\x2\x642\x643\x3\x2\x2\x2"+
+		"\x643\x64E\x5\xE2r\x2\x644\x646\x5\x174\xBB\x2\x645\x644\x3\x2\x2\x2\x645"+
+		"\x646\x3\x2\x2\x2\x646\x647\x3\x2\x2\x2\x647\x649\a)\x2\x2\x648\x64A\x5"+
+		"\x174\xBB\x2\x649\x648\x3\x2\x2\x2\x649\x64A\x3\x2\x2\x2\x64A\x64B\x3"+
+		"\x2\x2\x2\x64B\x64D\x5\xE2r\x2\x64C\x645\x3\x2\x2\x2\x64D\x650\x3\x2\x2"+
+		"\x2\x64E\x64C\x3\x2\x2\x2\x64E\x64F\x3\x2\x2\x2\x64F\xE1\x3\x2\x2\x2\x650"+
+		"\x64E\x3\x2\x2\x2\x651\x653\x5\x118\x8D\x2\x652\x654\x5\x174\xBB\x2\x653"+
+		"\x652\x3\x2\x2\x2\x653\x654\x3\x2\x2\x2\x654\x655\x3\x2\x2\x2\x655\x657"+
+		"\a\xD4\x2\x2\x656\x658\x5\x174\xBB\x2\x657\x656\x3\x2\x2\x2\x657\x658"+
+		"\x3\x2\x2\x2\x658\x659\x3\x2\x2\x2\x659\x65B\x5\x134\x9B\x2\x65A\x65C"+
+		"\x5\x174\xBB\x2\x65B\x65A\x3\x2\x2\x2\x65B\x65C\x3\x2\x2\x2\x65C\x65D"+
+		"\x3\x2\x2\x2\x65D\x661\a\xDB\x2\x2\x65E\x65F\x5\x174\xBB\x2\x65F\x660"+
+		"\x5\x13C\x9F\x2\x660\x662\x3\x2\x2\x2\x661\x65E\x3\x2\x2\x2\x661\x662"+
+		"\x3\x2\x2\x2\x662\xE3\x3\x2\x2\x2\x663\x669\a\xAD\x2\x2\x664\x667\x5\x174"+
+		"\xBB\x2\x665\x668\a\x8C\x2\x2\x666\x668\x5\xFE\x80\x2\x667\x665\x3\x2"+
+		"\x2\x2\x667\x666\x3\x2\x2\x2\x668\x66A\x3\x2\x2\x2\x669\x664\x3\x2\x2"+
+		"\x2\x669\x66A\x3\x2\x2\x2\x66A\xE5\x3\x2\x2\x2\x66B\x66C\a\xAE\x2\x2\x66C"+
+		"\xE7\x3\x2\x2\x2\x66D\x66E\a\xAF\x2\x2\x66E\x66F\x5\x174\xBB\x2\x66F\x671"+
+		"\x5\xFE\x80\x2\x670\x672\x5\x174\xBB\x2\x671\x670\x3\x2\x2\x2\x671\x672"+
+		"\x3\x2\x2\x2\x672\x673\x3\x2\x2\x2\x673\x675\a\xD0\x2\x2\x674\x676\x5"+
+		"\x174\xBB\x2\x675\x674\x3\x2\x2\x2\x675\x676\x3\x2\x2\x2\x676\x677\x3"+
+		"\x2\x2\x2\x677\x678\x5\xFE\x80\x2\x678\xE9\x3\x2\x2\x2\x679\x67A\a\xB8"+
+		"\x2\x2\x67A\xEB\x3\x2\x2\x2\x67B\x67C\a\xB1\x2\x2\x67C\x67D\x5\x174\xBB"+
+		"\x2\x67D\x67E\a\x41\x2\x2\x67E\x67F\x5\x174\xBB\x2\x67F\x680\x5\xFE\x80"+
+		"\x2\x680\x684\x5\x160\xB1\x2\x681\x683\x5\xF0y\x2\x682\x681\x3\x2\x2\x2"+
+		"\x683\x686\x3\x2\x2\x2\x684\x682\x3\x2\x2\x2\x684\x685\x3\x2\x2\x2\x685"+
+		"\x687\x3\x2\x2\x2\x686\x684\x3\x2\x2\x2\x687\x688\a`\x2\x2\x688\xED\x3"+
+		"\x2\x2\x2\x689\x68B\a|\x2\x2\x68A\x68C\x5\x174\xBB\x2\x68B\x68A\x3\x2"+
+		"\x2\x2\x68B\x68C\x3\x2\x2\x2\x68C\x68D\x3\x2\x2\x2\x68D\x68F\x5\x140\xA1"+
+		"\x2\x68E\x690\x5\x174\xBB\x2\x68F\x68E\x3\x2\x2\x2\x68F\x690\x3\x2\x2"+
+		"\x2\x690\x691\x3\x2\x2\x2\x691\x692\x5\xFE\x80\x2\x692\x69B\x3\x2\x2\x2"+
+		"\x693\x694\x5\xFE\x80\x2\x694\x695\x5\x174\xBB\x2\x695\x696\a\xBE\x2\x2"+
+		"\x696\x697\x5\x174\xBB\x2\x697\x698\x5\xFE\x80\x2\x698\x69B\x3\x2\x2\x2"+
+		"\x699\x69B\x5\xFE\x80\x2\x69A\x689\x3\x2\x2\x2\x69A\x693\x3\x2\x2\x2\x69A"+
+		"\x699\x3\x2\x2\x2\x69B\xEF\x3\x2\x2\x2\x69C\x69D\a\x41\x2\x2\x69D\x69E"+
+		"\x5\x174\xBB\x2\x69E\x69F\x5\xF2z\x2\x69F\x6A1\x5\x160\xB1\x2\x6A0\x6A2"+
+		"\x5\x1E\x10\x2\x6A1\x6A0\x3\x2\x2\x2\x6A1\x6A2\x3\x2\x2\x2\x6A2\xF1\x3"+
+		"\x2\x2\x2\x6A3\x6B3\aY\x2\x2\x6A4\x6AF\x5\xEEx\x2\x6A5\x6A7\x5\x174\xBB"+
+		"\x2\x6A6\x6A5\x3\x2\x2\x2\x6A6\x6A7\x3\x2\x2\x2\x6A7\x6A8\x3\x2\x2\x2"+
+		"\x6A8\x6AA\a)\x2\x2\x6A9\x6AB\x5\x174\xBB\x2\x6AA\x6A9\x3\x2\x2\x2\x6AA"+
+		"\x6AB\x3\x2\x2\x2\x6AB\x6AC\x3\x2\x2\x2\x6AC\x6AE\x5\xEEx\x2\x6AD\x6A6"+
+		"\x3\x2\x2\x2\x6AE\x6B1\x3\x2\x2\x2\x6AF\x6AD\x3\x2\x2\x2\x6AF\x6B0\x3"+
+		"\x2\x2\x2\x6B0\x6B3\x3\x2\x2\x2\x6B1\x6AF\x3\x2\x2\x2\x6B2\x6A3\x3\x2"+
+		"\x2\x2\x6B2\x6A4\x3\x2\x2\x2\x6B3\xF3\x3\x2\x2\x2\x6B4\x6B5\a\xB2\x2\x2"+
+		"\x6B5\x6B6\x5\x174\xBB\x2\x6B6\x6B8\x5\xFE\x80\x2\x6B7\x6B9\x5\x174\xBB"+
+		"\x2\x6B8\x6B7\x3\x2\x2\x2\x6B8\x6B9\x3\x2\x2\x2\x6B9\x6BA\x3\x2\x2\x2"+
+		"\x6BA\x6BC\a\xD0\x2\x2\x6BB\x6BD\x5\x174\xBB\x2\x6BC\x6BB\x3\x2\x2\x2"+
+		"\x6BC\x6BD\x3\x2\x2\x2\x6BD\x6BE\x3\x2\x2\x2\x6BE\x6BF\x5\xFE\x80\x2\x6BF"+
+		"\xF5\x3\x2\x2\x2\x6C0\x6C1\x5\x156\xAC\x2\x6C1\x6C2\x5\x174\xBB\x2\x6C2"+
+		"\x6C4\x3\x2\x2\x2\x6C3\x6C0\x3\x2\x2\x2\x6C3\x6C4\x3\x2\x2\x2\x6C4\x6C7"+
+		"\x3\x2\x2\x2\x6C5\x6C6\a\xB6\x2\x2\x6C6\x6C8\x5\x174\xBB\x2\x6C7\x6C5"+
+		"\x3\x2\x2\x2\x6C7\x6C8\x3\x2\x2\x2\x6C8\x6C9\x3\x2\x2\x2\x6C9\x6CB\a\xBA"+
+		"\x2\x2\x6CA\x6CC\x5\x174\xBB\x2\x6CB\x6CA\x3\x2\x2\x2\x6CB\x6CC\x3\x2"+
+		"\x2\x2\x6CC\x6CD\x3\x2\x2\x2\x6CD\x6D2\x5\xF8}\x2\x6CE\x6D0\x5\x174\xBB"+
+		"\x2\x6CF\x6CE\x3\x2\x2\x2\x6CF\x6D0\x3\x2\x2\x2\x6D0\x6D1\x3\x2\x2\x2"+
+		"\x6D1\x6D3\x5\x12E\x98\x2\x6D2\x6CF\x3\x2\x2\x2\x6D2\x6D3\x3\x2\x2\x2"+
+		"\x6D3\x6D4\x3\x2\x2\x2\x6D4\x6D6\x5\x160\xB1\x2\x6D5\x6D7\x5\x1E\x10\x2"+
+		"\x6D6\x6D5\x3\x2\x2\x2\x6D6\x6D7\x3\x2\x2\x2\x6D7\x6D8\x3\x2\x2\x2\x6D8"+
+		"\x6D9\a\x61\x2\x2\x6D9\xF7\x3\x2\x2\x2\x6DA\x6DB\x5\x13A\x9E\x2\x6DB\xF9"+
+		"\x3\x2\x2\x2\x6DC\x6DD\x5\x156\xAC\x2\x6DD\x6DE\x5\x174\xBB\x2\x6DE\x6E0"+
+		"\x3\x2\x2\x2\x6DF\x6DC\x3\x2\x2\x2\x6DF\x6E0\x3\x2\x2\x2\x6E0\x6E1\x3"+
+		"\x2\x2\x2\x6E1\x6E2\a\xC0\x2\x2\x6E2\x6E3\x5\x174\xBB\x2\x6E3\x6E4\x5"+
+		"\x13A\x9E\x2\x6E4\x6E8\x5\x160\xB1\x2\x6E5\x6E7\x5\xFC\x7F\x2\x6E6\x6E5"+
+		"\x3\x2\x2\x2\x6E7\x6EA\x3\x2\x2\x2\x6E8\x6E6\x3\x2\x2\x2\x6E8\x6E9\x3"+
+		"\x2\x2\x2\x6E9\x6EB\x3\x2\x2\x2\x6EA\x6E8\x3\x2\x2\x2\x6EB\x6EC\a\x62"+
+		"\x2\x2\x6EC\xFB\x3\x2\x2\x2\x6ED\x6FC\x5\x13A\x9E\x2\x6EE\x6F0\x5\x174"+
+		"\xBB\x2\x6EF\x6EE\x3\x2\x2\x2\x6EF\x6F0\x3\x2\x2\x2\x6F0\x6F1\x3\x2\x2"+
+		"\x2\x6F1\x6F6\a\xD4\x2\x2\x6F2\x6F4\x5\x174\xBB\x2\x6F3\x6F2\x3\x2\x2"+
+		"\x2\x6F3\x6F4\x3\x2\x2\x2\x6F4\x6F5\x3\x2\x2\x2\x6F5\x6F7\x5\x134\x9B"+
+		"\x2\x6F6\x6F3\x3\x2\x2\x2\x6F6\x6F7\x3\x2\x2\x2\x6F7\x6F9\x3\x2\x2\x2"+
+		"\x6F8\x6FA\x5\x174\xBB\x2\x6F9\x6F8\x3\x2\x2\x2\x6F9\x6FA\x3\x2\x2\x2"+
+		"\x6FA\x6FB\x3\x2\x2\x2\x6FB\x6FD\a\xDB\x2\x2\x6FC\x6EF\x3\x2\x2\x2\x6FC"+
+		"\x6FD\x3\x2\x2\x2\x6FD\x701\x3\x2\x2\x2\x6FE\x6FF\x5\x174\xBB\x2\x6FF"+
+		"\x700\x5\x13C\x9F\x2\x700\x702\x3\x2\x2\x2\x701\x6FE\x3\x2\x2\x2\x701"+
+		"\x702\x3\x2\x2\x2\x702\x703\x3\x2\x2\x2\x703\x704\x5\x160\xB1\x2\x704"+
+		"\xFD\x3\x2\x2\x2\x705\x706\b\x80\x1\x2\x706\x708\a\x8D\x2\x2\x707\x709"+
+		"\x5\x174\xBB\x2\x708\x707\x3\x2\x2\x2\x708\x709\x3\x2\x2\x2\x709\x70A"+
+		"\x3\x2\x2\x2\x70A\x734\x5\xFE\x80\x16\x70B\x70D\a\x34\x2\x2\x70C\x70E"+
+		"\x5\x174\xBB\x2\x70D\x70C\x3\x2\x2\x2\x70D\x70E\x3\x2\x2\x2\x70E\x70F"+
+		"\x3\x2\x2\x2\x70F\x734\x5\xFE\x80\x13\x710\x712\x5\x138\x9D\x2\x711\x713"+
+		"\x5\x174\xBB\x2\x712\x711\x3\x2\x2\x2\x712\x713\x3\x2\x2\x2\x713\x714"+
+		"\x3\x2\x2\x2\x714\x716\a\xCD\x2\x2\x715\x717\x5\x174\xBB\x2\x716\x715"+
+		"\x3\x2\x2\x2\x716\x717\x3\x2\x2\x2\x717\x718\x3\x2\x2\x2\x718\x719\x5"+
+		"\xFE\x80\x12\x719\x734\x3\x2\x2\x2\x71A\x71C\a\xD6\x2\x2\x71B\x71D\x5"+
+		"\x174\xBB\x2\x71C\x71B\x3\x2\x2\x2\x71C\x71D\x3\x2\x2\x2\x71D\x71E\x3"+
+		"\x2\x2\x2\x71E\x734\x5\xFE\x80\x10\x71F\x721\a\x8E\x2\x2\x720\x722\x5"+
+		"\x174\xBB\x2\x721\x720\x3\x2\x2\x2\x721\x722\x3\x2\x2\x2\x722\x723\x3"+
+		"\x2\x2\x2\x723\x734\x5\xFE\x80\t\x724\x734\x5\x14E\xA8\x2\x725\x734\x5"+
+		"\x118\x8D\x2\x726\x728\a\xD4\x2\x2\x727\x729\x5\x174\xBB\x2\x728\x727"+
+		"\x3\x2\x2\x2\x728\x729\x3\x2\x2\x2\x729\x72A\x3\x2\x2\x2\x72A\x72C\x5"+
+		"\xFE\x80\x2\x72B\x72D\x5\x174\xBB\x2\x72C\x72B\x3\x2\x2\x2\x72C\x72D\x3"+
+		"\x2\x2\x2\x72D\x72E\x3\x2\x2\x2\x72E\x72F\a\xDB\x2\x2\x72F\x734\x3\x2"+
+		"\x2\x2\x730\x734\x5\x100\x81\x2\x731\x734\x5\xD0i\x2\x732\x734\x5\x38"+
+		"\x1D\x2\x733\x705\x3\x2\x2\x2\x733\x70B\x3\x2\x2\x2\x733\x710\x3\x2\x2"+
+		"\x2\x733\x71A\x3\x2\x2\x2\x733\x71F\x3\x2\x2\x2\x733\x724\x3\x2\x2\x2"+
+		"\x733\x725\x3\x2\x2\x2\x733\x726\x3\x2\x2\x2\x733\x730\x3\x2\x2\x2\x733"+
+		"\x731\x3\x2\x2\x2\x733\x732\x3\x2\x2\x2\x734\x7A3\x3\x2\x2\x2\x735\x737"+
+		"\f\x11\x2\x2\x736\x738\x5\x174\xBB\x2\x737\x736\x3\x2\x2\x2\x737\x738"+
+		"\x3\x2\x2\x2\x738\x739\x3\x2\x2\x2\x739\x73B\a\xDA\x2\x2\x73A\x73C\x5"+
+		"\x174\xBB\x2\x73B\x73A\x3\x2\x2\x2\x73B\x73C\x3\x2\x2\x2\x73C\x73D\x3"+
+		"\x2\x2\x2\x73D\x7A2\x5\xFE\x80\x12\x73E\x740\f\xF\x2\x2\x73F\x741\x5\x174"+
+		"\xBB\x2\x740\x73F\x3\x2\x2\x2\x740\x741\x3\x2\x2\x2\x741\x742\x3\x2\x2"+
+		"\x2\x742\x744\t\f\x2\x2\x743\x745\x5\x174\xBB\x2\x744\x743\x3\x2\x2\x2"+
+		"\x744\x745\x3\x2\x2\x2\x745\x746\x3\x2\x2\x2\x746\x7A2\x5\xFE\x80\x10"+
+		"\x747\x749\f\xE\x2\x2\x748\x74A\x5\x174\xBB\x2\x749\x748\x3\x2\x2\x2\x749"+
+		"\x74A\x3\x2\x2\x2\x74A\x74B\x3\x2\x2\x2\x74B\x74D\a\xCF\x2\x2\x74C\x74E"+
+		"\x5\x174\xBB\x2\x74D\x74C\x3\x2\x2\x2\x74D\x74E\x3\x2\x2\x2\x74E\x74F"+
+		"\x3\x2\x2\x2\x74F\x7A2\x5\xFE\x80\xF\x750\x752\f\r\x2\x2\x751\x753\x5"+
+		"\x174\xBB\x2\x752\x751\x3\x2\x2\x2\x752\x753\x3\x2\x2\x2\x753\x754\x3"+
+		"\x2\x2\x2\x754\x756\a\x8B\x2\x2\x755\x757\x5\x174\xBB\x2\x756\x755\x3"+
+		"\x2\x2\x2\x756\x757\x3\x2\x2\x2\x757\x758\x3\x2\x2\x2\x758\x7A2\x5\xFE"+
+		"\x80\xE\x759\x75B\f\f\x2\x2\x75A\x75C\x5\x174\xBB\x2\x75B\x75A\x3\x2\x2"+
+		"\x2\x75B\x75C\x3\x2\x2\x2\x75C\x75D\x3\x2\x2\x2\x75D\x75F\t\r\x2\x2\x75E"+
+		"\x760\x5\x174\xBB\x2\x75F\x75E\x3\x2\x2\x2\x75F\x760\x3\x2\x2\x2\x760"+
+		"\x761\x3\x2\x2\x2\x761\x7A2\x5\xFE\x80\r\x762\x764\f\v\x2\x2\x763\x765"+
+		"\x5\x174\xBB\x2\x764\x763\x3\x2\x2\x2\x764\x765\x3\x2\x2\x2\x765\x766"+
+		"\x3\x2\x2\x2\x766\x768\a\x32\x2\x2\x767\x769\x5\x174\xBB\x2\x768\x767"+
+		"\x3\x2\x2\x2\x768\x769\x3\x2\x2\x2\x769\x76A\x3\x2\x2\x2\x76A\x7A2\x5"+
+		"\xFE\x80\f\x76B\x76D\f\n\x2\x2\x76C\x76E\x5\x174\xBB\x2\x76D\x76C\x3\x2"+
+		"\x2\x2\x76D\x76E\x3\x2\x2\x2\x76E\x76F\x3\x2\x2\x2\x76F\x771\t\xE\x2\x2"+
+		"\x770\x772\x5\x174\xBB\x2\x771\x770\x3\x2\x2\x2\x771\x772\x3\x2\x2\x2"+
+		"\x772\x773\x3\x2\x2\x2\x773\x7A2\x5\xFE\x80\v\x774\x776\f\b\x2\x2\x775"+
+		"\x777\x5\x174\xBB\x2\x776\x775\x3\x2\x2\x2\x776\x777\x3\x2\x2\x2\x777"+
+		"\x778\x3\x2\x2\x2\x778\x77A\a\x36\x2\x2\x779\x77B\x5\x174\xBB\x2\x77A"+
+		"\x779\x3\x2\x2\x2\x77A\x77B\x3\x2\x2\x2\x77B\x77C\x3\x2\x2\x2\x77C\x7A2"+
+		"\x5\xFE\x80\t\x77D\x77F\f\a\x2\x2\x77E\x780\x5\x174\xBB\x2\x77F\x77E\x3"+
+		"\x2\x2\x2\x77F\x780\x3\x2\x2\x2\x780\x781\x3\x2\x2\x2\x781\x783\a\x9A"+
+		"\x2\x2\x782\x784\x5\x174\xBB\x2\x783\x782\x3\x2\x2\x2\x783\x784\x3\x2"+
+		"\x2\x2\x784\x785\x3\x2\x2\x2\x785\x7A2\x5\xFE\x80\b\x786\x788\f\x6\x2"+
+		"\x2\x787\x789\x5\x174\xBB\x2\x788\x787\x3\x2\x2\x2\x788\x789\x3\x2\x2"+
+		"\x2\x789\x78A\x3\x2\x2\x2\x78A\x78C\a\xCC\x2\x2\x78B\x78D\x5\x174\xBB"+
+		"\x2\x78C\x78B\x3\x2\x2\x2\x78C\x78D\x3\x2\x2\x2\x78D\x78E\x3\x2\x2\x2"+
+		"\x78E\x7A2\x5\xFE\x80\a\x78F\x791\f\x5\x2\x2\x790\x792\x5\x174\xBB\x2"+
+		"\x791\x790\x3\x2\x2\x2\x791\x792\x3\x2\x2\x2\x792\x793\x3\x2\x2\x2\x793"+
+		"\x795\a\x66\x2\x2\x794\x796\x5\x174\xBB\x2\x795\x794\x3\x2\x2\x2\x795"+
+		"\x796\x3\x2\x2\x2\x796\x797\x3\x2\x2\x2\x797\x7A2\x5\xFE\x80\x6\x798\x79A"+
+		"\f\x4\x2\x2\x799\x79B\x5\x174\xBB\x2\x79A\x799\x3\x2\x2\x2\x79A\x79B\x3"+
+		"\x2\x2\x2\x79B\x79C\x3\x2\x2\x2\x79C\x79E\ax\x2\x2\x79D\x79F\x5\x174\xBB"+
+		"\x2\x79E\x79D\x3\x2\x2\x2\x79E\x79F\x3\x2\x2\x2\x79F\x7A0\x3\x2\x2\x2"+
+		"\x7A0\x7A2\x5\xFE\x80\x5\x7A1\x735\x3\x2\x2\x2\x7A1\x73E\x3\x2\x2\x2\x7A1"+
+		"\x747\x3\x2\x2\x2\x7A1\x750\x3\x2\x2\x2\x7A1\x759\x3\x2\x2\x2\x7A1\x762"+
+		"\x3\x2\x2\x2\x7A1\x76B\x3\x2\x2\x2\x7A1\x774\x3\x2\x2\x2\x7A1\x77D\x3"+
+		"\x2\x2\x2\x7A1\x786\x3\x2\x2\x2\x7A1\x78F\x3\x2\x2\x2\x7A1\x798\x3\x2"+
+		"\x2\x2\x7A2\x7A5\x3\x2\x2\x2\x7A3\x7A1\x3\x2\x2\x2\x7A3\x7A4\x3\x2\x2"+
+		"\x2\x7A4\xFF\x3\x2\x2\x2\x7A5\x7A3\x3\x2\x2\x2\x7A6\x7A7\a\xC1\x2\x2\x7A7"+
+		"\x7A8\x5\x174\xBB\x2\x7A8\x7AE\x5\xFE\x80\x2\x7A9\x7AA\x5\x174\xBB\x2"+
+		"\x7AA\x7AB\a|\x2\x2\x7AB\x7AC\x5\x174\xBB\x2\x7AC\x7AD\x5\x152\xAA\x2"+
+		"\x7AD\x7AF\x3\x2\x2\x2\x7AE\x7A9\x3\x2\x2\x2\x7AE\x7AF\x3\x2\x2\x2\x7AF"+
+		"\x101\x3\x2\x2\x2\x7B0\x7B4\aU\x2\x2\x7B1\x7B4\a\xB6\x2\x2\x7B2\x7B4\x5"+
+		"\x156\xAC\x2\x7B3\x7B0\x3\x2\x2\x2\x7B3\x7B1\x3\x2\x2\x2\x7B3\x7B2\x3"+
+		"\x2\x2\x2\x7B4\x7B5\x3\x2\x2\x2\x7B5\x7B8\x5\x174\xBB\x2\x7B6\x7B7\a\xCA"+
+		"\x2\x2\x7B7\x7B9\x5\x174\xBB\x2\x7B8\x7B6\x3\x2\x2\x2\x7B8\x7B9\x3\x2"+
+		"\x2\x2\x7B9\x7BA\x3\x2\x2\x2\x7BA\x7BB\x5\x104\x83\x2\x7BB\x103\x3\x2"+
+		"\x2\x2\x7BC\x7C7\x5\x106\x84\x2\x7BD\x7BF\x5\x174\xBB\x2\x7BE\x7BD\x3"+
+		"\x2\x2\x2\x7BE\x7BF\x3\x2\x2\x2\x7BF\x7C0\x3\x2\x2\x2\x7C0\x7C2\a)\x2"+
+		"\x2\x7C1\x7C3\x5\x174\xBB\x2\x7C2\x7C1\x3\x2\x2\x2\x7C2\x7C3\x3\x2\x2"+
+		"\x2\x7C3\x7C4\x3\x2\x2\x2\x7C4\x7C6\x5\x106\x84\x2\x7C5\x7BE\x3\x2\x2"+
+		"\x2\x7C6\x7C9\x3\x2\x2\x2\x7C7\x7C5\x3\x2\x2\x2\x7C7\x7C8\x3\x2\x2\x2"+
+		"\x7C8\x105\x3\x2\x2\x2\x7C9\x7C7\x3\x2\x2\x2\x7CA\x7CC\x5\x13A\x9E\x2"+
+		"\x7CB\x7CD\x5\x154\xAB\x2\x7CC\x7CB\x3\x2\x2\x2\x7CC\x7CD\x3\x2\x2\x2"+
+		"\x7CD\x7DF\x3\x2\x2\x2\x7CE\x7D0\x5\x174\xBB\x2\x7CF\x7CE\x3\x2\x2\x2"+
+		"\x7CF\x7D0\x3\x2\x2\x2\x7D0\x7D1\x3\x2\x2\x2\x7D1\x7D3\a\xD4\x2\x2\x7D2"+
+		"\x7D4\x5\x174\xBB\x2\x7D3\x7D2\x3\x2\x2\x2\x7D3\x7D4\x3\x2\x2\x2\x7D4"+
+		"\x7D9\x3\x2\x2\x2\x7D5\x7D7\x5\x134\x9B\x2\x7D6\x7D8\x5\x174\xBB\x2\x7D7"+
+		"\x7D6\x3\x2\x2\x2\x7D7\x7D8\x3\x2\x2\x2\x7D8\x7DA\x3\x2\x2\x2\x7D9\x7D5"+
+		"\x3\x2\x2\x2\x7D9\x7DA\x3\x2\x2\x2\x7DA\x7DB\x3\x2\x2\x2\x7DB\x7DD\a\xDB"+
+		"\x2\x2\x7DC\x7DE\x5\x174\xBB\x2\x7DD\x7DC\x3\x2\x2\x2\x7DD\x7DE\x3\x2"+
+		"\x2\x2\x7DE\x7E0\x3\x2\x2\x2\x7DF\x7CF\x3\x2\x2\x2\x7DF\x7E0\x3\x2\x2"+
+		"\x2\x7E0\x7E4\x3\x2\x2\x2\x7E1\x7E2\x5\x174\xBB\x2\x7E2\x7E3\x5\x13C\x9F"+
+		"\x2\x7E3\x7E5\x3\x2\x2\x2\x7E4\x7E1\x3\x2\x2\x2\x7E4\x7E5\x3\x2\x2\x2"+
+		"\x7E5\x107\x3\x2\x2\x2\x7E6\x7E7\a\xC7\x2\x2\x7E7\x7E8\x5\x174\xBB\x2"+
+		"\x7E8\x7E9\x5\xFE\x80\x2\x7E9\x7EB\x5\x160\xB1\x2\x7EA\x7EC\x5\x1E\x10"+
+		"\x2\x7EB\x7EA\x3\x2\x2\x2\x7EB\x7EC\x3\x2\x2\x2\x7EC\x7ED\x3\x2\x2\x2"+
+		"\x7ED\x7EE\a\xC6\x2\x2\x7EE\x109\x3\x2\x2\x2\x7EF\x7F0\a\xC9\x2\x2\x7F0"+
+		"\x7F1\x5\x174\xBB\x2\x7F1\x7F2\x5\x10C\x87\x2\x7F2\x7F4\x5\x160\xB1\x2"+
+		"\x7F3\x7F5\x5\x1E\x10\x2\x7F4\x7F3\x3\x2\x2\x2\x7F4\x7F5\x3\x2\x2\x2\x7F5"+
+		"\x7F6\x3\x2\x2\x2\x7F6\x7F7\a\x63\x2\x2\x7F7\x10B\x3\x2\x2\x2\x7F8\x7F9"+
+		"\x5\xFE\x80\x2\x7F9\x10D\x3\x2\x2\x2\x7FA\x7FB\a@\x2\x2\x7FB\x7FC\x5\x174"+
+		"\xBB\x2\x7FC\x7FD\x5\x110\x89\x2\x7FD\x10F\x3\x2\x2\x2\x7FE\x800\x5\x118"+
+		"\x8D\x2\x7FF\x7FE\x3\x2\x2\x2\x7FF\x800\x3\x2\x2\x2\x800\x801\x3\x2\x2"+
+		"\x2\x801\x802\a-\x2\x2\x802\x804\x5\x13A\x9E\x2\x803\x805\x5\x154\xAB"+
+		"\x2\x804\x803\x3\x2\x2\x2\x804\x805\x3\x2\x2\x2\x805\x813\x3\x2\x2\x2"+
+		"\x806\x808\x5\x174\xBB\x2\x807\x806\x3\x2\x2\x2\x807\x808\x3\x2\x2\x2"+
+		"\x808\x809\x3\x2\x2\x2\x809\x80B\a\xD4\x2\x2\x80A\x80C\x5\x174\xBB\x2"+
+		"\x80B\x80A\x3\x2\x2\x2\x80B\x80C\x3\x2\x2\x2\x80C\x80D\x3\x2\x2\x2\x80D"+
+		"\x80F\x5\x128\x95\x2\x80E\x810\x5\x174\xBB\x2\x80F\x80E\x3\x2\x2\x2\x80F"+
+		"\x810\x3\x2\x2\x2\x810\x811\x3\x2\x2\x2\x811\x812\a\xDB\x2\x2\x812\x814"+
+		"\x3\x2\x2\x2\x813\x807\x3\x2\x2\x2\x813\x814\x3\x2\x2\x2\x814\x81E\x3"+
+		"\x2\x2\x2\x815\x817\x5\x174\xBB\x2\x816\x815\x3\x2\x2\x2\x816\x817\x3"+
+		"\x2\x2\x2\x817\x818\x3\x2\x2\x2\x818\x819\a\xD4\x2\x2\x819\x81A\x5\x134"+
+		"\x9B\x2\x81A\x81B\a\xDB\x2\x2\x81B\x81D\x3\x2\x2\x2\x81C\x816\x3\x2\x2"+
+		"\x2\x81D\x820\x3\x2\x2\x2\x81E\x81C\x3\x2\x2\x2\x81E\x81F\x3\x2\x2\x2"+
+		"\x81F\x841\x3\x2\x2\x2\x820\x81E\x3\x2\x2\x2\x821\x823\x5\x13A\x9E\x2"+
+		"\x822\x824\x5\x154\xAB\x2\x823\x822\x3\x2\x2\x2\x823\x824\x3\x2\x2\x2"+
+		"\x824\x832\x3\x2\x2\x2\x825\x827\x5\x174\xBB\x2\x826\x825\x3\x2\x2\x2"+
+		"\x826\x827\x3\x2\x2\x2\x827\x828\x3\x2\x2\x2\x828\x82A\a\xD4\x2\x2\x829"+
+		"\x82B\x5\x174\xBB\x2\x82A\x829\x3\x2\x2\x2\x82A\x82B\x3\x2\x2\x2\x82B"+
+		"\x82C\x3\x2\x2\x2\x82C\x82E\x5\x128\x95\x2\x82D\x82F\x5\x174\xBB\x2\x82E"+
+		"\x82D\x3\x2\x2\x2\x82E\x82F\x3\x2\x2\x2\x82F\x830\x3\x2\x2\x2\x830\x831"+
+		"\a\xDB\x2\x2\x831\x833\x3\x2\x2\x2\x832\x826\x3\x2\x2\x2\x832\x833\x3"+
+		"\x2\x2\x2\x833\x83D\x3\x2\x2\x2\x834\x836\x5\x174\xBB\x2\x835\x834\x3"+
+		"\x2\x2\x2\x835\x836\x3\x2\x2\x2\x836\x837\x3\x2\x2\x2\x837\x838\a\xD4"+
+		"\x2\x2\x838\x839\x5\x134\x9B\x2\x839\x83A\a\xDB\x2\x2\x83A\x83C\x3\x2"+
+		"\x2\x2\x83B\x835\x3\x2\x2\x2\x83C\x83F\x3\x2\x2\x2\x83D\x83B\x3\x2\x2"+
+		"\x2\x83D\x83E\x3\x2\x2\x2\x83E\x841\x3\x2\x2\x2\x83F\x83D\x3\x2\x2\x2"+
+		"\x840\x7FF\x3\x2\x2\x2\x840\x821\x3\x2\x2\x2\x841\x111\x3\x2\x2\x2\x842"+
+		"\x845\x5\x114\x8B\x2\x843\x845\x5\x116\x8C\x2\x844\x842\x3\x2\x2\x2\x844"+
+		"\x843\x3\x2\x2\x2\x845\x113\x3\x2\x2\x2\x846\x848\x5\x118\x8D\x2\x847"+
+		"\x846\x3\x2\x2\x2\x847\x848\x3\x2\x2\x2\x848\x84A\x3\x2\x2\x2\x849\x84B"+
+		"\x5\x174\xBB\x2\x84A\x849\x3\x2\x2\x2\x84A\x84B\x3\x2\x2\x2\x84B\x84C"+
+		"\x3\x2\x2\x2\x84C\x84E\a-\x2\x2\x84D\x84F\x5\x174\xBB\x2\x84E\x84D\x3"+
+		"\x2\x2\x2\x84E\x84F\x3\x2\x2\x2\x84F\x850\x3\x2\x2\x2\x850\x852\x5\x138"+
+		"\x9D\x2\x851\x853\x5\x154\xAB\x2\x852\x851\x3\x2\x2\x2\x852\x853\x3\x2"+
+		"\x2\x2\x853\x857\x3\x2\x2\x2\x854\x855\x5\x174\xBB\x2\x855\x856\x5\x128"+
+		"\x95\x2\x856\x858\x3\x2\x2\x2\x857\x854\x3\x2\x2\x2\x857\x858\x3\x2\x2"+
+		"\x2\x858\x85D\x3\x2\x2\x2\x859\x85B\x5\x174\xBB\x2\x85A\x859\x3\x2\x2"+
+		"\x2\x85A\x85B\x3\x2\x2\x2\x85B\x85C\x3\x2\x2\x2\x85C\x85E\x5\x12C\x97"+
+		"\x2\x85D\x85A\x3\x2\x2\x2\x85D\x85E\x3\x2\x2\x2\x85E\x868\x3\x2\x2\x2"+
+		"\x85F\x861\x5\x174\xBB\x2\x860\x85F\x3\x2\x2\x2\x860\x861\x3\x2\x2\x2"+
+		"\x861\x862\x3\x2\x2\x2\x862\x863\a\xD4\x2\x2\x863\x864\x5\x134\x9B\x2"+
+		"\x864\x865\a\xDB\x2\x2\x865\x867\x3\x2\x2\x2\x866\x860\x3\x2\x2\x2\x867"+
+		"\x86A\x3\x2\x2\x2\x868\x866\x3\x2\x2\x2\x868\x869\x3\x2\x2\x2\x869\x115"+
+		"\x3\x2\x2\x2\x86A\x868\x3\x2\x2\x2\x86B\x86F\x5\x13A\x9E\x2\x86C\x86D"+
+		"\x5\x174\xBB\x2\x86D\x86E\x5\x128\x95\x2\x86E\x870\x3\x2\x2\x2\x86F\x86C"+
+		"\x3\x2\x2\x2\x86F\x870\x3\x2\x2\x2\x870\x87A\x3\x2\x2\x2\x871\x873\x5"+
+		"\x174\xBB\x2\x872\x871\x3\x2\x2\x2\x872\x873\x3\x2\x2\x2\x873\x874\x3"+
+		"\x2\x2\x2\x874\x875\a\xD4\x2\x2\x875\x876\x5\x134\x9B\x2\x876\x877\a\xDB"+
+		"\x2\x2\x877\x879\x3\x2\x2\x2\x878\x872\x3\x2\x2\x2\x879\x87C\x3\x2\x2"+
+		"\x2\x87A\x878\x3\x2\x2\x2\x87A\x87B\x3\x2\x2\x2\x87B\x117\x3\x2\x2\x2"+
+		"\x87C\x87A\x3\x2\x2\x2\x87D\x882\x5\x122\x92\x2\x87E\x882\x5\x11A\x8E"+
+		"\x2\x87F\x882\x5\x11C\x8F\x2\x880\x882\x5\x126\x94\x2\x881\x87D\x3\x2"+
+		"\x2\x2\x881\x87E\x3\x2\x2\x2\x881\x87F\x3\x2\x2\x2\x881\x880\x3\x2\x2"+
+		"\x2\x882\x119\x3\x2\x2\x2\x883\x885\x5\x13A\x9E\x2\x884\x886\x5\x154\xAB"+
+		"\x2\x885\x884\x3\x2\x2\x2\x885\x886\x3\x2\x2\x2\x886\x88B\x3\x2\x2\x2"+
+		"\x887\x889\x5\x174\xBB\x2\x888\x887\x3\x2\x2\x2\x888\x889\x3\x2\x2\x2"+
+		"\x889\x88A\x3\x2\x2\x2\x88A\x88C\x5\x12C\x97\x2\x88B\x888\x3\x2\x2\x2"+
+		"\x88B\x88C\x3\x2\x2\x2\x88C\x896\x3\x2\x2\x2\x88D\x88F\x5\x174\xBB\x2"+
+		"\x88E\x88D\x3\x2\x2\x2\x88E\x88F\x3\x2\x2\x2\x88F\x890\x3\x2\x2\x2\x890"+
+		"\x891\a\xD4\x2\x2\x891\x892\x5\x134\x9B\x2\x892\x893\a\xDB\x2\x2\x893"+
+		"\x895\x3\x2\x2\x2\x894\x88E\x3\x2\x2\x2\x895\x898\x3\x2\x2\x2\x896\x894"+
+		"\x3\x2\x2\x2\x896\x897\x3\x2\x2\x2\x897\x11B\x3\x2\x2\x2\x898\x896\x3"+
+		"\x2\x2\x2\x899\x89C\x5\x13A\x9E\x2\x89A\x89C\x5\x13E\xA0\x2\x89B\x899"+
+		"\x3\x2\x2\x2\x89B\x89A\x3\x2\x2\x2\x89C\x89E\x3\x2\x2\x2\x89D\x89F\x5"+
+		"\x154\xAB\x2\x89E\x89D\x3\x2\x2\x2\x89E\x89F\x3\x2\x2\x2\x89F\x8A1\x3"+
+		"\x2\x2\x2\x8A0\x8A2\x5\x174\xBB\x2\x8A1\x8A0\x3\x2\x2\x2\x8A1\x8A2\x3"+
+		"\x2\x2\x2\x8A2\x8A3\x3\x2\x2\x2\x8A3\x8A5\a\xD4\x2\x2\x8A4\x8A6\x5\x174"+
+		"\xBB\x2\x8A5\x8A4\x3\x2\x2\x2\x8A5\x8A6\x3\x2\x2\x2\x8A6\x8AB\x3\x2\x2"+
+		"\x2\x8A7\x8A9\x5\x128\x95\x2\x8A8\x8AA\x5\x174\xBB\x2\x8A9\x8A8\x3\x2"+
+		"\x2\x2\x8A9\x8AA\x3\x2\x2\x2\x8AA\x8AC\x3\x2\x2\x2\x8AB\x8A7\x3\x2\x2"+
+		"\x2\x8AB\x8AC\x3\x2\x2\x2\x8AC\x8AD\x3\x2\x2\x2\x8AD\x8B2\a\xDB\x2\x2"+
+		"\x8AE\x8B0\x5\x174\xBB\x2\x8AF\x8AE\x3\x2\x2\x2\x8AF\x8B0\x3\x2\x2\x2"+
+		"\x8B0\x8B1\x3\x2\x2\x2\x8B1\x8B3\x5\x12C\x97\x2\x8B2\x8AF\x3\x2\x2\x2"+
+		"\x8B2\x8B3\x3\x2\x2\x2\x8B3\x8BD\x3\x2\x2\x2\x8B4\x8B6\x5\x174\xBB\x2"+
+		"\x8B5\x8B4\x3\x2\x2\x2\x8B5\x8B6\x3\x2\x2\x2\x8B6\x8B7\x3\x2\x2\x2\x8B7"+
+		"\x8B8\a\xD4\x2\x2\x8B8\x8B9\x5\x134\x9B\x2\x8B9\x8BA\a\xDB\x2\x2\x8BA"+
+		"\x8BC\x3\x2\x2\x2\x8BB\x8B5\x3\x2\x2\x2\x8BC\x8BF\x3\x2\x2\x2\x8BD\x8BB"+
+		"\x3\x2\x2\x2\x8BD\x8BE\x3\x2\x2\x2\x8BE\x11D\x3\x2\x2\x2\x8BF\x8BD\x3"+
+		"\x2\x2\x2\x8C0\x8C2\x5\x138\x9D\x2\x8C1\x8C3\x5\x154\xAB\x2\x8C2\x8C1"+
+		"\x3\x2\x2\x2\x8C2\x8C3\x3\x2\x2\x2\x8C3\x8C8\x3\x2\x2\x2\x8C4\x8C6\x5"+
+		"\x174\xBB\x2\x8C5\x8C4\x3\x2\x2\x2\x8C5\x8C6\x3\x2\x2\x2\x8C6\x8C7\x3"+
+		"\x2\x2\x2\x8C7\x8C9\x5\x12C\x97\x2\x8C8\x8C5\x3\x2\x2\x2\x8C8\x8C9\x3"+
+		"\x2\x2\x2\x8C9\x8D3\x3\x2\x2\x2\x8CA\x8CC\x5\x174\xBB\x2\x8CB\x8CA\x3"+
+		"\x2\x2\x2\x8CB\x8CC\x3\x2\x2\x2\x8CC\x8CD\x3\x2\x2\x2\x8CD\x8CE\a\xD4"+
+		"\x2\x2\x8CE\x8CF\x5\x134\x9B\x2\x8CF\x8D0\a\xDB\x2\x2\x8D0\x8D2\x3\x2"+
+		"\x2\x2\x8D1\x8CB\x3\x2\x2\x2\x8D2\x8D5\x3\x2\x2\x2\x8D3\x8D1\x3\x2\x2"+
+		"\x2\x8D3\x8D4\x3\x2\x2\x2\x8D4\x11F\x3\x2\x2\x2\x8D5\x8D3\x3\x2\x2\x2"+
+		"\x8D6\x8D9\x5\x138\x9D\x2\x8D7\x8D9\x5\x13E\xA0\x2\x8D8\x8D6\x3\x2\x2"+
+		"\x2\x8D8\x8D7\x3\x2\x2\x2\x8D9\x8DB\x3\x2\x2\x2\x8DA\x8DC\x5\x154\xAB"+
+		"\x2\x8DB\x8DA\x3\x2\x2\x2\x8DB\x8DC\x3\x2\x2\x2\x8DC\x8DE\x3\x2\x2\x2"+
+		"\x8DD\x8DF\x5\x174\xBB\x2\x8DE\x8DD\x3\x2\x2\x2\x8DE\x8DF\x3\x2\x2\x2"+
+		"\x8DF\x8E0\x3\x2\x2\x2\x8E0\x8E2\a\xD4\x2\x2\x8E1\x8E3\x5\x174\xBB\x2"+
+		"\x8E2\x8E1\x3\x2\x2\x2\x8E2\x8E3\x3\x2\x2\x2\x8E3\x8E8\x3\x2\x2\x2\x8E4"+
+		"\x8E6\x5\x128\x95\x2\x8E5\x8E7\x5\x174\xBB\x2\x8E6\x8E5\x3\x2\x2\x2\x8E6"+
+		"\x8E7\x3\x2\x2\x2\x8E7\x8E9\x3\x2\x2\x2\x8E8\x8E4\x3\x2\x2\x2\x8E8\x8E9"+
+		"\x3\x2\x2\x2\x8E9\x8EA\x3\x2\x2\x2\x8EA\x8EF\a\xDB\x2\x2\x8EB\x8ED\x5"+
+		"\x174\xBB\x2\x8EC\x8EB\x3\x2\x2\x2\x8EC\x8ED\x3\x2\x2\x2\x8ED\x8EE\x3"+
+		"\x2\x2\x2\x8EE\x8F0\x5\x12C\x97\x2\x8EF\x8EC\x3\x2\x2\x2\x8EF\x8F0\x3"+
+		"\x2\x2\x2\x8F0\x8FA\x3\x2\x2\x2\x8F1\x8F3\x5\x174\xBB\x2\x8F2\x8F1\x3"+
+		"\x2\x2\x2\x8F2\x8F3\x3\x2\x2\x2\x8F3\x8F4\x3\x2\x2\x2\x8F4\x8F5\a\xD4"+
+		"\x2\x2\x8F5\x8F6\x5\x134\x9B\x2\x8F6\x8F7\a\xDB\x2\x2\x8F7\x8F9\x3\x2"+
+		"\x2\x2\x8F8\x8F2\x3\x2\x2\x2\x8F9\x8FC\x3\x2\x2\x2\x8FA\x8F8\x3\x2\x2"+
+		"\x2\x8FA\x8FB\x3\x2\x2\x2\x8FB\x121\x3\x2\x2\x2\x8FC\x8FA\x3\x2\x2\x2"+
+		"\x8FD\x900\x5\x11A\x8E\x2\x8FE\x900\x5\x11C\x8F\x2\x8FF\x8FD\x3\x2\x2"+
+		"\x2\x8FF\x8FE\x3\x2\x2\x2\x8FF\x900\x3\x2\x2\x2\x900\x905\x3\x2\x2\x2"+
+		"\x901\x903\x5\x124\x93\x2\x902\x904\x5\x174\xBB\x2\x903\x902\x3\x2\x2"+
+		"\x2\x903\x904\x3\x2\x2\x2\x904\x906\x3\x2\x2\x2\x905\x901\x3\x2\x2\x2"+
+		"\x906\x907\x3\x2\x2\x2\x907\x905\x3\x2\x2\x2\x907\x908\x3\x2\x2\x2\x908"+
+		"\x90D\x3\x2\x2\x2\x909\x90B\x5\x174\xBB\x2\x90A\x909\x3\x2\x2\x2\x90A"+
+		"\x90B\x3\x2\x2\x2\x90B\x90C\x3\x2\x2\x2\x90C\x90E\x5\x12C\x97\x2\x90D"+
+		"\x90A\x3\x2\x2\x2\x90D\x90E\x3\x2\x2\x2\x90E\x918\x3\x2\x2\x2\x90F\x911"+
+		"\x5\x174\xBB\x2\x910\x90F\x3\x2\x2\x2\x910\x911\x3\x2\x2\x2\x911\x912"+
+		"\x3\x2\x2\x2\x912\x913\a\xD4\x2\x2\x913\x914\x5\x134\x9B\x2\x914\x915"+
+		"\a\xDB\x2\x2\x915\x917\x3\x2\x2\x2\x916\x910\x3\x2\x2\x2\x917\x91A\x3"+
+		"\x2\x2\x2\x918\x916\x3\x2\x2\x2\x918\x919\x3\x2\x2\x2\x919\x123\x3\x2"+
+		"\x2\x2\x91A\x918\x3\x2\x2\x2\x91B\x91D\t\xF\x2\x2\x91C\x91E\x5\x174\xBB"+
+		"\x2\x91D\x91C\x3\x2\x2\x2\x91D\x91E\x3\x2\x2\x2\x91E\x921\x3\x2\x2\x2"+
+		"\x91F\x922\x5\x11E\x90\x2\x920\x922\x5\x120\x91\x2\x921\x91F\x3\x2\x2"+
+		"\x2\x921\x920\x3\x2\x2\x2\x922\x125\x3\x2\x2\x2\x923\x925\x5\x174\xBB"+
+		"\x2\x924\x923\x3\x2\x2\x2\x924\x925\x3\x2\x2\x2\x925\x926\x3\x2\x2\x2"+
+		"\x926\x927\x5\x12C\x97\x2\x927\x127\x3\x2\x2\x2\x928\x92A\x5\x12A\x96"+
+		"\x2\x929\x928\x3\x2\x2\x2\x929\x92A\x3\x2\x2\x2\x92A\x92C\x3\x2\x2\x2"+
+		"\x92B\x92D\x5\x174\xBB\x2\x92C\x92B\x3\x2\x2\x2\x92C\x92D\x3\x2\x2\x2"+
+		"\x92D\x92E\x3\x2\x2\x2\x92E\x930\t\x6\x2\x2\x92F\x931\x5\x174\xBB\x2\x930"+
+		"\x92F\x3\x2\x2\x2\x930\x931\x3\x2\x2\x2\x931\x933\x3\x2\x2\x2\x932\x929"+
+		"\x3\x2\x2\x2\x933\x936\x3\x2\x2\x2\x934\x932\x3\x2\x2\x2\x934\x935\x3"+
+		"\x2\x2\x2\x935\x937\x3\x2\x2\x2\x936\x934\x3\x2\x2\x2\x937\x944\x5\x12A"+
+		"\x96\x2\x938\x93A\x5\x174\xBB\x2\x939\x938\x3\x2\x2\x2\x939\x93A\x3\x2"+
+		"\x2\x2\x93A\x93B\x3\x2\x2\x2\x93B\x93D\t\x6\x2\x2\x93C\x93E\x5\x174\xBB"+
+		"\x2\x93D\x93C\x3\x2\x2\x2\x93D\x93E\x3\x2\x2\x2\x93E\x940\x3\x2\x2\x2"+
+		"\x93F\x941\x5\x12A\x96\x2\x940\x93F\x3\x2\x2\x2\x940\x941\x3\x2\x2\x2"+
+		"\x941\x943\x3\x2\x2\x2\x942\x939\x3\x2\x2\x2\x943\x946\x3\x2\x2\x2\x944"+
+		"\x942\x3\x2\x2\x2\x944\x945\x3\x2\x2\x2\x945\x129\x3\x2\x2\x2\x946\x944"+
+		"\x3\x2\x2\x2\x947\x949\a\xD4\x2\x2\x948\x947\x3\x2\x2\x2\x948\x949\x3"+
+		"\x2\x2\x2\x949\x94C\x3\x2\x2\x2\x94A\x94B\t\x10\x2\x2\x94B\x94D\x5\x174"+
+		"\xBB\x2\x94C\x94A\x3\x2\x2\x2\x94C\x94D\x3\x2\x2\x2\x94D\x94F\x3\x2\x2"+
+		"\x2\x94E\x950\a\xDB\x2\x2\x94F\x94E\x3\x2\x2\x2\x94F\x950\x3\x2\x2\x2"+
+		"\x950\x951\x3\x2\x2\x2\x951\x952\x5\xFE\x80\x2\x952\x12B\x3\x2\x2\x2\x953"+
+		"\x955\a,\x2\x2\x954\x956\x5\x174\xBB\x2\x955\x954\x3\x2\x2\x2\x955\x956"+
+		"\x3\x2\x2\x2\x956\x957\x3\x2\x2\x2\x957\x959\x5\x138\x9D\x2\x958\x95A"+
+		"\x5\x154\xAB\x2\x959\x958\x3\x2\x2\x2\x959\x95A\x3\x2\x2\x2\x95A\x12D"+
+		"\x3\x2\x2\x2\x95B\x96D\a\xD4\x2\x2\x95C\x95E\x5\x174\xBB\x2\x95D\x95C"+
+		"\x3\x2\x2\x2\x95D\x95E\x3\x2\x2\x2\x95E\x95F\x3\x2\x2\x2\x95F\x96A\x5"+
+		"\x130\x99\x2\x960\x962\x5\x174\xBB\x2\x961\x960\x3\x2\x2\x2\x961\x962"+
+		"\x3\x2\x2\x2\x962\x963\x3\x2\x2\x2\x963\x965\a)\x2\x2\x964\x966\x5\x174"+
+		"\xBB\x2\x965\x964\x3\x2\x2\x2\x965\x966\x3\x2\x2\x2\x966\x967\x3\x2\x2"+
+		"\x2\x967\x969\x5\x130\x99\x2\x968\x961\x3\x2\x2\x2\x969\x96C\x3\x2\x2"+
+		"\x2\x96A\x968\x3\x2\x2\x2\x96A\x96B\x3\x2\x2\x2\x96B\x96E\x3\x2\x2\x2"+
+		"\x96C\x96A\x3\x2\x2\x2\x96D\x95D\x3\x2\x2\x2\x96D\x96E\x3\x2\x2\x2\x96E"+
+		"\x970\x3\x2\x2\x2\x96F\x971\x5\x174\xBB\x2\x970\x96F\x3\x2\x2\x2\x970"+
+		"\x971\x3\x2\x2\x2\x971\x972\x3\x2\x2\x2\x972\x973\a\xDB\x2\x2\x973\x12F"+
+		"\x3\x2\x2\x2\x974\x975\a\x95\x2\x2\x975\x977\x5\x174\xBB\x2\x976\x974"+
+		"\x3\x2\x2\x2\x976\x977\x3\x2\x2\x2\x977\x97A\x3\x2\x2\x2\x978\x979\t\x11"+
+		"\x2\x2\x979\x97B\x5\x174\xBB\x2\x97A\x978\x3\x2\x2\x2\x97A\x97B\x3\x2"+
+		"\x2\x2\x97B\x97E\x3\x2\x2\x2\x97C\x97D\a\x9C\x2\x2\x97D\x97F\x5\x174\xBB"+
+		"\x2\x97E\x97C\x3\x2\x2\x2\x97E\x97F\x3\x2\x2\x2\x97F\x980\x3\x2\x2\x2"+
+		"\x980\x982\x5\x138\x9D\x2\x981\x983\x5\x154\xAB\x2\x982\x981\x3\x2\x2"+
+		"\x2\x982\x983\x3\x2\x2\x2\x983\x98C\x3\x2\x2\x2\x984\x986\x5\x174\xBB"+
+		"\x2\x985\x984\x3\x2\x2\x2\x985\x986\x3\x2\x2\x2\x986\x987\x3\x2\x2\x2"+
+		"\x987\x989\a\xD4\x2\x2\x988\x98A\x5\x174\xBB\x2\x989\x988\x3\x2\x2\x2"+
+		"\x989\x98A\x3\x2\x2\x2\x98A\x98B\x3\x2\x2\x2\x98B\x98D\a\xDB\x2\x2\x98C"+
+		"\x985\x3\x2\x2\x2\x98C\x98D\x3\x2\x2\x2\x98D\x992\x3\x2\x2\x2\x98E\x990"+
+		"\x5\x174\xBB\x2\x98F\x98E\x3\x2\x2\x2\x98F\x990\x3\x2\x2\x2\x990\x991"+
+		"\x3\x2\x2\x2\x991\x993\x5\x13C\x9F\x2\x992\x98F\x3\x2\x2\x2\x992\x993"+
+		"\x3\x2\x2\x2\x993\x998\x3\x2\x2\x2\x994\x996\x5\x174\xBB\x2\x995\x994"+
+		"\x3\x2\x2\x2\x995\x996\x3\x2\x2\x2\x996\x997\x3\x2\x2\x2\x997\x999\x5"+
+		"\x132\x9A\x2\x998\x995\x3\x2\x2\x2\x998\x999\x3\x2\x2\x2\x999\x131\x3"+
+		"\x2\x2\x2\x99A\x99C\a\xD0\x2\x2\x99B\x99D\x5\x174\xBB\x2\x99C\x99B\x3"+
+		"\x2\x2\x2\x99C\x99D\x3\x2\x2\x2\x99D\x99E\x3\x2\x2\x2\x99E\x99F\x5\xFE"+
+		"\x80\x2\x99F\x133\x3\x2\x2\x2\x9A0\x9AB\x5\x136\x9C\x2\x9A1\x9A3\x5\x174"+
+		"\xBB\x2\x9A2\x9A1\x3\x2\x2\x2\x9A2\x9A3\x3\x2\x2\x2\x9A3\x9A4\x3\x2\x2"+
+		"\x2\x9A4\x9A6\a)\x2\x2\x9A5\x9A7\x5\x174\xBB\x2\x9A6\x9A5\x3\x2\x2\x2"+
+		"\x9A6\x9A7\x3\x2\x2\x2\x9A7\x9A8\x3\x2\x2\x2\x9A8\x9AA\x5\x136\x9C\x2"+
+		"\x9A9\x9A2\x3\x2\x2\x2\x9AA\x9AD\x3\x2\x2\x2\x9AB\x9A9\x3\x2\x2\x2\x9AB"+
+		"\x9AC\x3\x2\x2\x2\x9AC\x135\x3\x2\x2\x2\x9AD\x9AB\x3\x2\x2\x2\x9AE\x9AF"+
+		"\x5\xFE\x80\x2\x9AF\x9B0\x5\x174\xBB\x2\x9B0\x9B1\a\xBE\x2\x2\x9B1\x9B2"+
+		"\x5\x174\xBB\x2\x9B2\x9B4\x3\x2\x2\x2\x9B3\x9AE\x3\x2\x2\x2\x9B3\x9B4"+
+		"\x3\x2\x2\x2\x9B4\x9B5\x3\x2\x2\x2\x9B5\x9B6\x5\xFE\x80\x2\x9B6\x137\x3"+
+		"\x2\x2\x2\x9B7\x9BB\x5\x13A\x9E\x2\x9B8\x9BB\x5\x15C\xAF\x2\x9B9\x9BB"+
+		"\x5\x15A\xAE\x2\x9BA\x9B7\x3\x2\x2\x2\x9BA\x9B8\x3\x2\x2\x2\x9BA\x9B9"+
+		"\x3\x2\x2\x2\x9BB\x139\x3\x2\x2\x2\x9BC\x9BF\a\xEE\x2\x2\x9BD\x9BF\x5"+
+		"\x158\xAD\x2\x9BE\x9BC\x3\x2\x2\x2\x9BE\x9BD\x3\x2\x2\x2\x9BF\x13B\x3"+
+		"\x2\x2\x2\x9C0\x9C2\a\x39\x2\x2\x9C1\x9C3\x5\x174\xBB\x2\x9C2\x9C1\x3"+
+		"\x2\x2\x2\x9C2\x9C3\x3\x2\x2\x2\x9C3\x9C6\x3\x2\x2\x2\x9C4\x9C5\a\x8D"+
+		"\x2\x2\x9C5\x9C7\x5\x174\xBB\x2\x9C6\x9C4\x3\x2\x2\x2\x9C6\x9C7\x3\x2"+
+		"\x2\x2\x9C7\x9C8\x3\x2\x2\x2\x9C8\x9CD\x5\x152\xAA\x2\x9C9\x9CB\x5\x174"+
+		"\xBB\x2\x9CA\x9C9\x3\x2\x2\x2\x9CA\x9CB\x3\x2\x2\x2\x9CB\x9CC\x3\x2\x2"+
+		"\x2\x9CC\x9CE\x5\x144\xA3\x2\x9CD\x9CA\x3\x2\x2\x2\x9CD\x9CE\x3\x2\x2"+
+		"\x2\x9CE\x13D\x3\x2\x2\x2\x9CF\x9D0\t\x12\x2\x2\x9D0\x13F\x3\x2\x2\x2"+
+		"\x9D1\x9D2\t\xE\x2\x2\x9D2\x141\x3\x2\x2\x2\x9D3\x9D8\x5\x13A\x9E\x2\x9D4"+
+		"\x9D5\t\xF\x2\x2\x9D5\x9D7\x5\x13A\x9E\x2\x9D6\x9D4\x3\x2\x2\x2\x9D7\x9DA"+
+		"\x3\x2\x2\x2\x9D8\x9D6\x3\x2\x2\x2\x9D8\x9D9\x3\x2\x2\x2\x9D9\x143\x3"+
+		"\x2\x2\x2\x9DA\x9D8\x3\x2\x2\x2\x9DB\x9DD\a\xD7\x2\x2\x9DC\x9DE\x5\x174"+
+		"\xBB\x2\x9DD\x9DC\x3\x2\x2\x2\x9DD\x9DE\x3\x2\x2\x2\x9DE\x9E1\x3\x2\x2"+
+		"\x2\x9DF\x9E2\x5\x150\xA9\x2\x9E0\x9E2\x5\x13A\x9E\x2\x9E1\x9DF\x3\x2"+
+		"\x2\x2\x9E1\x9E0\x3\x2\x2\x2\x9E2\x145\x3\x2\x2\x2\x9E3\x9E5\x5\x148\xA5"+
+		"\x2\x9E4\x9E6\x5\x174\xBB\x2\x9E5\x9E4\x3\x2\x2\x2\x9E5\x9E6\x3\x2\x2"+
+		"\x2\x9E6\x9E7\x3\x2\x2\x2\x9E7\x9E8\a*\x2\x2\x9E8\x147\x3\x2\x2\x2\x9E9"+
+		"\x9EC\x5\x14A\xA6\x2\x9EA\x9EC\x5\x14C\xA7\x2\x9EB\x9E9\x3\x2\x2\x2\x9EB"+
+		"\x9EA\x3\x2\x2\x2\x9EC\x149\x3\x2\x2\x2\x9ED\x9EE\x5\x138\x9D\x2\x9EE"+
+		"\x14B\x3\x2\x2\x2\x9EF\x9F0\x5\x150\xA9\x2\x9F0\x14D\x3\x2\x2\x2\x9F1"+
+		"\x9FA\x5\x150\xA9\x2\x9F2\x9FA\a\xE8\x2\x2\x9F3\x9FA\a\xE3\x2\x2\x9F4"+
+		"\x9FA\a\xBF\x2\x2\x9F5\x9FA\ao\x2\x2\x9F6\x9FA\a\x8F\x2\x2\x9F7\x9FA\a"+
+		"\x90\x2\x2\x9F8\x9FA\a[\x2\x2\x9F9\x9F1\x3\x2\x2\x2\x9F9\x9F2\x3\x2\x2"+
+		"\x2\x9F9\x9F3\x3\x2\x2\x2\x9F9\x9F4\x3\x2\x2\x2\x9F9\x9F5\x3\x2\x2\x2"+
+		"\x9F9\x9F6\x3\x2\x2\x2\x9F9\x9F7\x3\x2\x2\x2\x9F9\x9F8\x3\x2\x2\x2\x9FA"+
+		"\x14F\x3\x2\x2\x2\x9FB\x9FC\t\x13\x2\x2\x9FC\x151\x3\x2\x2\x2\x9FD\xA00"+
+		"\x5\x13E\xA0\x2\x9FE\xA00\x5\x142\xA2\x2\x9FF\x9FD\x3\x2\x2\x2\x9FF\x9FE"+
+		"\x3\x2\x2\x2\xA00\xA09\x3\x2\x2\x2\xA01\xA03\x5\x174\xBB\x2\xA02\xA01"+
+		"\x3\x2\x2\x2\xA02\xA03\x3\x2\x2\x2\xA03\xA04\x3\x2\x2\x2\xA04\xA06\a\xD4"+
+		"\x2\x2\xA05\xA07\x5\x174\xBB\x2\xA06\xA05\x3\x2\x2\x2\xA06\xA07\x3\x2"+
+		"\x2\x2\xA07\xA08\x3\x2\x2\x2\xA08\xA0A\a\xDB\x2\x2\xA09\xA02\x3\x2\x2"+
+		"\x2\xA09\xA0A\x3\x2\x2\x2\xA0A\x153\x3\x2\x2\x2\xA0B\xA0C\t\x14\x2\x2"+
+		"\xA0C\x155\x3\x2\x2\x2\xA0D\xA0E\t\x15\x2\x2\xA0E\x157\x3\x2\x2\x2\xA0F"+
+		"\xA10\t\x16\x2\x2\xA10\x159\x3\x2\x2\x2\xA11\xA12\a\x39\x2\x2\xA12\x15B"+
+		"\x3\x2\x2\x2\xA13\xA14\t\x17\x2\x2\xA14\x15D\x3\x2\x2\x2\xA15\xA17\x5"+
+		"\x174\xBB\x2\xA16\xA15\x3\x2\x2\x2\xA16\xA17\x3\x2\x2\x2\xA17\xA19\x3"+
+		"\x2\x2\x2\xA18\xA1A\x5\x162\xB2\x2\xA19\xA18\x3\x2\x2\x2\xA19\xA1A\x3"+
+		"\x2\x2\x2\xA1A\x15F\x3\x2\x2\x2\xA1B\xA1C\x5\x15E\xB0\x2\xA1C\xA1E\a\xE9"+
+		"\x2\x2\xA1D\xA1F\x5\x174\xBB\x2\xA1E\xA1D\x3\x2\x2\x2\xA1E\xA1F\x3\x2"+
+		"\x2\x2\xA1F\xA28\x3\x2\x2\x2\xA20\xA22\x5\x174\xBB\x2\xA21\xA20\x3\x2"+
+		"\x2\x2\xA21\xA22\x3\x2\x2\x2\xA22\xA23\x3\x2\x2\x2\xA23\xA25\a*\x2\x2"+
+		"\xA24\xA26\x5\x174\xBB\x2\xA25\xA24\x3\x2\x2\x2\xA25\xA26\x3\x2\x2\x2"+
+		"\xA26\xA28\x3\x2\x2\x2\xA27\xA1B\x3\x2\x2\x2\xA27\xA21\x3\x2\x2\x2\xA28"+
+		"\xA2A\x3\x2\x2\x2\xA29\xA27\x3\x2\x2\x2\xA2A\xA2D\x3\x2\x2\x2\xA2B\xA29"+
+		"\x3\x2\x2\x2\xA2B\xA2C\x3\x2\x2\x2\xA2C\xA32\x3\x2\x2\x2\xA2D\xA2B\x3"+
+		"\x2\x2\x2\xA2E\xA2F\x5\x15E\xB0\x2\xA2F\xA30\a\x2\x2\x3\xA30\xA32\x3\x2"+
+		"\x2\x2\xA31\xA2B\x3\x2\x2\x2\xA31\xA2E\x3\x2\x2\x2\xA32\x161\x3\x2\x2"+
+		"\x2\xA33\xA37\x5\x16A\xB6\x2\xA34\xA37\x5\x166\xB4\x2\xA35\xA37\x5\x164"+
+		"\xB3\x2\xA36\xA33\x3\x2\x2\x2\xA36\xA34\x3\x2\x2\x2\xA36\xA35\x3\x2\x2"+
+		"\x2\xA37\x163\x3\x2\x2\x2\xA38\xA3A\a\xAB\x2\x2\xA39\xA3B\x5\x174\xBB"+
+		"\x2\xA3A\xA39\x3\x2\x2\x2\xA3A\xA3B\x3\x2\x2\x2\xA3B\xA3C\x3\x2\x2\x2"+
+		"\xA3C\xA3D\x5\x168\xB5\x2\xA3D\x165\x3\x2\x2\x2\xA3E\xA3F\a\xEA\x2\x2"+
+		"\xA3F\xA40\x5\x168\xB5\x2\xA40\x167\x3\x2\x2\x2\xA41\xA44\a\xEF\x2\x2"+
+		"\xA42\xA44\n\x18\x2\x2\xA43\xA41\x3\x2\x2\x2\xA43\xA42\x3\x2\x2\x2\xA44"+
+		"\xA47\x3\x2\x2\x2\xA45\xA43\x3\x2\x2\x2\xA45\xA46\x3\x2\x2\x2\xA46\x169"+
+		"\x3\x2\x2\x2\xA47\xA45\x3\x2\x2\x2\xA48\xA4E\a\xEA\x2\x2\xA49\xA4A\a/"+
+		"\x2\x2\xA4A\xA4C\x5\x16C\xB7\x2\xA4B\xA4D\x5\x174\xBB\x2\xA4C\xA4B\x3"+
+		"\x2\x2\x2\xA4C\xA4D\x3\x2\x2\x2\xA4D\xA4F\x3\x2\x2\x2\xA4E\xA49\x3\x2"+
+		"\x2\x2\xA4F\xA50\x3\x2\x2\x2\xA50\xA4E\x3\x2\x2\x2\xA50\xA51\x3\x2\x2"+
+		"\x2\xA51\x16B\x3\x2\x2\x2\xA52\xA54\x5\x16E\xB8\x2\xA53\xA55\x5\x170\xB9"+
+		"\x2\xA54\xA53\x3\x2\x2\x2\xA54\xA55\x3\x2\x2\x2\xA55\x16D\x3\x2\x2\x2"+
+		"\xA56\xA57\x5\x138\x9D\x2\xA57\x16F\x3\x2\x2\x2\xA58\xA59\x5\x174\xBB"+
+		"\x2\xA59\xA5A\x5\x172\xBA\x2\xA5A\xA95\x3\x2\x2\x2\xA5B\xA5C\x5\x174\xBB"+
+		"\x2\xA5C\xA65\x5\x172\xBA\x2\xA5D\xA5F\x5\x174\xBB\x2\xA5E\xA5D\x3\x2"+
+		"\x2\x2\xA5E\xA5F\x3\x2\x2\x2\xA5F\xA60\x3\x2\x2\x2\xA60\xA62\a)\x2\x2"+
+		"\xA61\xA63\x5\x174\xBB\x2\xA62\xA61\x3\x2\x2\x2\xA62\xA63\x3\x2\x2\x2"+
+		"\xA63\xA64\x3\x2\x2\x2\xA64\xA66\x5\x172\xBA\x2\xA65\xA5E\x3\x2\x2\x2"+
+		"\xA66\xA67\x3\x2\x2\x2\xA67\xA65\x3\x2\x2\x2\xA67\xA68\x3\x2\x2\x2\xA68"+
+		"\xA95\x3\x2\x2\x2\xA69\xA6B\x5\x174\xBB\x2\xA6A\xA69\x3\x2\x2\x2\xA6A"+
+		"\xA6B\x3\x2\x2\x2\xA6B\xA6C\x3\x2\x2\x2\xA6C\xA6E\a\xD4\x2\x2\xA6D\xA6F"+
+		"\x5\x174\xBB\x2\xA6E\xA6D\x3\x2\x2\x2\xA6E\xA6F\x3\x2\x2\x2\xA6F\xA70"+
+		"\x3\x2\x2\x2\xA70\xA95\a\xDB\x2\x2\xA71\xA73\x5\x174\xBB\x2\xA72\xA71"+
+		"\x3\x2\x2\x2\xA72\xA73\x3\x2\x2\x2\xA73\xA74\x3\x2\x2\x2\xA74\xA76\a\xD4"+
+		"\x2\x2\xA75\xA77\x5\x174\xBB\x2\xA76\xA75\x3\x2\x2\x2\xA76\xA77\x3\x2"+
+		"\x2\x2\xA77\xA78\x3\x2\x2\x2\xA78\xA7A\x5\x172\xBA\x2\xA79\xA7B\x5\x174"+
+		"\xBB\x2\xA7A\xA79\x3\x2\x2\x2\xA7A\xA7B\x3\x2\x2\x2\xA7B\xA7C\x3\x2\x2"+
+		"\x2\xA7C\xA7D\a\xDB\x2\x2\xA7D\xA95\x3\x2\x2\x2\xA7E\xA80\x5\x174\xBB"+
+		"\x2\xA7F\xA7E\x3\x2\x2\x2\xA7F\xA80\x3\x2\x2\x2\xA80\xA81\x3\x2\x2\x2"+
+		"\xA81\xA82\a\xD4\x2\x2\xA82\xA8B\x5\x172\xBA\x2\xA83\xA85\x5\x174\xBB"+
+		"\x2\xA84\xA83\x3\x2\x2\x2\xA84\xA85\x3\x2\x2\x2\xA85\xA86\x3\x2\x2\x2"+
+		"\xA86\xA88\a)\x2\x2\xA87\xA89\x5\x174\xBB\x2\xA88\xA87\x3\x2\x2\x2\xA88"+
+		"\xA89\x3\x2\x2\x2\xA89\xA8A\x3\x2\x2\x2\xA8A\xA8C\x5\x172\xBA\x2\xA8B"+
+		"\xA84\x3\x2\x2\x2\xA8C\xA8D\x3\x2\x2\x2\xA8D\xA8B\x3\x2\x2\x2\xA8D\xA8E"+
+		"\x3\x2\x2\x2\xA8E\xA90\x3\x2\x2\x2\xA8F\xA91\x5\x174\xBB\x2\xA90\xA8F"+
+		"\x3\x2\x2\x2\xA90\xA91\x3\x2\x2\x2\xA91\xA92\x3\x2\x2\x2\xA92\xA93\a\xDB"+
+		"\x2\x2\xA93\xA95\x3\x2\x2\x2\xA94\xA58\x3\x2\x2\x2\xA94\xA5B\x3\x2\x2"+
+		"\x2\xA94\xA6A\x3\x2\x2\x2\xA94\xA72\x3\x2\x2\x2\xA94\xA7F\x3\x2\x2\x2"+
+		"\xA95\x171\x3\x2\x2\x2\xA96\xA97\x5\xFE\x80\x2\xA97\x173\x3\x2\x2\x2\xA98"+
+		"\xA9A\t\x19\x2\x2\xA99\xA98\x3\x2\x2\x2\xA9A\xA9B\x3\x2\x2\x2\xA9B\xA99"+
+		"\x3\x2\x2\x2\xA9B\xA9C\x3\x2\x2\x2\xA9C\x175\x3\x2\x2\x2\x1BE\x179\x17F"+
+		"\x182\x186\x18A\x18E\x196\x199\x1A3\x1A5\x1AB\x1B3\x1BA\x1C0\x1C9\x1D1"+
+		"\x1E0\x1EB\x1F3\x1FD\x203\x207\x20B\x20F\x214\x221\x249\x258\x260\x265"+
+		"\x26A\x273\x287\x28B\x293\x29E\x2A4\x2A8\x2AD\x2B4\x2B8\x2C2\x2C6\x2C9"+
+		"\x2CF\x2D5\x2DF\x2E3\x2E6\x2EC\x2F0\x2FA\x2FE\x308\x30C\x30F\x313\x318"+
+		"\x31F\x323\x328\x330\x334\x338\x340\x343\x347\x34B\x355\x359\x35C\x362"+
+		"\x366\x36C\x370\x375\x37E\x382\x385\x388\x38C\x398\x39C\x39F\x3A2\x3A6"+
+		"\x3AF\x3B5\x3B9\x3BE\x3C3\x3C8\x3CB\x3CF\x3D6\x3DC\x3E2\x3ED\x3F0\x3F3"+
+		"\x3F8\x3FE\x402\x407\x40F\x415\x419\x425\x429\x434\x43F\x446\x44E\x453"+
+		"\x45C\x463\x467\x46A\x474\x478\x47D\x487\x48D\x49E\x4A4\x4AA\x4AE\x4BA"+
+		"\x4BE\x4C4\x4C9\x4CD\x4D1\x4D5\x4D8\x4DB\x4DE\x4E1\x4E5\x4FA\x4FF\x503"+
+		"\x50E\x516\x519\x51B\x520\x524\x528\x52C\x530\x536\x53A\x53E\x543\x549"+
+		"\x54C\x550\x554\x557\x55B\x560\x562\x566\x56A\x56D\x571\x574\x580\x584"+
+		"\x588\x590\x594\x59A\x59E\x5A2\x5B0\x5BA\x5BE\x5C3\x5CE\x5D2\x5D7\x5DD"+
+		"\x5E1\x5E7\x5EA\x5ED\x5F2\x5F6\x5FD\x601\x607\x60A\x60E\x615\x619\x61F"+
+		"\x622\x626\x62E\x632\x636\x638\x63B\x641\x645\x649\x64E\x653\x657\x65B"+
+		"\x661\x667\x669\x671\x675\x684\x68B\x68F\x69A\x6A1\x6A6\x6AA\x6AF\x6B2"+
+		"\x6B8\x6BC\x6C3\x6C7\x6CB\x6CF\x6D2\x6D6\x6DF\x6E8\x6EF\x6F3\x6F6\x6F9"+
+		"\x6FC\x701\x708\x70D\x712\x716\x71C\x721\x728\x72C\x733\x737\x73B\x740"+
+		"\x744\x749\x74D\x752\x756\x75B\x75F\x764\x768\x76D\x771\x776\x77A\x77F"+
+		"\x783\x788\x78C\x791\x795\x79A\x79E\x7A1\x7A3\x7AE\x7B3\x7B8\x7BE\x7C2"+
+		"\x7C7\x7CC\x7CF\x7D3\x7D7\x7D9\x7DD\x7DF\x7E4\x7EB\x7F4\x7FF\x804\x807"+
+		"\x80B\x80F\x813\x816\x81E\x823\x826\x82A\x82E\x832\x835\x83D\x840\x844"+
+		"\x847\x84A\x84E\x852\x857\x85A\x85D\x860\x868\x86F\x872\x87A\x881\x885"+
+		"\x888\x88B\x88E\x896\x89B\x89E\x8A1\x8A5\x8A9\x8AB\x8AF\x8B2\x8B5\x8BD"+
+		"\x8C2\x8C5\x8C8\x8CB\x8D3\x8D8\x8DB\x8DE\x8E2\x8E6\x8E8\x8EC\x8EF\x8F2"+
+		"\x8FA\x8FF\x903\x907\x90A\x90D\x910\x918\x91D\x921\x924\x929\x92C\x930"+
+		"\x934\x939\x93D\x940\x944\x948\x94C\x94F\x955\x959\x95D\x961\x965\x96A"+
+		"\x96D\x970\x976\x97A\x97E\x982\x985\x989\x98C\x98F\x992\x995\x998\x99C"+
+		"\x9A2\x9A6\x9AB\x9B3\x9BA\x9BE\x9C2\x9C6\x9CA\x9CD\x9D8\x9DD\x9E1\x9E5"+
+		"\x9EB\x9F9\x9FF\xA02\xA06\xA09\xA16\xA19\xA1E\xA21\xA25\xA27\xA2B\xA31"+
+		"\xA36\xA3A\xA43\xA45\xA4C\xA50\xA54\xA5E\xA62\xA67\xA6A\xA6E\xA72\xA76"+
+		"\xA7A\xA7F\xA84\xA88\xA8D\xA90\xA94\xA9B";
 	public static readonly ATN _ATN =
 		new ATNDeserializer().Deserialize(_serializedATN.ToCharArray());
 }

--- a/Rubberduck.Parsing/Grammar/VBAParser.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParser.cs
@@ -141,25 +141,26 @@ public partial class VBAParser : Parser {
 		RULE_subStmt = 122, RULE_subroutineName = 123, RULE_typeStmt = 124, RULE_typeStmt_Element = 125, 
 		RULE_valueStmt = 126, RULE_typeOfIsExpression = 127, RULE_variableStmt = 128, 
 		RULE_variableListStmt = 129, RULE_variableSubStmt = 130, RULE_whileWendStmt = 131, 
-		RULE_withStmt = 132, RULE_withStmtExpression = 133, RULE_explicitCallStmt = 134, 
-		RULE_explicitCallStmtExpression = 135, RULE_implicitCallStmt_InBlock = 136, 
-		RULE_iCS_B_MemberProcedureCall = 137, RULE_iCS_B_ProcedureCall = 138, 
-		RULE_implicitCallStmt_InStmt = 139, RULE_iCS_S_VariableOrProcedureCall = 140, 
-		RULE_iCS_S_ProcedureOrArrayCall = 141, RULE_iCS_S_VariableOrProcedureCallUnrestricted = 142, 
-		RULE_iCS_S_ProcedureOrArrayCallUnrestricted = 143, RULE_iCS_S_MembersCall = 144, 
-		RULE_iCS_S_MemberCall = 145, RULE_iCS_S_DictionaryCall = 146, RULE_argsCall = 147, 
-		RULE_argCall = 148, RULE_dictionaryCallStmt = 149, RULE_argList = 150, 
-		RULE_arg = 151, RULE_argDefaultValue = 152, RULE_subscripts = 153, RULE_subscript = 154, 
-		RULE_unrestrictedIdentifier = 155, RULE_identifier = 156, RULE_asTypeClause = 157, 
-		RULE_baseType = 158, RULE_comparisonOperator = 159, RULE_complexType = 160, 
-		RULE_fieldLength = 161, RULE_statementLabelDefinition = 162, RULE_statementLabel = 163, 
-		RULE_identifierStatementLabel = 164, RULE_lineNumberLabel = 165, RULE_literal = 166, 
-		RULE_numberLiteral = 167, RULE_type = 168, RULE_typeHint = 169, RULE_visibility = 170, 
-		RULE_keyword = 171, RULE_markerKeyword = 172, RULE_statementKeyword = 173, 
-		RULE_endOfLine = 174, RULE_endOfStatement = 175, RULE_commentOrAnnotation = 176, 
-		RULE_remComment = 177, RULE_comment = 178, RULE_commentBody = 179, RULE_annotationList = 180, 
-		RULE_annotation = 181, RULE_annotationName = 182, RULE_annotationArgList = 183, 
-		RULE_annotationArg = 184, RULE_whiteSpace = 185;
+		RULE_withStmt = 132, RULE_circleSpecialForm = 133, RULE_scaleSpecialForm = 134, 
+		RULE_tuple = 135, RULE_withStmtExpression = 136, RULE_explicitCallStmt = 137, 
+		RULE_explicitCallStmtExpression = 138, RULE_implicitCallStmt_InBlock = 139, 
+		RULE_iCS_B_MemberProcedureCall = 140, RULE_iCS_B_ProcedureCall = 141, 
+		RULE_implicitCallStmt_InStmt = 142, RULE_iCS_S_VariableOrProcedureCall = 143, 
+		RULE_iCS_S_ProcedureOrArrayCall = 144, RULE_iCS_S_VariableOrProcedureCallUnrestricted = 145, 
+		RULE_iCS_S_ProcedureOrArrayCallUnrestricted = 146, RULE_iCS_S_MembersCall = 147, 
+		RULE_iCS_S_MemberCall = 148, RULE_iCS_S_DictionaryCall = 149, RULE_argsCall = 150, 
+		RULE_argCall = 151, RULE_dictionaryCallStmt = 152, RULE_argList = 153, 
+		RULE_arg = 154, RULE_argDefaultValue = 155, RULE_subscripts = 156, RULE_subscript = 157, 
+		RULE_unrestrictedIdentifier = 158, RULE_identifier = 159, RULE_asTypeClause = 160, 
+		RULE_baseType = 161, RULE_comparisonOperator = 162, RULE_complexType = 163, 
+		RULE_fieldLength = 164, RULE_statementLabelDefinition = 165, RULE_statementLabel = 166, 
+		RULE_identifierStatementLabel = 167, RULE_lineNumberLabel = 168, RULE_literal = 169, 
+		RULE_numberLiteral = 170, RULE_type = 171, RULE_typeHint = 172, RULE_visibility = 173, 
+		RULE_keyword = 174, RULE_markerKeyword = 175, RULE_statementKeyword = 176, 
+		RULE_endOfLine = 177, RULE_endOfStatement = 178, RULE_commentOrAnnotation = 179, 
+		RULE_remComment = 180, RULE_comment = 181, RULE_commentBody = 182, RULE_annotationList = 183, 
+		RULE_annotation = 184, RULE_annotationName = 185, RULE_annotationArgList = 186, 
+		RULE_annotationArg = 187, RULE_whiteSpace = 188;
 	public static readonly string[] ruleNames = {
 		"startRule", "module", "moduleHeader", "moduleConfig", "moduleConfigElement", 
 		"moduleAttributes", "moduleDeclarations", "moduleOption", "moduleDeclarationsElement", 
@@ -186,10 +187,11 @@ public partial class VBAParser : Parser {
 		"resumeStmt", "returnStmt", "rsetStmt", "stopStmt", "selectCaseStmt", 
 		"sC_Selection", "sC_Case", "sC_Cond", "setStmt", "subStmt", "subroutineName", 
 		"typeStmt", "typeStmt_Element", "valueStmt", "typeOfIsExpression", "variableStmt", 
-		"variableListStmt", "variableSubStmt", "whileWendStmt", "withStmt", "withStmtExpression", 
-		"explicitCallStmt", "explicitCallStmtExpression", "implicitCallStmt_InBlock", 
-		"iCS_B_MemberProcedureCall", "iCS_B_ProcedureCall", "implicitCallStmt_InStmt", 
-		"iCS_S_VariableOrProcedureCall", "iCS_S_ProcedureOrArrayCall", "iCS_S_VariableOrProcedureCallUnrestricted", 
+		"variableListStmt", "variableSubStmt", "whileWendStmt", "withStmt", "circleSpecialForm", 
+		"scaleSpecialForm", "tuple", "withStmtExpression", "explicitCallStmt", 
+		"explicitCallStmtExpression", "implicitCallStmt_InBlock", "iCS_B_MemberProcedureCall", 
+		"iCS_B_ProcedureCall", "implicitCallStmt_InStmt", "iCS_S_VariableOrProcedureCall", 
+		"iCS_S_ProcedureOrArrayCall", "iCS_S_VariableOrProcedureCallUnrestricted", 
 		"iCS_S_ProcedureOrArrayCallUnrestricted", "iCS_S_MembersCall", "iCS_S_MemberCall", 
 		"iCS_S_DictionaryCall", "argsCall", "argCall", "dictionaryCallStmt", "argList", 
 		"arg", "argDefaultValue", "subscripts", "subscript", "unrestrictedIdentifier", 
@@ -246,7 +248,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 372; module();
+			State = 378; module();
 			}
 		}
 		catch (RecognitionException re) {
@@ -312,60 +314,60 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 375;
+			State = 381;
 			switch ( Interpreter.AdaptivePredict(_input,0,_ctx) ) {
 			case 1:
 				{
-				State = 374; whiteSpace();
+				State = 380; whiteSpace();
 				}
 				break;
 			}
-			State = 377; endOfStatement();
-			State = 381;
+			State = 383; endOfStatement();
+			State = 387;
 			switch ( Interpreter.AdaptivePredict(_input,1,_ctx) ) {
 			case 1:
 				{
-				State = 378; moduleHeader();
-				State = 379; endOfStatement();
+				State = 384; moduleHeader();
+				State = 385; endOfStatement();
 				}
 				break;
 			}
-			State = 384;
+			State = 390;
 			switch ( Interpreter.AdaptivePredict(_input,2,_ctx) ) {
 			case 1:
 				{
-				State = 383; moduleConfig();
+				State = 389; moduleConfig();
 				}
 				break;
 			}
-			State = 386; endOfStatement();
-			State = 388;
+			State = 392; endOfStatement();
+			State = 394;
 			switch ( Interpreter.AdaptivePredict(_input,3,_ctx) ) {
 			case 1:
 				{
-				State = 387; moduleAttributes();
+				State = 393; moduleAttributes();
 				}
 				break;
 			}
-			State = 390; endOfStatement();
-			State = 392;
+			State = 396; endOfStatement();
+			State = 398;
 			switch ( Interpreter.AdaptivePredict(_input,4,_ctx) ) {
 			case 1:
 				{
-				State = 391; moduleDeclarations();
+				State = 397; moduleDeclarations();
 				}
 				break;
 			}
-			State = 394; endOfStatement();
-			State = 396;
+			State = 400; endOfStatement();
+			State = 402;
 			switch ( Interpreter.AdaptivePredict(_input,5,_ctx) ) {
 			case 1:
 				{
-				State = 395; moduleBody();
+				State = 401; moduleBody();
 				}
 				break;
 			}
-			State = 398; endOfStatement();
+			State = 404; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -421,26 +423,26 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 400; Match(VERSION);
-			State = 401; whiteSpace();
-			State = 402; numberLiteral();
-			State = 404;
+			State = 406; Match(VERSION);
+			State = 407; whiteSpace();
+			State = 408; numberLiteral();
+			State = 410;
 			switch ( Interpreter.AdaptivePredict(_input,6,_ctx) ) {
 			case 1:
 				{
-				State = 403; whiteSpace();
+				State = 409; whiteSpace();
 				}
 				break;
 			}
-			State = 407;
+			State = 413;
 			switch ( Interpreter.AdaptivePredict(_input,7,_ctx) ) {
 			case 1:
 				{
-				State = 406; Match(CLASS);
+				State = 412; Match(CLASS);
 				}
 				break;
 			}
-			State = 409; endOfStatement();
+			State = 415; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -504,28 +506,28 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 411; Match(BEGIN);
-			State = 419;
+			State = 417; Match(BEGIN);
+			State = 425;
 			switch ( Interpreter.AdaptivePredict(_input,9,_ctx) ) {
 			case 1:
 				{
-				State = 412; whiteSpace();
-				State = 413; Match(GUIDLITERAL);
-				State = 414; whiteSpace();
-				State = 415; unrestrictedIdentifier();
-				State = 417;
+				State = 418; whiteSpace();
+				State = 419; Match(GUIDLITERAL);
+				State = 420; whiteSpace();
+				State = 421; unrestrictedIdentifier();
+				State = 423;
 				switch ( Interpreter.AdaptivePredict(_input,8,_ctx) ) {
 				case 1:
 					{
-					State = 416; whiteSpace();
+					State = 422; whiteSpace();
 					}
 					break;
 				}
 				}
 				break;
 			}
-			State = 421; endOfStatement();
-			State = 423;
+			State = 427; endOfStatement();
+			State = 429;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -533,18 +535,18 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 422; moduleConfigElement();
+					State = 428; moduleConfigElement();
 					}
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 425;
+				State = 431;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,10,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-			State = 427; Match(END);
+			State = 433; Match(END);
 			}
 		}
 		catch (RecognitionException re) {
@@ -608,47 +610,47 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 429; unrestrictedIdentifier();
-			State = 433;
+			State = 435; unrestrictedIdentifier();
+			State = 439;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==WS || _la==LINE_CONTINUATION) {
 				{
 				{
-				State = 430; whiteSpace();
+				State = 436; whiteSpace();
 				}
 				}
-				State = 435;
+				State = 441;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 436; Match(EQ);
-			State = 440;
+			State = 442; Match(EQ);
+			State = 446;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,12,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 437; whiteSpace();
+					State = 443; whiteSpace();
 					}
 					} 
 				}
-				State = 442;
+				State = 448;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,12,_ctx);
 			}
-			State = 443; valueStmt(0);
-			State = 446;
+			State = 449; valueStmt(0);
+			State = 452;
 			switch ( Interpreter.AdaptivePredict(_input,13,_ctx) ) {
 			case 1:
 				{
-				State = 444; Match(COLON);
-				State = 445; numberLiteral();
+				State = 450; Match(COLON);
+				State = 451; numberLiteral();
 				}
 				break;
 			}
-			State = 448; endOfStatement();
+			State = 454; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -703,7 +705,7 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 453;
+			State = 459;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -711,15 +713,15 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 450; attributeStmt();
-					State = 451; endOfStatement();
+					State = 456; attributeStmt();
+					State = 457; endOfStatement();
 					}
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 455;
+				State = 461;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,14,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
@@ -777,24 +779,24 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 457; moduleDeclarationsElement();
-			State = 463;
+			State = 463; moduleDeclarationsElement();
+			State = 469;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,15,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 458; endOfStatement();
-					State = 459; moduleDeclarationsElement();
+					State = 464; endOfStatement();
+					State = 465; moduleDeclarationsElement();
 					}
 					} 
 				}
-				State = 465;
+				State = 471;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,15,_ctx);
 			}
-			State = 466; endOfStatement();
+			State = 472; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -907,24 +909,24 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 14, RULE_moduleOption);
 		int _la;
 		try {
-			State = 478;
+			State = 484;
 			switch (_input.La(1)) {
 			case OPTION_BASE:
 				_localctx = new OptionBaseStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 468; Match(OPTION_BASE);
-				State = 469; whiteSpace();
-				State = 470; numberLiteral();
+				State = 474; Match(OPTION_BASE);
+				State = 475; whiteSpace();
+				State = 476; numberLiteral();
 				}
 				break;
 			case OPTION_COMPARE:
 				_localctx = new OptionCompareStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 472; Match(OPTION_COMPARE);
-				State = 473; whiteSpace();
-				State = 474;
+				State = 478; Match(OPTION_COMPARE);
+				State = 479; whiteSpace();
+				State = 480;
 				_la = _input.La(1);
 				if ( !(_la==BINARY || _la==DATABASE || _la==TEXT) ) {
 				_errHandler.RecoverInline(this);
@@ -936,14 +938,14 @@ public partial class VBAParser : Parser {
 				_localctx = new OptionExplicitStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 476; Match(OPTION_EXPLICIT);
+				State = 482; Match(OPTION_EXPLICIT);
 				}
 				break;
 			case OPTION_PRIVATE_MODULE:
 				_localctx = new OptionPrivateModuleStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 477; Match(OPTION_PRIVATE_MODULE);
+				State = 483; Match(OPTION_PRIVATE_MODULE);
 				}
 				break;
 			default:
@@ -1014,68 +1016,68 @@ public partial class VBAParser : Parser {
 		ModuleDeclarationsElementContext _localctx = new ModuleDeclarationsElementContext(_ctx, State);
 		EnterRule(_localctx, 16, RULE_moduleDeclarationsElement);
 		try {
-			State = 489;
+			State = 495;
 			switch ( Interpreter.AdaptivePredict(_input,17,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 480; declareStmt();
+				State = 486; declareStmt();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 481; defDirective();
+				State = 487; defDirective();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 482; enumerationStmt();
+				State = 488; enumerationStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 483; eventStmt();
+				State = 489; eventStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 484; constStmt();
+				State = 490; constStmt();
 				}
 				break;
 
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 485; implementsStmt();
+				State = 491; implementsStmt();
 				}
 				break;
 
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 486; variableStmt();
+				State = 492; variableStmt();
 				}
 				break;
 
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 487; moduleOption();
+				State = 493; moduleOption();
 				}
 				break;
 
 			case 9:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 488; typeStmt();
+				State = 494; typeStmt();
 				}
 				break;
 			}
@@ -1132,24 +1134,24 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 491; moduleBodyElement();
-			State = 497;
+			State = 497; moduleBodyElement();
+			State = 503;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,18,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 492; endOfStatement();
-					State = 493; moduleBodyElement();
+					State = 498; endOfStatement();
+					State = 499; moduleBodyElement();
 					}
 					} 
 				}
-				State = 499;
+				State = 505;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,18,_ctx);
 			}
-			State = 500; endOfStatement();
+			State = 506; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -1204,40 +1206,40 @@ public partial class VBAParser : Parser {
 		ModuleBodyElementContext _localctx = new ModuleBodyElementContext(_ctx, State);
 		EnterRule(_localctx, 20, RULE_moduleBodyElement);
 		try {
-			State = 507;
+			State = 513;
 			switch ( Interpreter.AdaptivePredict(_input,19,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 502; functionStmt();
+				State = 508; functionStmt();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 503; propertyGetStmt();
+				State = 509; propertyGetStmt();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 504; propertySetStmt();
+				State = 510; propertySetStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 505; propertyLetStmt();
+				State = 511; propertyLetStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 506; subStmt();
+				State = 512; subStmt();
 				}
 				break;
 			}
@@ -1304,56 +1306,56 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 509; Match(ATTRIBUTE);
-			State = 510; whiteSpace();
-			State = 511; attributeName();
-			State = 513;
+			State = 515; Match(ATTRIBUTE);
+			State = 516; whiteSpace();
+			State = 517; attributeName();
+			State = 519;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 512; whiteSpace();
+				State = 518; whiteSpace();
 				}
 			}
 
-			State = 515; Match(EQ);
-			State = 517;
+			State = 521; Match(EQ);
+			State = 523;
 			switch ( Interpreter.AdaptivePredict(_input,21,_ctx) ) {
 			case 1:
 				{
-				State = 516; whiteSpace();
+				State = 522; whiteSpace();
 				}
 				break;
 			}
-			State = 519; attributeValue();
-			State = 530;
+			State = 525; attributeValue();
+			State = 536;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,24,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 521;
+					State = 527;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 520; whiteSpace();
+						State = 526; whiteSpace();
 						}
 					}
 
-					State = 523; Match(COMMA);
-					State = 525;
+					State = 529; Match(COMMA);
+					State = 531;
 					switch ( Interpreter.AdaptivePredict(_input,23,_ctx) ) {
 					case 1:
 						{
-						State = 524; whiteSpace();
+						State = 530; whiteSpace();
 						}
 						break;
 					}
-					State = 527; attributeValue();
+					State = 533; attributeValue();
 					}
 					} 
 				}
-				State = 532;
+				State = 538;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,24,_ctx);
 			}
@@ -1401,7 +1403,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 533; implicitCallStmt_InStmt();
+			State = 539; implicitCallStmt_InStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -1446,7 +1448,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 535; valueStmt(0);
+			State = 541; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -1501,24 +1503,24 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 537; blockStmt();
-			State = 543;
+			State = 543; blockStmt();
+			State = 549;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,25,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 538; endOfStatement();
-					State = 539; blockStmt();
+					State = 544; endOfStatement();
+					State = 545; blockStmt();
 					}
 					} 
 				}
-				State = 545;
+				State = 551;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,25,_ctx);
 			}
-			State = 546; endOfStatement();
+			State = 552; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -1581,6 +1583,9 @@ public partial class VBAParser : Parser {
 		public OnGoToStmtContext onGoToStmt() {
 			return GetRuleContext<OnGoToStmtContext>(0);
 		}
+		public ScaleSpecialFormContext scaleSpecialForm() {
+			return GetRuleContext<ScaleSpecialFormContext>(0);
+		}
 		public ConstStmtContext constStmt() {
 			return GetRuleContext<ConstStmtContext>(0);
 		}
@@ -1610,6 +1615,9 @@ public partial class VBAParser : Parser {
 		}
 		public OnGoSubStmtContext onGoSubStmt() {
 			return GetRuleContext<OnGoSubStmtContext>(0);
+		}
+		public CircleSpecialFormContext circleSpecialForm() {
+			return GetRuleContext<CircleSpecialFormContext>(0);
 		}
 		public ErrorStmtContext errorStmt() {
 			return GetRuleContext<ErrorStmtContext>(0);
@@ -1663,250 +1671,264 @@ public partial class VBAParser : Parser {
 		BlockStmtContext _localctx = new BlockStmtContext(_ctx, State);
 		EnterRule(_localctx, 30, RULE_blockStmt);
 		try {
-			State = 583;
+			State = 591;
 			switch ( Interpreter.AdaptivePredict(_input,26,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 548; statementLabelDefinition();
+				State = 554; statementLabelDefinition();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 549; fileStmt();
+				State = 555; fileStmt();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 550; attributeStmt();
+				State = 556; attributeStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 551; constStmt();
+				State = 557; constStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 552; doLoopStmt();
+				State = 558; doLoopStmt();
 				}
 				break;
 
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 553; endStmt();
+				State = 559; endStmt();
 				}
 				break;
 
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 554; eraseStmt();
+				State = 560; eraseStmt();
 				}
 				break;
 
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 555; errorStmt();
+				State = 561; errorStmt();
 				}
 				break;
 
 			case 9:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 556; exitStmt();
+				State = 562; exitStmt();
 				}
 				break;
 
 			case 10:
 				EnterOuterAlt(_localctx, 10);
 				{
-				State = 557; explicitCallStmt();
+				State = 563; explicitCallStmt();
 				}
 				break;
 
 			case 11:
 				EnterOuterAlt(_localctx, 11);
 				{
-				State = 558; forEachStmt();
+				State = 564; forEachStmt();
 				}
 				break;
 
 			case 12:
 				EnterOuterAlt(_localctx, 12);
 				{
-				State = 559; forNextStmt();
+				State = 565; forNextStmt();
 				}
 				break;
 
 			case 13:
 				EnterOuterAlt(_localctx, 13);
 				{
-				State = 560; goSubStmt();
+				State = 566; goSubStmt();
 				}
 				break;
 
 			case 14:
 				EnterOuterAlt(_localctx, 14);
 				{
-				State = 561; goToStmt();
+				State = 567; goToStmt();
 				}
 				break;
 
 			case 15:
 				EnterOuterAlt(_localctx, 15);
 				{
-				State = 562; ifStmt();
+				State = 568; ifStmt();
 				}
 				break;
 
 			case 16:
 				EnterOuterAlt(_localctx, 16);
 				{
-				State = 563; singleLineIfStmt();
+				State = 569; singleLineIfStmt();
 				}
 				break;
 
 			case 17:
 				EnterOuterAlt(_localctx, 17);
 				{
-				State = 564; implementsStmt();
+				State = 570; implementsStmt();
 				}
 				break;
 
 			case 18:
 				EnterOuterAlt(_localctx, 18);
 				{
-				State = 565; letStmt();
+				State = 571; letStmt();
 				}
 				break;
 
 			case 19:
 				EnterOuterAlt(_localctx, 19);
 				{
-				State = 566; lsetStmt();
+				State = 572; lsetStmt();
 				}
 				break;
 
 			case 20:
 				EnterOuterAlt(_localctx, 20);
 				{
-				State = 567; midStmt();
+				State = 573; midStmt();
 				}
 				break;
 
 			case 21:
 				EnterOuterAlt(_localctx, 21);
 				{
-				State = 568; onErrorStmt();
+				State = 574; onErrorStmt();
 				}
 				break;
 
 			case 22:
 				EnterOuterAlt(_localctx, 22);
 				{
-				State = 569; onGoToStmt();
+				State = 575; onGoToStmt();
 				}
 				break;
 
 			case 23:
 				EnterOuterAlt(_localctx, 23);
 				{
-				State = 570; onGoSubStmt();
+				State = 576; onGoSubStmt();
 				}
 				break;
 
 			case 24:
 				EnterOuterAlt(_localctx, 24);
 				{
-				State = 571; raiseEventStmt();
+				State = 577; raiseEventStmt();
 				}
 				break;
 
 			case 25:
 				EnterOuterAlt(_localctx, 25);
 				{
-				State = 572; redimStmt();
+				State = 578; redimStmt();
 				}
 				break;
 
 			case 26:
 				EnterOuterAlt(_localctx, 26);
 				{
-				State = 573; resumeStmt();
+				State = 579; resumeStmt();
 				}
 				break;
 
 			case 27:
 				EnterOuterAlt(_localctx, 27);
 				{
-				State = 574; returnStmt();
+				State = 580; returnStmt();
 				}
 				break;
 
 			case 28:
 				EnterOuterAlt(_localctx, 28);
 				{
-				State = 575; rsetStmt();
+				State = 581; rsetStmt();
 				}
 				break;
 
 			case 29:
 				EnterOuterAlt(_localctx, 29);
 				{
-				State = 576; selectCaseStmt();
+				State = 582; selectCaseStmt();
 				}
 				break;
 
 			case 30:
 				EnterOuterAlt(_localctx, 30);
 				{
-				State = 577; setStmt();
+				State = 583; setStmt();
 				}
 				break;
 
 			case 31:
 				EnterOuterAlt(_localctx, 31);
 				{
-				State = 578; stopStmt();
+				State = 584; stopStmt();
 				}
 				break;
 
 			case 32:
 				EnterOuterAlt(_localctx, 32);
 				{
-				State = 579; variableStmt();
+				State = 585; variableStmt();
 				}
 				break;
 
 			case 33:
 				EnterOuterAlt(_localctx, 33);
 				{
-				State = 580; whileWendStmt();
+				State = 586; whileWendStmt();
 				}
 				break;
 
 			case 34:
 				EnterOuterAlt(_localctx, 34);
 				{
-				State = 581; withStmt();
+				State = 587; withStmt();
 				}
 				break;
 
 			case 35:
 				EnterOuterAlt(_localctx, 35);
 				{
-				State = 582; implicitCallStmt_InBlock();
+				State = 588; circleSpecialForm();
+				}
+				break;
+
+			case 36:
+				EnterOuterAlt(_localctx, 36);
+				{
+				State = 589; scaleSpecialForm();
+				}
+				break;
+
+			case 37:
+				EnterOuterAlt(_localctx, 37);
+				{
+				State = 590; implicitCallStmt_InBlock();
 				}
 				break;
 			}
@@ -1987,84 +2009,84 @@ public partial class VBAParser : Parser {
 		FileStmtContext _localctx = new FileStmtContext(_ctx, State);
 		EnterRule(_localctx, 32, RULE_fileStmt);
 		try {
-			State = 598;
+			State = 606;
 			switch (_input.La(1)) {
 			case OPEN:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 585; openStmt();
+				State = 593; openStmt();
 				}
 				break;
 			case RESET:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 586; resetStmt();
+				State = 594; resetStmt();
 				}
 				break;
 			case CLOSE:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 587; closeStmt();
+				State = 595; closeStmt();
 				}
 				break;
 			case SEEK:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 588; seekStmt();
+				State = 596; seekStmt();
 				}
 				break;
 			case LOCK:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 589; lockStmt();
+				State = 597; lockStmt();
 				}
 				break;
 			case UNLOCK:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 590; unlockStmt();
+				State = 598; unlockStmt();
 				}
 				break;
 			case LINE_INPUT:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 591; lineInputStmt();
+				State = 599; lineInputStmt();
 				}
 				break;
 			case WIDTH:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 592; widthStmt();
+				State = 600; widthStmt();
 				}
 				break;
 			case PRINT:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 593; printStmt();
+				State = 601; printStmt();
 				}
 				break;
 			case WRITE:
 				EnterOuterAlt(_localctx, 10);
 				{
-				State = 594; writeStmt();
+				State = 602; writeStmt();
 				}
 				break;
 			case INPUT:
 				EnterOuterAlt(_localctx, 11);
 				{
-				State = 595; inputStmt();
+				State = 603; inputStmt();
 				}
 				break;
 			case PUT:
 				EnterOuterAlt(_localctx, 12);
 				{
-				State = 596; putStmt();
+				State = 604; putStmt();
 				}
 				break;
 			case GET:
 				EnterOuterAlt(_localctx, 13);
 				{
-				State = 597; getStmt();
+				State = 605; getStmt();
 				}
 				break;
 			default:
@@ -2136,46 +2158,46 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 600; Match(OPEN);
-			State = 601; whiteSpace();
-			State = 602; pathName();
-			State = 606;
+			State = 608; Match(OPEN);
+			State = 609; whiteSpace();
+			State = 610; pathName();
+			State = 614;
 			switch ( Interpreter.AdaptivePredict(_input,28,_ctx) ) {
 			case 1:
 				{
-				State = 603; whiteSpace();
-				State = 604; modeClause();
+				State = 611; whiteSpace();
+				State = 612; modeClause();
 				}
 				break;
 			}
-			State = 611;
+			State = 619;
 			switch ( Interpreter.AdaptivePredict(_input,29,_ctx) ) {
 			case 1:
 				{
-				State = 608; whiteSpace();
-				State = 609; accessClause();
+				State = 616; whiteSpace();
+				State = 617; accessClause();
 				}
 				break;
 			}
-			State = 616;
+			State = 624;
 			switch ( Interpreter.AdaptivePredict(_input,30,_ctx) ) {
 			case 1:
 				{
-				State = 613; whiteSpace();
-				State = 614; @lock();
+				State = 621; whiteSpace();
+				State = 622; @lock();
 				}
 				break;
 			}
-			State = 618; whiteSpace();
-			State = 619; Match(AS);
-			State = 620; whiteSpace();
-			State = 621; fileNumber();
-			State = 625;
+			State = 626; whiteSpace();
+			State = 627; Match(AS);
+			State = 628; whiteSpace();
+			State = 629; fileNumber();
+			State = 633;
 			switch ( Interpreter.AdaptivePredict(_input,31,_ctx) ) {
 			case 1:
 				{
-				State = 622; whiteSpace();
-				State = 623; lenClause();
+				State = 630; whiteSpace();
+				State = 631; lenClause();
 				}
 				break;
 			}
@@ -2223,7 +2245,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 627; valueStmt(0);
+			State = 635; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2272,9 +2294,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 629; Match(FOR);
-			State = 630; whiteSpace();
-			State = 631; fileMode();
+			State = 637; Match(FOR);
+			State = 638; whiteSpace();
+			State = 639; fileMode();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2322,7 +2344,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 633;
+			State = 641;
 			_la = _input.La(1);
 			if ( !(_la==APPEND || _la==BINARY || ((((_la - 121)) & ~0x3f) == 0 && ((1L << (_la - 121)) & ((1L << (INPUT - 121)) | (1L << (OUTPUT - 121)) | (1L << (RANDOM - 121)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2376,9 +2398,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 635; Match(ACCESS);
-			State = 636; whiteSpace();
-			State = 637; access();
+			State = 643; Match(ACCESS);
+			State = 644; whiteSpace();
+			State = 645; access();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2424,7 +2446,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 639;
+			State = 647;
 			_la = _input.La(1);
 			if ( !(((((_la - 166)) & ~0x3f) == 0 && ((1L << (_la - 166)) & ((1L << (READ - 166)) | (1L << (READ_WRITE - 166)) | (1L << (WRITE - 166)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2476,7 +2498,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 641;
+			State = 649;
 			_la = _input.La(1);
 			if ( !(((((_la - 131)) & ~0x3f) == 0 && ((1L << (_la - 131)) & ((1L << (LOCK_READ - 131)) | (1L << (LOCK_WRITE - 131)) | (1L << (LOCK_READ_WRITE - 131)) | (1L << (SHARED - 131)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2535,25 +2557,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 643; Match(LEN);
-			State = 645;
+			State = 651; Match(LEN);
+			State = 653;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 644; whiteSpace();
+				State = 652; whiteSpace();
 				}
 			}
 
-			State = 647; Match(EQ);
-			State = 649;
+			State = 655; Match(EQ);
+			State = 657;
 			switch ( Interpreter.AdaptivePredict(_input,33,_ctx) ) {
 			case 1:
 				{
-				State = 648; whiteSpace();
+				State = 656; whiteSpace();
 				}
 				break;
 			}
-			State = 651; recLength();
+			State = 659; recLength();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2598,7 +2620,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 653; valueStmt(0);
+			State = 661; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2644,19 +2666,19 @@ public partial class VBAParser : Parser {
 		FileNumberContext _localctx = new FileNumberContext(_ctx, State);
 		EnterRule(_localctx, 52, RULE_fileNumber);
 		try {
-			State = 657;
+			State = 665;
 			switch ( Interpreter.AdaptivePredict(_input,34,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 655; markedFileNumber();
+				State = 663; markedFileNumber();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 656; unmarkedFileNumber();
+				State = 664; unmarkedFileNumber();
 				}
 				break;
 			}
@@ -2704,8 +2726,8 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 659; Match(HASH);
-			State = 660; valueStmt(0);
+			State = 667; Match(HASH);
+			State = 668; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2750,7 +2772,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 662; valueStmt(0);
+			State = 670; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2799,13 +2821,13 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 664; Match(CLOSE);
-			State = 668;
+			State = 672; Match(CLOSE);
+			State = 676;
 			switch ( Interpreter.AdaptivePredict(_input,35,_ctx) ) {
 			case 1:
 				{
-				State = 665; whiteSpace();
-				State = 666; fileNumberList();
+				State = 673; whiteSpace();
+				State = 674; fileNumberList();
 				}
 				break;
 			}
@@ -2851,7 +2873,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 670; Match(RESET);
+			State = 678; Match(RESET);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2911,36 +2933,36 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 672; fileNumber();
-			State = 683;
+			State = 680; fileNumber();
+			State = 691;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,38,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 674;
+					State = 682;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 673; whiteSpace();
+						State = 681; whiteSpace();
 						}
 					}
 
-					State = 676; Match(COMMA);
-					State = 678;
+					State = 684; Match(COMMA);
+					State = 686;
 					switch ( Interpreter.AdaptivePredict(_input,37,_ctx) ) {
 					case 1:
 						{
-						State = 677; whiteSpace();
+						State = 685; whiteSpace();
 						}
 						break;
 					}
-					State = 680; fileNumber();
+					State = 688; fileNumber();
 					}
 					} 
 				}
-				State = 685;
+				State = 693;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,38,_ctx);
 			}
@@ -3000,27 +3022,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 686; Match(SEEK);
-			State = 687; whiteSpace();
-			State = 688; fileNumber();
-			State = 690;
+			State = 694; Match(SEEK);
+			State = 695; whiteSpace();
+			State = 696; fileNumber();
+			State = 698;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 689; whiteSpace();
+				State = 697; whiteSpace();
 				}
 			}
 
-			State = 692; Match(COMMA);
-			State = 694;
+			State = 700; Match(COMMA);
+			State = 702;
 			switch ( Interpreter.AdaptivePredict(_input,40,_ctx) ) {
 			case 1:
 				{
-				State = 693; whiteSpace();
+				State = 701; whiteSpace();
 				}
 				break;
 			}
-			State = 696; position();
+			State = 704; position();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3065,7 +3087,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 698; valueStmt(0);
+			State = 706; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3122,31 +3144,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 700; Match(LOCK);
-			State = 701; whiteSpace();
-			State = 702; fileNumber();
-			State = 711;
+			State = 708; Match(LOCK);
+			State = 709; whiteSpace();
+			State = 710; fileNumber();
+			State = 719;
 			switch ( Interpreter.AdaptivePredict(_input,43,_ctx) ) {
 			case 1:
 				{
-				State = 704;
+				State = 712;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 703; whiteSpace();
+					State = 711; whiteSpace();
 					}
 				}
 
-				State = 706; Match(COMMA);
-				State = 708;
+				State = 714; Match(COMMA);
+				State = 716;
 				switch ( Interpreter.AdaptivePredict(_input,42,_ctx) ) {
 				case 1:
 					{
-					State = 707; whiteSpace();
+					State = 715; whiteSpace();
 					}
 					break;
 				}
-				State = 710; recordRange();
+				State = 718; recordRange();
 				}
 				break;
 			}
@@ -3202,30 +3224,30 @@ public partial class VBAParser : Parser {
 		RecordRangeContext _localctx = new RecordRangeContext(_ctx, State);
 		EnterRule(_localctx, 70, RULE_recordRange);
 		try {
-			State = 723;
+			State = 731;
 			switch ( Interpreter.AdaptivePredict(_input,45,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 713; startRecordNumber();
+				State = 721; startRecordNumber();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 717;
+				State = 725;
 				switch ( Interpreter.AdaptivePredict(_input,44,_ctx) ) {
 				case 1:
 					{
-					State = 714; startRecordNumber();
-					State = 715; whiteSpace();
+					State = 722; startRecordNumber();
+					State = 723; whiteSpace();
 					}
 					break;
 				}
-				State = 719; Match(TO);
-				State = 720; whiteSpace();
-				State = 721; endRecordNumber();
+				State = 727; Match(TO);
+				State = 728; whiteSpace();
+				State = 729; endRecordNumber();
 				}
 				break;
 			}
@@ -3272,7 +3294,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 725; valueStmt(0);
+			State = 733; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3317,7 +3339,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 727; valueStmt(0);
+			State = 735; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3374,31 +3396,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 729; Match(UNLOCK);
-			State = 730; whiteSpace();
-			State = 731; fileNumber();
-			State = 740;
+			State = 737; Match(UNLOCK);
+			State = 738; whiteSpace();
+			State = 739; fileNumber();
+			State = 748;
 			switch ( Interpreter.AdaptivePredict(_input,48,_ctx) ) {
 			case 1:
 				{
-				State = 733;
+				State = 741;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 732; whiteSpace();
+					State = 740; whiteSpace();
 					}
 				}
 
-				State = 735; Match(COMMA);
-				State = 737;
+				State = 743; Match(COMMA);
+				State = 745;
 				switch ( Interpreter.AdaptivePredict(_input,47,_ctx) ) {
 				case 1:
 					{
-					State = 736; whiteSpace();
+					State = 744; whiteSpace();
 					}
 					break;
 				}
-				State = 739; recordRange();
+				State = 747; recordRange();
 				}
 				break;
 			}
@@ -3458,27 +3480,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 742; Match(LINE_INPUT);
-			State = 743; whiteSpace();
-			State = 744; markedFileNumber();
-			State = 746;
+			State = 750; Match(LINE_INPUT);
+			State = 751; whiteSpace();
+			State = 752; markedFileNumber();
+			State = 754;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 745; whiteSpace();
+				State = 753; whiteSpace();
 				}
 			}
 
-			State = 748; Match(COMMA);
-			State = 750;
+			State = 756; Match(COMMA);
+			State = 758;
 			switch ( Interpreter.AdaptivePredict(_input,50,_ctx) ) {
 			case 1:
 				{
-				State = 749; whiteSpace();
+				State = 757; whiteSpace();
 				}
 				break;
 			}
-			State = 752; variableName();
+			State = 760; variableName();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3523,7 +3545,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 754; valueStmt(0);
+			State = 762; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3580,27 +3602,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 756; Match(WIDTH);
-			State = 757; whiteSpace();
-			State = 758; markedFileNumber();
-			State = 760;
+			State = 764; Match(WIDTH);
+			State = 765; whiteSpace();
+			State = 766; markedFileNumber();
+			State = 768;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 759; whiteSpace();
+				State = 767; whiteSpace();
 				}
 			}
 
-			State = 762; Match(COMMA);
-			State = 764;
+			State = 770; Match(COMMA);
+			State = 772;
 			switch ( Interpreter.AdaptivePredict(_input,52,_ctx) ) {
 			case 1:
 				{
-				State = 763; whiteSpace();
+				State = 771; whiteSpace();
 				}
 				break;
 			}
-			State = 766; lineWidth();
+			State = 774; lineWidth();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3645,7 +3667,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 768; valueStmt(0);
+			State = 776; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3702,31 +3724,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 770; Match(PRINT);
-			State = 771; whiteSpace();
-			State = 772; markedFileNumber();
-			State = 774;
+			State = 778; Match(PRINT);
+			State = 779; whiteSpace();
+			State = 780; markedFileNumber();
+			State = 782;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 773; whiteSpace();
+				State = 781; whiteSpace();
 				}
 			}
 
-			State = 776; Match(COMMA);
-			State = 781;
+			State = 784; Match(COMMA);
+			State = 789;
 			switch ( Interpreter.AdaptivePredict(_input,55,_ctx) ) {
 			case 1:
 				{
-				State = 778;
+				State = 786;
 				switch ( Interpreter.AdaptivePredict(_input,54,_ctx) ) {
 				case 1:
 					{
-					State = 777; whiteSpace();
+					State = 785; whiteSpace();
 					}
 					break;
 				}
-				State = 780; outputList();
+				State = 788; outputList();
 				}
 				break;
 			}
@@ -3784,27 +3806,27 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 783; outputItem();
-			State = 790;
+			State = 791; outputItem();
+			State = 798;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,57,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 785;
+					State = 793;
 					switch ( Interpreter.AdaptivePredict(_input,56,_ctx) ) {
 					case 1:
 						{
-						State = 784; whiteSpace();
+						State = 792; whiteSpace();
 						}
 						break;
 					}
-					State = 787; outputItem();
+					State = 795; outputItem();
 					}
 					} 
 				}
-				State = 792;
+				State = 800;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,57,_ctx);
 			}
@@ -3857,35 +3879,35 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 90, RULE_outputItem);
 		int _la;
 		try {
-			State = 801;
+			State = 809;
 			switch ( Interpreter.AdaptivePredict(_input,59,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 793; outputClause();
+				State = 801; outputClause();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 794; charPosition();
+				State = 802; charPosition();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 795; outputClause();
-				State = 797;
+				State = 803; outputClause();
+				State = 805;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 796; whiteSpace();
+					State = 804; whiteSpace();
 					}
 				}
 
-				State = 799; charPosition();
+				State = 807; charPosition();
 				}
 				break;
 			}
@@ -3936,26 +3958,26 @@ public partial class VBAParser : Parser {
 		OutputClauseContext _localctx = new OutputClauseContext(_ctx, State);
 		EnterRule(_localctx, 92, RULE_outputClause);
 		try {
-			State = 806;
+			State = 814;
 			switch ( Interpreter.AdaptivePredict(_input,60,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 803; spcClause();
+				State = 811; spcClause();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 804; tabClause();
+				State = 812; tabClause();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 805; outputExpression();
+				State = 813; outputExpression();
 				}
 				break;
 			}
@@ -4002,7 +4024,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 808;
+			State = 816;
 			_la = _input.La(1);
 			if ( !(_la==COMMA || _la==SEMICOLON) ) {
 			_errHandler.RecoverInline(this);
@@ -4052,7 +4074,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 810; valueStmt(0);
+			State = 818; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4107,25 +4129,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 812; Match(SPC);
-			State = 814;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 813; whiteSpace();
-				}
-			}
-
-			State = 816; Match(LPAREN);
-			State = 818;
-			switch ( Interpreter.AdaptivePredict(_input,62,_ctx) ) {
-			case 1:
-				{
-				State = 817; whiteSpace();
-				}
-				break;
-			}
-			State = 820; spcNumber();
+			State = 820; Match(SPC);
 			State = 822;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
@@ -4134,7 +4138,25 @@ public partial class VBAParser : Parser {
 				}
 			}
 
-			State = 824; Match(RPAREN);
+			State = 824; Match(LPAREN);
+			State = 826;
+			switch ( Interpreter.AdaptivePredict(_input,62,_ctx) ) {
+			case 1:
+				{
+				State = 825; whiteSpace();
+				}
+				break;
+			}
+			State = 828; spcNumber();
+			State = 830;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 829; whiteSpace();
+				}
+			}
+
+			State = 832; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4179,7 +4201,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 826; valueStmt(0);
+			State = 834; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4229,20 +4251,20 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 828; Match(TAB);
-			State = 833;
+			State = 836; Match(TAB);
+			State = 841;
 			switch ( Interpreter.AdaptivePredict(_input,65,_ctx) ) {
 			case 1:
 				{
-				State = 830;
+				State = 838;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 829; whiteSpace();
+					State = 837; whiteSpace();
 					}
 				}
 
-				State = 832; tabNumberClause();
+				State = 840; tabNumberClause();
 				}
 				break;
 			}
@@ -4299,25 +4321,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 835; Match(LPAREN);
-			State = 837;
+			State = 843; Match(LPAREN);
+			State = 845;
 			switch ( Interpreter.AdaptivePredict(_input,66,_ctx) ) {
 			case 1:
 				{
-				State = 836; whiteSpace();
+				State = 844; whiteSpace();
 				}
 				break;
 			}
-			State = 839; tabNumber();
-			State = 841;
+			State = 847; tabNumber();
+			State = 849;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 840; whiteSpace();
+				State = 848; whiteSpace();
 				}
 			}
 
-			State = 843; Match(RPAREN);
+			State = 851; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4362,7 +4384,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 845; valueStmt(0);
+			State = 853; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4419,31 +4441,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 847; Match(WRITE);
-			State = 848; whiteSpace();
-			State = 849; markedFileNumber();
-			State = 851;
+			State = 855; Match(WRITE);
+			State = 856; whiteSpace();
+			State = 857; markedFileNumber();
+			State = 859;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 850; whiteSpace();
+				State = 858; whiteSpace();
 				}
 			}
 
-			State = 853; Match(COMMA);
-			State = 858;
+			State = 861; Match(COMMA);
+			State = 866;
 			switch ( Interpreter.AdaptivePredict(_input,70,_ctx) ) {
 			case 1:
 				{
-				State = 855;
+				State = 863;
 				switch ( Interpreter.AdaptivePredict(_input,69,_ctx) ) {
 				case 1:
 					{
-					State = 854; whiteSpace();
+					State = 862; whiteSpace();
 					}
 					break;
 				}
-				State = 857; outputList();
+				State = 865; outputList();
 				}
 				break;
 			}
@@ -4503,27 +4525,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 860; Match(INPUT);
-			State = 861; whiteSpace();
-			State = 862; markedFileNumber();
-			State = 864;
+			State = 868; Match(INPUT);
+			State = 869; whiteSpace();
+			State = 870; markedFileNumber();
+			State = 872;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 863; whiteSpace();
+				State = 871; whiteSpace();
 				}
 			}
 
-			State = 866; Match(COMMA);
-			State = 868;
+			State = 874; Match(COMMA);
+			State = 876;
 			switch ( Interpreter.AdaptivePredict(_input,72,_ctx) ) {
 			case 1:
 				{
-				State = 867; whiteSpace();
+				State = 875; whiteSpace();
 				}
 				break;
 			}
-			State = 870; inputList();
+			State = 878; inputList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4583,36 +4605,36 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 872; inputVariable();
-			State = 883;
+			State = 880; inputVariable();
+			State = 891;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,75,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 874;
+					State = 882;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 873; whiteSpace();
+						State = 881; whiteSpace();
 						}
 					}
 
-					State = 876; Match(COMMA);
-					State = 878;
+					State = 884; Match(COMMA);
+					State = 886;
 					switch ( Interpreter.AdaptivePredict(_input,74,_ctx) ) {
 					case 1:
 						{
-						State = 877; whiteSpace();
+						State = 885; whiteSpace();
 						}
 						break;
 					}
-					State = 880; inputVariable();
+					State = 888; inputVariable();
 					}
 					} 
 				}
-				State = 885;
+				State = 893;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,75,_ctx);
 			}
@@ -4660,7 +4682,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 886; valueStmt(0);
+			State = 894; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4723,52 +4745,52 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 888; Match(PUT);
-			State = 889; whiteSpace();
-			State = 890; fileNumber();
-			State = 892;
+			State = 896; Match(PUT);
+			State = 897; whiteSpace();
+			State = 898; fileNumber();
+			State = 900;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 891; whiteSpace();
+				State = 899; whiteSpace();
 				}
 			}
 
-			State = 894; Match(COMMA);
-			State = 896;
+			State = 902; Match(COMMA);
+			State = 904;
 			switch ( Interpreter.AdaptivePredict(_input,77,_ctx) ) {
 			case 1:
 				{
-				State = 895; whiteSpace();
+				State = 903; whiteSpace();
 				}
 				break;
 			}
-			State = 899;
+			State = 907;
 			switch ( Interpreter.AdaptivePredict(_input,78,_ctx) ) {
 			case 1:
 				{
-				State = 898; recordNumber();
+				State = 906; recordNumber();
 				}
 				break;
 			}
-			State = 902;
+			State = 910;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 901; whiteSpace();
+				State = 909; whiteSpace();
 				}
 			}
 
-			State = 904; Match(COMMA);
-			State = 906;
+			State = 912; Match(COMMA);
+			State = 914;
 			switch ( Interpreter.AdaptivePredict(_input,80,_ctx) ) {
 			case 1:
 				{
-				State = 905; whiteSpace();
+				State = 913; whiteSpace();
 				}
 				break;
 			}
-			State = 908; data();
+			State = 916; data();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4813,7 +4835,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 910; valueStmt(0);
+			State = 918; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4858,7 +4880,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 912; valueStmt(0);
+			State = 920; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4921,52 +4943,52 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 914; Match(GET);
-			State = 915; whiteSpace();
-			State = 916; fileNumber();
-			State = 918;
+			State = 922; Match(GET);
+			State = 923; whiteSpace();
+			State = 924; fileNumber();
+			State = 926;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 917; whiteSpace();
+				State = 925; whiteSpace();
 				}
 			}
 
-			State = 920; Match(COMMA);
-			State = 922;
+			State = 928; Match(COMMA);
+			State = 930;
 			switch ( Interpreter.AdaptivePredict(_input,82,_ctx) ) {
 			case 1:
 				{
-				State = 921; whiteSpace();
+				State = 929; whiteSpace();
 				}
 				break;
 			}
-			State = 925;
+			State = 933;
 			switch ( Interpreter.AdaptivePredict(_input,83,_ctx) ) {
 			case 1:
 				{
-				State = 924; recordNumber();
+				State = 932; recordNumber();
 				}
 				break;
 			}
-			State = 928;
+			State = 936;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 927; whiteSpace();
+				State = 935; whiteSpace();
 				}
 			}
 
-			State = 930; Match(COMMA);
-			State = 932;
+			State = 938; Match(COMMA);
+			State = 940;
 			switch ( Interpreter.AdaptivePredict(_input,85,_ctx) ) {
 			case 1:
 				{
-				State = 931; whiteSpace();
+				State = 939; whiteSpace();
 				}
 				break;
 			}
-			State = 934; variable();
+			State = 942; variable();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5011,7 +5033,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 936; valueStmt(0);
+			State = 944; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5075,47 +5097,47 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 941;
+			State = 949;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 938; visibility();
-				State = 939; whiteSpace();
+				State = 946; visibility();
+				State = 947; whiteSpace();
 				}
 			}
 
-			State = 943; Match(CONST);
-			State = 944; whiteSpace();
-			State = 945; constSubStmt();
-			State = 956;
+			State = 951; Match(CONST);
+			State = 952; whiteSpace();
+			State = 953; constSubStmt();
+			State = 964;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,89,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 947;
+					State = 955;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 946; whiteSpace();
+						State = 954; whiteSpace();
 						}
 					}
 
-					State = 949; Match(COMMA);
-					State = 951;
+					State = 957; Match(COMMA);
+					State = 959;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 950; whiteSpace();
+						State = 958; whiteSpace();
 						}
 					}
 
-					State = 953; constSubStmt();
+					State = 961; constSubStmt();
 					}
 					} 
 				}
-				State = 958;
+				State = 966;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,89,_ctx);
 			}
@@ -5180,42 +5202,42 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 959; identifier();
-			State = 961;
+			State = 967; identifier();
+			State = 969;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 960; typeHint();
+				State = 968; typeHint();
 				}
 			}
 
-			State = 966;
+			State = 974;
 			switch ( Interpreter.AdaptivePredict(_input,91,_ctx) ) {
 			case 1:
 				{
-				State = 963; whiteSpace();
-				State = 964; asTypeClause();
+				State = 971; whiteSpace();
+				State = 972; asTypeClause();
 				}
 				break;
 			}
-			State = 969;
+			State = 977;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 968; whiteSpace();
+				State = 976; whiteSpace();
 				}
 			}
 
-			State = 971; Match(EQ);
-			State = 973;
+			State = 979; Match(EQ);
+			State = 981;
 			switch ( Interpreter.AdaptivePredict(_input,93,_ctx) ) {
 			case 1:
 				{
-				State = 972; whiteSpace();
+				State = 980; whiteSpace();
 				}
 				break;
 			}
-			State = 975; valueStmt(0);
+			State = 983; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5289,79 +5311,79 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 980;
+			State = 988;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 977; visibility();
-				State = 978; whiteSpace();
+				State = 985; visibility();
+				State = 986; whiteSpace();
 				}
 			}
 
-			State = 982; Match(DECLARE);
-			State = 983; whiteSpace();
-			State = 986;
+			State = 990; Match(DECLARE);
+			State = 991; whiteSpace();
+			State = 994;
 			_la = _input.La(1);
 			if (_la==PTRSAFE) {
 				{
-				State = 984; Match(PTRSAFE);
-				State = 985; whiteSpace();
+				State = 992; Match(PTRSAFE);
+				State = 993; whiteSpace();
 				}
 			}
 
-			State = 988;
+			State = 996;
 			_la = _input.La(1);
 			if ( !(_la==FUNCTION || _la==SUB) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 989; whiteSpace();
-			State = 990; identifier();
-			State = 992;
+			State = 997; whiteSpace();
+			State = 998; identifier();
+			State = 1000;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 991; typeHint();
+				State = 999; typeHint();
 				}
 			}
 
-			State = 994; whiteSpace();
-			State = 995; Match(LIB);
-			State = 996; whiteSpace();
-			State = 997; Match(STRINGLITERAL);
-			State = 1003;
+			State = 1002; whiteSpace();
+			State = 1003; Match(LIB);
+			State = 1004; whiteSpace();
+			State = 1005; Match(STRINGLITERAL);
+			State = 1011;
 			switch ( Interpreter.AdaptivePredict(_input,97,_ctx) ) {
 			case 1:
 				{
-				State = 998; whiteSpace();
-				State = 999; Match(ALIAS);
-				State = 1000; whiteSpace();
-				State = 1001; Match(STRINGLITERAL);
+				State = 1006; whiteSpace();
+				State = 1007; Match(ALIAS);
+				State = 1008; whiteSpace();
+				State = 1009; Match(STRINGLITERAL);
 				}
 				break;
 			}
-			State = 1009;
+			State = 1017;
 			switch ( Interpreter.AdaptivePredict(_input,99,_ctx) ) {
 			case 1:
 				{
-				State = 1006;
+				State = 1014;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1005; whiteSpace();
+					State = 1013; whiteSpace();
 					}
 				}
 
-				State = 1008; argList();
+				State = 1016; argList();
 				}
 				break;
 			}
-			State = 1014;
+			State = 1022;
 			switch ( Interpreter.AdaptivePredict(_input,100,_ctx) ) {
 			case 1:
 				{
-				State = 1011; whiteSpace();
-				State = 1012; asTypeClause();
+				State = 1019; whiteSpace();
+				State = 1020; asTypeClause();
 				}
 				break;
 			}
@@ -5427,38 +5449,38 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1016; defType();
-			State = 1017; whiteSpace();
-			State = 1018; letterSpec();
-			State = 1029;
+			State = 1024; defType();
+			State = 1025; whiteSpace();
+			State = 1026; letterSpec();
+			State = 1037;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,103,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1020;
+					State = 1028;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1019; whiteSpace();
+						State = 1027; whiteSpace();
 						}
 					}
 
-					State = 1022; Match(COMMA);
-					State = 1024;
+					State = 1030; Match(COMMA);
+					State = 1032;
 					switch ( Interpreter.AdaptivePredict(_input,102,_ctx) ) {
 					case 1:
 						{
-						State = 1023; whiteSpace();
+						State = 1031; whiteSpace();
 						}
 						break;
 					}
-					State = 1026; letterSpec();
+					State = 1034; letterSpec();
 					}
 					} 
 				}
-				State = 1031;
+				State = 1039;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,103,_ctx);
 			}
@@ -5517,7 +5539,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1032;
+			State = 1040;
 			_la = _input.La(1);
 			if ( !(((((_la - 70)) & ~0x3f) == 0 && ((1L << (_la - 70)) & ((1L << (DEFBOOL - 70)) | (1L << (DEFBYTE - 70)) | (1L << (DEFDATE - 70)) | (1L << (DEFDBL - 70)) | (1L << (DEFCUR - 70)) | (1L << (DEFINT - 70)) | (1L << (DEFLNG - 70)) | (1L << (DEFLNGLNG - 70)) | (1L << (DEFLNGPTR - 70)) | (1L << (DEFOBJ - 70)) | (1L << (DEFSNG - 70)) | (1L << (DEFSTR - 70)) | (1L << (DEFVAR - 70)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -5571,26 +5593,26 @@ public partial class VBAParser : Parser {
 		LetterSpecContext _localctx = new LetterSpecContext(_ctx, State);
 		EnterRule(_localctx, 136, RULE_letterSpec);
 		try {
-			State = 1037;
+			State = 1045;
 			switch ( Interpreter.AdaptivePredict(_input,104,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1034; singleLetter();
+				State = 1042; singleLetter();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1035; universalLetterRange();
+				State = 1043; universalLetterRange();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1036; letterRange();
+				State = 1044; letterRange();
 				}
 				break;
 			}
@@ -5637,7 +5659,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1039; unrestrictedIdentifier();
+			State = 1047; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5693,25 +5715,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1041; upperCaseA();
-			State = 1043;
+			State = 1049; upperCaseA();
+			State = 1051;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1042; whiteSpace();
+				State = 1050; whiteSpace();
 				}
 			}
 
-			State = 1045; Match(MINUS);
-			State = 1047;
+			State = 1053; Match(MINUS);
+			State = 1055;
 			switch ( Interpreter.AdaptivePredict(_input,106,_ctx) ) {
 			case 1:
 				{
-				State = 1046; whiteSpace();
+				State = 1054; whiteSpace();
 				}
 				break;
 			}
-			State = 1049; upperCaseZ();
+			State = 1057; upperCaseZ();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5756,9 +5778,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1051;
+			State = 1059;
 			if (!(_input.Lt(1).Text.Equals("A"))) throw new FailedPredicateException(this, "_input.Lt(1).Text.Equals(\"A\")");
-			State = 1052; unrestrictedIdentifier();
+			State = 1060; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5803,9 +5825,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1054;
+			State = 1062;
 			if (!(_input.Lt(1).Text.Equals("Z"))) throw new FailedPredicateException(this, "_input.Lt(1).Text.Equals(\"Z\")");
-			State = 1055; unrestrictedIdentifier();
+			State = 1063; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5861,25 +5883,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1057; firstLetter();
-			State = 1059;
+			State = 1065; firstLetter();
+			State = 1067;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1058; whiteSpace();
+				State = 1066; whiteSpace();
 				}
 			}
 
-			State = 1061; Match(MINUS);
-			State = 1063;
+			State = 1069; Match(MINUS);
+			State = 1071;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1062; whiteSpace();
+				State = 1070; whiteSpace();
 				}
 			}
 
-			State = 1065; lastLetter();
+			State = 1073; lastLetter();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5924,7 +5946,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1067; unrestrictedIdentifier();
+			State = 1075; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5969,7 +5991,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1069; unrestrictedIdentifier();
+			State = 1077; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6029,74 +6051,74 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 152, RULE_doLoopStmt);
 		int _la;
 		try {
-			State = 1100;
+			State = 1108;
 			switch ( Interpreter.AdaptivePredict(_input,112,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1071; Match(DO);
-				State = 1072; endOfStatement();
-				State = 1074;
+				State = 1079; Match(DO);
+				State = 1080; endOfStatement();
+				State = 1082;
 				switch ( Interpreter.AdaptivePredict(_input,109,_ctx) ) {
 				case 1:
 					{
-					State = 1073; block();
+					State = 1081; block();
 					}
 					break;
 				}
-				State = 1076; Match(LOOP);
+				State = 1084; Match(LOOP);
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1078; Match(DO);
-				State = 1079; whiteSpace();
-				State = 1080;
+				State = 1086; Match(DO);
+				State = 1087; whiteSpace();
+				State = 1088;
 				_la = _input.La(1);
 				if ( !(_la==UNTIL || _la==WHILE) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 1081; whiteSpace();
-				State = 1082; valueStmt(0);
-				State = 1083; endOfStatement();
-				State = 1085;
+				State = 1089; whiteSpace();
+				State = 1090; valueStmt(0);
+				State = 1091; endOfStatement();
+				State = 1093;
 				switch ( Interpreter.AdaptivePredict(_input,110,_ctx) ) {
 				case 1:
 					{
-					State = 1084; block();
+					State = 1092; block();
 					}
 					break;
 				}
-				State = 1087; Match(LOOP);
+				State = 1095; Match(LOOP);
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1089; Match(DO);
-				State = 1090; endOfStatement();
-				State = 1092;
+				State = 1097; Match(DO);
+				State = 1098; endOfStatement();
+				State = 1100;
 				switch ( Interpreter.AdaptivePredict(_input,111,_ctx) ) {
 				case 1:
 					{
-					State = 1091; block();
+					State = 1099; block();
 					}
 					break;
 				}
-				State = 1094; Match(LOOP);
-				State = 1095; whiteSpace();
-				State = 1096;
+				State = 1102; Match(LOOP);
+				State = 1103; whiteSpace();
+				State = 1104;
 				_la = _input.La(1);
 				if ( !(_la==UNTIL || _la==WHILE) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 1097; whiteSpace();
-				State = 1098; valueStmt(0);
+				State = 1105; whiteSpace();
+				State = 1106; valueStmt(0);
 				}
 				break;
 			}
@@ -6164,33 +6186,33 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1105;
+			State = 1113;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1102; visibility();
-				State = 1103; whiteSpace();
+				State = 1110; visibility();
+				State = 1111; whiteSpace();
 				}
 			}
 
-			State = 1107; Match(ENUM);
-			State = 1108; whiteSpace();
-			State = 1109; identifier();
-			State = 1110; endOfStatement();
-			State = 1114;
+			State = 1115; Match(ENUM);
+			State = 1116; whiteSpace();
+			State = 1117; identifier();
+			State = 1118; endOfStatement();
+			State = 1122;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
 				{
-				State = 1111; enumerationStmt_Constant();
+				State = 1119; enumerationStmt_Constant();
 				}
 				}
-				State = 1116;
+				State = 1124;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1117; Match(END_ENUM);
+			State = 1125; Match(END_ENUM);
 			}
 		}
 		catch (RecognitionException re) {
@@ -6249,33 +6271,33 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1119; identifier();
-			State = 1128;
+			State = 1127; identifier();
+			State = 1136;
 			switch ( Interpreter.AdaptivePredict(_input,117,_ctx) ) {
 			case 1:
 				{
-				State = 1121;
+				State = 1129;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1120; whiteSpace();
+					State = 1128; whiteSpace();
 					}
 				}
 
-				State = 1123; Match(EQ);
-				State = 1125;
+				State = 1131; Match(EQ);
+				State = 1133;
 				switch ( Interpreter.AdaptivePredict(_input,116,_ctx) ) {
 				case 1:
 					{
-					State = 1124; whiteSpace();
+					State = 1132; whiteSpace();
 					}
 					break;
 				}
-				State = 1127; valueStmt(0);
+				State = 1135; valueStmt(0);
 				}
 				break;
 			}
-			State = 1130; endOfStatement();
+			State = 1138; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6318,7 +6340,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1132; Match(END);
+			State = 1140; Match(END);
 			}
 		}
 		catch (RecognitionException re) {
@@ -6379,38 +6401,38 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1134; Match(ERASE);
-			State = 1135; whiteSpace();
-			State = 1136; valueStmt(0);
-			State = 1147;
+			State = 1142; Match(ERASE);
+			State = 1143; whiteSpace();
+			State = 1144; valueStmt(0);
+			State = 1155;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,120,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1138;
+					State = 1146;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1137; whiteSpace();
+						State = 1145; whiteSpace();
 						}
 					}
 
-					State = 1140; Match(COMMA);
-					State = 1142;
+					State = 1148; Match(COMMA);
+					State = 1150;
 					switch ( Interpreter.AdaptivePredict(_input,119,_ctx) ) {
 					case 1:
 						{
-						State = 1141; whiteSpace();
+						State = 1149; whiteSpace();
 						}
 						break;
 					}
-					State = 1144; valueStmt(0);
+					State = 1152; valueStmt(0);
 					}
 					} 
 				}
-				State = 1149;
+				State = 1157;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,120,_ctx);
 			}
@@ -6462,9 +6484,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1150; Match(ERROR);
-			State = 1151; whiteSpace();
-			State = 1152; valueStmt(0);
+			State = 1158; Match(ERROR);
+			State = 1159; whiteSpace();
+			State = 1160; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -6523,27 +6545,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1157;
+			State = 1165;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1154; visibility();
-				State = 1155; whiteSpace();
+				State = 1162; visibility();
+				State = 1163; whiteSpace();
 				}
 			}
 
-			State = 1159; Match(EVENT);
-			State = 1160; whiteSpace();
-			State = 1161; identifier();
-			State = 1163;
+			State = 1167; Match(EVENT);
+			State = 1168; whiteSpace();
+			State = 1169; identifier();
+			State = 1171;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1162; whiteSpace();
+				State = 1170; whiteSpace();
 				}
 			}
 
-			State = 1165; argList();
+			State = 1173; argList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6591,7 +6613,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1167;
+			State = 1175;
 			_la = _input.La(1);
 			if ( !(((((_la - 104)) & ~0x3f) == 0 && ((1L << (_la - 104)) & ((1L << (EXIT_DO - 104)) | (1L << (EXIT_FOR - 104)) | (1L << (EXIT_FUNCTION - 104)) | (1L << (EXIT_PROPERTY - 104)) | (1L << (EXIT_SUB - 104)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -6660,31 +6682,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1169; Match(FOR);
-			State = 1170; whiteSpace();
-			State = 1171; Match(EACH);
-			State = 1172; whiteSpace();
-			State = 1173; valueStmt(0);
-			State = 1174; whiteSpace();
-			State = 1175; Match(IN);
-			State = 1176; whiteSpace();
-			State = 1177; valueStmt(0);
-			State = 1178; endOfStatement();
-			State = 1180;
+			State = 1177; Match(FOR);
+			State = 1178; whiteSpace();
+			State = 1179; Match(EACH);
+			State = 1180; whiteSpace();
+			State = 1181; valueStmt(0);
+			State = 1182; whiteSpace();
+			State = 1183; Match(IN);
+			State = 1184; whiteSpace();
+			State = 1185; valueStmt(0);
+			State = 1186; endOfStatement();
+			State = 1188;
 			switch ( Interpreter.AdaptivePredict(_input,123,_ctx) ) {
 			case 1:
 				{
-				State = 1179; block();
+				State = 1187; block();
 				}
 				break;
 			}
-			State = 1182; Match(NEXT);
-			State = 1186;
+			State = 1190; Match(NEXT);
+			State = 1194;
 			switch ( Interpreter.AdaptivePredict(_input,124,_ctx) ) {
 			case 1:
 				{
-				State = 1183; whiteSpace();
-				State = 1184; valueStmt(0);
+				State = 1191; whiteSpace();
+				State = 1192; valueStmt(0);
 				}
 				break;
 			}
@@ -6753,58 +6775,58 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1188; Match(FOR);
-			State = 1189; whiteSpace();
-			State = 1190; valueStmt(0);
-			State = 1192;
+			State = 1196; Match(FOR);
+			State = 1197; whiteSpace();
+			State = 1198; valueStmt(0);
+			State = 1200;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1191; whiteSpace();
+				State = 1199; whiteSpace();
 				}
 			}
 
-			State = 1194; Match(EQ);
-			State = 1196;
+			State = 1202; Match(EQ);
+			State = 1204;
 			switch ( Interpreter.AdaptivePredict(_input,126,_ctx) ) {
 			case 1:
 				{
-				State = 1195; whiteSpace();
+				State = 1203; whiteSpace();
 				}
 				break;
 			}
-			State = 1198; valueStmt(0);
-			State = 1199; whiteSpace();
-			State = 1200; Match(TO);
-			State = 1201; whiteSpace();
-			State = 1202; valueStmt(0);
-			State = 1208;
+			State = 1206; valueStmt(0);
+			State = 1207; whiteSpace();
+			State = 1208; Match(TO);
+			State = 1209; whiteSpace();
+			State = 1210; valueStmt(0);
+			State = 1216;
 			switch ( Interpreter.AdaptivePredict(_input,127,_ctx) ) {
 			case 1:
 				{
-				State = 1203; whiteSpace();
-				State = 1204; Match(STEP);
-				State = 1205; whiteSpace();
-				State = 1206; valueStmt(0);
+				State = 1211; whiteSpace();
+				State = 1212; Match(STEP);
+				State = 1213; whiteSpace();
+				State = 1214; valueStmt(0);
 				}
 				break;
 			}
-			State = 1210; endOfStatement();
-			State = 1212;
+			State = 1218; endOfStatement();
+			State = 1220;
 			switch ( Interpreter.AdaptivePredict(_input,128,_ctx) ) {
 			case 1:
 				{
-				State = 1211; block();
+				State = 1219; block();
 				}
 				break;
 			}
-			State = 1214; Match(NEXT);
-			State = 1218;
+			State = 1222; Match(NEXT);
+			State = 1226;
 			switch ( Interpreter.AdaptivePredict(_input,129,_ctx) ) {
 			case 1:
 				{
-				State = 1215; whiteSpace();
-				State = 1216; valueStmt(0);
+				State = 1223; whiteSpace();
+				State = 1224; valueStmt(0);
 				}
 				break;
 			}
@@ -6880,84 +6902,84 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1223;
+			State = 1231;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1220; visibility();
-				State = 1221; whiteSpace();
+				State = 1228; visibility();
+				State = 1229; whiteSpace();
 				}
 			}
 
-			State = 1227;
+			State = 1235;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1225; Match(STATIC);
-				State = 1226; whiteSpace();
+				State = 1233; Match(STATIC);
+				State = 1234; whiteSpace();
 				}
 			}
 
-			State = 1229; Match(FUNCTION);
-			State = 1231;
+			State = 1237; Match(FUNCTION);
+			State = 1239;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1230; whiteSpace();
+				State = 1238; whiteSpace();
 				}
 			}
 
-			State = 1233; functionName();
-			State = 1235;
+			State = 1241; functionName();
+			State = 1243;
 			switch ( Interpreter.AdaptivePredict(_input,133,_ctx) ) {
 			case 1:
 				{
-				State = 1234; typeHint();
+				State = 1242; typeHint();
 				}
 				break;
 			}
-			State = 1241;
+			State = 1249;
 			switch ( Interpreter.AdaptivePredict(_input,135,_ctx) ) {
 			case 1:
 				{
-				State = 1238;
+				State = 1246;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1237; whiteSpace();
+					State = 1245; whiteSpace();
 					}
 				}
 
-				State = 1240; argList();
+				State = 1248; argList();
 				}
 				break;
 			}
-			State = 1247;
+			State = 1255;
 			switch ( Interpreter.AdaptivePredict(_input,137,_ctx) ) {
 			case 1:
 				{
-				State = 1244;
+				State = 1252;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1243; whiteSpace();
+					State = 1251; whiteSpace();
 					}
 				}
 
-				State = 1246; asTypeClause();
+				State = 1254; asTypeClause();
 				}
 				break;
 			}
-			State = 1249; endOfStatement();
-			State = 1251;
+			State = 1257; endOfStatement();
+			State = 1259;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1250; block();
+				State = 1258; block();
 				}
 			}
 
-			State = 1253; Match(END_FUNCTION);
+			State = 1261; Match(END_FUNCTION);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7002,7 +7024,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1255; identifier();
+			State = 1263; identifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -7051,9 +7073,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1257; Match(GOSUB);
-			State = 1258; whiteSpace();
-			State = 1259; valueStmt(0);
+			State = 1265; Match(GOSUB);
+			State = 1266; whiteSpace();
+			State = 1267; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7102,9 +7124,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1261; Match(GOTO);
-			State = 1262; whiteSpace();
-			State = 1263; valueStmt(0);
+			State = 1269; Match(GOTO);
+			State = 1270; whiteSpace();
+			State = 1271; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7174,42 +7196,42 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1265; Match(IF);
-			State = 1266; whiteSpace();
-			State = 1267; booleanExpression();
-			State = 1268; whiteSpace();
-			State = 1269; Match(THEN);
-			State = 1270; endOfStatement();
-			State = 1272;
+			State = 1273; Match(IF);
+			State = 1274; whiteSpace();
+			State = 1275; booleanExpression();
+			State = 1276; whiteSpace();
+			State = 1277; Match(THEN);
+			State = 1278; endOfStatement();
+			State = 1280;
 			switch ( Interpreter.AdaptivePredict(_input,139,_ctx) ) {
 			case 1:
 				{
-				State = 1271; block();
+				State = 1279; block();
 				}
 				break;
 			}
-			State = 1277;
+			State = 1285;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==ELSEIF) {
 				{
 				{
-				State = 1274; elseIfBlock();
+				State = 1282; elseIfBlock();
 				}
 				}
-				State = 1279;
+				State = 1287;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1281;
+			State = 1289;
 			_la = _input.La(1);
 			if (_la==ELSE) {
 				{
-				State = 1280; elseBlock();
+				State = 1288; elseBlock();
 				}
 			}
 
-			State = 1283; Match(END_IF);
+			State = 1291; Match(END_IF);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7266,22 +7288,22 @@ public partial class VBAParser : Parser {
 		ElseIfBlockContext _localctx = new ElseIfBlockContext(_ctx, State);
 		EnterRule(_localctx, 182, RULE_elseIfBlock);
 		try {
-			State = 1305;
+			State = 1313;
 			switch ( Interpreter.AdaptivePredict(_input,145,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1285; Match(ELSEIF);
-				State = 1286; whiteSpace();
-				State = 1287; booleanExpression();
-				State = 1288; whiteSpace();
-				State = 1289; Match(THEN);
-				State = 1290; endOfStatement();
-				State = 1292;
+				State = 1293; Match(ELSEIF);
+				State = 1294; whiteSpace();
+				State = 1295; booleanExpression();
+				State = 1296; whiteSpace();
+				State = 1297; Match(THEN);
+				State = 1298; endOfStatement();
+				State = 1300;
 				switch ( Interpreter.AdaptivePredict(_input,142,_ctx) ) {
 				case 1:
 					{
-					State = 1291; block();
+					State = 1299; block();
 					}
 					break;
 				}
@@ -7291,24 +7313,24 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1294; Match(ELSEIF);
-				State = 1295; whiteSpace();
-				State = 1296; booleanExpression();
-				State = 1297; whiteSpace();
-				State = 1298; Match(THEN);
-				State = 1300;
+				State = 1302; Match(ELSEIF);
+				State = 1303; whiteSpace();
+				State = 1304; booleanExpression();
+				State = 1305; whiteSpace();
+				State = 1306; Match(THEN);
+				State = 1308;
 				switch ( Interpreter.AdaptivePredict(_input,143,_ctx) ) {
 				case 1:
 					{
-					State = 1299; whiteSpace();
+					State = 1307; whiteSpace();
 					}
 					break;
 				}
-				State = 1303;
+				State = 1311;
 				switch ( Interpreter.AdaptivePredict(_input,144,_ctx) ) {
 				case 1:
 					{
-					State = 1302; block();
+					State = 1310; block();
 					}
 					break;
 				}
@@ -7363,13 +7385,13 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1307; Match(ELSE);
-			State = 1308; endOfStatement();
-			State = 1310;
+			State = 1315; Match(ELSE);
+			State = 1316; endOfStatement();
+			State = 1318;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1309; block();
+				State = 1317; block();
 				}
 			}
 
@@ -7418,19 +7440,19 @@ public partial class VBAParser : Parser {
 		SingleLineIfStmtContext _localctx = new SingleLineIfStmtContext(_ctx, State);
 		EnterRule(_localctx, 186, RULE_singleLineIfStmt);
 		try {
-			State = 1314;
+			State = 1322;
 			switch ( Interpreter.AdaptivePredict(_input,147,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1312; ifWithNonEmptyThen();
+				State = 1320; ifWithNonEmptyThen();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1313; ifWithEmptyThen();
+				State = 1321; ifWithEmptyThen();
 				}
 				break;
 			}
@@ -7492,40 +7514,40 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1316; Match(IF);
-			State = 1318;
-			switch ( Interpreter.AdaptivePredict(_input,148,_ctx) ) {
-			case 1:
-				{
-				State = 1317; whiteSpace();
-				}
-				break;
-			}
-			State = 1320; booleanExpression();
-			State = 1322;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1321; whiteSpace();
-				}
-			}
-
-			State = 1324; Match(THEN);
+			State = 1324; Match(IF);
 			State = 1326;
-			switch ( Interpreter.AdaptivePredict(_input,150,_ctx) ) {
+			switch ( Interpreter.AdaptivePredict(_input,148,_ctx) ) {
 			case 1:
 				{
 				State = 1325; whiteSpace();
 				}
 				break;
 			}
-			State = 1328; listOrLabel();
-			State = 1332;
+			State = 1328; booleanExpression();
+			State = 1330;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 1329; whiteSpace();
+				}
+			}
+
+			State = 1332; Match(THEN);
+			State = 1334;
+			switch ( Interpreter.AdaptivePredict(_input,150,_ctx) ) {
+			case 1:
+				{
+				State = 1333; whiteSpace();
+				}
+				break;
+			}
+			State = 1336; listOrLabel();
+			State = 1340;
 			switch ( Interpreter.AdaptivePredict(_input,151,_ctx) ) {
 			case 1:
 				{
-				State = 1329; whiteSpace();
-				State = 1330; singleLineElseClause();
+				State = 1337; whiteSpace();
+				State = 1338; singleLineElseClause();
 				}
 				break;
 			}
@@ -7588,35 +7610,35 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1334; Match(IF);
-			State = 1336;
+			State = 1342; Match(IF);
+			State = 1344;
 			switch ( Interpreter.AdaptivePredict(_input,152,_ctx) ) {
 			case 1:
 				{
-				State = 1335; whiteSpace();
+				State = 1343; whiteSpace();
 				}
 				break;
 			}
-			State = 1338; booleanExpression();
-			State = 1340;
+			State = 1346; booleanExpression();
+			State = 1348;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1339; whiteSpace();
+				State = 1347; whiteSpace();
 				}
 			}
 
-			State = 1342; Match(THEN);
-			State = 1343; endOfStatement();
-			State = 1345;
+			State = 1350; Match(THEN);
+			State = 1351; endOfStatement();
+			State = 1353;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1344; whiteSpace();
+				State = 1352; whiteSpace();
 				}
 			}
 
-			State = 1347; singleLineElseClause();
+			State = 1355; singleLineElseClause();
 			}
 		}
 		catch (RecognitionException re) {
@@ -7665,20 +7687,20 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1349; Match(ELSE);
-			State = 1351;
+			State = 1357; Match(ELSE);
+			State = 1359;
 			switch ( Interpreter.AdaptivePredict(_input,155,_ctx) ) {
 			case 1:
 				{
-				State = 1350; whiteSpace();
+				State = 1358; whiteSpace();
 				}
 				break;
 			}
-			State = 1354;
+			State = 1362;
 			switch ( Interpreter.AdaptivePredict(_input,156,_ctx) ) {
 			case 1:
 				{
-				State = 1353; listOrLabel();
+				State = 1361; listOrLabel();
 				}
 				break;
 			}
@@ -7742,48 +7764,48 @@ public partial class VBAParser : Parser {
 		int _la;
 		try {
 			int _alt;
-			State = 1394;
+			State = 1402;
 			switch ( Interpreter.AdaptivePredict(_input,167,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1356; lineNumberLabel();
-				State = 1369;
+				State = 1364; lineNumberLabel();
+				State = 1377;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,160,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1358;
+						State = 1366;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1357; whiteSpace();
+							State = 1365; whiteSpace();
 							}
 						}
 
-						State = 1360; Match(COLON);
-						State = 1362;
+						State = 1368; Match(COLON);
+						State = 1370;
 						switch ( Interpreter.AdaptivePredict(_input,158,_ctx) ) {
 						case 1:
 							{
-							State = 1361; whiteSpace();
+							State = 1369; whiteSpace();
 							}
 							break;
 						}
-						State = 1365;
+						State = 1373;
 						switch ( Interpreter.AdaptivePredict(_input,159,_ctx) ) {
 						case 1:
 							{
-							State = 1364; sameLineStatement();
+							State = 1372; sameLineStatement();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 1371;
+					State = 1379;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,160,_ctx);
 				}
@@ -7793,59 +7815,59 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1376;
+				State = 1384;
 				_la = _input.La(1);
 				if (_la==COLON) {
 					{
-					State = 1372; Match(COLON);
-					State = 1374;
+					State = 1380; Match(COLON);
+					State = 1382;
 					switch ( Interpreter.AdaptivePredict(_input,161,_ctx) ) {
 					case 1:
 						{
-						State = 1373; whiteSpace();
+						State = 1381; whiteSpace();
 						}
 						break;
 					}
 					}
 				}
 
-				State = 1378; sameLineStatement();
-				State = 1391;
+				State = 1386; sameLineStatement();
+				State = 1399;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,166,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1380;
+						State = 1388;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1379; whiteSpace();
+							State = 1387; whiteSpace();
 							}
 						}
 
-						State = 1382; Match(COLON);
-						State = 1384;
+						State = 1390; Match(COLON);
+						State = 1392;
 						switch ( Interpreter.AdaptivePredict(_input,164,_ctx) ) {
 						case 1:
 							{
-							State = 1383; whiteSpace();
+							State = 1391; whiteSpace();
 							}
 							break;
 						}
-						State = 1387;
+						State = 1395;
 						switch ( Interpreter.AdaptivePredict(_input,165,_ctx) ) {
 						case 1:
 							{
-							State = 1386; sameLineStatement();
+							State = 1394; sameLineStatement();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 1393;
+					State = 1401;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,166,_ctx);
 				}
@@ -7895,7 +7917,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1396; blockStmt();
+			State = 1404; blockStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -7940,7 +7962,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1398; valueStmt(0);
+			State = 1406; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7989,9 +8011,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1400; Match(IMPLEMENTS);
-			State = 1401; whiteSpace();
-			State = 1402; valueStmt(0);
+			State = 1408; Match(IMPLEMENTS);
+			State = 1409; whiteSpace();
+			State = 1410; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8048,34 +8070,34 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1406;
+			State = 1414;
 			switch ( Interpreter.AdaptivePredict(_input,168,_ctx) ) {
 			case 1:
 				{
-				State = 1404; Match(LET);
-				State = 1405; whiteSpace();
-				}
-				break;
-			}
-			State = 1408; valueStmt(0);
-			State = 1410;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1409; whiteSpace();
-				}
-			}
-
-			State = 1412; Match(EQ);
-			State = 1414;
-			switch ( Interpreter.AdaptivePredict(_input,170,_ctx) ) {
-			case 1:
-				{
+				State = 1412; Match(LET);
 				State = 1413; whiteSpace();
 				}
 				break;
 			}
 			State = 1416; valueStmt(0);
+			State = 1418;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 1417; whiteSpace();
+				}
+			}
+
+			State = 1420; Match(EQ);
+			State = 1422;
+			switch ( Interpreter.AdaptivePredict(_input,170,_ctx) ) {
+			case 1:
+				{
+				State = 1421; whiteSpace();
+				}
+				break;
+			}
+			State = 1424; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8132,27 +8154,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1418; Match(LSET);
-			State = 1419; whiteSpace();
-			State = 1420; valueStmt(0);
-			State = 1422;
+			State = 1426; Match(LSET);
+			State = 1427; whiteSpace();
+			State = 1428; valueStmt(0);
+			State = 1430;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1421; whiteSpace();
+				State = 1429; whiteSpace();
 				}
 			}
 
-			State = 1424; Match(EQ);
-			State = 1426;
+			State = 1432; Match(EQ);
+			State = 1434;
 			switch ( Interpreter.AdaptivePredict(_input,172,_ctx) ) {
 			case 1:
 				{
-				State = 1425; whiteSpace();
+				State = 1433; whiteSpace();
 				}
 				break;
 			}
-			State = 1428; valueStmt(0);
+			State = 1436; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8207,25 +8229,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1430; Match(MID);
-			State = 1432;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1431; whiteSpace();
-				}
-			}
-
-			State = 1434; Match(LPAREN);
-			State = 1436;
-			switch ( Interpreter.AdaptivePredict(_input,174,_ctx) ) {
-			case 1:
-				{
-				State = 1435; whiteSpace();
-				}
-				break;
-			}
-			State = 1438; argsCall();
+			State = 1438; Match(MID);
 			State = 1440;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
@@ -8234,7 +8238,25 @@ public partial class VBAParser : Parser {
 				}
 			}
 
-			State = 1442; Match(RPAREN);
+			State = 1442; Match(LPAREN);
+			State = 1444;
+			switch ( Interpreter.AdaptivePredict(_input,174,_ctx) ) {
+			case 1:
+				{
+				State = 1443; whiteSpace();
+				}
+				break;
+			}
+			State = 1446; argsCall();
+			State = 1448;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 1447; whiteSpace();
+				}
+			}
+
+			State = 1450; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8291,27 +8313,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1444;
+			State = 1452;
 			_la = _input.La(1);
 			if ( !(_la==ON_ERROR || _la==ON_LOCAL_ERROR) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 1445; whiteSpace();
-			State = 1454;
+			State = 1453; whiteSpace();
+			State = 1462;
 			switch (_input.La(1)) {
 			case GOTO:
 				{
-				State = 1446; Match(GOTO);
-				State = 1447; whiteSpace();
-				State = 1448; valueStmt(0);
+				State = 1454; Match(GOTO);
+				State = 1455; whiteSpace();
+				State = 1456; valueStmt(0);
 				}
 				break;
 			case RESUME:
 				{
-				State = 1450; Match(RESUME);
-				State = 1451; whiteSpace();
-				State = 1452; Match(NEXT);
+				State = 1458; Match(RESUME);
+				State = 1459; whiteSpace();
+				State = 1460; Match(NEXT);
 				}
 				break;
 			default:
@@ -8378,42 +8400,42 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1456; Match(ON);
-			State = 1457; whiteSpace();
-			State = 1458; valueStmt(0);
-			State = 1459; whiteSpace();
-			State = 1460; Match(GOTO);
-			State = 1461; whiteSpace();
-			State = 1462; valueStmt(0);
-			State = 1473;
+			State = 1464; Match(ON);
+			State = 1465; whiteSpace();
+			State = 1466; valueStmt(0);
+			State = 1467; whiteSpace();
+			State = 1468; Match(GOTO);
+			State = 1469; whiteSpace();
+			State = 1470; valueStmt(0);
+			State = 1481;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,179,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1464;
+					State = 1472;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1463; whiteSpace();
+						State = 1471; whiteSpace();
 						}
 					}
 
-					State = 1466; Match(COMMA);
-					State = 1468;
+					State = 1474; Match(COMMA);
+					State = 1476;
 					switch ( Interpreter.AdaptivePredict(_input,178,_ctx) ) {
 					case 1:
 						{
-						State = 1467; whiteSpace();
+						State = 1475; whiteSpace();
 						}
 						break;
 					}
-					State = 1470; valueStmt(0);
+					State = 1478; valueStmt(0);
 					}
 					} 
 				}
-				State = 1475;
+				State = 1483;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,179,_ctx);
 			}
@@ -8478,42 +8500,42 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1476; Match(ON);
-			State = 1477; whiteSpace();
-			State = 1478; valueStmt(0);
-			State = 1479; whiteSpace();
-			State = 1480; Match(GOSUB);
-			State = 1481; whiteSpace();
-			State = 1482; valueStmt(0);
-			State = 1493;
+			State = 1484; Match(ON);
+			State = 1485; whiteSpace();
+			State = 1486; valueStmt(0);
+			State = 1487; whiteSpace();
+			State = 1488; Match(GOSUB);
+			State = 1489; whiteSpace();
+			State = 1490; valueStmt(0);
+			State = 1501;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,182,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1484;
+					State = 1492;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1483; whiteSpace();
+						State = 1491; whiteSpace();
 						}
 					}
 
-					State = 1486; Match(COMMA);
-					State = 1488;
+					State = 1494; Match(COMMA);
+					State = 1496;
 					switch ( Interpreter.AdaptivePredict(_input,181,_ctx) ) {
 					case 1:
 						{
-						State = 1487; whiteSpace();
+						State = 1495; whiteSpace();
 						}
 						break;
 					}
-					State = 1490; valueStmt(0);
+					State = 1498; valueStmt(0);
 					}
 					} 
 				}
-				State = 1495;
+				State = 1503;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,182,_ctx);
 			}
@@ -8589,70 +8611,70 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1499;
+			State = 1507;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1496; visibility();
-				State = 1497; whiteSpace();
+				State = 1504; visibility();
+				State = 1505; whiteSpace();
 				}
 			}
 
-			State = 1503;
+			State = 1511;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1501; Match(STATIC);
-				State = 1502; whiteSpace();
+				State = 1509; Match(STATIC);
+				State = 1510; whiteSpace();
 				}
 			}
 
-			State = 1505; Match(PROPERTY_GET);
-			State = 1506; whiteSpace();
-			State = 1507; functionName();
-			State = 1509;
+			State = 1513; Match(PROPERTY_GET);
+			State = 1514; whiteSpace();
+			State = 1515; functionName();
+			State = 1517;
 			switch ( Interpreter.AdaptivePredict(_input,185,_ctx) ) {
 			case 1:
 				{
-				State = 1508; typeHint();
+				State = 1516; typeHint();
 				}
 				break;
 			}
-			State = 1515;
+			State = 1523;
 			switch ( Interpreter.AdaptivePredict(_input,187,_ctx) ) {
 			case 1:
 				{
-				State = 1512;
+				State = 1520;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1511; whiteSpace();
+					State = 1519; whiteSpace();
 					}
 				}
 
-				State = 1514; argList();
+				State = 1522; argList();
 				}
 				break;
 			}
-			State = 1520;
+			State = 1528;
 			switch ( Interpreter.AdaptivePredict(_input,188,_ctx) ) {
 			case 1:
 				{
-				State = 1517; whiteSpace();
-				State = 1518; asTypeClause();
+				State = 1525; whiteSpace();
+				State = 1526; asTypeClause();
 				}
 				break;
 			}
-			State = 1522; endOfStatement();
-			State = 1524;
+			State = 1530; endOfStatement();
+			State = 1532;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1523; block();
+				State = 1531; block();
 				}
 			}
 
-			State = 1526; Match(END_PROPERTY);
+			State = 1534; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8719,53 +8741,53 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1531;
+			State = 1539;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1528; visibility();
-				State = 1529; whiteSpace();
+				State = 1536; visibility();
+				State = 1537; whiteSpace();
 				}
 			}
 
-			State = 1535;
+			State = 1543;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1533; Match(STATIC);
-				State = 1534; whiteSpace();
+				State = 1541; Match(STATIC);
+				State = 1542; whiteSpace();
 				}
 			}
 
-			State = 1537; Match(PROPERTY_SET);
-			State = 1538; whiteSpace();
-			State = 1539; subroutineName();
-			State = 1544;
+			State = 1545; Match(PROPERTY_SET);
+			State = 1546; whiteSpace();
+			State = 1547; subroutineName();
+			State = 1552;
 			switch ( Interpreter.AdaptivePredict(_input,193,_ctx) ) {
 			case 1:
 				{
-				State = 1541;
+				State = 1549;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1540; whiteSpace();
+					State = 1548; whiteSpace();
 					}
 				}
 
-				State = 1543; argList();
+				State = 1551; argList();
 				}
 				break;
 			}
-			State = 1546; endOfStatement();
-			State = 1548;
+			State = 1554; endOfStatement();
+			State = 1556;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1547; block();
+				State = 1555; block();
 				}
 			}
 
-			State = 1550; Match(END_PROPERTY);
+			State = 1558; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8832,53 +8854,53 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1555;
+			State = 1563;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1552; visibility();
-				State = 1553; whiteSpace();
+				State = 1560; visibility();
+				State = 1561; whiteSpace();
 				}
 			}
 
-			State = 1559;
+			State = 1567;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1557; Match(STATIC);
-				State = 1558; whiteSpace();
+				State = 1565; Match(STATIC);
+				State = 1566; whiteSpace();
 				}
 			}
 
-			State = 1561; Match(PROPERTY_LET);
-			State = 1562; whiteSpace();
-			State = 1563; subroutineName();
-			State = 1568;
+			State = 1569; Match(PROPERTY_LET);
+			State = 1570; whiteSpace();
+			State = 1571; subroutineName();
+			State = 1576;
 			switch ( Interpreter.AdaptivePredict(_input,198,_ctx) ) {
 			case 1:
 				{
-				State = 1565;
+				State = 1573;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1564; whiteSpace();
+					State = 1572; whiteSpace();
 					}
 				}
 
-				State = 1567; argList();
+				State = 1575; argList();
 				}
 				break;
 			}
-			State = 1570; endOfStatement();
-			State = 1572;
+			State = 1578; endOfStatement();
+			State = 1580;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1571; block();
+				State = 1579; block();
 				}
 			}
 
-			State = 1574; Match(END_PROPERTY);
+			State = 1582; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8936,47 +8958,47 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1576; Match(RAISEEVENT);
-			State = 1577; whiteSpace();
-			State = 1578; identifier();
-			State = 1593;
+			State = 1584; Match(RAISEEVENT);
+			State = 1585; whiteSpace();
+			State = 1586; identifier();
+			State = 1601;
 			switch ( Interpreter.AdaptivePredict(_input,204,_ctx) ) {
 			case 1:
 				{
-				State = 1580;
+				State = 1588;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1579; whiteSpace();
+					State = 1587; whiteSpace();
 					}
 				}
 
-				State = 1582; Match(LPAREN);
-				State = 1584;
+				State = 1590; Match(LPAREN);
+				State = 1592;
 				switch ( Interpreter.AdaptivePredict(_input,201,_ctx) ) {
 				case 1:
 					{
-					State = 1583; whiteSpace();
+					State = 1591; whiteSpace();
 					}
 					break;
 				}
-				State = 1590;
+				State = 1598;
 				switch ( Interpreter.AdaptivePredict(_input,203,_ctx) ) {
 				case 1:
 					{
-					State = 1586; argsCall();
-					State = 1588;
+					State = 1594; argsCall();
+					State = 1596;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1587; whiteSpace();
+						State = 1595; whiteSpace();
 						}
 					}
 
 					}
 					break;
 				}
-				State = 1592; Match(RPAREN);
+				State = 1600; Match(RPAREN);
 				}
 				break;
 			}
@@ -9041,47 +9063,47 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1595; Match(REDIM);
-			State = 1596; whiteSpace();
-			State = 1599;
+			State = 1603; Match(REDIM);
+			State = 1604; whiteSpace();
+			State = 1607;
 			switch ( Interpreter.AdaptivePredict(_input,205,_ctx) ) {
 			case 1:
 				{
-				State = 1597; Match(PRESERVE);
-				State = 1598; whiteSpace();
+				State = 1605; Match(PRESERVE);
+				State = 1606; whiteSpace();
 				}
 				break;
 			}
-			State = 1601; redimSubStmt();
-			State = 1612;
+			State = 1609; redimSubStmt();
+			State = 1620;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,208,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1603;
+					State = 1611;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1602; whiteSpace();
+						State = 1610; whiteSpace();
 						}
 					}
 
-					State = 1605; Match(COMMA);
-					State = 1607;
+					State = 1613; Match(COMMA);
+					State = 1615;
 					switch ( Interpreter.AdaptivePredict(_input,207,_ctx) ) {
 					case 1:
 						{
-						State = 1606; whiteSpace();
+						State = 1614; whiteSpace();
 						}
 						break;
 					}
-					State = 1609; redimSubStmt();
+					State = 1617; redimSubStmt();
 					}
 					} 
 				}
-				State = 1614;
+				State = 1622;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,208,_ctx);
 			}
@@ -9144,25 +9166,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1615; implicitCallStmt_InStmt();
-			State = 1617;
-			_la = _input.La(1);
-			if (_la==WS || _la==LINE_CONTINUATION) {
-				{
-				State = 1616; whiteSpace();
-				}
-			}
-
-			State = 1619; Match(LPAREN);
-			State = 1621;
-			switch ( Interpreter.AdaptivePredict(_input,210,_ctx) ) {
-			case 1:
-				{
-				State = 1620; whiteSpace();
-				}
-				break;
-			}
-			State = 1623; subscripts();
+			State = 1623; implicitCallStmt_InStmt();
 			State = 1625;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
@@ -9171,13 +9175,31 @@ public partial class VBAParser : Parser {
 				}
 			}
 
-			State = 1627; Match(RPAREN);
-			State = 1631;
-			switch ( Interpreter.AdaptivePredict(_input,212,_ctx) ) {
+			State = 1627; Match(LPAREN);
+			State = 1629;
+			switch ( Interpreter.AdaptivePredict(_input,210,_ctx) ) {
 			case 1:
 				{
 				State = 1628; whiteSpace();
-				State = 1629; asTypeClause();
+				}
+				break;
+			}
+			State = 1631; subscripts();
+			State = 1633;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 1632; whiteSpace();
+				}
+			}
+
+			State = 1635; Match(RPAREN);
+			State = 1639;
+			switch ( Interpreter.AdaptivePredict(_input,212,_ctx) ) {
+			case 1:
+				{
+				State = 1636; whiteSpace();
+				State = 1637; asTypeClause();
 				}
 				break;
 			}
@@ -9230,23 +9252,23 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1633; Match(RESUME);
-			State = 1639;
+			State = 1641; Match(RESUME);
+			State = 1647;
 			switch ( Interpreter.AdaptivePredict(_input,214,_ctx) ) {
 			case 1:
 				{
-				State = 1634; whiteSpace();
-				State = 1637;
+				State = 1642; whiteSpace();
+				State = 1645;
 				switch ( Interpreter.AdaptivePredict(_input,213,_ctx) ) {
 				case 1:
 					{
-					State = 1635; Match(NEXT);
+					State = 1643; Match(NEXT);
 					}
 					break;
 
 				case 2:
 					{
-					State = 1636; valueStmt(0);
+					State = 1644; valueStmt(0);
 					}
 					break;
 				}
@@ -9295,7 +9317,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1641; Match(RETURN);
+			State = 1649; Match(RETURN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9352,27 +9374,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1643; Match(RSET);
-			State = 1644; whiteSpace();
-			State = 1645; valueStmt(0);
-			State = 1647;
+			State = 1651; Match(RSET);
+			State = 1652; whiteSpace();
+			State = 1653; valueStmt(0);
+			State = 1655;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1646; whiteSpace();
+				State = 1654; whiteSpace();
 				}
 			}
 
-			State = 1649; Match(EQ);
-			State = 1651;
+			State = 1657; Match(EQ);
+			State = 1659;
 			switch ( Interpreter.AdaptivePredict(_input,216,_ctx) ) {
 			case 1:
 				{
-				State = 1650; whiteSpace();
+				State = 1658; whiteSpace();
 				}
 				break;
 			}
-			State = 1653; valueStmt(0);
+			State = 1661; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9415,7 +9437,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1655; Match(STOP);
+			State = 1663; Match(STOP);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9479,26 +9501,26 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1657; Match(SELECT);
-			State = 1658; whiteSpace();
-			State = 1659; Match(CASE);
-			State = 1660; whiteSpace();
-			State = 1661; valueStmt(0);
-			State = 1662; endOfStatement();
-			State = 1666;
+			State = 1665; Match(SELECT);
+			State = 1666; whiteSpace();
+			State = 1667; Match(CASE);
+			State = 1668; whiteSpace();
+			State = 1669; valueStmt(0);
+			State = 1670; endOfStatement();
+			State = 1674;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==CASE) {
 				{
 				{
-				State = 1663; sC_Case();
+				State = 1671; sC_Case();
 				}
 				}
-				State = 1668;
+				State = 1676;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1669; Match(END_SELECT);
+			State = 1677; Match(END_SELECT);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9608,31 +9630,31 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 236, RULE_sC_Selection);
 		int _la;
 		try {
-			State = 1688;
+			State = 1696;
 			switch ( Interpreter.AdaptivePredict(_input,220,_ctx) ) {
 			case 1:
 				_localctx = new CaseCondIsContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1671; Match(IS);
-				State = 1673;
+				State = 1679; Match(IS);
+				State = 1681;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1672; whiteSpace();
+					State = 1680; whiteSpace();
 					}
 				}
 
-				State = 1675; comparisonOperator();
-				State = 1677;
+				State = 1683; comparisonOperator();
+				State = 1685;
 				switch ( Interpreter.AdaptivePredict(_input,219,_ctx) ) {
 				case 1:
 					{
-					State = 1676; whiteSpace();
+					State = 1684; whiteSpace();
 					}
 					break;
 				}
-				State = 1679; valueStmt(0);
+				State = 1687; valueStmt(0);
 				}
 				break;
 
@@ -9640,11 +9662,11 @@ public partial class VBAParser : Parser {
 				_localctx = new CaseCondToContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1681; valueStmt(0);
-				State = 1682; whiteSpace();
-				State = 1683; Match(TO);
-				State = 1684; whiteSpace();
-				State = 1685; valueStmt(0);
+				State = 1689; valueStmt(0);
+				State = 1690; whiteSpace();
+				State = 1691; Match(TO);
+				State = 1692; whiteSpace();
+				State = 1693; valueStmt(0);
 				}
 				break;
 
@@ -9652,7 +9674,7 @@ public partial class VBAParser : Parser {
 				_localctx = new CaseCondValueContext(_localctx);
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1687; valueStmt(0);
+				State = 1695; valueStmt(0);
 				}
 				break;
 			}
@@ -9709,15 +9731,15 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1690; Match(CASE);
-			State = 1691; whiteSpace();
-			State = 1692; sC_Cond();
-			State = 1693; endOfStatement();
-			State = 1695;
+			State = 1698; Match(CASE);
+			State = 1699; whiteSpace();
+			State = 1700; sC_Cond();
+			State = 1701; endOfStatement();
+			State = 1703;
 			switch ( Interpreter.AdaptivePredict(_input,221,_ctx) ) {
 			case 1:
 				{
-				State = 1694; block();
+				State = 1702; block();
 				}
 				break;
 			}
@@ -9803,13 +9825,13 @@ public partial class VBAParser : Parser {
 		int _la;
 		try {
 			int _alt;
-			State = 1712;
+			State = 1720;
 			switch ( Interpreter.AdaptivePredict(_input,225,_ctx) ) {
 			case 1:
 				_localctx = new CaseCondElseContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1697; Match(ELSE);
+				State = 1705; Match(ELSE);
 				}
 				break;
 
@@ -9817,36 +9839,36 @@ public partial class VBAParser : Parser {
 				_localctx = new CaseCondSelectionContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1698; sC_Selection();
-				State = 1709;
+				State = 1706; sC_Selection();
+				State = 1717;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,224,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1700;
+						State = 1708;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1699; whiteSpace();
+							State = 1707; whiteSpace();
 							}
 						}
 
-						State = 1702; Match(COMMA);
-						State = 1704;
+						State = 1710; Match(COMMA);
+						State = 1712;
 						switch ( Interpreter.AdaptivePredict(_input,223,_ctx) ) {
 						case 1:
 							{
-							State = 1703; whiteSpace();
+							State = 1711; whiteSpace();
 							}
 							break;
 						}
-						State = 1706; sC_Selection();
+						State = 1714; sC_Selection();
 						}
 						} 
 					}
-					State = 1711;
+					State = 1719;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,224,_ctx);
 				}
@@ -9908,27 +9930,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1714; Match(SET);
-			State = 1715; whiteSpace();
-			State = 1716; valueStmt(0);
-			State = 1718;
+			State = 1722; Match(SET);
+			State = 1723; whiteSpace();
+			State = 1724; valueStmt(0);
+			State = 1726;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1717; whiteSpace();
+				State = 1725; whiteSpace();
 				}
 			}
 
-			State = 1720; Match(EQ);
-			State = 1722;
+			State = 1728; Match(EQ);
+			State = 1730;
 			switch ( Interpreter.AdaptivePredict(_input,227,_ctx) ) {
 			case 1:
 				{
-				State = 1721; whiteSpace();
+				State = 1729; whiteSpace();
 				}
 				break;
 			}
-			State = 1724; valueStmt(0);
+			State = 1732; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9995,60 +10017,60 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1729;
+			State = 1737;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1726; visibility();
-				State = 1727; whiteSpace();
+				State = 1734; visibility();
+				State = 1735; whiteSpace();
 				}
 			}
 
-			State = 1733;
+			State = 1741;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1731; Match(STATIC);
-				State = 1732; whiteSpace();
+				State = 1739; Match(STATIC);
+				State = 1740; whiteSpace();
 				}
 			}
 
-			State = 1735; Match(SUB);
-			State = 1737;
+			State = 1743; Match(SUB);
+			State = 1745;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1736; whiteSpace();
+				State = 1744; whiteSpace();
 				}
 			}
 
-			State = 1739; subroutineName();
-			State = 1744;
+			State = 1747; subroutineName();
+			State = 1752;
 			switch ( Interpreter.AdaptivePredict(_input,232,_ctx) ) {
 			case 1:
 				{
-				State = 1741;
+				State = 1749;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1740; whiteSpace();
+					State = 1748; whiteSpace();
 					}
 				}
 
-				State = 1743; argList();
+				State = 1751; argList();
 				}
 				break;
 			}
-			State = 1746; endOfStatement();
-			State = 1748;
+			State = 1754; endOfStatement();
+			State = 1756;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1747; block();
+				State = 1755; block();
 				}
 			}
 
-			State = 1750; Match(END_SUB);
+			State = 1758; Match(END_SUB);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10093,7 +10115,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1752; identifier();
+			State = 1760; identifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -10159,33 +10181,33 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1757;
+			State = 1765;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1754; visibility();
-				State = 1755; whiteSpace();
+				State = 1762; visibility();
+				State = 1763; whiteSpace();
 				}
 			}
 
-			State = 1759; Match(TYPE);
-			State = 1760; whiteSpace();
-			State = 1761; identifier();
-			State = 1762; endOfStatement();
-			State = 1766;
+			State = 1767; Match(TYPE);
+			State = 1768; whiteSpace();
+			State = 1769; identifier();
+			State = 1770; endOfStatement();
+			State = 1774;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
 				{
-				State = 1763; typeStmt_Element();
+				State = 1771; typeStmt_Element();
 				}
 				}
-				State = 1768;
+				State = 1776;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1769; Match(END_TYPE);
+			State = 1777; Match(END_TYPE);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10248,58 +10270,58 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1771; identifier();
-			State = 1786;
+			State = 1779; identifier();
+			State = 1794;
 			switch ( Interpreter.AdaptivePredict(_input,240,_ctx) ) {
 			case 1:
 				{
-				State = 1773;
+				State = 1781;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1772; whiteSpace();
+					State = 1780; whiteSpace();
 					}
 				}
 
-				State = 1775; Match(LPAREN);
-				State = 1780;
+				State = 1783; Match(LPAREN);
+				State = 1788;
 				switch ( Interpreter.AdaptivePredict(_input,238,_ctx) ) {
 				case 1:
 					{
-					State = 1777;
+					State = 1785;
 					switch ( Interpreter.AdaptivePredict(_input,237,_ctx) ) {
 					case 1:
 						{
-						State = 1776; whiteSpace();
+						State = 1784; whiteSpace();
 						}
 						break;
 					}
-					State = 1779; subscripts();
+					State = 1787; subscripts();
 					}
 					break;
 				}
-				State = 1783;
+				State = 1791;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1782; whiteSpace();
+					State = 1790; whiteSpace();
 					}
 				}
 
-				State = 1785; Match(RPAREN);
+				State = 1793; Match(RPAREN);
 				}
 				break;
 			}
-			State = 1791;
+			State = 1799;
 			switch ( Interpreter.AdaptivePredict(_input,241,_ctx) ) {
 			case 1:
 				{
-				State = 1788; whiteSpace();
-				State = 1789; asTypeClause();
+				State = 1796; whiteSpace();
+				State = 1797; asTypeClause();
 				}
 				break;
 			}
-			State = 1793; endOfStatement();
+			State = 1801; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -10943,7 +10965,7 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1841;
+			State = 1849;
 			switch ( Interpreter.AdaptivePredict(_input,250,_ctx) ) {
 			case 1:
 				{
@@ -10951,16 +10973,16 @@ public partial class VBAParser : Parser {
 				_ctx = _localctx;
 				_prevctx = _localctx;
 
-				State = 1796; Match(NEW);
-				State = 1798;
+				State = 1804; Match(NEW);
+				State = 1806;
 				switch ( Interpreter.AdaptivePredict(_input,242,_ctx) ) {
 				case 1:
 					{
-					State = 1797; whiteSpace();
+					State = 1805; whiteSpace();
 					}
 					break;
 				}
-				State = 1800; valueStmt(20);
+				State = 1808; valueStmt(20);
 				}
 				break;
 
@@ -10969,16 +10991,16 @@ public partial class VBAParser : Parser {
 				_localctx = new VsAddressOfContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1801; Match(ADDRESSOF);
-				State = 1803;
+				State = 1809; Match(ADDRESSOF);
+				State = 1811;
 				switch ( Interpreter.AdaptivePredict(_input,243,_ctx) ) {
 				case 1:
 					{
-					State = 1802; whiteSpace();
+					State = 1810; whiteSpace();
 					}
 					break;
 				}
-				State = 1805; valueStmt(17);
+				State = 1813; valueStmt(17);
 				}
 				break;
 
@@ -10987,25 +11009,25 @@ public partial class VBAParser : Parser {
 				_localctx = new VsAssignContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1806; unrestrictedIdentifier();
-				State = 1808;
+				State = 1814; unrestrictedIdentifier();
+				State = 1816;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1807; whiteSpace();
+					State = 1815; whiteSpace();
 					}
 				}
 
-				State = 1810; Match(ASSIGN);
-				State = 1812;
+				State = 1818; Match(ASSIGN);
+				State = 1820;
 				switch ( Interpreter.AdaptivePredict(_input,245,_ctx) ) {
 				case 1:
 					{
-					State = 1811; whiteSpace();
+					State = 1819; whiteSpace();
 					}
 					break;
 				}
-				State = 1814; valueStmt(16);
+				State = 1822; valueStmt(16);
 				}
 				break;
 
@@ -11014,16 +11036,16 @@ public partial class VBAParser : Parser {
 				_localctx = new VsNegationContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1816; Match(MINUS);
-				State = 1818;
+				State = 1824; Match(MINUS);
+				State = 1826;
 				switch ( Interpreter.AdaptivePredict(_input,246,_ctx) ) {
 				case 1:
 					{
-					State = 1817; whiteSpace();
+					State = 1825; whiteSpace();
 					}
 					break;
 				}
-				State = 1820; valueStmt(14);
+				State = 1828; valueStmt(14);
 				}
 				break;
 
@@ -11032,16 +11054,16 @@ public partial class VBAParser : Parser {
 				_localctx = new VsNotContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1821; Match(NOT);
-				State = 1823;
+				State = 1829; Match(NOT);
+				State = 1831;
 				switch ( Interpreter.AdaptivePredict(_input,247,_ctx) ) {
 				case 1:
 					{
-					State = 1822; whiteSpace();
+					State = 1830; whiteSpace();
 					}
 					break;
 				}
-				State = 1825; valueStmt(7);
+				State = 1833; valueStmt(7);
 				}
 				break;
 
@@ -11050,7 +11072,7 @@ public partial class VBAParser : Parser {
 				_localctx = new VsLiteralContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1826; literal();
+				State = 1834; literal();
 				}
 				break;
 
@@ -11059,7 +11081,7 @@ public partial class VBAParser : Parser {
 				_localctx = new VsICSContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1827; implicitCallStmt_InStmt();
+				State = 1835; implicitCallStmt_InStmt();
 				}
 				break;
 
@@ -11068,25 +11090,25 @@ public partial class VBAParser : Parser {
 				_localctx = new VsStructContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1828; Match(LPAREN);
-				State = 1830;
+				State = 1836; Match(LPAREN);
+				State = 1838;
 				switch ( Interpreter.AdaptivePredict(_input,248,_ctx) ) {
 				case 1:
 					{
-					State = 1829; whiteSpace();
+					State = 1837; whiteSpace();
 					}
 					break;
 				}
-				State = 1832; valueStmt(0);
-				State = 1834;
+				State = 1840; valueStmt(0);
+				State = 1842;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1833; whiteSpace();
+					State = 1841; whiteSpace();
 					}
 				}
 
-				State = 1836; Match(RPAREN);
+				State = 1844; Match(RPAREN);
 				}
 				break;
 
@@ -11095,7 +11117,7 @@ public partial class VBAParser : Parser {
 				_localctx = new VsTypeOfContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1838; typeOfIsExpression();
+				State = 1846; typeOfIsExpression();
 				}
 				break;
 
@@ -11104,7 +11126,7 @@ public partial class VBAParser : Parser {
 				_localctx = new VsMidContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1839; midStmt();
+				State = 1847; midStmt();
 				}
 				break;
 
@@ -11113,12 +11135,12 @@ public partial class VBAParser : Parser {
 				_localctx = new VsMarkedFileNumberContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 1840; markedFileNumber();
+				State = 1848; markedFileNumber();
 				}
 				break;
 			}
 			_ctx.stop = _input.Lt(-1);
-			State = 1953;
+			State = 1961;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,276,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
@@ -11126,32 +11148,32 @@ public partial class VBAParser : Parser {
 					if ( _parseListeners!=null ) TriggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					State = 1951;
+					State = 1959;
 					switch ( Interpreter.AdaptivePredict(_input,275,_ctx) ) {
 					case 1:
 						{
 						_localctx = new VsPowContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1843;
+						State = 1851;
 						if (!(Precpred(_ctx, 15))) throw new FailedPredicateException(this, "Precpred(_ctx, 15)");
-						State = 1845;
+						State = 1853;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1844; whiteSpace();
+							State = 1852; whiteSpace();
 							}
 						}
 
-						State = 1847; Match(POW);
-						State = 1849;
+						State = 1855; Match(POW);
+						State = 1857;
 						switch ( Interpreter.AdaptivePredict(_input,252,_ctx) ) {
 						case 1:
 							{
-							State = 1848; whiteSpace();
+							State = 1856; whiteSpace();
 							}
 							break;
 						}
-						State = 1851; valueStmt(16);
+						State = 1859; valueStmt(16);
 						}
 						break;
 
@@ -11159,31 +11181,31 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsMultContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1852;
+						State = 1860;
 						if (!(Precpred(_ctx, 13))) throw new FailedPredicateException(this, "Precpred(_ctx, 13)");
-						State = 1854;
+						State = 1862;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1853; whiteSpace();
+							State = 1861; whiteSpace();
 							}
 						}
 
-						State = 1856;
+						State = 1864;
 						_la = _input.La(1);
 						if ( !(_la==DIV || _la==MULT) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 1858;
+						State = 1866;
 						switch ( Interpreter.AdaptivePredict(_input,254,_ctx) ) {
 						case 1:
 							{
-							State = 1857; whiteSpace();
+							State = 1865; whiteSpace();
 							}
 							break;
 						}
-						State = 1860; valueStmt(14);
+						State = 1868; valueStmt(14);
 						}
 						break;
 
@@ -11191,26 +11213,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsIntDivContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1861;
+						State = 1869;
 						if (!(Precpred(_ctx, 12))) throw new FailedPredicateException(this, "Precpred(_ctx, 12)");
-						State = 1863;
+						State = 1871;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1862; whiteSpace();
+							State = 1870; whiteSpace();
 							}
 						}
 
-						State = 1865; Match(INTDIV);
-						State = 1867;
+						State = 1873; Match(INTDIV);
+						State = 1875;
 						switch ( Interpreter.AdaptivePredict(_input,256,_ctx) ) {
 						case 1:
 							{
-							State = 1866; whiteSpace();
+							State = 1874; whiteSpace();
 							}
 							break;
 						}
-						State = 1869; valueStmt(13);
+						State = 1877; valueStmt(13);
 						}
 						break;
 
@@ -11218,26 +11240,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsModContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1870;
+						State = 1878;
 						if (!(Precpred(_ctx, 11))) throw new FailedPredicateException(this, "Precpred(_ctx, 11)");
-						State = 1872;
+						State = 1880;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1871; whiteSpace();
+							State = 1879; whiteSpace();
 							}
 						}
 
-						State = 1874; Match(MOD);
-						State = 1876;
+						State = 1882; Match(MOD);
+						State = 1884;
 						switch ( Interpreter.AdaptivePredict(_input,258,_ctx) ) {
 						case 1:
 							{
-							State = 1875; whiteSpace();
+							State = 1883; whiteSpace();
 							}
 							break;
 						}
-						State = 1878; valueStmt(12);
+						State = 1886; valueStmt(12);
 						}
 						break;
 
@@ -11245,31 +11267,31 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsAddContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1879;
+						State = 1887;
 						if (!(Precpred(_ctx, 10))) throw new FailedPredicateException(this, "Precpred(_ctx, 10)");
-						State = 1881;
+						State = 1889;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1880; whiteSpace();
+							State = 1888; whiteSpace();
 							}
 						}
 
-						State = 1883;
+						State = 1891;
 						_la = _input.La(1);
 						if ( !(_la==MINUS || _la==PLUS) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 1885;
+						State = 1893;
 						switch ( Interpreter.AdaptivePredict(_input,260,_ctx) ) {
 						case 1:
 							{
-							State = 1884; whiteSpace();
+							State = 1892; whiteSpace();
 							}
 							break;
 						}
-						State = 1887; valueStmt(11);
+						State = 1895; valueStmt(11);
 						}
 						break;
 
@@ -11277,26 +11299,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsAmpContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1888;
+						State = 1896;
 						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
-						State = 1890;
+						State = 1898;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1889; whiteSpace();
+							State = 1897; whiteSpace();
 							}
 						}
 
-						State = 1892; Match(AMPERSAND);
-						State = 1894;
+						State = 1900; Match(AMPERSAND);
+						State = 1902;
 						switch ( Interpreter.AdaptivePredict(_input,262,_ctx) ) {
 						case 1:
 							{
-							State = 1893; whiteSpace();
+							State = 1901; whiteSpace();
 							}
 							break;
 						}
-						State = 1896; valueStmt(10);
+						State = 1904; valueStmt(10);
 						}
 						break;
 
@@ -11304,31 +11326,31 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsRelationalContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1897;
+						State = 1905;
 						if (!(Precpred(_ctx, 8))) throw new FailedPredicateException(this, "Precpred(_ctx, 8)");
-						State = 1899;
+						State = 1907;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1898; whiteSpace();
+							State = 1906; whiteSpace();
 							}
 						}
 
-						State = 1901;
+						State = 1909;
 						_la = _input.La(1);
 						if ( !(_la==IS || _la==LIKE || ((((_la - 206)) & ~0x3f) == 0 && ((1L << (_la - 206)) & ((1L << (EQ - 206)) | (1L << (GEQ - 206)) | (1L << (GT - 206)) | (1L << (LEQ - 206)) | (1L << (LT - 206)) | (1L << (NEQ - 206)))) != 0)) ) {
 						_errHandler.RecoverInline(this);
 						}
 						Consume();
-						State = 1903;
+						State = 1911;
 						switch ( Interpreter.AdaptivePredict(_input,264,_ctx) ) {
 						case 1:
 							{
-							State = 1902; whiteSpace();
+							State = 1910; whiteSpace();
 							}
 							break;
 						}
-						State = 1905; valueStmt(9);
+						State = 1913; valueStmt(9);
 						}
 						break;
 
@@ -11336,26 +11358,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsAndContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1906;
+						State = 1914;
 						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
-						State = 1908;
+						State = 1916;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1907; whiteSpace();
+							State = 1915; whiteSpace();
 							}
 						}
 
-						State = 1910; Match(AND);
-						State = 1912;
+						State = 1918; Match(AND);
+						State = 1920;
 						switch ( Interpreter.AdaptivePredict(_input,266,_ctx) ) {
 						case 1:
 							{
-							State = 1911; whiteSpace();
+							State = 1919; whiteSpace();
 							}
 							break;
 						}
-						State = 1914; valueStmt(7);
+						State = 1922; valueStmt(7);
 						}
 						break;
 
@@ -11363,26 +11385,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsOrContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1915;
+						State = 1923;
 						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
-						State = 1917;
+						State = 1925;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1916; whiteSpace();
+							State = 1924; whiteSpace();
 							}
 						}
 
-						State = 1919; Match(OR);
-						State = 1921;
+						State = 1927; Match(OR);
+						State = 1929;
 						switch ( Interpreter.AdaptivePredict(_input,268,_ctx) ) {
 						case 1:
 							{
-							State = 1920; whiteSpace();
+							State = 1928; whiteSpace();
 							}
 							break;
 						}
-						State = 1923; valueStmt(6);
+						State = 1931; valueStmt(6);
 						}
 						break;
 
@@ -11390,26 +11412,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsXorContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1924;
+						State = 1932;
 						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
-						State = 1926;
+						State = 1934;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1925; whiteSpace();
+							State = 1933; whiteSpace();
 							}
 						}
 
-						State = 1928; Match(XOR);
-						State = 1930;
+						State = 1936; Match(XOR);
+						State = 1938;
 						switch ( Interpreter.AdaptivePredict(_input,270,_ctx) ) {
 						case 1:
 							{
-							State = 1929; whiteSpace();
+							State = 1937; whiteSpace();
 							}
 							break;
 						}
-						State = 1932; valueStmt(5);
+						State = 1940; valueStmt(5);
 						}
 						break;
 
@@ -11417,26 +11439,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsEqvContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1933;
+						State = 1941;
 						if (!(Precpred(_ctx, 3))) throw new FailedPredicateException(this, "Precpred(_ctx, 3)");
-						State = 1935;
+						State = 1943;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1934; whiteSpace();
+							State = 1942; whiteSpace();
 							}
 						}
 
-						State = 1937; Match(EQV);
-						State = 1939;
+						State = 1945; Match(EQV);
+						State = 1947;
 						switch ( Interpreter.AdaptivePredict(_input,272,_ctx) ) {
 						case 1:
 							{
-							State = 1938; whiteSpace();
+							State = 1946; whiteSpace();
 							}
 							break;
 						}
-						State = 1941; valueStmt(4);
+						State = 1949; valueStmt(4);
 						}
 						break;
 
@@ -11444,32 +11466,32 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new VsImpContext(new ValueStmtContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_valueStmt);
-						State = 1942;
+						State = 1950;
 						if (!(Precpred(_ctx, 2))) throw new FailedPredicateException(this, "Precpred(_ctx, 2)");
-						State = 1944;
+						State = 1952;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1943; whiteSpace();
+							State = 1951; whiteSpace();
 							}
 						}
 
-						State = 1946; Match(IMP);
-						State = 1948;
+						State = 1954; Match(IMP);
+						State = 1956;
 						switch ( Interpreter.AdaptivePredict(_input,274,_ctx) ) {
 						case 1:
 							{
-							State = 1947; whiteSpace();
+							State = 1955; whiteSpace();
 							}
 							break;
 						}
-						State = 1950; valueStmt(3);
+						State = 1958; valueStmt(3);
 						}
 						break;
 					}
 					} 
 				}
-				State = 1955;
+				State = 1963;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,276,_ctx);
 			}
@@ -11528,17 +11550,17 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1956; Match(TYPEOF);
-			State = 1957; whiteSpace();
-			State = 1958; valueStmt(0);
-			State = 1964;
+			State = 1964; Match(TYPEOF);
+			State = 1965; whiteSpace();
+			State = 1966; valueStmt(0);
+			State = 1972;
 			switch ( Interpreter.AdaptivePredict(_input,277,_ctx) ) {
 			case 1:
 				{
-				State = 1959; whiteSpace();
-				State = 1960; Match(IS);
-				State = 1961; whiteSpace();
-				State = 1962; type();
+				State = 1967; whiteSpace();
+				State = 1968; Match(IS);
+				State = 1969; whiteSpace();
+				State = 1970; type();
 				}
 				break;
 			}
@@ -11598,16 +11620,16 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1969;
+			State = 1977;
 			switch (_input.La(1)) {
 			case DIM:
 				{
-				State = 1966; Match(DIM);
+				State = 1974; Match(DIM);
 				}
 				break;
 			case STATIC:
 				{
-				State = 1967; Match(STATIC);
+				State = 1975; Match(STATIC);
 				}
 				break;
 			case FRIEND:
@@ -11615,23 +11637,23 @@ public partial class VBAParser : Parser {
 			case PRIVATE:
 			case PUBLIC:
 				{
-				State = 1968; visibility();
+				State = 1976; visibility();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 1971; whiteSpace();
-			State = 1974;
+			State = 1979; whiteSpace();
+			State = 1982;
 			switch ( Interpreter.AdaptivePredict(_input,279,_ctx) ) {
 			case 1:
 				{
-				State = 1972; Match(WITHEVENTS);
-				State = 1973; whiteSpace();
+				State = 1980; Match(WITHEVENTS);
+				State = 1981; whiteSpace();
 				}
 				break;
 			}
-			State = 1976; variableListStmt();
+			State = 1984; variableListStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -11691,36 +11713,36 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1978; variableSubStmt();
-			State = 1989;
+			State = 1986; variableSubStmt();
+			State = 1997;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,282,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1980;
+					State = 1988;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1979; whiteSpace();
+						State = 1987; whiteSpace();
 						}
 					}
 
-					State = 1982; Match(COMMA);
-					State = 1984;
+					State = 1990; Match(COMMA);
+					State = 1992;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1983; whiteSpace();
+						State = 1991; whiteSpace();
 						}
 					}
 
-					State = 1986; variableSubStmt();
+					State = 1994; variableSubStmt();
 					}
 					} 
 				}
-				State = 1991;
+				State = 1999;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,282,_ctx);
 			}
@@ -11786,70 +11808,70 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1992; identifier();
-			State = 1994;
+			State = 2000; identifier();
+			State = 2002;
 			switch ( Interpreter.AdaptivePredict(_input,283,_ctx) ) {
 			case 1:
 				{
-				State = 1993; typeHint();
+				State = 2001; typeHint();
 				}
 				break;
 			}
-			State = 2013;
+			State = 2021;
 			switch ( Interpreter.AdaptivePredict(_input,289,_ctx) ) {
 			case 1:
 				{
-				State = 1997;
+				State = 2005;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1996; whiteSpace();
+					State = 2004; whiteSpace();
 					}
 				}
 
-				State = 1999; Match(LPAREN);
-				State = 2001;
+				State = 2007; Match(LPAREN);
+				State = 2009;
 				switch ( Interpreter.AdaptivePredict(_input,285,_ctx) ) {
 				case 1:
 					{
-					State = 2000; whiteSpace();
+					State = 2008; whiteSpace();
 					}
 					break;
 				}
-				State = 2007;
+				State = 2015;
 				_la = _input.La(1);
-				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 					{
-					State = 2003; subscripts();
-					State = 2005;
+					State = 2011; subscripts();
+					State = 2013;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2004; whiteSpace();
+						State = 2012; whiteSpace();
 						}
 					}
 
 					}
 				}
 
-				State = 2009; Match(RPAREN);
-				State = 2011;
+				State = 2017; Match(RPAREN);
+				State = 2019;
 				switch ( Interpreter.AdaptivePredict(_input,288,_ctx) ) {
 				case 1:
 					{
-					State = 2010; whiteSpace();
+					State = 2018; whiteSpace();
 					}
 					break;
 				}
 				}
 				break;
 			}
-			State = 2018;
+			State = 2026;
 			switch ( Interpreter.AdaptivePredict(_input,290,_ctx) ) {
 			case 1:
 				{
-				State = 2015; whiteSpace();
-				State = 2016; asTypeClause();
+				State = 2023; whiteSpace();
+				State = 2024; asTypeClause();
 				}
 				break;
 			}
@@ -11908,19 +11930,19 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2020; Match(WHILE);
-			State = 2021; whiteSpace();
-			State = 2022; valueStmt(0);
-			State = 2023; endOfStatement();
-			State = 2025;
+			State = 2028; Match(WHILE);
+			State = 2029; whiteSpace();
+			State = 2030; valueStmt(0);
+			State = 2031; endOfStatement();
+			State = 2033;
 			switch ( Interpreter.AdaptivePredict(_input,291,_ctx) ) {
 			case 1:
 				{
-				State = 2024; block();
+				State = 2032; block();
 				}
 				break;
 			}
-			State = 2027; Match(WEND);
+			State = 2035; Match(WEND);
 			}
 		}
 		catch (RecognitionException re) {
@@ -11976,19 +11998,364 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2029; Match(WITH);
-			State = 2030; whiteSpace();
-			State = 2031; withStmtExpression();
-			State = 2032; endOfStatement();
-			State = 2034;
+			State = 2037; Match(WITH);
+			State = 2038; whiteSpace();
+			State = 2039; withStmtExpression();
+			State = 2040; endOfStatement();
+			State = 2042;
 			switch ( Interpreter.AdaptivePredict(_input,292,_ctx) ) {
 			case 1:
 				{
-				State = 2033; block();
+				State = 2041; block();
 				}
 				break;
 			}
-			State = 2036; Match(END_WITH);
+			State = 2044; Match(END_WITH);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class CircleSpecialFormContext : ParserRuleContext {
+		public ITerminalNode DOT() { return GetToken(VBAParser.DOT, 0); }
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public IReadOnlyList<ValueStmtContext> valueStmt() {
+			return GetRuleContexts<ValueStmtContext>();
+		}
+		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public TupleContext tuple() {
+			return GetRuleContext<TupleContext>(0);
+		}
+		public ITerminalNode STEP() { return GetToken(VBAParser.STEP, 0); }
+		public ValueStmtContext valueStmt(int i) {
+			return GetRuleContext<ValueStmtContext>(i);
+		}
+		public ITerminalNode COMMA(int i) {
+			return GetToken(VBAParser.COMMA, i);
+		}
+		public ITerminalNode CIRCLE() { return GetToken(VBAParser.CIRCLE, 0); }
+		public CircleSpecialFormContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_circleSpecialForm; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterCircleSpecialForm(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitCircleSpecialForm(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitCircleSpecialForm(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public CircleSpecialFormContext circleSpecialForm() {
+		CircleSpecialFormContext _localctx = new CircleSpecialFormContext(_ctx, State);
+		EnterRule(_localctx, 266, RULE_circleSpecialForm);
+		int _la;
+		try {
+			int _alt;
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 2054;
+			_la = _input.La(1);
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+				{
+				State = 2046; valueStmt(0);
+				State = 2048;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 2047; whiteSpace();
+					}
+				}
+
+				State = 2050; Match(DOT);
+				State = 2052;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 2051; whiteSpace();
+					}
+				}
+
+				}
+			}
+
+			State = 2056; Match(CIRCLE);
+			State = 2057; whiteSpace();
+			State = 2062;
+			_la = _input.La(1);
+			if (_la==STEP) {
+				{
+				State = 2058; Match(STEP);
+				State = 2060;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 2059; whiteSpace();
+					}
+				}
+
+				}
+			}
+
+			State = 2064; tuple();
+			State = 2073;
+			_errHandler.Sync(this);
+			_alt = 1;
+			do {
+				switch (_alt) {
+				case 1:
+					{
+					{
+					State = 2066;
+					_la = _input.La(1);
+					if (_la==WS || _la==LINE_CONTINUATION) {
+						{
+						State = 2065; whiteSpace();
+						}
+					}
+
+					State = 2068; Match(COMMA);
+					State = 2070;
+					switch ( Interpreter.AdaptivePredict(_input,299,_ctx) ) {
+					case 1:
+						{
+						State = 2069; whiteSpace();
+						}
+						break;
+					}
+					State = 2072; valueStmt(0);
+					}
+					}
+					break;
+				default:
+					throw new NoViableAltException(this);
+				}
+				State = 2075;
+				_errHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(_input,300,_ctx);
+			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class ScaleSpecialFormContext : ParserRuleContext {
+		public ITerminalNode SCALE() { return GetToken(VBAParser.SCALE, 0); }
+		public ITerminalNode DOT() { return GetToken(VBAParser.DOT, 0); }
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ValueStmtContext valueStmt() {
+			return GetRuleContext<ValueStmtContext>(0);
+		}
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public IReadOnlyList<TupleContext> tuple() {
+			return GetRuleContexts<TupleContext>();
+		}
+		public ITerminalNode MINUS() { return GetToken(VBAParser.MINUS, 0); }
+		public TupleContext tuple(int i) {
+			return GetRuleContext<TupleContext>(i);
+		}
+		public ScaleSpecialFormContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_scaleSpecialForm; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterScaleSpecialForm(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitScaleSpecialForm(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitScaleSpecialForm(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public ScaleSpecialFormContext scaleSpecialForm() {
+		ScaleSpecialFormContext _localctx = new ScaleSpecialFormContext(_ctx, State);
+		EnterRule(_localctx, 268, RULE_scaleSpecialForm);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 2085;
+			_la = _input.La(1);
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (WS - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+				{
+				State = 2077; valueStmt(0);
+				State = 2079;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 2078; whiteSpace();
+					}
+				}
+
+				State = 2081; Match(DOT);
+				State = 2083;
+				_la = _input.La(1);
+				if (_la==WS || _la==LINE_CONTINUATION) {
+					{
+					State = 2082; whiteSpace();
+					}
+				}
+
+				}
+			}
+
+			State = 2087; Match(SCALE);
+			State = 2088; whiteSpace();
+			State = 2089; tuple();
+			State = 2091;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 2090; whiteSpace();
+				}
+			}
+
+			State = 2093; Match(MINUS);
+			State = 2095;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 2094; whiteSpace();
+				}
+			}
+
+			State = 2097; tuple();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class TupleContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public ITerminalNode LPAREN() { return GetToken(VBAParser.LPAREN, 0); }
+		public IReadOnlyList<ValueStmtContext> valueStmt() {
+			return GetRuleContexts<ValueStmtContext>();
+		}
+		public ITerminalNode COMMA() { return GetToken(VBAParser.COMMA, 0); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode RPAREN() { return GetToken(VBAParser.RPAREN, 0); }
+		public ValueStmtContext valueStmt(int i) {
+			return GetRuleContext<ValueStmtContext>(i);
+		}
+		public TupleContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_tuple; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterTuple(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitTuple(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitTuple(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public TupleContext tuple() {
+		TupleContext _localctx = new TupleContext(_ctx, State);
+		EnterRule(_localctx, 270, RULE_tuple);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 2099; Match(LPAREN);
+			State = 2101;
+			switch ( Interpreter.AdaptivePredict(_input,306,_ctx) ) {
+			case 1:
+				{
+				State = 2100; whiteSpace();
+				}
+				break;
+			}
+			State = 2103; valueStmt(0);
+			State = 2105;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 2104; whiteSpace();
+				}
+			}
+
+			State = 2107; Match(COMMA);
+			State = 2109;
+			switch ( Interpreter.AdaptivePredict(_input,308,_ctx) ) {
+			case 1:
+				{
+				State = 2108; whiteSpace();
+				}
+				break;
+			}
+			State = 2111; valueStmt(0);
+			State = 2113;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 2112; whiteSpace();
+				}
+			}
+
+			State = 2115; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12029,11 +12396,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WithStmtExpressionContext withStmtExpression() {
 		WithStmtExpressionContext _localctx = new WithStmtExpressionContext(_ctx, State);
-		EnterRule(_localctx, 266, RULE_withStmtExpression);
+		EnterRule(_localctx, 272, RULE_withStmtExpression);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2038; valueStmt(0);
+			State = 2117; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12078,13 +12445,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ExplicitCallStmtContext explicitCallStmt() {
 		ExplicitCallStmtContext _localctx = new ExplicitCallStmtContext(_ctx, State);
-		EnterRule(_localctx, 268, RULE_explicitCallStmt);
+		EnterRule(_localctx, 274, RULE_explicitCallStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2040; Match(CALL);
-			State = 2041; whiteSpace();
-			State = 2042; explicitCallStmtExpression();
+			State = 2119; Match(CALL);
+			State = 2120; whiteSpace();
+			State = 2121; explicitCallStmtExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -12208,92 +12575,92 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ExplicitCallStmtExpressionContext explicitCallStmtExpression() {
 		ExplicitCallStmtExpressionContext _localctx = new ExplicitCallStmtExpressionContext(_ctx, State);
-		EnterRule(_localctx, 270, RULE_explicitCallStmtExpression);
+		EnterRule(_localctx, 276, RULE_explicitCallStmtExpression);
 		int _la;
 		try {
 			int _alt;
-			State = 2110;
-			switch ( Interpreter.AdaptivePredict(_input,308,_ctx) ) {
+			State = 2189;
+			switch ( Interpreter.AdaptivePredict(_input,325,_ctx) ) {
 			case 1:
 				_localctx = new ECS_MemberCallContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2045;
-				switch ( Interpreter.AdaptivePredict(_input,293,_ctx) ) {
+				State = 2124;
+				switch ( Interpreter.AdaptivePredict(_input,310,_ctx) ) {
 				case 1:
 					{
-					State = 2044; implicitCallStmt_InStmt();
+					State = 2123; implicitCallStmt_InStmt();
 					}
 					break;
 				}
-				State = 2047; Match(DOT);
-				State = 2048; identifier();
-				State = 2050;
-				switch ( Interpreter.AdaptivePredict(_input,294,_ctx) ) {
+				State = 2126; Match(DOT);
+				State = 2127; identifier();
+				State = 2129;
+				switch ( Interpreter.AdaptivePredict(_input,311,_ctx) ) {
 				case 1:
 					{
-					State = 2049; typeHint();
+					State = 2128; typeHint();
 					}
 					break;
 				}
-				State = 2065;
-				switch ( Interpreter.AdaptivePredict(_input,298,_ctx) ) {
+				State = 2144;
+				switch ( Interpreter.AdaptivePredict(_input,315,_ctx) ) {
 				case 1:
 					{
-					State = 2053;
+					State = 2132;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2052; whiteSpace();
+						State = 2131; whiteSpace();
 						}
 					}
 
-					State = 2055; Match(LPAREN);
-					State = 2057;
-					switch ( Interpreter.AdaptivePredict(_input,296,_ctx) ) {
+					State = 2134; Match(LPAREN);
+					State = 2136;
+					switch ( Interpreter.AdaptivePredict(_input,313,_ctx) ) {
 					case 1:
 						{
-						State = 2056; whiteSpace();
+						State = 2135; whiteSpace();
 						}
 						break;
 					}
-					State = 2059; argsCall();
-					State = 2061;
+					State = 2138; argsCall();
+					State = 2140;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2060; whiteSpace();
+						State = 2139; whiteSpace();
 						}
 					}
 
-					State = 2063; Match(RPAREN);
+					State = 2142; Match(RPAREN);
 					}
 					break;
 				}
-				State = 2076;
+				State = 2155;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,300,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,317,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2068;
+						State = 2147;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2067; whiteSpace();
+							State = 2146; whiteSpace();
 							}
 						}
 
-						State = 2070; Match(LPAREN);
-						State = 2071; subscripts();
-						State = 2072; Match(RPAREN);
+						State = 2149; Match(LPAREN);
+						State = 2150; subscripts();
+						State = 2151; Match(RPAREN);
 						}
 						} 
 					}
-					State = 2078;
+					State = 2157;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,300,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,317,_ctx);
 				}
 				}
 				break;
@@ -12302,73 +12669,73 @@ public partial class VBAParser : Parser {
 				_localctx = new ECS_ProcedureCallContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2079; identifier();
-				State = 2081;
-				switch ( Interpreter.AdaptivePredict(_input,301,_ctx) ) {
+				State = 2158; identifier();
+				State = 2160;
+				switch ( Interpreter.AdaptivePredict(_input,318,_ctx) ) {
 				case 1:
 					{
-					State = 2080; typeHint();
+					State = 2159; typeHint();
 					}
 					break;
 				}
-				State = 2096;
-				switch ( Interpreter.AdaptivePredict(_input,305,_ctx) ) {
+				State = 2175;
+				switch ( Interpreter.AdaptivePredict(_input,322,_ctx) ) {
 				case 1:
 					{
-					State = 2084;
+					State = 2163;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2083; whiteSpace();
+						State = 2162; whiteSpace();
 						}
 					}
 
-					State = 2086; Match(LPAREN);
-					State = 2088;
-					switch ( Interpreter.AdaptivePredict(_input,303,_ctx) ) {
+					State = 2165; Match(LPAREN);
+					State = 2167;
+					switch ( Interpreter.AdaptivePredict(_input,320,_ctx) ) {
 					case 1:
 						{
-						State = 2087; whiteSpace();
+						State = 2166; whiteSpace();
 						}
 						break;
 					}
-					State = 2090; argsCall();
-					State = 2092;
+					State = 2169; argsCall();
+					State = 2171;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2091; whiteSpace();
+						State = 2170; whiteSpace();
 						}
 					}
 
-					State = 2094; Match(RPAREN);
+					State = 2173; Match(RPAREN);
 					}
 					break;
 				}
-				State = 2107;
+				State = 2186;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,307,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,324,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2099;
+						State = 2178;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2098; whiteSpace();
+							State = 2177; whiteSpace();
 							}
 						}
 
-						State = 2101; Match(LPAREN);
-						State = 2102; subscripts();
-						State = 2103; Match(RPAREN);
+						State = 2180; Match(LPAREN);
+						State = 2181; subscripts();
+						State = 2182; Match(RPAREN);
 						}
 						} 
 					}
-					State = 2109;
+					State = 2188;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,307,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,324,_ctx);
 				}
 				}
 				break;
@@ -12415,21 +12782,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ImplicitCallStmt_InBlockContext implicitCallStmt_InBlock() {
 		ImplicitCallStmt_InBlockContext _localctx = new ImplicitCallStmt_InBlockContext(_ctx, State);
-		EnterRule(_localctx, 272, RULE_implicitCallStmt_InBlock);
+		EnterRule(_localctx, 278, RULE_implicitCallStmt_InBlock);
 		try {
-			State = 2114;
-			switch ( Interpreter.AdaptivePredict(_input,309,_ctx) ) {
+			State = 2193;
+			switch ( Interpreter.AdaptivePredict(_input,326,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2112; iCS_B_MemberProcedureCall();
+				State = 2191; iCS_B_MemberProcedureCall();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2113; iCS_B_ProcedureCall();
+				State = 2192; iCS_B_ProcedureCall();
 				}
 				break;
 			}
@@ -12505,95 +12872,95 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_B_MemberProcedureCallContext iCS_B_MemberProcedureCall() {
 		ICS_B_MemberProcedureCallContext _localctx = new ICS_B_MemberProcedureCallContext(_ctx, State);
-		EnterRule(_localctx, 274, RULE_iCS_B_MemberProcedureCall);
+		EnterRule(_localctx, 280, RULE_iCS_B_MemberProcedureCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2117;
-			switch ( Interpreter.AdaptivePredict(_input,310,_ctx) ) {
+			State = 2196;
+			switch ( Interpreter.AdaptivePredict(_input,327,_ctx) ) {
 			case 1:
 				{
-				State = 2116; implicitCallStmt_InStmt();
+				State = 2195; implicitCallStmt_InStmt();
 				}
 				break;
 			}
-			State = 2120;
+			State = 2199;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2119; whiteSpace();
+				State = 2198; whiteSpace();
 				}
 			}
 
-			State = 2122; Match(DOT);
-			State = 2124;
+			State = 2201; Match(DOT);
+			State = 2203;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2123; whiteSpace();
+				State = 2202; whiteSpace();
 				}
 			}
 
-			State = 2126; unrestrictedIdentifier();
-			State = 2128;
-			switch ( Interpreter.AdaptivePredict(_input,313,_ctx) ) {
+			State = 2205; unrestrictedIdentifier();
+			State = 2207;
+			switch ( Interpreter.AdaptivePredict(_input,330,_ctx) ) {
 			case 1:
 				{
-				State = 2127; typeHint();
+				State = 2206; typeHint();
 				}
 				break;
 			}
-			State = 2133;
-			switch ( Interpreter.AdaptivePredict(_input,314,_ctx) ) {
+			State = 2212;
+			switch ( Interpreter.AdaptivePredict(_input,331,_ctx) ) {
 			case 1:
 				{
-				State = 2130; whiteSpace();
-				State = 2131; argsCall();
+				State = 2209; whiteSpace();
+				State = 2210; argsCall();
 				}
 				break;
 			}
-			State = 2139;
-			switch ( Interpreter.AdaptivePredict(_input,316,_ctx) ) {
+			State = 2218;
+			switch ( Interpreter.AdaptivePredict(_input,333,_ctx) ) {
 			case 1:
 				{
-				State = 2136;
+				State = 2215;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2135; whiteSpace();
+					State = 2214; whiteSpace();
 					}
 				}
 
-				State = 2138; dictionaryCallStmt();
+				State = 2217; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2150;
+			State = 2229;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,318,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,335,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2142;
+					State = 2221;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2141; whiteSpace();
+						State = 2220; whiteSpace();
 						}
 					}
 
-					State = 2144; Match(LPAREN);
-					State = 2145; subscripts();
-					State = 2146; Match(RPAREN);
+					State = 2223; Match(LPAREN);
+					State = 2224; subscripts();
+					State = 2225; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2152;
+				State = 2231;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,318,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,335,_ctx);
 			}
 			}
 		}
@@ -12658,46 +13025,46 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_B_ProcedureCallContext iCS_B_ProcedureCall() {
 		ICS_B_ProcedureCallContext _localctx = new ICS_B_ProcedureCallContext(_ctx, State);
-		EnterRule(_localctx, 276, RULE_iCS_B_ProcedureCall);
+		EnterRule(_localctx, 282, RULE_iCS_B_ProcedureCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2153; identifier();
-			State = 2157;
-			switch ( Interpreter.AdaptivePredict(_input,319,_ctx) ) {
+			State = 2232; identifier();
+			State = 2236;
+			switch ( Interpreter.AdaptivePredict(_input,336,_ctx) ) {
 			case 1:
 				{
-				State = 2154; whiteSpace();
-				State = 2155; argsCall();
+				State = 2233; whiteSpace();
+				State = 2234; argsCall();
 				}
 				break;
 			}
-			State = 2168;
+			State = 2247;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,321,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,338,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2160;
+					State = 2239;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2159; whiteSpace();
+						State = 2238; whiteSpace();
 						}
 					}
 
-					State = 2162; Match(LPAREN);
-					State = 2163; subscripts();
-					State = 2164; Match(RPAREN);
+					State = 2241; Match(LPAREN);
+					State = 2242; subscripts();
+					State = 2243; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2170;
+				State = 2249;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,321,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,338,_ctx);
 			}
 			}
 		}
@@ -12748,35 +13115,35 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ImplicitCallStmt_InStmtContext implicitCallStmt_InStmt() {
 		ImplicitCallStmt_InStmtContext _localctx = new ImplicitCallStmt_InStmtContext(_ctx, State);
-		EnterRule(_localctx, 278, RULE_implicitCallStmt_InStmt);
+		EnterRule(_localctx, 284, RULE_implicitCallStmt_InStmt);
 		try {
-			State = 2175;
-			switch ( Interpreter.AdaptivePredict(_input,322,_ctx) ) {
+			State = 2254;
+			switch ( Interpreter.AdaptivePredict(_input,339,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2171; iCS_S_MembersCall();
+				State = 2250; iCS_S_MembersCall();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2172; iCS_S_VariableOrProcedureCall();
+				State = 2251; iCS_S_VariableOrProcedureCall();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2173; iCS_S_ProcedureOrArrayCall();
+				State = 2252; iCS_S_ProcedureOrArrayCall();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2174; iCS_S_DictionaryCall();
+				State = 2253; iCS_S_DictionaryCall();
 				}
 				break;
 			}
@@ -12845,61 +13212,61 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_VariableOrProcedureCallContext iCS_S_VariableOrProcedureCall() {
 		ICS_S_VariableOrProcedureCallContext _localctx = new ICS_S_VariableOrProcedureCallContext(_ctx, State);
-		EnterRule(_localctx, 280, RULE_iCS_S_VariableOrProcedureCall);
+		EnterRule(_localctx, 286, RULE_iCS_S_VariableOrProcedureCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2177; identifier();
-			State = 2179;
-			switch ( Interpreter.AdaptivePredict(_input,323,_ctx) ) {
+			State = 2256; identifier();
+			State = 2258;
+			switch ( Interpreter.AdaptivePredict(_input,340,_ctx) ) {
 			case 1:
 				{
-				State = 2178; typeHint();
+				State = 2257; typeHint();
 				}
 				break;
 			}
-			State = 2185;
-			switch ( Interpreter.AdaptivePredict(_input,325,_ctx) ) {
+			State = 2264;
+			switch ( Interpreter.AdaptivePredict(_input,342,_ctx) ) {
 			case 1:
 				{
-				State = 2182;
+				State = 2261;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2181; whiteSpace();
+					State = 2260; whiteSpace();
 					}
 				}
 
-				State = 2184; dictionaryCallStmt();
+				State = 2263; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2196;
+			State = 2275;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,327,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,344,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2188;
+					State = 2267;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2187; whiteSpace();
+						State = 2266; whiteSpace();
 						}
 					}
 
-					State = 2190; Match(LPAREN);
-					State = 2191; subscripts();
-					State = 2192; Match(RPAREN);
+					State = 2269; Match(LPAREN);
+					State = 2270; subscripts();
+					State = 2271; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2198;
+				State = 2277;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,327,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,344,_ctx);
 			}
 			}
 		}
@@ -12973,108 +13340,108 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_ProcedureOrArrayCallContext iCS_S_ProcedureOrArrayCall() {
 		ICS_S_ProcedureOrArrayCallContext _localctx = new ICS_S_ProcedureOrArrayCallContext(_ctx, State);
-		EnterRule(_localctx, 282, RULE_iCS_S_ProcedureOrArrayCall);
+		EnterRule(_localctx, 288, RULE_iCS_S_ProcedureOrArrayCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2201;
-			switch ( Interpreter.AdaptivePredict(_input,328,_ctx) ) {
+			State = 2280;
+			switch ( Interpreter.AdaptivePredict(_input,345,_ctx) ) {
 			case 1:
 				{
-				State = 2199; identifier();
+				State = 2278; identifier();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2200; baseType();
+				State = 2279; baseType();
 				}
 				break;
 			}
-			State = 2204;
+			State = 2283;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 2203; typeHint();
+				State = 2282; typeHint();
 				}
 			}
 
-			State = 2207;
+			State = 2286;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2206; whiteSpace();
+				State = 2285; whiteSpace();
 				}
 			}
 
-			State = 2209; Match(LPAREN);
-			State = 2211;
-			switch ( Interpreter.AdaptivePredict(_input,331,_ctx) ) {
+			State = 2288; Match(LPAREN);
+			State = 2290;
+			switch ( Interpreter.AdaptivePredict(_input,348,_ctx) ) {
 			case 1:
 				{
-				State = 2210; whiteSpace();
+				State = 2289; whiteSpace();
 				}
 				break;
 			}
-			State = 2217;
-			switch ( Interpreter.AdaptivePredict(_input,333,_ctx) ) {
+			State = 2296;
+			switch ( Interpreter.AdaptivePredict(_input,350,_ctx) ) {
 			case 1:
 				{
-				State = 2213; argsCall();
-				State = 2215;
+				State = 2292; argsCall();
+				State = 2294;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2214; whiteSpace();
+					State = 2293; whiteSpace();
 					}
 				}
 
 				}
 				break;
 			}
-			State = 2219; Match(RPAREN);
-			State = 2224;
-			switch ( Interpreter.AdaptivePredict(_input,335,_ctx) ) {
+			State = 2298; Match(RPAREN);
+			State = 2303;
+			switch ( Interpreter.AdaptivePredict(_input,352,_ctx) ) {
 			case 1:
 				{
-				State = 2221;
+				State = 2300;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2220; whiteSpace();
+					State = 2299; whiteSpace();
 					}
 				}
 
-				State = 2223; dictionaryCallStmt();
+				State = 2302; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2235;
+			State = 2314;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,337,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,354,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2227;
+					State = 2306;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2226; whiteSpace();
+						State = 2305; whiteSpace();
 						}
 					}
 
-					State = 2229; Match(LPAREN);
-					State = 2230; subscripts();
-					State = 2231; Match(RPAREN);
+					State = 2308; Match(LPAREN);
+					State = 2309; subscripts();
+					State = 2310; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2237;
+				State = 2316;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,337,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,354,_ctx);
 			}
 			}
 		}
@@ -13142,61 +13509,61 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_VariableOrProcedureCallUnrestrictedContext iCS_S_VariableOrProcedureCallUnrestricted() {
 		ICS_S_VariableOrProcedureCallUnrestrictedContext _localctx = new ICS_S_VariableOrProcedureCallUnrestrictedContext(_ctx, State);
-		EnterRule(_localctx, 284, RULE_iCS_S_VariableOrProcedureCallUnrestricted);
+		EnterRule(_localctx, 290, RULE_iCS_S_VariableOrProcedureCallUnrestricted);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2238; unrestrictedIdentifier();
-			State = 2240;
-			switch ( Interpreter.AdaptivePredict(_input,338,_ctx) ) {
+			State = 2317; unrestrictedIdentifier();
+			State = 2319;
+			switch ( Interpreter.AdaptivePredict(_input,355,_ctx) ) {
 			case 1:
 				{
-				State = 2239; typeHint();
+				State = 2318; typeHint();
 				}
 				break;
 			}
-			State = 2246;
-			switch ( Interpreter.AdaptivePredict(_input,340,_ctx) ) {
+			State = 2325;
+			switch ( Interpreter.AdaptivePredict(_input,357,_ctx) ) {
 			case 1:
 				{
-				State = 2243;
+				State = 2322;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2242; whiteSpace();
+					State = 2321; whiteSpace();
 					}
 				}
 
-				State = 2245; dictionaryCallStmt();
+				State = 2324; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2257;
+			State = 2336;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,342,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,359,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2249;
+					State = 2328;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2248; whiteSpace();
+						State = 2327; whiteSpace();
 						}
 					}
 
-					State = 2251; Match(LPAREN);
-					State = 2252; subscripts();
-					State = 2253; Match(RPAREN);
+					State = 2330; Match(LPAREN);
+					State = 2331; subscripts();
+					State = 2332; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2259;
+				State = 2338;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,342,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,359,_ctx);
 			}
 			}
 		}
@@ -13270,108 +13637,108 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_ProcedureOrArrayCallUnrestrictedContext iCS_S_ProcedureOrArrayCallUnrestricted() {
 		ICS_S_ProcedureOrArrayCallUnrestrictedContext _localctx = new ICS_S_ProcedureOrArrayCallUnrestrictedContext(_ctx, State);
-		EnterRule(_localctx, 286, RULE_iCS_S_ProcedureOrArrayCallUnrestricted);
+		EnterRule(_localctx, 292, RULE_iCS_S_ProcedureOrArrayCallUnrestricted);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2262;
-			switch ( Interpreter.AdaptivePredict(_input,343,_ctx) ) {
+			State = 2341;
+			switch ( Interpreter.AdaptivePredict(_input,360,_ctx) ) {
 			case 1:
 				{
-				State = 2260; unrestrictedIdentifier();
+				State = 2339; unrestrictedIdentifier();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2261; baseType();
+				State = 2340; baseType();
 				}
 				break;
 			}
-			State = 2265;
+			State = 2344;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 2264; typeHint();
+				State = 2343; typeHint();
 				}
 			}
 
-			State = 2268;
+			State = 2347;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2267; whiteSpace();
+				State = 2346; whiteSpace();
 				}
 			}
 
-			State = 2270; Match(LPAREN);
-			State = 2272;
-			switch ( Interpreter.AdaptivePredict(_input,346,_ctx) ) {
+			State = 2349; Match(LPAREN);
+			State = 2351;
+			switch ( Interpreter.AdaptivePredict(_input,363,_ctx) ) {
 			case 1:
 				{
-				State = 2271; whiteSpace();
+				State = 2350; whiteSpace();
 				}
 				break;
 			}
-			State = 2278;
-			switch ( Interpreter.AdaptivePredict(_input,348,_ctx) ) {
+			State = 2357;
+			switch ( Interpreter.AdaptivePredict(_input,365,_ctx) ) {
 			case 1:
 				{
-				State = 2274; argsCall();
-				State = 2276;
+				State = 2353; argsCall();
+				State = 2355;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2275; whiteSpace();
+					State = 2354; whiteSpace();
 					}
 				}
 
 				}
 				break;
 			}
-			State = 2280; Match(RPAREN);
-			State = 2285;
-			switch ( Interpreter.AdaptivePredict(_input,350,_ctx) ) {
+			State = 2359; Match(RPAREN);
+			State = 2364;
+			switch ( Interpreter.AdaptivePredict(_input,367,_ctx) ) {
 			case 1:
 				{
-				State = 2282;
+				State = 2361;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2281; whiteSpace();
+					State = 2360; whiteSpace();
 					}
 				}
 
-				State = 2284; dictionaryCallStmt();
+				State = 2363; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2296;
+			State = 2375;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,352,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,369,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2288;
+					State = 2367;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2287; whiteSpace();
+						State = 2366; whiteSpace();
 						}
 					}
 
-					State = 2290; Match(LPAREN);
-					State = 2291; subscripts();
-					State = 2292; Match(RPAREN);
+					State = 2369; Match(LPAREN);
+					State = 2370; subscripts();
+					State = 2371; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2298;
+				State = 2377;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,352,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,369,_ctx);
 			}
 			}
 		}
@@ -13445,27 +13812,27 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_MembersCallContext iCS_S_MembersCall() {
 		ICS_S_MembersCallContext _localctx = new ICS_S_MembersCallContext(_ctx, State);
-		EnterRule(_localctx, 288, RULE_iCS_S_MembersCall);
+		EnterRule(_localctx, 294, RULE_iCS_S_MembersCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2301;
-			switch ( Interpreter.AdaptivePredict(_input,353,_ctx) ) {
+			State = 2380;
+			switch ( Interpreter.AdaptivePredict(_input,370,_ctx) ) {
 			case 1:
 				{
-				State = 2299; iCS_S_VariableOrProcedureCall();
+				State = 2378; iCS_S_VariableOrProcedureCall();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2300; iCS_S_ProcedureOrArrayCall();
+				State = 2379; iCS_S_ProcedureOrArrayCall();
 				}
 				break;
 			}
-			State = 2307;
+			State = 2386;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -13473,12 +13840,12 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 2303; iCS_S_MemberCall();
-					State = 2305;
-					switch ( Interpreter.AdaptivePredict(_input,354,_ctx) ) {
+					State = 2382; iCS_S_MemberCall();
+					State = 2384;
+					switch ( Interpreter.AdaptivePredict(_input,371,_ctx) ) {
 					case 1:
 						{
-						State = 2304; whiteSpace();
+						State = 2383; whiteSpace();
 						}
 						break;
 					}
@@ -13488,50 +13855,50 @@ public partial class VBAParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 2309;
+				State = 2388;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,355,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,372,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-			State = 2315;
-			switch ( Interpreter.AdaptivePredict(_input,357,_ctx) ) {
+			State = 2394;
+			switch ( Interpreter.AdaptivePredict(_input,374,_ctx) ) {
 			case 1:
 				{
-				State = 2312;
+				State = 2391;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2311; whiteSpace();
+					State = 2390; whiteSpace();
 					}
 				}
 
-				State = 2314; dictionaryCallStmt();
+				State = 2393; dictionaryCallStmt();
 				}
 				break;
 			}
-			State = 2326;
+			State = 2405;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,359,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,376,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2318;
+					State = 2397;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2317; whiteSpace();
+						State = 2396; whiteSpace();
 						}
 					}
 
-					State = 2320; Match(LPAREN);
-					State = 2321; subscripts();
-					State = 2322; Match(RPAREN);
+					State = 2399; Match(LPAREN);
+					State = 2400; subscripts();
+					State = 2401; Match(RPAREN);
 					}
 					} 
 				}
-				State = 2328;
+				State = 2407;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,359,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,376,_ctx);
 			}
 			}
 		}
@@ -13581,36 +13948,36 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_MemberCallContext iCS_S_MemberCall() {
 		ICS_S_MemberCallContext _localctx = new ICS_S_MemberCallContext(_ctx, State);
-		EnterRule(_localctx, 290, RULE_iCS_S_MemberCall);
+		EnterRule(_localctx, 296, RULE_iCS_S_MemberCall);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2329;
+			State = 2408;
 			_la = _input.La(1);
 			if ( !(_la==EXCLAMATIONPOINT || _la==DOT) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 2331;
+			State = 2410;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2330; whiteSpace();
+				State = 2409; whiteSpace();
 				}
 			}
 
-			State = 2335;
-			switch ( Interpreter.AdaptivePredict(_input,361,_ctx) ) {
+			State = 2414;
+			switch ( Interpreter.AdaptivePredict(_input,378,_ctx) ) {
 			case 1:
 				{
-				State = 2333; iCS_S_VariableOrProcedureCallUnrestricted();
+				State = 2412; iCS_S_VariableOrProcedureCallUnrestricted();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2334; iCS_S_ProcedureOrArrayCallUnrestricted();
+				State = 2413; iCS_S_ProcedureOrArrayCallUnrestricted();
 				}
 				break;
 			}
@@ -13657,20 +14024,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ICS_S_DictionaryCallContext iCS_S_DictionaryCall() {
 		ICS_S_DictionaryCallContext _localctx = new ICS_S_DictionaryCallContext(_ctx, State);
-		EnterRule(_localctx, 292, RULE_iCS_S_DictionaryCall);
+		EnterRule(_localctx, 298, RULE_iCS_S_DictionaryCall);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2338;
+			State = 2417;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2337; whiteSpace();
+				State = 2416; whiteSpace();
 				}
 			}
 
-			State = 2340; dictionaryCallStmt();
+			State = 2419; dictionaryCallStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -13728,100 +14095,100 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgsCallContext argsCall() {
 		ArgsCallContext _localctx = new ArgsCallContext(_ctx, State);
-		EnterRule(_localctx, 294, RULE_argsCall);
+		EnterRule(_localctx, 300, RULE_argsCall);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2354;
+			State = 2433;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,366,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,383,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2343;
-					switch ( Interpreter.AdaptivePredict(_input,363,_ctx) ) {
+					State = 2422;
+					switch ( Interpreter.AdaptivePredict(_input,380,_ctx) ) {
 					case 1:
 						{
-						State = 2342; argCall();
+						State = 2421; argCall();
 						}
 						break;
 					}
-					State = 2346;
+					State = 2425;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2345; whiteSpace();
+						State = 2424; whiteSpace();
 						}
 					}
 
-					State = 2348;
+					State = 2427;
 					_la = _input.La(1);
 					if ( !(_la==COMMA || _la==SEMICOLON) ) {
 					_errHandler.RecoverInline(this);
 					}
 					Consume();
-					State = 2350;
-					switch ( Interpreter.AdaptivePredict(_input,365,_ctx) ) {
+					State = 2429;
+					switch ( Interpreter.AdaptivePredict(_input,382,_ctx) ) {
 					case 1:
 						{
-						State = 2349; whiteSpace();
+						State = 2428; whiteSpace();
 						}
 						break;
 					}
 					}
 					} 
 				}
-				State = 2356;
+				State = 2435;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,366,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,383,_ctx);
 			}
-			State = 2357; argCall();
-			State = 2370;
+			State = 2436; argCall();
+			State = 2449;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,370,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,387,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2359;
+					State = 2438;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2358; whiteSpace();
+						State = 2437; whiteSpace();
 						}
 					}
 
-					State = 2361;
+					State = 2440;
 					_la = _input.La(1);
 					if ( !(_la==COMMA || _la==SEMICOLON) ) {
 					_errHandler.RecoverInline(this);
 					}
 					Consume();
-					State = 2363;
-					switch ( Interpreter.AdaptivePredict(_input,368,_ctx) ) {
+					State = 2442;
+					switch ( Interpreter.AdaptivePredict(_input,385,_ctx) ) {
 					case 1:
 						{
-						State = 2362; whiteSpace();
+						State = 2441; whiteSpace();
 						}
 						break;
 					}
-					State = 2366;
-					switch ( Interpreter.AdaptivePredict(_input,369,_ctx) ) {
+					State = 2445;
+					switch ( Interpreter.AdaptivePredict(_input,386,_ctx) ) {
 					case 1:
 						{
-						State = 2365; argCall();
+						State = 2444; argCall();
 						}
 						break;
 					}
 					}
 					} 
 				}
-				State = 2372;
+				State = 2451;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,370,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,387,_ctx);
 			}
 			}
 		}
@@ -13871,42 +14238,42 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgCallContext argCall() {
 		ArgCallContext _localctx = new ArgCallContext(_ctx, State);
-		EnterRule(_localctx, 296, RULE_argCall);
+		EnterRule(_localctx, 302, RULE_argCall);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2374;
-			switch ( Interpreter.AdaptivePredict(_input,371,_ctx) ) {
+			State = 2453;
+			switch ( Interpreter.AdaptivePredict(_input,388,_ctx) ) {
 			case 1:
 				{
-				State = 2373; Match(LPAREN);
+				State = 2452; Match(LPAREN);
 				}
 				break;
 			}
-			State = 2378;
-			switch ( Interpreter.AdaptivePredict(_input,372,_ctx) ) {
+			State = 2457;
+			switch ( Interpreter.AdaptivePredict(_input,389,_ctx) ) {
 			case 1:
 				{
-				State = 2376;
+				State = 2455;
 				_la = _input.La(1);
 				if ( !(_la==BYVAL || _la==BYREF || _la==PARAMARRAY) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 2377; whiteSpace();
+				State = 2456; whiteSpace();
 				}
 				break;
 			}
-			State = 2381;
+			State = 2460;
 			_la = _input.La(1);
 			if (_la==RPAREN) {
 				{
-				State = 2380; Match(RPAREN);
+				State = 2459; Match(RPAREN);
 				}
 			}
 
-			State = 2383; valueStmt(0);
+			State = 2462; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -13954,26 +14321,26 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public DictionaryCallStmtContext dictionaryCallStmt() {
 		DictionaryCallStmtContext _localctx = new DictionaryCallStmtContext(_ctx, State);
-		EnterRule(_localctx, 298, RULE_dictionaryCallStmt);
+		EnterRule(_localctx, 304, RULE_dictionaryCallStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2385; Match(EXCLAMATIONPOINT);
-			State = 2387;
+			State = 2464; Match(EXCLAMATIONPOINT);
+			State = 2466;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2386; whiteSpace();
+				State = 2465; whiteSpace();
 				}
 			}
 
-			State = 2389; unrestrictedIdentifier();
-			State = 2391;
-			switch ( Interpreter.AdaptivePredict(_input,375,_ctx) ) {
+			State = 2468; unrestrictedIdentifier();
+			State = 2470;
+			switch ( Interpreter.AdaptivePredict(_input,392,_ctx) ) {
 			case 1:
 				{
-				State = 2390; typeHint();
+				State = 2469; typeHint();
 				}
 				break;
 			}
@@ -14032,70 +14399,70 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgListContext argList() {
 		ArgListContext _localctx = new ArgListContext(_ctx, State);
-		EnterRule(_localctx, 300, RULE_argList);
+		EnterRule(_localctx, 306, RULE_argList);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2393; Match(LPAREN);
-			State = 2411;
-			switch ( Interpreter.AdaptivePredict(_input,380,_ctx) ) {
+			State = 2472; Match(LPAREN);
+			State = 2490;
+			switch ( Interpreter.AdaptivePredict(_input,397,_ctx) ) {
 			case 1:
 				{
-				State = 2395;
+				State = 2474;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2394; whiteSpace();
+					State = 2473; whiteSpace();
 					}
 				}
 
-				State = 2397; arg();
-				State = 2408;
+				State = 2476; arg();
+				State = 2487;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,379,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,396,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2399;
+						State = 2478;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2398; whiteSpace();
+							State = 2477; whiteSpace();
 							}
 						}
 
-						State = 2401; Match(COMMA);
-						State = 2403;
+						State = 2480; Match(COMMA);
+						State = 2482;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2402; whiteSpace();
+							State = 2481; whiteSpace();
 							}
 						}
 
-						State = 2405; arg();
+						State = 2484; arg();
 						}
 						} 
 					}
-					State = 2410;
+					State = 2489;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,379,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,396,_ctx);
 				}
 				}
 				break;
 			}
-			State = 2414;
+			State = 2493;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2413; whiteSpace();
+				State = 2492; whiteSpace();
 				}
 			}
 
-			State = 2416; Match(RPAREN);
+			State = 2495; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -14157,106 +14524,106 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgContext arg() {
 		ArgContext _localctx = new ArgContext(_ctx, State);
-		EnterRule(_localctx, 302, RULE_arg);
+		EnterRule(_localctx, 308, RULE_arg);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2420;
-			switch ( Interpreter.AdaptivePredict(_input,382,_ctx) ) {
+			State = 2499;
+			switch ( Interpreter.AdaptivePredict(_input,399,_ctx) ) {
 			case 1:
 				{
-				State = 2418; Match(OPTIONAL);
-				State = 2419; whiteSpace();
+				State = 2497; Match(OPTIONAL);
+				State = 2498; whiteSpace();
 				}
 				break;
 			}
-			State = 2424;
-			switch ( Interpreter.AdaptivePredict(_input,383,_ctx) ) {
+			State = 2503;
+			switch ( Interpreter.AdaptivePredict(_input,400,_ctx) ) {
 			case 1:
 				{
-				State = 2422;
+				State = 2501;
 				_la = _input.La(1);
 				if ( !(_la==BYVAL || _la==BYREF) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 2423; whiteSpace();
+				State = 2502; whiteSpace();
 				}
 				break;
 			}
-			State = 2428;
-			switch ( Interpreter.AdaptivePredict(_input,384,_ctx) ) {
+			State = 2507;
+			switch ( Interpreter.AdaptivePredict(_input,401,_ctx) ) {
 			case 1:
 				{
-				State = 2426; Match(PARAMARRAY);
-				State = 2427; whiteSpace();
+				State = 2505; Match(PARAMARRAY);
+				State = 2506; whiteSpace();
 				}
 				break;
 			}
-			State = 2430; unrestrictedIdentifier();
-			State = 2432;
+			State = 2509; unrestrictedIdentifier();
+			State = 2511;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) {
 				{
-				State = 2431; typeHint();
+				State = 2510; typeHint();
 				}
 			}
 
-			State = 2442;
-			switch ( Interpreter.AdaptivePredict(_input,388,_ctx) ) {
+			State = 2521;
+			switch ( Interpreter.AdaptivePredict(_input,405,_ctx) ) {
 			case 1:
 				{
-				State = 2435;
+				State = 2514;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2434; whiteSpace();
+					State = 2513; whiteSpace();
 					}
 				}
 
-				State = 2437; Match(LPAREN);
-				State = 2439;
+				State = 2516; Match(LPAREN);
+				State = 2518;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2438; whiteSpace();
+					State = 2517; whiteSpace();
 					}
 				}
 
-				State = 2441; Match(RPAREN);
+				State = 2520; Match(RPAREN);
 				}
 				break;
 			}
-			State = 2448;
-			switch ( Interpreter.AdaptivePredict(_input,390,_ctx) ) {
+			State = 2527;
+			switch ( Interpreter.AdaptivePredict(_input,407,_ctx) ) {
 			case 1:
 				{
-				State = 2445;
+				State = 2524;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2444; whiteSpace();
+					State = 2523; whiteSpace();
 					}
 				}
 
-				State = 2447; asTypeClause();
+				State = 2526; asTypeClause();
 				}
 				break;
 			}
-			State = 2454;
-			switch ( Interpreter.AdaptivePredict(_input,392,_ctx) ) {
+			State = 2533;
+			switch ( Interpreter.AdaptivePredict(_input,409,_ctx) ) {
 			case 1:
 				{
-				State = 2451;
+				State = 2530;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2450; whiteSpace();
+					State = 2529; whiteSpace();
 					}
 				}
 
-				State = 2453; argDefaultValue();
+				State = 2532; argDefaultValue();
 				}
 				break;
 			}
@@ -14304,20 +14671,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgDefaultValueContext argDefaultValue() {
 		ArgDefaultValueContext _localctx = new ArgDefaultValueContext(_ctx, State);
-		EnterRule(_localctx, 304, RULE_argDefaultValue);
+		EnterRule(_localctx, 310, RULE_argDefaultValue);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2456; Match(EQ);
-			State = 2458;
-			switch ( Interpreter.AdaptivePredict(_input,393,_ctx) ) {
+			State = 2535; Match(EQ);
+			State = 2537;
+			switch ( Interpreter.AdaptivePredict(_input,410,_ctx) ) {
 			case 1:
 				{
-				State = 2457; whiteSpace();
+				State = 2536; whiteSpace();
 				}
 				break;
 			}
-			State = 2460; valueStmt(0);
+			State = 2539; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -14371,44 +14738,44 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubscriptsContext subscripts() {
 		SubscriptsContext _localctx = new SubscriptsContext(_ctx, State);
-		EnterRule(_localctx, 306, RULE_subscripts);
+		EnterRule(_localctx, 312, RULE_subscripts);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2462; subscript();
-			State = 2473;
+			State = 2541; subscript();
+			State = 2552;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,396,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,413,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2464;
+					State = 2543;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2463; whiteSpace();
+						State = 2542; whiteSpace();
 						}
 					}
 
-					State = 2466; Match(COMMA);
-					State = 2468;
-					switch ( Interpreter.AdaptivePredict(_input,395,_ctx) ) {
+					State = 2545; Match(COMMA);
+					State = 2547;
+					switch ( Interpreter.AdaptivePredict(_input,412,_ctx) ) {
 					case 1:
 						{
-						State = 2467; whiteSpace();
+						State = 2546; whiteSpace();
 						}
 						break;
 					}
-					State = 2470; subscript();
+					State = 2549; subscript();
 					}
 					} 
 				}
-				State = 2475;
+				State = 2554;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,396,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,413,_ctx);
 			}
 			}
 		}
@@ -14460,22 +14827,22 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubscriptContext subscript() {
 		SubscriptContext _localctx = new SubscriptContext(_ctx, State);
-		EnterRule(_localctx, 308, RULE_subscript);
+		EnterRule(_localctx, 314, RULE_subscript);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2481;
-			switch ( Interpreter.AdaptivePredict(_input,397,_ctx) ) {
+			State = 2560;
+			switch ( Interpreter.AdaptivePredict(_input,414,_ctx) ) {
 			case 1:
 				{
-				State = 2476; valueStmt(0);
-				State = 2477; whiteSpace();
-				State = 2478; Match(TO);
-				State = 2479; whiteSpace();
+				State = 2555; valueStmt(0);
+				State = 2556; whiteSpace();
+				State = 2557; Match(TO);
+				State = 2558; whiteSpace();
 				}
 				break;
 			}
-			State = 2483; valueStmt(0);
+			State = 2562; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -14522,9 +14889,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UnrestrictedIdentifierContext unrestrictedIdentifier() {
 		UnrestrictedIdentifierContext _localctx = new UnrestrictedIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 310, RULE_unrestrictedIdentifier);
+		EnterRule(_localctx, 316, RULE_unrestrictedIdentifier);
 		try {
-			State = 2488;
+			State = 2567;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -14536,7 +14903,6 @@ public partial class VBAParser : Parser {
 			case CDBL:
 			case CDEC:
 			case CINT:
-			case CIRCLE:
 			case CLNG:
 			case CLNGLNG:
 			case CLNGPTR:
@@ -14559,7 +14925,6 @@ public partial class VBAParser : Parser {
 			case MIDBTYPESUFFIX:
 			case MIDTYPESUFFIX:
 			case PSET:
-			case SCALE:
 			case SGN:
 			case UBOUND:
 			case ACCESS:
@@ -14654,7 +15019,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2485; identifier();
+				State = 2564; identifier();
 				}
 				break;
 			case EXIT:
@@ -14715,13 +15080,13 @@ public partial class VBAParser : Parser {
 			case WITH:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2486; statementKeyword();
+				State = 2565; statementKeyword();
 				}
 				break;
 			case AS:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2487; markerKeyword();
+				State = 2566; markerKeyword();
 				}
 				break;
 			default:
@@ -14767,14 +15132,14 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IdentifierContext identifier() {
 		IdentifierContext _localctx = new IdentifierContext(_ctx, State);
-		EnterRule(_localctx, 312, RULE_identifier);
+		EnterRule(_localctx, 318, RULE_identifier);
 		try {
-			State = 2492;
+			State = 2571;
 			switch (_input.La(1)) {
 			case IDENTIFIER:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2490; Match(IDENTIFIER);
+				State = 2569; Match(IDENTIFIER);
 				}
 				break;
 			case ABS:
@@ -14787,7 +15152,6 @@ public partial class VBAParser : Parser {
 			case CDBL:
 			case CDEC:
 			case CINT:
-			case CIRCLE:
 			case CLNG:
 			case CLNGLNG:
 			case CLNGPTR:
@@ -14810,7 +15174,6 @@ public partial class VBAParser : Parser {
 			case MIDBTYPESUFFIX:
 			case MIDTYPESUFFIX:
 			case PSET:
-			case SCALE:
 			case SGN:
 			case UBOUND:
 			case ACCESS:
@@ -14904,7 +15267,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2491; keyword();
+				State = 2570; keyword();
 				}
 				break;
 			default:
@@ -14960,43 +15323,43 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AsTypeClauseContext asTypeClause() {
 		AsTypeClauseContext _localctx = new AsTypeClauseContext(_ctx, State);
-		EnterRule(_localctx, 314, RULE_asTypeClause);
+		EnterRule(_localctx, 320, RULE_asTypeClause);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2494; Match(AS);
-			State = 2496;
+			State = 2573; Match(AS);
+			State = 2575;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2495; whiteSpace();
+				State = 2574; whiteSpace();
 				}
 			}
 
-			State = 2500;
-			switch ( Interpreter.AdaptivePredict(_input,401,_ctx) ) {
+			State = 2579;
+			switch ( Interpreter.AdaptivePredict(_input,418,_ctx) ) {
 			case 1:
 				{
-				State = 2498; Match(NEW);
-				State = 2499; whiteSpace();
+				State = 2577; Match(NEW);
+				State = 2578; whiteSpace();
 				}
 				break;
 			}
-			State = 2502; type();
-			State = 2507;
-			switch ( Interpreter.AdaptivePredict(_input,403,_ctx) ) {
+			State = 2581; type();
+			State = 2586;
+			switch ( Interpreter.AdaptivePredict(_input,420,_ctx) ) {
 			case 1:
 				{
-				State = 2504;
+				State = 2583;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2503; whiteSpace();
+					State = 2582; whiteSpace();
 					}
 				}
 
-				State = 2506; fieldLength();
+				State = 2585; fieldLength();
 				}
 				break;
 			}
@@ -15049,12 +15412,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public BaseTypeContext baseType() {
 		BaseTypeContext _localctx = new BaseTypeContext(_ctx, State);
-		EnterRule(_localctx, 316, RULE_baseType);
+		EnterRule(_localctx, 322, RULE_baseType);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2509;
+			State = 2588;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << CURRENCY) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << BOOLEAN) | (1L << BYTE))) != 0) || ((((_la - 68)) & ~0x3f) == 0 && ((1L << (_la - 68)) & ((1L << (DATE - 68)) | (1L << (DOUBLE - 68)) | (1L << (INTEGER - 68)) | (1L << (LONG - 68)))) != 0) || ((((_la - 178)) & ~0x3f) == 0 && ((1L << (_la - 178)) & ((1L << (SINGLE - 178)) | (1L << (STRING - 178)) | (1L << (VARIANT - 178)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -15105,12 +15468,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ComparisonOperatorContext comparisonOperator() {
 		ComparisonOperatorContext _localctx = new ComparisonOperatorContext(_ctx, State);
-		EnterRule(_localctx, 318, RULE_comparisonOperator);
+		EnterRule(_localctx, 324, RULE_comparisonOperator);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2511;
+			State = 2590;
 			_la = _input.La(1);
 			if ( !(_la==IS || _la==LIKE || ((((_la - 206)) & ~0x3f) == 0 && ((1L << (_la - 206)) & ((1L << (EQ - 206)) | (1L << (GEQ - 206)) | (1L << (GT - 206)) | (1L << (LEQ - 206)) | (1L << (LT - 206)) | (1L << (NEQ - 206)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -15167,33 +15530,33 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ComplexTypeContext complexType() {
 		ComplexTypeContext _localctx = new ComplexTypeContext(_ctx, State);
-		EnterRule(_localctx, 320, RULE_complexType);
+		EnterRule(_localctx, 326, RULE_complexType);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2513; identifier();
-			State = 2518;
+			State = 2592; identifier();
+			State = 2597;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,404,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,421,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2514;
+					State = 2593;
 					_la = _input.La(1);
 					if ( !(_la==EXCLAMATIONPOINT || _la==DOT) ) {
 					_errHandler.RecoverInline(this);
 					}
 					Consume();
-					State = 2515; identifier();
+					State = 2594; identifier();
 					}
 					} 
 				}
-				State = 2520;
+				State = 2599;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,404,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,421,_ctx);
 			}
 			}
 		}
@@ -15242,28 +15605,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public FieldLengthContext fieldLength() {
 		FieldLengthContext _localctx = new FieldLengthContext(_ctx, State);
-		EnterRule(_localctx, 322, RULE_fieldLength);
+		EnterRule(_localctx, 328, RULE_fieldLength);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2521; Match(MULT);
-			State = 2523;
+			State = 2600; Match(MULT);
+			State = 2602;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2522; whiteSpace();
+				State = 2601; whiteSpace();
 				}
 			}
 
-			State = 2527;
+			State = 2606;
 			switch (_input.La(1)) {
 			case OCTLITERAL:
 			case HEXLITERAL:
 			case FLOATLITERAL:
 			case INTEGERLITERAL:
 				{
-				State = 2525; numberLiteral();
+				State = 2604; numberLiteral();
 				}
 				break;
 			case ABS:
@@ -15276,7 +15639,6 @@ public partial class VBAParser : Parser {
 			case CDBL:
 			case CDEC:
 			case CINT:
-			case CIRCLE:
 			case CLNG:
 			case CLNGLNG:
 			case CLNGPTR:
@@ -15299,7 +15661,6 @@ public partial class VBAParser : Parser {
 			case MIDBTYPESUFFIX:
 			case MIDTYPESUFFIX:
 			case PSET:
-			case SCALE:
 			case SGN:
 			case UBOUND:
 			case ACCESS:
@@ -15393,7 +15754,7 @@ public partial class VBAParser : Parser {
 			case SETATTR:
 			case RESUME_NEXT:
 				{
-				State = 2526; identifier();
+				State = 2605; identifier();
 				}
 				break;
 			default:
@@ -15443,21 +15804,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementLabelDefinitionContext statementLabelDefinition() {
 		StatementLabelDefinitionContext _localctx = new StatementLabelDefinitionContext(_ctx, State);
-		EnterRule(_localctx, 324, RULE_statementLabelDefinition);
+		EnterRule(_localctx, 330, RULE_statementLabelDefinition);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2529; statementLabel();
-			State = 2531;
+			State = 2608; statementLabel();
+			State = 2610;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2530; whiteSpace();
+				State = 2609; whiteSpace();
 				}
 			}
 
-			State = 2533; Match(COLON);
+			State = 2612; Match(COLON);
 			}
 		}
 		catch (RecognitionException re) {
@@ -15501,9 +15862,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementLabelContext statementLabel() {
 		StatementLabelContext _localctx = new StatementLabelContext(_ctx, State);
-		EnterRule(_localctx, 326, RULE_statementLabel);
+		EnterRule(_localctx, 332, RULE_statementLabel);
 		try {
-			State = 2537;
+			State = 2616;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -15515,7 +15876,6 @@ public partial class VBAParser : Parser {
 			case CDBL:
 			case CDEC:
 			case CINT:
-			case CIRCLE:
 			case CLNG:
 			case CLNGLNG:
 			case CLNGPTR:
@@ -15540,7 +15900,6 @@ public partial class VBAParser : Parser {
 			case MIDTYPESUFFIX:
 			case OPTION:
 			case PSET:
-			case SCALE:
 			case SGN:
 			case UBOUND:
 			case ACCESS:
@@ -15690,7 +16049,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2535; identifierStatementLabel();
+				State = 2614; identifierStatementLabel();
 				}
 				break;
 			case OCTLITERAL:
@@ -15699,7 +16058,7 @@ public partial class VBAParser : Parser {
 			case INTEGERLITERAL:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2536; lineNumberLabel();
+				State = 2615; lineNumberLabel();
 				}
 				break;
 			default:
@@ -15744,11 +16103,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IdentifierStatementLabelContext identifierStatementLabel() {
 		IdentifierStatementLabelContext _localctx = new IdentifierStatementLabelContext(_ctx, State);
-		EnterRule(_localctx, 328, RULE_identifierStatementLabel);
+		EnterRule(_localctx, 334, RULE_identifierStatementLabel);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2539; unrestrictedIdentifier();
+			State = 2618; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -15789,11 +16148,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LineNumberLabelContext lineNumberLabel() {
 		LineNumberLabelContext _localctx = new LineNumberLabelContext(_ctx, State);
-		EnterRule(_localctx, 330, RULE_lineNumberLabel);
+		EnterRule(_localctx, 336, RULE_lineNumberLabel);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2541; numberLiteral();
+			State = 2620; numberLiteral();
 			}
 		}
 		catch (RecognitionException re) {
@@ -15841,9 +16200,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LiteralContext literal() {
 		LiteralContext _localctx = new LiteralContext(_ctx, State);
-		EnterRule(_localctx, 332, RULE_literal);
+		EnterRule(_localctx, 338, RULE_literal);
 		try {
-			State = 2551;
+			State = 2630;
 			switch (_input.La(1)) {
 			case OCTLITERAL:
 			case HEXLITERAL:
@@ -15851,49 +16210,49 @@ public partial class VBAParser : Parser {
 			case INTEGERLITERAL:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2543; numberLiteral();
+				State = 2622; numberLiteral();
 				}
 				break;
 			case DATELITERAL:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2544; Match(DATELITERAL);
+				State = 2623; Match(DATELITERAL);
 				}
 				break;
 			case STRINGLITERAL:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2545; Match(STRINGLITERAL);
+				State = 2624; Match(STRINGLITERAL);
 				}
 				break;
 			case TRUE:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2546; Match(TRUE);
+				State = 2625; Match(TRUE);
 				}
 				break;
 			case FALSE:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 2547; Match(FALSE);
+				State = 2626; Match(FALSE);
 				}
 				break;
 			case NOTHING:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 2548; Match(NOTHING);
+				State = 2627; Match(NOTHING);
 				}
 				break;
 			case NULL:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 2549; Match(NULL);
+				State = 2628; Match(NULL);
 				}
 				break;
 			case EMPTY:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 2550; Match(EMPTY);
+				State = 2629; Match(EMPTY);
 				}
 				break;
 			default:
@@ -15939,12 +16298,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public NumberLiteralContext numberLiteral() {
 		NumberLiteralContext _localctx = new NumberLiteralContext(_ctx, State);
-		EnterRule(_localctx, 334, RULE_numberLiteral);
+		EnterRule(_localctx, 340, RULE_numberLiteral);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2553;
+			State = 2632;
 			_la = _input.La(1);
 			if ( !(((((_la - 226)) & ~0x3f) == 0 && ((1L << (_la - 226)) & ((1L << (OCTLITERAL - 226)) | (1L << (HEXLITERAL - 226)) | (1L << (FLOATLITERAL - 226)) | (1L << (INTEGERLITERAL - 226)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -16001,47 +16360,47 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeContext type() {
 		TypeContext _localctx = new TypeContext(_ctx, State);
-		EnterRule(_localctx, 336, RULE_type);
+		EnterRule(_localctx, 342, RULE_type);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2557;
-			switch ( Interpreter.AdaptivePredict(_input,410,_ctx) ) {
+			State = 2636;
+			switch ( Interpreter.AdaptivePredict(_input,427,_ctx) ) {
 			case 1:
 				{
-				State = 2555; baseType();
+				State = 2634; baseType();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2556; complexType();
+				State = 2635; complexType();
 				}
 				break;
 			}
-			State = 2567;
-			switch ( Interpreter.AdaptivePredict(_input,413,_ctx) ) {
+			State = 2646;
+			switch ( Interpreter.AdaptivePredict(_input,430,_ctx) ) {
 			case 1:
 				{
-				State = 2560;
+				State = 2639;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2559; whiteSpace();
+					State = 2638; whiteSpace();
 					}
 				}
 
-				State = 2562; Match(LPAREN);
-				State = 2564;
+				State = 2641; Match(LPAREN);
+				State = 2643;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2563; whiteSpace();
+					State = 2642; whiteSpace();
 					}
 				}
 
-				State = 2566; Match(RPAREN);
+				State = 2645; Match(RPAREN);
 				}
 				break;
 			}
@@ -16089,12 +16448,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeHintContext typeHint() {
 		TypeHintContext _localctx = new TypeHintContext(_ctx, State);
-		EnterRule(_localctx, 338, RULE_typeHint);
+		EnterRule(_localctx, 344, RULE_typeHint);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2569;
+			State = 2648;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) ) {
 			_errHandler.RecoverInline(this);
@@ -16141,12 +16500,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VisibilityContext visibility() {
 		VisibilityContext _localctx = new VisibilityContext(_ctx, State);
-		EnterRule(_localctx, 340, RULE_visibility);
+		EnterRule(_localctx, 346, RULE_visibility);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2571;
+			State = 2650;
 			_la = _input.La(1);
 			if ( !(((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -16171,7 +16530,6 @@ public partial class VBAParser : Parser {
 		public ITerminalNode XOR() { return GetToken(VBAParser.XOR, 0); }
 		public ITerminalNode LOAD() { return GetToken(VBAParser.LOAD, 0); }
 		public ITerminalNode MIDTYPESUFFIX() { return GetToken(VBAParser.MIDTYPESUFFIX, 0); }
-		public ITerminalNode SCALE() { return GetToken(VBAParser.SCALE, 0); }
 		public ITerminalNode BYREF() { return GetToken(VBAParser.BYREF, 0); }
 		public ITerminalNode DEBUG() { return GetToken(VBAParser.DEBUG, 0); }
 		public ITerminalNode CLNGPTR() { return GetToken(VBAParser.CLNGPTR, 0); }
@@ -16254,7 +16612,6 @@ public partial class VBAParser : Parser {
 		public ITerminalNode INPUT() { return GetToken(VBAParser.INPUT, 0); }
 		public ITerminalNode SEEK() { return GetToken(VBAParser.SEEK, 0); }
 		public ITerminalNode CURRENCY() { return GetToken(VBAParser.CURRENCY, 0); }
-		public ITerminalNode CIRCLE() { return GetToken(VBAParser.CIRCLE, 0); }
 		public ITerminalNode LEN(int i) {
 			return GetToken(VBAParser.LEN, i);
 		}
@@ -16320,14 +16677,14 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public KeywordContext keyword() {
 		KeywordContext _localctx = new KeywordContext(_ctx, State);
-		EnterRule(_localctx, 342, RULE_keyword);
+		EnterRule(_localctx, 348, RULE_keyword);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2573;
+			State = 2652;
 			_la = _input.La(1);
-			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) ) {
+			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
@@ -16369,11 +16726,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public MarkerKeywordContext markerKeyword() {
 		MarkerKeywordContext _localctx = new MarkerKeywordContext(_ctx, State);
-		EnterRule(_localctx, 344, RULE_markerKeyword);
+		EnterRule(_localctx, 350, RULE_markerKeyword);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2575; Match(AS);
+			State = 2654; Match(AS);
 			}
 		}
 		catch (RecognitionException re) {
@@ -16467,12 +16824,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementKeywordContext statementKeyword() {
 		StatementKeywordContext _localctx = new StatementKeywordContext(_ctx, State);
-		EnterRule(_localctx, 346, RULE_statementKeyword);
+		EnterRule(_localctx, 352, RULE_statementKeyword);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2577;
+			State = 2656;
 			_la = _input.La(1);
 			if ( !(((((_la - 22)) & ~0x3f) == 0 && ((1L << (_la - 22)) & ((1L << (EXIT - 22)) | (1L << (OPTION - 22)) | (1L << (CALL - 22)) | (1L << (CASE - 22)) | (1L << (CONST - 22)) | (1L << (DECLARE - 22)) | (1L << (DEFBOOL - 22)) | (1L << (DEFBYTE - 22)) | (1L << (DEFDATE - 22)) | (1L << (DEFDBL - 22)) | (1L << (DEFCUR - 22)) | (1L << (DEFINT - 22)) | (1L << (DEFLNG - 22)) | (1L << (DEFLNGLNG - 22)) | (1L << (DEFLNGPTR - 22)) | (1L << (DEFOBJ - 22)) | (1L << (DEFSNG - 22)) | (1L << (DEFSTR - 22)) | (1L << (DEFVAR - 22)) | (1L << (DIM - 22)) | (1L << (DO - 22)))) != 0) || ((((_la - 87)) & ~0x3f) == 0 && ((1L << (_la - 87)) & ((1L << (ELSE - 87)) | (1L << (ELSEIF - 87)) | (1L << (ENUM - 87)) | (1L << (ERASE - 87)) | (1L << (EVENT - 87)) | (1L << (FRIEND - 87)) | (1L << (FOR - 87)) | (1L << (FUNCTION - 87)) | (1L << (GLOBAL - 87)) | (1L << (GOSUB - 87)) | (1L << (GOTO - 87)) | (1L << (IF - 87)) | (1L << (IMPLEMENTS - 87)) | (1L << (LOOP - 87)) | (1L << (LET - 87)) | (1L << (LSET - 87)) | (1L << (NEXT - 87)) | (1L << (ON - 87)))) != 0) || ((((_la - 156)) & ~0x3f) == 0 && ((1L << (_la - 156)) & ((1L << (PRINT - 156)) | (1L << (PRIVATE - 156)) | (1L << (PUBLIC - 156)) | (1L << (RAISEEVENT - 156)) | (1L << (REDIM - 156)) | (1L << (RESUME - 156)) | (1L << (RETURN - 156)) | (1L << (RSET - 156)) | (1L << (SELECT - 156)) | (1L << (SET - 156)) | (1L << (STATIC - 156)) | (1L << (STOP - 156)) | (1L << (SUB - 156)) | (1L << (TYPE - 156)) | (1L << (WEND - 156)) | (1L << (WHILE - 156)) | (1L << (WITH - 156)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -16521,24 +16878,24 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EndOfLineContext endOfLine() {
 		EndOfLineContext _localctx = new EndOfLineContext(_ctx, State);
-		EnterRule(_localctx, 348, RULE_endOfLine);
+		EnterRule(_localctx, 354, RULE_endOfLine);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2580;
+			State = 2659;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2579; whiteSpace();
+				State = 2658; whiteSpace();
 				}
 			}
 
-			State = 2583;
+			State = 2662;
 			_la = _input.La(1);
 			if (_la==REM || _la==SINGLEQUOTE) {
 				{
-				State = 2582; commentOrAnnotation();
+				State = 2661; commentOrAnnotation();
 				}
 			}
 
@@ -16600,34 +16957,34 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EndOfStatementContext endOfStatement() {
 		EndOfStatementContext _localctx = new EndOfStatementContext(_ctx, State);
-		EnterRule(_localctx, 350, RULE_endOfStatement);
+		EnterRule(_localctx, 356, RULE_endOfStatement);
 		int _la;
 		try {
 			int _alt;
-			State = 2607;
-			switch ( Interpreter.AdaptivePredict(_input,421,_ctx) ) {
+			State = 2686;
+			switch ( Interpreter.AdaptivePredict(_input,438,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2601;
+				State = 2680;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,420,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,437,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2597;
-						switch ( Interpreter.AdaptivePredict(_input,419,_ctx) ) {
+						State = 2676;
+						switch ( Interpreter.AdaptivePredict(_input,436,_ctx) ) {
 						case 1:
 							{
 							{
-							State = 2585; endOfLine();
-							State = 2586; Match(NEWLINE);
-							State = 2588;
-							switch ( Interpreter.AdaptivePredict(_input,416,_ctx) ) {
+							State = 2664; endOfLine();
+							State = 2665; Match(NEWLINE);
+							State = 2667;
+							switch ( Interpreter.AdaptivePredict(_input,433,_ctx) ) {
 							case 1:
 								{
-								State = 2587; whiteSpace();
+								State = 2666; whiteSpace();
 								}
 								break;
 							}
@@ -16638,20 +16995,20 @@ public partial class VBAParser : Parser {
 						case 2:
 							{
 							{
-							State = 2591;
+							State = 2670;
 							_la = _input.La(1);
 							if (_la==WS || _la==LINE_CONTINUATION) {
 								{
-								State = 2590; whiteSpace();
+								State = 2669; whiteSpace();
 								}
 							}
 
-							State = 2593; Match(COLON);
-							State = 2595;
-							switch ( Interpreter.AdaptivePredict(_input,418,_ctx) ) {
+							State = 2672; Match(COLON);
+							State = 2674;
+							switch ( Interpreter.AdaptivePredict(_input,435,_ctx) ) {
 							case 1:
 								{
-								State = 2594; whiteSpace();
+								State = 2673; whiteSpace();
 								}
 								break;
 							}
@@ -16662,9 +17019,9 @@ public partial class VBAParser : Parser {
 						}
 						} 
 					}
-					State = 2603;
+					State = 2682;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,420,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,437,_ctx);
 				}
 				}
 				break;
@@ -16672,8 +17029,8 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2604; endOfLine();
-				State = 2605; Match(Eof);
+				State = 2683; endOfLine();
+				State = 2684; Match(Eof);
 				}
 				break;
 			}
@@ -16722,28 +17079,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentOrAnnotationContext commentOrAnnotation() {
 		CommentOrAnnotationContext _localctx = new CommentOrAnnotationContext(_ctx, State);
-		EnterRule(_localctx, 352, RULE_commentOrAnnotation);
+		EnterRule(_localctx, 358, RULE_commentOrAnnotation);
 		try {
-			State = 2612;
-			switch ( Interpreter.AdaptivePredict(_input,422,_ctx) ) {
+			State = 2691;
+			switch ( Interpreter.AdaptivePredict(_input,439,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2609; annotationList();
+				State = 2688; annotationList();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2610; comment();
+				State = 2689; comment();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2611; remComment();
+				State = 2690; remComment();
 				}
 				break;
 			}
@@ -16790,20 +17147,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RemCommentContext remComment() {
 		RemCommentContext _localctx = new RemCommentContext(_ctx, State);
-		EnterRule(_localctx, 354, RULE_remComment);
+		EnterRule(_localctx, 360, RULE_remComment);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2614; Match(REM);
-			State = 2616;
-			switch ( Interpreter.AdaptivePredict(_input,423,_ctx) ) {
+			State = 2693; Match(REM);
+			State = 2695;
+			switch ( Interpreter.AdaptivePredict(_input,440,_ctx) ) {
 			case 1:
 				{
-				State = 2615; whiteSpace();
+				State = 2694; whiteSpace();
 				}
 				break;
 			}
-			State = 2618; commentBody();
+			State = 2697; commentBody();
 			}
 		}
 		catch (RecognitionException re) {
@@ -16845,12 +17202,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentContext comment() {
 		CommentContext _localctx = new CommentContext(_ctx, State);
-		EnterRule(_localctx, 356, RULE_comment);
+		EnterRule(_localctx, 362, RULE_comment);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2620; Match(SINGLEQUOTE);
-			State = 2621; commentBody();
+			State = 2699; Match(SINGLEQUOTE);
+			State = 2700; commentBody();
 			}
 		}
 		catch (RecognitionException re) {
@@ -16896,27 +17253,27 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentBodyContext commentBody() {
 		CommentBodyContext _localctx = new CommentBodyContext(_ctx, State);
-		EnterRule(_localctx, 358, RULE_commentBody);
+		EnterRule(_localctx, 364, RULE_commentBody);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2627;
+			State = 2706;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << COMMA) | (1L << COLON) | (1L << SEMICOLON) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (EACH - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_ENUM - 64)) | (1L << (END_FUNCTION - 64)) | (1L << (END_IF - 64)) | (1L << (END_PROPERTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_SUB - 64)) | (1L << (END_TYPE - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OPTION_BASE - 128)) | (1L << (OPTION_EXPLICIT - 128)) | (1L << (OPTION_COMPARE - 128)) | (1L << (OPTION_PRIVATE_MODULE - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PROPERTY_GET - 128)) | (1L << (PROPERTY_LET - 128)) | (1L << (PROPERTY_SET - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)) | (1L << (TYPEOF - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (ASSIGN - 192)) | (1L << (DIV - 192)) | (1L << (INTDIV - 192)) | (1L << (EQ - 192)) | (1L << (GEQ - 192)) | (1L << (GT - 192)) | (1L << (LEQ - 192)) | (1L << (LPAREN - 192)) | (1L << (LT - 192)) | (1L << (MINUS - 192)) | (1L << (MULT - 192)) | (1L << (NEQ - 192)) | (1L << (PLUS - 192)) | (1L << (POW - 192)) | (1L << (RPAREN - 192)) | (1L << (HASHCONST - 192)) | (1L << (HASHIF - 192)) | (1L << (HASHELSEIF - 192)) | (1L << (HASHELSE - 192)) | (1L << (HASHENDIF - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (R_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (SINGLEQUOTE - 192)) | (1L << (UNDERSCORE - 192)) | (1L << (WS - 192)) | (1L << (GUIDLITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (ERRORCHAR - 192)) | (1L << (COLLECTION - 192)) | (1L << (DELETESETTING - 192)) | (1L << (LOAD - 192)) | (1L << (RMDIR - 192)) | (1L << (SENDKEYS - 192)) | (1L << (SETATTR - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 2625;
-				switch ( Interpreter.AdaptivePredict(_input,424,_ctx) ) {
+				State = 2704;
+				switch ( Interpreter.AdaptivePredict(_input,441,_ctx) ) {
 				case 1:
 					{
-					State = 2623; Match(LINE_CONTINUATION);
+					State = 2702; Match(LINE_CONTINUATION);
 					}
 					break;
 
 				case 2:
 					{
-					State = 2624;
+					State = 2703;
 					_la = _input.La(1);
 					if ( _la <= 0 || (_la==NEWLINE) ) {
 					_errHandler.RecoverInline(this);
@@ -16926,7 +17283,7 @@ public partial class VBAParser : Parser {
 					break;
 				}
 				}
-				State = 2629;
+				State = 2708;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
@@ -16984,31 +17341,31 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationListContext annotationList() {
 		AnnotationListContext _localctx = new AnnotationListContext(_ctx, State);
-		EnterRule(_localctx, 360, RULE_annotationList);
+		EnterRule(_localctx, 366, RULE_annotationList);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2630; Match(SINGLEQUOTE);
-			State = 2636;
+			State = 2709; Match(SINGLEQUOTE);
+			State = 2715;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			do {
 				{
 				{
-				State = 2631; Match(AT);
-				State = 2632; annotation();
-				State = 2634;
+				State = 2710; Match(AT);
+				State = 2711; annotation();
+				State = 2713;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2633; whiteSpace();
+					State = 2712; whiteSpace();
 					}
 				}
 
 				}
 				}
-				State = 2638;
+				State = 2717;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			} while ( _la==AT );
@@ -17055,16 +17412,16 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationContext annotation() {
 		AnnotationContext _localctx = new AnnotationContext(_ctx, State);
-		EnterRule(_localctx, 362, RULE_annotation);
+		EnterRule(_localctx, 368, RULE_annotation);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2640; annotationName();
-			State = 2642;
-			switch ( Interpreter.AdaptivePredict(_input,428,_ctx) ) {
+			State = 2719; annotationName();
+			State = 2721;
+			switch ( Interpreter.AdaptivePredict(_input,445,_ctx) ) {
 			case 1:
 				{
-				State = 2641; annotationArgList();
+				State = 2720; annotationArgList();
 				}
 				break;
 			}
@@ -17108,11 +17465,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationNameContext annotationName() {
 		AnnotationNameContext _localctx = new AnnotationNameContext(_ctx, State);
-		EnterRule(_localctx, 364, RULE_annotationName);
+		EnterRule(_localctx, 370, RULE_annotationName);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2644; unrestrictedIdentifier();
+			State = 2723; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -17168,26 +17525,26 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationArgListContext annotationArgList() {
 		AnnotationArgListContext _localctx = new AnnotationArgListContext(_ctx, State);
-		EnterRule(_localctx, 366, RULE_annotationArgList);
+		EnterRule(_localctx, 372, RULE_annotationArgList);
 		int _la;
 		try {
 			int _alt;
-			State = 2706;
-			switch ( Interpreter.AdaptivePredict(_input,442,_ctx) ) {
+			State = 2785;
+			switch ( Interpreter.AdaptivePredict(_input,459,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2646; whiteSpace();
-				State = 2647; annotationArg();
+				State = 2725; whiteSpace();
+				State = 2726; annotationArg();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2649; whiteSpace();
-				State = 2650; annotationArg();
-				State = 2659;
+				State = 2728; whiteSpace();
+				State = 2729; annotationArg();
+				State = 2738;
 				_errHandler.Sync(this);
 				_alt = 1;
 				do {
@@ -17195,33 +17552,33 @@ public partial class VBAParser : Parser {
 					case 1:
 						{
 						{
-						State = 2652;
+						State = 2731;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2651; whiteSpace();
+							State = 2730; whiteSpace();
 							}
 						}
 
-						State = 2654; Match(COMMA);
-						State = 2656;
-						switch ( Interpreter.AdaptivePredict(_input,430,_ctx) ) {
+						State = 2733; Match(COMMA);
+						State = 2735;
+						switch ( Interpreter.AdaptivePredict(_input,447,_ctx) ) {
 						case 1:
 							{
-							State = 2655; whiteSpace();
+							State = 2734; whiteSpace();
 							}
 							break;
 						}
-						State = 2658; annotationArg();
+						State = 2737; annotationArg();
 						}
 						}
 						break;
 					default:
 						throw new NoViableAltException(this);
 					}
-					State = 2661;
+					State = 2740;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,431,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,448,_ctx);
 				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
 				}
 				break;
@@ -17229,74 +17586,74 @@ public partial class VBAParser : Parser {
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2664;
+				State = 2743;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2663; whiteSpace();
+					State = 2742; whiteSpace();
 					}
 				}
 
-				State = 2666; Match(LPAREN);
-				State = 2668;
+				State = 2745; Match(LPAREN);
+				State = 2747;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2667; whiteSpace();
+					State = 2746; whiteSpace();
 					}
 				}
 
-				State = 2670; Match(RPAREN);
+				State = 2749; Match(RPAREN);
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2672;
+				State = 2751;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2671; whiteSpace();
+					State = 2750; whiteSpace();
 					}
 				}
 
-				State = 2674; Match(LPAREN);
-				State = 2676;
-				switch ( Interpreter.AdaptivePredict(_input,435,_ctx) ) {
+				State = 2753; Match(LPAREN);
+				State = 2755;
+				switch ( Interpreter.AdaptivePredict(_input,452,_ctx) ) {
 				case 1:
 					{
-					State = 2675; whiteSpace();
+					State = 2754; whiteSpace();
 					}
 					break;
 				}
-				State = 2678; annotationArg();
-				State = 2680;
+				State = 2757; annotationArg();
+				State = 2759;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2679; whiteSpace();
+					State = 2758; whiteSpace();
 					}
 				}
 
-				State = 2682; Match(RPAREN);
+				State = 2761; Match(RPAREN);
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 2685;
+				State = 2764;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2684; whiteSpace();
+					State = 2763; whiteSpace();
 					}
 				}
 
-				State = 2687; Match(LPAREN);
-				State = 2688; annotationArg();
-				State = 2697;
+				State = 2766; Match(LPAREN);
+				State = 2767; annotationArg();
+				State = 2776;
 				_errHandler.Sync(this);
 				_alt = 1;
 				do {
@@ -17304,43 +17661,43 @@ public partial class VBAParser : Parser {
 					case 1:
 						{
 						{
-						State = 2690;
+						State = 2769;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2689; whiteSpace();
+							State = 2768; whiteSpace();
 							}
 						}
 
-						State = 2692; Match(COMMA);
-						State = 2694;
-						switch ( Interpreter.AdaptivePredict(_input,439,_ctx) ) {
+						State = 2771; Match(COMMA);
+						State = 2773;
+						switch ( Interpreter.AdaptivePredict(_input,456,_ctx) ) {
 						case 1:
 							{
-							State = 2693; whiteSpace();
+							State = 2772; whiteSpace();
 							}
 							break;
 						}
-						State = 2696; annotationArg();
+						State = 2775; annotationArg();
 						}
 						}
 						break;
 					default:
 						throw new NoViableAltException(this);
 					}
-					State = 2699;
+					State = 2778;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,440,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,457,_ctx);
 				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-				State = 2702;
+				State = 2781;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2701; whiteSpace();
+					State = 2780; whiteSpace();
 					}
 				}
 
-				State = 2704; Match(RPAREN);
+				State = 2783; Match(RPAREN);
 				}
 				break;
 			}
@@ -17383,11 +17740,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationArgContext annotationArg() {
 		AnnotationArgContext _localctx = new AnnotationArgContext(_ctx, State);
-		EnterRule(_localctx, 368, RULE_annotationArg);
+		EnterRule(_localctx, 374, RULE_annotationArg);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2708; valueStmt(0);
+			State = 2787; valueStmt(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -17433,13 +17790,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WhiteSpaceContext whiteSpace() {
 		WhiteSpaceContext _localctx = new WhiteSpaceContext(_ctx, State);
-		EnterRule(_localctx, 370, RULE_whiteSpace);
+		EnterRule(_localctx, 376, RULE_whiteSpace);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2711;
+			State = 2790;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -17447,7 +17804,7 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 2710;
+					State = 2789;
 					_la = _input.La(1);
 					if ( !(_la==WS || _la==LINE_CONTINUATION) ) {
 					_errHandler.RecoverInline(this);
@@ -17459,9 +17816,9 @@ public partial class VBAParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 2713;
+				State = 2792;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,443,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,460,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
 			}
 		}
@@ -17528,7 +17885,7 @@ public partial class VBAParser : Parser {
 	}
 
 	public static readonly string _serializedATN =
-		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xF7\xA9E\x4\x2"+
+		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xF7\xAED\x4\x2"+
 		"\t\x2\x4\x3\t\x3\x4\x4\t\x4\x4\x5\t\x5\x4\x6\t\x6\x4\a\t\a\x4\b\t\b\x4"+
 		"\t\t\t\x4\n\t\n\x4\v\t\v\x4\f\t\f\x4\r\t\r\x4\xE\t\xE\x4\xF\t\xF\x4\x10"+
 		"\t\x10\x4\x11\t\x11\x4\x12\t\x12\x4\x13\t\x13\x4\x14\t\x14\x4\x15\t\x15"+
@@ -17556,1267 +17913,1309 @@ public partial class VBAParser : Parser {
 		"\x4\xA9\t\xA9\x4\xAA\t\xAA\x4\xAB\t\xAB\x4\xAC\t\xAC\x4\xAD\t\xAD\x4\xAE"+
 		"\t\xAE\x4\xAF\t\xAF\x4\xB0\t\xB0\x4\xB1\t\xB1\x4\xB2\t\xB2\x4\xB3\t\xB3"+
 		"\x4\xB4\t\xB4\x4\xB5\t\xB5\x4\xB6\t\xB6\x4\xB7\t\xB7\x4\xB8\t\xB8\x4\xB9"+
-		"\t\xB9\x4\xBA\t\xBA\x4\xBB\t\xBB\x3\x2\x3\x2\x3\x3\x5\x3\x17A\n\x3\x3"+
-		"\x3\x3\x3\x3\x3\x3\x3\x5\x3\x180\n\x3\x3\x3\x5\x3\x183\n\x3\x3\x3\x3\x3"+
-		"\x5\x3\x187\n\x3\x3\x3\x3\x3\x5\x3\x18B\n\x3\x3\x3\x3\x3\x5\x3\x18F\n"+
-		"\x3\x3\x3\x3\x3\x3\x4\x3\x4\x3\x4\x3\x4\x5\x4\x197\n\x4\x3\x4\x5\x4\x19A"+
-		"\n\x4\x3\x4\x3\x4\x3\x5\x3\x5\x3\x5\x3\x5\x3\x5\x3\x5\x5\x5\x1A4\n\x5"+
-		"\x5\x5\x1A6\n\x5\x3\x5\x3\x5\x6\x5\x1AA\n\x5\r\x5\xE\x5\x1AB\x3\x5\x3"+
-		"\x5\x3\x6\x3\x6\a\x6\x1B2\n\x6\f\x6\xE\x6\x1B5\v\x6\x3\x6\x3\x6\a\x6\x1B9"+
-		"\n\x6\f\x6\xE\x6\x1BC\v\x6\x3\x6\x3\x6\x3\x6\x5\x6\x1C1\n\x6\x3\x6\x3"+
-		"\x6\x3\a\x3\a\x3\a\x6\a\x1C8\n\a\r\a\xE\a\x1C9\x3\b\x3\b\x3\b\x3\b\a\b"+
-		"\x1D0\n\b\f\b\xE\b\x1D3\v\b\x3\b\x3\b\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3"+
-		"\t\x3\t\x3\t\x3\t\x5\t\x1E1\n\t\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3"+
-		"\n\x3\n\x5\n\x1EC\n\n\x3\v\x3\v\x3\v\x3\v\a\v\x1F2\n\v\f\v\xE\v\x1F5\v"+
-		"\v\x3\v\x3\v\x3\f\x3\f\x3\f\x3\f\x3\f\x5\f\x1FE\n\f\x3\r\x3\r\x3\r\x3"+
-		"\r\x5\r\x204\n\r\x3\r\x3\r\x5\r\x208\n\r\x3\r\x3\r\x5\r\x20C\n\r\x3\r"+
-		"\x3\r\x5\r\x210\n\r\x3\r\a\r\x213\n\r\f\r\xE\r\x216\v\r\x3\xE\x3\xE\x3"+
-		"\xF\x3\xF\x3\x10\x3\x10\x3\x10\x3\x10\a\x10\x220\n\x10\f\x10\xE\x10\x223"+
-		"\v\x10\x3\x10\x3\x10\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x5\x11\x24A\n"+
-		"\x11\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3"+
-		"\x12\x3\x12\x3\x12\x3\x12\x5\x12\x259\n\x12\x3\x13\x3\x13\x3\x13\x3\x13"+
-		"\x3\x13\x3\x13\x5\x13\x261\n\x13\x3\x13\x3\x13\x3\x13\x5\x13\x266\n\x13"+
-		"\x3\x13\x3\x13\x3\x13\x5\x13\x26B\n\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3"+
-		"\x13\x3\x13\x3\x13\x5\x13\x274\n\x13\x3\x14\x3\x14\x3\x15\x3\x15\x3\x15"+
-		"\x3\x15\x3\x16\x3\x16\x3\x17\x3\x17\x3\x17\x3\x17\x3\x18\x3\x18\x3\x19"+
-		"\x3\x19\x3\x1A\x3\x1A\x5\x1A\x288\n\x1A\x3\x1A\x3\x1A\x5\x1A\x28C\n\x1A"+
-		"\x3\x1A\x3\x1A\x3\x1B\x3\x1B\x3\x1C\x3\x1C\x5\x1C\x294\n\x1C\x3\x1D\x3"+
-		"\x1D\x3\x1D\x3\x1E\x3\x1E\x3\x1F\x3\x1F\x3\x1F\x3\x1F\x5\x1F\x29F\n\x1F"+
-		"\x3 \x3 \x3!\x3!\x5!\x2A5\n!\x3!\x3!\x5!\x2A9\n!\x3!\a!\x2AC\n!\f!\xE"+
-		"!\x2AF\v!\x3\"\x3\"\x3\"\x3\"\x5\"\x2B5\n\"\x3\"\x3\"\x5\"\x2B9\n\"\x3"+
-		"\"\x3\"\x3#\x3#\x3$\x3$\x3$\x3$\x5$\x2C3\n$\x3$\x3$\x5$\x2C7\n$\x3$\x5"+
-		"$\x2CA\n$\x3%\x3%\x3%\x3%\x5%\x2D0\n%\x3%\x3%\x3%\x3%\x5%\x2D6\n%\x3&"+
-		"\x3&\x3\'\x3\'\x3(\x3(\x3(\x3(\x5(\x2E0\n(\x3(\x3(\x5(\x2E4\n(\x3(\x5"+
-		"(\x2E7\n(\x3)\x3)\x3)\x3)\x5)\x2ED\n)\x3)\x3)\x5)\x2F1\n)\x3)\x3)\x3*"+
-		"\x3*\x3+\x3+\x3+\x3+\x5+\x2FB\n+\x3+\x3+\x5+\x2FF\n+\x3+\x3+\x3,\x3,\x3"+
-		"-\x3-\x3-\x3-\x5-\x309\n-\x3-\x3-\x5-\x30D\n-\x3-\x5-\x310\n-\x3.\x3."+
-		"\x5.\x314\n.\x3.\a.\x317\n.\f.\xE.\x31A\v.\x3/\x3/\x3/\x3/\x5/\x320\n"+
-		"/\x3/\x3/\x5/\x324\n/\x3\x30\x3\x30\x3\x30\x5\x30\x329\n\x30\x3\x31\x3"+
-		"\x31\x3\x32\x3\x32\x3\x33\x3\x33\x5\x33\x331\n\x33\x3\x33\x3\x33\x5\x33"+
-		"\x335\n\x33\x3\x33\x3\x33\x5\x33\x339\n\x33\x3\x33\x3\x33\x3\x34\x3\x34"+
-		"\x3\x35\x3\x35\x5\x35\x341\n\x35\x3\x35\x5\x35\x344\n\x35\x3\x36\x3\x36"+
-		"\x5\x36\x348\n\x36\x3\x36\x3\x36\x5\x36\x34C\n\x36\x3\x36\x3\x36\x3\x37"+
-		"\x3\x37\x3\x38\x3\x38\x3\x38\x3\x38\x5\x38\x356\n\x38\x3\x38\x3\x38\x5"+
-		"\x38\x35A\n\x38\x3\x38\x5\x38\x35D\n\x38\x3\x39\x3\x39\x3\x39\x3\x39\x5"+
-		"\x39\x363\n\x39\x3\x39\x3\x39\x5\x39\x367\n\x39\x3\x39\x3\x39\x3:\x3:"+
-		"\x5:\x36D\n:\x3:\x3:\x5:\x371\n:\x3:\a:\x374\n:\f:\xE:\x377\v:\x3;\x3"+
-		";\x3<\x3<\x3<\x3<\x5<\x37F\n<\x3<\x3<\x5<\x383\n<\x3<\x5<\x386\n<\x3<"+
-		"\x5<\x389\n<\x3<\x3<\x5<\x38D\n<\x3<\x3<\x3=\x3=\x3>\x3>\x3?\x3?\x3?\x3"+
-		"?\x5?\x399\n?\x3?\x3?\x5?\x39D\n?\x3?\x5?\x3A0\n?\x3?\x5?\x3A3\n?\x3?"+
-		"\x3?\x5?\x3A7\n?\x3?\x3?\x3@\x3@\x3\x41\x3\x41\x3\x41\x5\x41\x3B0\n\x41"+
-		"\x3\x41\x3\x41\x3\x41\x3\x41\x5\x41\x3B6\n\x41\x3\x41\x3\x41\x5\x41\x3BA"+
-		"\n\x41\x3\x41\a\x41\x3BD\n\x41\f\x41\xE\x41\x3C0\v\x41\x3\x42\x3\x42\x5"+
-		"\x42\x3C4\n\x42\x3\x42\x3\x42\x3\x42\x5\x42\x3C9\n\x42\x3\x42\x5\x42\x3CC"+
-		"\n\x42\x3\x42\x3\x42\x5\x42\x3D0\n\x42\x3\x42\x3\x42\x3\x43\x3\x43\x3"+
-		"\x43\x5\x43\x3D7\n\x43\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3DD\n\x43\x3"+
-		"\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3E3\n\x43\x3\x43\x3\x43\x3\x43\x3\x43"+
-		"\x3\x43\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3EE\n\x43\x3\x43\x5\x43\x3F1"+
-		"\n\x43\x3\x43\x5\x43\x3F4\n\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3F9\n\x43"+
-		"\x3\x44\x3\x44\x3\x44\x3\x44\x5\x44\x3FF\n\x44\x3\x44\x3\x44\x5\x44\x403"+
-		"\n\x44\x3\x44\a\x44\x406\n\x44\f\x44\xE\x44\x409\v\x44\x3\x45\x3\x45\x3"+
-		"\x46\x3\x46\x3\x46\x5\x46\x410\n\x46\x3G\x3G\x3H\x3H\x5H\x416\nH\x3H\x3"+
-		"H\x5H\x41A\nH\x3H\x3H\x3I\x3I\x3I\x3J\x3J\x3J\x3K\x3K\x5K\x426\nK\x3K"+
-		"\x3K\x5K\x42A\nK\x3K\x3K\x3L\x3L\x3M\x3M\x3N\x3N\x3N\x5N\x435\nN\x3N\x3"+
-		"N\x3N\x3N\x3N\x3N\x3N\x3N\x3N\x5N\x440\nN\x3N\x3N\x3N\x3N\x3N\x5N\x447"+
-		"\nN\x3N\x3N\x3N\x3N\x3N\x3N\x5N\x44F\nN\x3O\x3O\x3O\x5O\x454\nO\x3O\x3"+
-		"O\x3O\x3O\x3O\aO\x45B\nO\fO\xEO\x45E\vO\x3O\x3O\x3P\x3P\x5P\x464\nP\x3"+
-		"P\x3P\x5P\x468\nP\x3P\x5P\x46B\nP\x3P\x3P\x3Q\x3Q\x3R\x3R\x3R\x3R\x5R"+
-		"\x475\nR\x3R\x3R\x5R\x479\nR\x3R\aR\x47C\nR\fR\xER\x47F\vR\x3S\x3S\x3"+
-		"S\x3S\x3T\x3T\x3T\x5T\x488\nT\x3T\x3T\x3T\x3T\x5T\x48E\nT\x3T\x3T\x3U"+
-		"\x3U\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x5V\x49F\nV\x3V\x3V\x3"+
-		"V\x3V\x5V\x4A5\nV\x3W\x3W\x3W\x3W\x5W\x4AB\nW\x3W\x3W\x5W\x4AF\nW\x3W"+
-		"\x3W\x3W\x3W\x3W\x3W\x3W\x3W\x3W\x3W\x5W\x4BB\nW\x3W\x3W\x5W\x4BF\nW\x3"+
-		"W\x3W\x3W\x3W\x5W\x4C5\nW\x3X\x3X\x3X\x5X\x4CA\nX\x3X\x3X\x5X\x4CE\nX"+
-		"\x3X\x3X\x5X\x4D2\nX\x3X\x3X\x5X\x4D6\nX\x3X\x5X\x4D9\nX\x3X\x5X\x4DC"+
-		"\nX\x3X\x5X\x4DF\nX\x3X\x5X\x4E2\nX\x3X\x3X\x5X\x4E6\nX\x3X\x3X\x3Y\x3"+
-		"Y\x3Z\x3Z\x3Z\x3Z\x3[\x3[\x3[\x3[\x3\\\x3\\\x3\\\x3\\\x3\\\x3\\\x3\\\x5"+
-		"\\\x4FB\n\\\x3\\\a\\\x4FE\n\\\f\\\xE\\\x501\v\\\x3\\\x5\\\x504\n\\\x3"+
-		"\\\x3\\\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x5]\x50F\n]\x3]\x3]\x3]\x3]\x3]\x3"+
-		"]\x5]\x517\n]\x3]\x5]\x51A\n]\x5]\x51C\n]\x3^\x3^\x3^\x5^\x521\n^\x3_"+
-		"\x3_\x5_\x525\n_\x3`\x3`\x5`\x529\n`\x3`\x3`\x5`\x52D\n`\x3`\x3`\x5`\x531"+
-		"\n`\x3`\x3`\x3`\x3`\x5`\x537\n`\x3\x61\x3\x61\x5\x61\x53B\n\x61\x3\x61"+
-		"\x3\x61\x5\x61\x53F\n\x61\x3\x61\x3\x61\x3\x61\x5\x61\x544\n\x61\x3\x61"+
-		"\x3\x61\x3\x62\x3\x62\x5\x62\x54A\n\x62\x3\x62\x5\x62\x54D\n\x62\x3\x63"+
-		"\x3\x63\x5\x63\x551\n\x63\x3\x63\x3\x63\x5\x63\x555\n\x63\x3\x63\x5\x63"+
-		"\x558\n\x63\a\x63\x55A\n\x63\f\x63\xE\x63\x55D\v\x63\x3\x63\x3\x63\x5"+
-		"\x63\x561\n\x63\x5\x63\x563\n\x63\x3\x63\x3\x63\x5\x63\x567\n\x63\x3\x63"+
-		"\x3\x63\x5\x63\x56B\n\x63\x3\x63\x5\x63\x56E\n\x63\a\x63\x570\n\x63\f"+
-		"\x63\xE\x63\x573\v\x63\x5\x63\x575\n\x63\x3\x64\x3\x64\x3\x65\x3\x65\x3"+
-		"\x66\x3\x66\x3\x66\x3\x66\x3g\x3g\x5g\x581\ng\x3g\x3g\x5g\x585\ng\x3g"+
-		"\x3g\x5g\x589\ng\x3g\x3g\x3h\x3h\x3h\x3h\x5h\x591\nh\x3h\x3h\x5h\x595"+
-		"\nh\x3h\x3h\x3i\x3i\x5i\x59B\ni\x3i\x3i\x5i\x59F\ni\x3i\x3i\x5i\x5A3\n"+
-		"i\x3i\x3i\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x5j\x5B1\nj\x3k\x3k"+
-		"\x3k\x3k\x3k\x3k\x3k\x3k\x5k\x5BB\nk\x3k\x3k\x5k\x5BF\nk\x3k\ak\x5C2\n"+
-		"k\fk\xEk\x5C5\vk\x3l\x3l\x3l\x3l\x3l\x3l\x3l\x3l\x5l\x5CF\nl\x3l\x3l\x5"+
-		"l\x5D3\nl\x3l\al\x5D6\nl\fl\xEl\x5D9\vl\x3m\x3m\x3m\x5m\x5DE\nm\x3m\x3"+
-		"m\x5m\x5E2\nm\x3m\x3m\x3m\x3m\x5m\x5E8\nm\x3m\x5m\x5EB\nm\x3m\x5m\x5EE"+
-		"\nm\x3m\x3m\x3m\x5m\x5F3\nm\x3m\x3m\x5m\x5F7\nm\x3m\x3m\x3n\x3n\x3n\x5"+
-		"n\x5FE\nn\x3n\x3n\x5n\x602\nn\x3n\x3n\x3n\x3n\x5n\x608\nn\x3n\x5n\x60B"+
-		"\nn\x3n\x3n\x5n\x60F\nn\x3n\x3n\x3o\x3o\x3o\x5o\x616\no\x3o\x3o\x5o\x61A"+
-		"\no\x3o\x3o\x3o\x3o\x5o\x620\no\x3o\x5o\x623\no\x3o\x3o\x5o\x627\no\x3"+
-		"o\x3o\x3p\x3p\x3p\x3p\x5p\x62F\np\x3p\x3p\x5p\x633\np\x3p\x3p\x5p\x637"+
-		"\np\x5p\x639\np\x3p\x5p\x63C\np\x3q\x3q\x3q\x3q\x5q\x642\nq\x3q\x3q\x5"+
-		"q\x646\nq\x3q\x3q\x5q\x64A\nq\x3q\aq\x64D\nq\fq\xEq\x650\vq\x3r\x3r\x5"+
-		"r\x654\nr\x3r\x3r\x5r\x658\nr\x3r\x3r\x5r\x65C\nr\x3r\x3r\x3r\x3r\x5r"+
-		"\x662\nr\x3s\x3s\x3s\x3s\x5s\x668\ns\x5s\x66A\ns\x3t\x3t\x3u\x3u\x3u\x3"+
-		"u\x5u\x672\nu\x3u\x3u\x5u\x676\nu\x3u\x3u\x3v\x3v\x3w\x3w\x3w\x3w\x3w"+
-		"\x3w\x3w\aw\x683\nw\fw\xEw\x686\vw\x3w\x3w\x3x\x3x\x5x\x68C\nx\x3x\x3"+
-		"x\x5x\x690\nx\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x5x\x69B\nx\x3y\x3y"+
-		"\x3y\x3y\x3y\x5y\x6A2\ny\x3z\x3z\x3z\x5z\x6A7\nz\x3z\x3z\x5z\x6AB\nz\x3"+
-		"z\az\x6AE\nz\fz\xEz\x6B1\vz\x5z\x6B3\nz\x3{\x3{\x3{\x3{\x5{\x6B9\n{\x3"+
-		"{\x3{\x5{\x6BD\n{\x3{\x3{\x3|\x3|\x3|\x5|\x6C4\n|\x3|\x3|\x5|\x6C8\n|"+
-		"\x3|\x3|\x5|\x6CC\n|\x3|\x3|\x5|\x6D0\n|\x3|\x5|\x6D3\n|\x3|\x3|\x5|\x6D7"+
-		"\n|\x3|\x3|\x3}\x3}\x3~\x3~\x3~\x5~\x6E0\n~\x3~\x3~\x3~\x3~\x3~\a~\x6E7"+
-		"\n~\f~\xE~\x6EA\v~\x3~\x3~\x3\x7F\x3\x7F\x5\x7F\x6F0\n\x7F\x3\x7F\x3\x7F"+
-		"\x5\x7F\x6F4\n\x7F\x3\x7F\x5\x7F\x6F7\n\x7F\x3\x7F\x5\x7F\x6FA\n\x7F\x3"+
-		"\x7F\x5\x7F\x6FD\n\x7F\x3\x7F\x3\x7F\x3\x7F\x5\x7F\x702\n\x7F\x3\x7F\x3"+
-		"\x7F\x3\x80\x3\x80\x3\x80\x5\x80\x709\n\x80\x3\x80\x3\x80\x3\x80\x5\x80"+
-		"\x70E\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x713\n\x80\x3\x80\x3\x80\x5\x80"+
-		"\x717\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x71D\n\x80\x3\x80\x3\x80"+
-		"\x3\x80\x5\x80\x722\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x729"+
-		"\n\x80\x3\x80\x3\x80\x5\x80\x72D\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x3"+
-		"\x80\x5\x80\x734\n\x80\x3\x80\x3\x80\x5\x80\x738\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x73C\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x741\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x745\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x74A\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x74E\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x753\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x757\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x75C\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x760\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x765\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x769\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x76E\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x772\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x777\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x77B\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x780\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x784\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x789\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x78D\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x792\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x796\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x79B\n\x80\x3\x80\x3\x80\x5"+
-		"\x80\x79F\n\x80\x3\x80\a\x80\x7A2\n\x80\f\x80\xE\x80\x7A5\v\x80\x3\x81"+
-		"\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x5\x81\x7AF\n\x81\x3"+
-		"\x82\x3\x82\x3\x82\x5\x82\x7B4\n\x82\x3\x82\x3\x82\x3\x82\x5\x82\x7B9"+
-		"\n\x82\x3\x82\x3\x82\x3\x83\x3\x83\x5\x83\x7BF\n\x83\x3\x83\x3\x83\x5"+
-		"\x83\x7C3\n\x83\x3\x83\a\x83\x7C6\n\x83\f\x83\xE\x83\x7C9\v\x83\x3\x84"+
-		"\x3\x84\x5\x84\x7CD\n\x84\x3\x84\x5\x84\x7D0\n\x84\x3\x84\x3\x84\x5\x84"+
-		"\x7D4\n\x84\x3\x84\x3\x84\x5\x84\x7D8\n\x84\x5\x84\x7DA\n\x84\x3\x84\x3"+
-		"\x84\x5\x84\x7DE\n\x84\x5\x84\x7E0\n\x84\x3\x84\x3\x84\x3\x84\x5\x84\x7E5"+
-		"\n\x84\x3\x85\x3\x85\x3\x85\x3\x85\x3\x85\x5\x85\x7EC\n\x85\x3\x85\x3"+
-		"\x85\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x5\x86\x7F5\n\x86\x3\x86\x3\x86"+
-		"\x3\x87\x3\x87\x3\x88\x3\x88\x3\x88\x3\x88\x3\x89\x5\x89\x800\n\x89\x3"+
-		"\x89\x3\x89\x3\x89\x5\x89\x805\n\x89\x3\x89\x5\x89\x808\n\x89\x3\x89\x3"+
-		"\x89\x5\x89\x80C\n\x89\x3\x89\x3\x89\x5\x89\x810\n\x89\x3\x89\x3\x89\x5"+
-		"\x89\x814\n\x89\x3\x89\x5\x89\x817\n\x89\x3\x89\x3\x89\x3\x89\x3\x89\a"+
-		"\x89\x81D\n\x89\f\x89\xE\x89\x820\v\x89\x3\x89\x3\x89\x5\x89\x824\n\x89"+
-		"\x3\x89\x5\x89\x827\n\x89\x3\x89\x3\x89\x5\x89\x82B\n\x89\x3\x89\x3\x89"+
-		"\x5\x89\x82F\n\x89\x3\x89\x3\x89\x5\x89\x833\n\x89\x3\x89\x5\x89\x836"+
-		"\n\x89\x3\x89\x3\x89\x3\x89\x3\x89\a\x89\x83C\n\x89\f\x89\xE\x89\x83F"+
-		"\v\x89\x5\x89\x841\n\x89\x3\x8A\x3\x8A\x5\x8A\x845\n\x8A\x3\x8B\x5\x8B"+
-		"\x848\n\x8B\x3\x8B\x5\x8B\x84B\n\x8B\x3\x8B\x3\x8B\x5\x8B\x84F\n\x8B\x3"+
-		"\x8B\x3\x8B\x5\x8B\x853\n\x8B\x3\x8B\x3\x8B\x3\x8B\x5\x8B\x858\n\x8B\x3"+
-		"\x8B\x5\x8B\x85B\n\x8B\x3\x8B\x5\x8B\x85E\n\x8B\x3\x8B\x5\x8B\x861\n\x8B"+
-		"\x3\x8B\x3\x8B\x3\x8B\x3\x8B\a\x8B\x867\n\x8B\f\x8B\xE\x8B\x86A\v\x8B"+
-		"\x3\x8C\x3\x8C\x3\x8C\x3\x8C\x5\x8C\x870\n\x8C\x3\x8C\x5\x8C\x873\n\x8C"+
-		"\x3\x8C\x3\x8C\x3\x8C\x3\x8C\a\x8C\x879\n\x8C\f\x8C\xE\x8C\x87C\v\x8C"+
-		"\x3\x8D\x3\x8D\x3\x8D\x3\x8D\x5\x8D\x882\n\x8D\x3\x8E\x3\x8E\x5\x8E\x886"+
-		"\n\x8E\x3\x8E\x5\x8E\x889\n\x8E\x3\x8E\x5\x8E\x88C\n\x8E\x3\x8E\x5\x8E"+
-		"\x88F\n\x8E\x3\x8E\x3\x8E\x3\x8E\x3\x8E\a\x8E\x895\n\x8E\f\x8E\xE\x8E"+
-		"\x898\v\x8E\x3\x8F\x3\x8F\x5\x8F\x89C\n\x8F\x3\x8F\x5\x8F\x89F\n\x8F\x3"+
-		"\x8F\x5\x8F\x8A2\n\x8F\x3\x8F\x3\x8F\x5\x8F\x8A6\n\x8F\x3\x8F\x3\x8F\x5"+
-		"\x8F\x8AA\n\x8F\x5\x8F\x8AC\n\x8F\x3\x8F\x3\x8F\x5\x8F\x8B0\n\x8F\x3\x8F"+
-		"\x5\x8F\x8B3\n\x8F\x3\x8F\x5\x8F\x8B6\n\x8F\x3\x8F\x3\x8F\x3\x8F\x3\x8F"+
-		"\a\x8F\x8BC\n\x8F\f\x8F\xE\x8F\x8BF\v\x8F\x3\x90\x3\x90\x5\x90\x8C3\n"+
-		"\x90\x3\x90\x5\x90\x8C6\n\x90\x3\x90\x5\x90\x8C9\n\x90\x3\x90\x5\x90\x8CC"+
-		"\n\x90\x3\x90\x3\x90\x3\x90\x3\x90\a\x90\x8D2\n\x90\f\x90\xE\x90\x8D5"+
-		"\v\x90\x3\x91\x3\x91\x5\x91\x8D9\n\x91\x3\x91\x5\x91\x8DC\n\x91\x3\x91"+
-		"\x5\x91\x8DF\n\x91\x3\x91\x3\x91\x5\x91\x8E3\n\x91\x3\x91\x3\x91\x5\x91"+
-		"\x8E7\n\x91\x5\x91\x8E9\n\x91\x3\x91\x3\x91\x5\x91\x8ED\n\x91\x3\x91\x5"+
-		"\x91\x8F0\n\x91\x3\x91\x5\x91\x8F3\n\x91\x3\x91\x3\x91\x3\x91\x3\x91\a"+
-		"\x91\x8F9\n\x91\f\x91\xE\x91\x8FC\v\x91\x3\x92\x3\x92\x5\x92\x900\n\x92"+
-		"\x3\x92\x3\x92\x5\x92\x904\n\x92\x6\x92\x906\n\x92\r\x92\xE\x92\x907\x3"+
-		"\x92\x5\x92\x90B\n\x92\x3\x92\x5\x92\x90E\n\x92\x3\x92\x5\x92\x911\n\x92"+
-		"\x3\x92\x3\x92\x3\x92\x3\x92\a\x92\x917\n\x92\f\x92\xE\x92\x91A\v\x92"+
-		"\x3\x93\x3\x93\x5\x93\x91E\n\x93\x3\x93\x3\x93\x5\x93\x922\n\x93\x3\x94"+
-		"\x5\x94\x925\n\x94\x3\x94\x3\x94\x3\x95\x5\x95\x92A\n\x95\x3\x95\x5\x95"+
-		"\x92D\n\x95\x3\x95\x3\x95\x5\x95\x931\n\x95\a\x95\x933\n\x95\f\x95\xE"+
-		"\x95\x936\v\x95\x3\x95\x3\x95\x5\x95\x93A\n\x95\x3\x95\x3\x95\x5\x95\x93E"+
-		"\n\x95\x3\x95\x5\x95\x941\n\x95\a\x95\x943\n\x95\f\x95\xE\x95\x946\v\x95"+
-		"\x3\x96\x5\x96\x949\n\x96\x3\x96\x3\x96\x5\x96\x94D\n\x96\x3\x96\x5\x96"+
-		"\x950\n\x96\x3\x96\x3\x96\x3\x97\x3\x97\x5\x97\x956\n\x97\x3\x97\x3\x97"+
-		"\x5\x97\x95A\n\x97\x3\x98\x3\x98\x5\x98\x95E\n\x98\x3\x98\x3\x98\x5\x98"+
-		"\x962\n\x98\x3\x98\x3\x98\x5\x98\x966\n\x98\x3\x98\a\x98\x969\n\x98\f"+
-		"\x98\xE\x98\x96C\v\x98\x5\x98\x96E\n\x98\x3\x98\x5\x98\x971\n\x98\x3\x98"+
-		"\x3\x98\x3\x99\x3\x99\x5\x99\x977\n\x99\x3\x99\x3\x99\x5\x99\x97B\n\x99"+
-		"\x3\x99\x3\x99\x5\x99\x97F\n\x99\x3\x99\x3\x99\x5\x99\x983\n\x99\x3\x99"+
-		"\x5\x99\x986\n\x99\x3\x99\x3\x99\x5\x99\x98A\n\x99\x3\x99\x5\x99\x98D"+
-		"\n\x99\x3\x99\x5\x99\x990\n\x99\x3\x99\x5\x99\x993\n\x99\x3\x99\x5\x99"+
-		"\x996\n\x99\x3\x99\x5\x99\x999\n\x99\x3\x9A\x3\x9A\x5\x9A\x99D\n\x9A\x3"+
-		"\x9A\x3\x9A\x3\x9B\x3\x9B\x5\x9B\x9A3\n\x9B\x3\x9B\x3\x9B\x5\x9B\x9A7"+
-		"\n\x9B\x3\x9B\a\x9B\x9AA\n\x9B\f\x9B\xE\x9B\x9AD\v\x9B\x3\x9C\x3\x9C\x3"+
-		"\x9C\x3\x9C\x3\x9C\x5\x9C\x9B4\n\x9C\x3\x9C\x3\x9C\x3\x9D\x3\x9D\x3\x9D"+
-		"\x5\x9D\x9BB\n\x9D\x3\x9E\x3\x9E\x5\x9E\x9BF\n\x9E\x3\x9F\x3\x9F\x5\x9F"+
-		"\x9C3\n\x9F\x3\x9F\x3\x9F\x5\x9F\x9C7\n\x9F\x3\x9F\x3\x9F\x5\x9F\x9CB"+
-		"\n\x9F\x3\x9F\x5\x9F\x9CE\n\x9F\x3\xA0\x3\xA0\x3\xA1\x3\xA1\x3\xA2\x3"+
-		"\xA2\x3\xA2\a\xA2\x9D7\n\xA2\f\xA2\xE\xA2\x9DA\v\xA2\x3\xA3\x3\xA3\x5"+
-		"\xA3\x9DE\n\xA3\x3\xA3\x3\xA3\x5\xA3\x9E2\n\xA3\x3\xA4\x3\xA4\x5\xA4\x9E6"+
-		"\n\xA4\x3\xA4\x3\xA4\x3\xA5\x3\xA5\x5\xA5\x9EC\n\xA5\x3\xA6\x3\xA6\x3"+
-		"\xA7\x3\xA7\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x3\xA8\x5"+
-		"\xA8\x9FA\n\xA8\x3\xA9\x3\xA9\x3\xAA\x3\xAA\x5\xAA\xA00\n\xAA\x3\xAA\x5"+
-		"\xAA\xA03\n\xAA\x3\xAA\x3\xAA\x5\xAA\xA07\n\xAA\x3\xAA\x5\xAA\xA0A\n\xAA"+
-		"\x3\xAB\x3\xAB\x3\xAC\x3\xAC\x3\xAD\x3\xAD\x3\xAE\x3\xAE\x3\xAF\x3\xAF"+
-		"\x3\xB0\x5\xB0\xA17\n\xB0\x3\xB0\x5\xB0\xA1A\n\xB0\x3\xB1\x3\xB1\x3\xB1"+
-		"\x5\xB1\xA1F\n\xB1\x3\xB1\x5\xB1\xA22\n\xB1\x3\xB1\x3\xB1\x5\xB1\xA26"+
-		"\n\xB1\x5\xB1\xA28\n\xB1\a\xB1\xA2A\n\xB1\f\xB1\xE\xB1\xA2D\v\xB1\x3\xB1"+
-		"\x3\xB1\x3\xB1\x5\xB1\xA32\n\xB1\x3\xB2\x3\xB2\x3\xB2\x5\xB2\xA37\n\xB2"+
-		"\x3\xB3\x3\xB3\x5\xB3\xA3B\n\xB3\x3\xB3\x3\xB3\x3\xB4\x3\xB4\x3\xB4\x3"+
-		"\xB5\x3\xB5\a\xB5\xA44\n\xB5\f\xB5\xE\xB5\xA47\v\xB5\x3\xB6\x3\xB6\x3"+
-		"\xB6\x3\xB6\x5\xB6\xA4D\n\xB6\x6\xB6\xA4F\n\xB6\r\xB6\xE\xB6\xA50\x3\xB7"+
-		"\x3\xB7\x5\xB7\xA55\n\xB7\x3\xB8\x3\xB8\x3\xB9\x3\xB9\x3\xB9\x3\xB9\x3"+
-		"\xB9\x3\xB9\x5\xB9\xA5F\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA63\n\xB9\x3\xB9\x6"+
-		"\xB9\xA66\n\xB9\r\xB9\xE\xB9\xA67\x3\xB9\x5\xB9\xA6B\n\xB9\x3\xB9\x3\xB9"+
-		"\x5\xB9\xA6F\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA73\n\xB9\x3\xB9\x3\xB9\x5\xB9"+
-		"\xA77\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA7B\n\xB9\x3\xB9\x3\xB9\x3\xB9\x5\xB9"+
-		"\xA80\n\xB9\x3\xB9\x3\xB9\x3\xB9\x5\xB9\xA85\n\xB9\x3\xB9\x3\xB9\x5\xB9"+
-		"\xA89\n\xB9\x3\xB9\x6\xB9\xA8C\n\xB9\r\xB9\xE\xB9\xA8D\x3\xB9\x5\xB9\xA91"+
-		"\n\xB9\x3\xB9\x3\xB9\x5\xB9\xA95\n\xB9\x3\xBA\x3\xBA\x3\xBB\x6\xBB\xA9A"+
-		"\n\xBB\r\xBB\xE\xBB\xA9B\x3\xBB\x2\x2\x3\xFE\xBC\x2\x2\x4\x2\x6\x2\b\x2"+
-		"\n\x2\f\x2\xE\x2\x10\x2\x12\x2\x14\x2\x16\x2\x18\x2\x1A\x2\x1C\x2\x1E"+
-		"\x2 \x2\"\x2$\x2&\x2(\x2*\x2,\x2.\x2\x30\x2\x32\x2\x34\x2\x36\x2\x38\x2"+
-		":\x2<\x2>\x2@\x2\x42\x2\x44\x2\x46\x2H\x2J\x2L\x2N\x2P\x2R\x2T\x2V\x2"+
-		"X\x2Z\x2\\\x2^\x2`\x2\x62\x2\x64\x2\x66\x2h\x2j\x2l\x2n\x2p\x2r\x2t\x2"+
-		"v\x2x\x2z\x2|\x2~\x2\x80\x2\x82\x2\x84\x2\x86\x2\x88\x2\x8A\x2\x8C\x2"+
-		"\x8E\x2\x90\x2\x92\x2\x94\x2\x96\x2\x98\x2\x9A\x2\x9C\x2\x9E\x2\xA0\x2"+
-		"\xA2\x2\xA4\x2\xA6\x2\xA8\x2\xAA\x2\xAC\x2\xAE\x2\xB0\x2\xB2\x2\xB4\x2"+
-		"\xB6\x2\xB8\x2\xBA\x2\xBC\x2\xBE\x2\xC0\x2\xC2\x2\xC4\x2\xC6\x2\xC8\x2"+
-		"\xCA\x2\xCC\x2\xCE\x2\xD0\x2\xD2\x2\xD4\x2\xD6\x2\xD8\x2\xDA\x2\xDC\x2"+
-		"\xDE\x2\xE0\x2\xE2\x2\xE4\x2\xE6\x2\xE8\x2\xEA\x2\xEC\x2\xEE\x2\xF0\x2"+
-		"\xF2\x2\xF4\x2\xF6\x2\xF8\x2\xFA\x2\xFC\x2\xFE\x2\x100\x2\x102\x2\x104"+
-		"\x2\x106\x2\x108\x2\x10A\x2\x10C\x2\x10E\x2\x110\x2\x112\x2\x114\x2\x116"+
-		"\x2\x118\x2\x11A\x2\x11C\x2\x11E\x2\x120\x2\x122\x2\x124\x2\x126\x2\x128"+
-		"\x2\x12A\x2\x12C\x2\x12E\x2\x130\x2\x132\x2\x134\x2\x136\x2\x138\x2\x13A"+
-		"\x2\x13C\x2\x13E\x2\x140\x2\x142\x2\x144\x2\x146\x2\x148\x2\x14A\x2\x14C"+
-		"\x2\x14E\x2\x150\x2\x152\x2\x154\x2\x156\x2\x158\x2\x15A\x2\x15C\x2\x15E"+
-		"\x2\x160\x2\x162\x2\x164\x2\x166\x2\x168\x2\x16A\x2\x16C\x2\x16E\x2\x170"+
-		"\x2\x172\x2\x174\x2\x2\x1A\x5\x2;;\x45\x45\xBC\xBC\a\x2\x38\x38;;{{\x9B"+
-		"\x9B\xA6\xA6\x4\x2\xA8\xA9\xCB\xCB\x4\x2\x85\x87\xB3\xB3\x4\x2))++\x4"+
-		"\x2rr\xBA\xBA\x3\x2HT\x4\x2\xC3\xC3\xC7\xC7\x3\x2jn\x3\x2\x92\x93\x4\x2"+
-		"\xCE\xCE\xD7\xD7\x4\x2\xD6\xD6\xD9\xD9\a\x2||\x83\x83\xD0\xD3\xD5\xD5"+
-		"\xD8\xD8\x3\x2,-\x4\x2=>\x9C\x9C\x3\x2=>\r\x2\x13\x13\x1F <<??\x46\x46"+
-		"WW}}\x7F\x7F\xB4\xB4\xB9\xB9\xC4\xC4\x3\x2\xE4\xE7\x5\x2,,.\x32\xDA\xDA"+
-		"\x6\x2pptt\x9F\x9F\xA4\xA4$\x2\x3\x17\x19#%(\x33\x38:?\x42\x43\x45\x46"+
+		"\t\xB9\x4\xBA\t\xBA\x4\xBB\t\xBB\x4\xBC\t\xBC\x4\xBD\t\xBD\x4\xBE\t\xBE"+
+		"\x3\x2\x3\x2\x3\x3\x5\x3\x180\n\x3\x3\x3\x3\x3\x3\x3\x3\x3\x5\x3\x186"+
+		"\n\x3\x3\x3\x5\x3\x189\n\x3\x3\x3\x3\x3\x5\x3\x18D\n\x3\x3\x3\x3\x3\x5"+
+		"\x3\x191\n\x3\x3\x3\x3\x3\x5\x3\x195\n\x3\x3\x3\x3\x3\x3\x4\x3\x4\x3\x4"+
+		"\x3\x4\x5\x4\x19D\n\x4\x3\x4\x5\x4\x1A0\n\x4\x3\x4\x3\x4\x3\x5\x3\x5\x3"+
+		"\x5\x3\x5\x3\x5\x3\x5\x5\x5\x1AA\n\x5\x5\x5\x1AC\n\x5\x3\x5\x3\x5\x6\x5"+
+		"\x1B0\n\x5\r\x5\xE\x5\x1B1\x3\x5\x3\x5\x3\x6\x3\x6\a\x6\x1B8\n\x6\f\x6"+
+		"\xE\x6\x1BB\v\x6\x3\x6\x3\x6\a\x6\x1BF\n\x6\f\x6\xE\x6\x1C2\v\x6\x3\x6"+
+		"\x3\x6\x3\x6\x5\x6\x1C7\n\x6\x3\x6\x3\x6\x3\a\x3\a\x3\a\x6\a\x1CE\n\a"+
+		"\r\a\xE\a\x1CF\x3\b\x3\b\x3\b\x3\b\a\b\x1D6\n\b\f\b\xE\b\x1D9\v\b\x3\b"+
+		"\x3\b\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x3\t\x5\t\x1E7\n\t"+
+		"\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x3\n\x5\n\x1F2\n\n\x3\v\x3\v"+
+		"\x3\v\x3\v\a\v\x1F8\n\v\f\v\xE\v\x1FB\v\v\x3\v\x3\v\x3\f\x3\f\x3\f\x3"+
+		"\f\x3\f\x5\f\x204\n\f\x3\r\x3\r\x3\r\x3\r\x5\r\x20A\n\r\x3\r\x3\r\x5\r"+
+		"\x20E\n\r\x3\r\x3\r\x5\r\x212\n\r\x3\r\x3\r\x5\r\x216\n\r\x3\r\a\r\x219"+
+		"\n\r\f\r\xE\r\x21C\v\r\x3\xE\x3\xE\x3\xF\x3\xF\x3\x10\x3\x10\x3\x10\x3"+
+		"\x10\a\x10\x226\n\x10\f\x10\xE\x10\x229\v\x10\x3\x10\x3\x10\x3\x11\x3"+
+		"\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3"+
+		"\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3"+
+		"\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3"+
+		"\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x5\x11\x252\n\x11\x3\x12\x3\x12"+
+		"\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12"+
+		"\x3\x12\x5\x12\x261\n\x12\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x5"+
+		"\x13\x269\n\x13\x3\x13\x3\x13\x3\x13\x5\x13\x26E\n\x13\x3\x13\x3\x13\x3"+
+		"\x13\x5\x13\x273\n\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13"+
+		"\x5\x13\x27C\n\x13\x3\x14\x3\x14\x3\x15\x3\x15\x3\x15\x3\x15\x3\x16\x3"+
+		"\x16\x3\x17\x3\x17\x3\x17\x3\x17\x3\x18\x3\x18\x3\x19\x3\x19\x3\x1A\x3"+
+		"\x1A\x5\x1A\x290\n\x1A\x3\x1A\x3\x1A\x5\x1A\x294\n\x1A\x3\x1A\x3\x1A\x3"+
+		"\x1B\x3\x1B\x3\x1C\x3\x1C\x5\x1C\x29C\n\x1C\x3\x1D\x3\x1D\x3\x1D\x3\x1E"+
+		"\x3\x1E\x3\x1F\x3\x1F\x3\x1F\x3\x1F\x5\x1F\x2A7\n\x1F\x3 \x3 \x3!\x3!"+
+		"\x5!\x2AD\n!\x3!\x3!\x5!\x2B1\n!\x3!\a!\x2B4\n!\f!\xE!\x2B7\v!\x3\"\x3"+
+		"\"\x3\"\x3\"\x5\"\x2BD\n\"\x3\"\x3\"\x5\"\x2C1\n\"\x3\"\x3\"\x3#\x3#\x3"+
+		"$\x3$\x3$\x3$\x5$\x2CB\n$\x3$\x3$\x5$\x2CF\n$\x3$\x5$\x2D2\n$\x3%\x3%"+
+		"\x3%\x3%\x5%\x2D8\n%\x3%\x3%\x3%\x3%\x5%\x2DE\n%\x3&\x3&\x3\'\x3\'\x3"+
+		"(\x3(\x3(\x3(\x5(\x2E8\n(\x3(\x3(\x5(\x2EC\n(\x3(\x5(\x2EF\n(\x3)\x3)"+
+		"\x3)\x3)\x5)\x2F5\n)\x3)\x3)\x5)\x2F9\n)\x3)\x3)\x3*\x3*\x3+\x3+\x3+\x3"+
+		"+\x5+\x303\n+\x3+\x3+\x5+\x307\n+\x3+\x3+\x3,\x3,\x3-\x3-\x3-\x3-\x5-"+
+		"\x311\n-\x3-\x3-\x5-\x315\n-\x3-\x5-\x318\n-\x3.\x3.\x5.\x31C\n.\x3.\a"+
+		".\x31F\n.\f.\xE.\x322\v.\x3/\x3/\x3/\x3/\x5/\x328\n/\x3/\x3/\x5/\x32C"+
+		"\n/\x3\x30\x3\x30\x3\x30\x5\x30\x331\n\x30\x3\x31\x3\x31\x3\x32\x3\x32"+
+		"\x3\x33\x3\x33\x5\x33\x339\n\x33\x3\x33\x3\x33\x5\x33\x33D\n\x33\x3\x33"+
+		"\x3\x33\x5\x33\x341\n\x33\x3\x33\x3\x33\x3\x34\x3\x34\x3\x35\x3\x35\x5"+
+		"\x35\x349\n\x35\x3\x35\x5\x35\x34C\n\x35\x3\x36\x3\x36\x5\x36\x350\n\x36"+
+		"\x3\x36\x3\x36\x5\x36\x354\n\x36\x3\x36\x3\x36\x3\x37\x3\x37\x3\x38\x3"+
+		"\x38\x3\x38\x3\x38\x5\x38\x35E\n\x38\x3\x38\x3\x38\x5\x38\x362\n\x38\x3"+
+		"\x38\x5\x38\x365\n\x38\x3\x39\x3\x39\x3\x39\x3\x39\x5\x39\x36B\n\x39\x3"+
+		"\x39\x3\x39\x5\x39\x36F\n\x39\x3\x39\x3\x39\x3:\x3:\x5:\x375\n:\x3:\x3"+
+		":\x5:\x379\n:\x3:\a:\x37C\n:\f:\xE:\x37F\v:\x3;\x3;\x3<\x3<\x3<\x3<\x5"+
+		"<\x387\n<\x3<\x3<\x5<\x38B\n<\x3<\x5<\x38E\n<\x3<\x5<\x391\n<\x3<\x3<"+
+		"\x5<\x395\n<\x3<\x3<\x3=\x3=\x3>\x3>\x3?\x3?\x3?\x3?\x5?\x3A1\n?\x3?\x3"+
+		"?\x5?\x3A5\n?\x3?\x5?\x3A8\n?\x3?\x5?\x3AB\n?\x3?\x3?\x5?\x3AF\n?\x3?"+
+		"\x3?\x3@\x3@\x3\x41\x3\x41\x3\x41\x5\x41\x3B8\n\x41\x3\x41\x3\x41\x3\x41"+
+		"\x3\x41\x5\x41\x3BE\n\x41\x3\x41\x3\x41\x5\x41\x3C2\n\x41\x3\x41\a\x41"+
+		"\x3C5\n\x41\f\x41\xE\x41\x3C8\v\x41\x3\x42\x3\x42\x5\x42\x3CC\n\x42\x3"+
+		"\x42\x3\x42\x3\x42\x5\x42\x3D1\n\x42\x3\x42\x5\x42\x3D4\n\x42\x3\x42\x3"+
+		"\x42\x5\x42\x3D8\n\x42\x3\x42\x3\x42\x3\x43\x3\x43\x3\x43\x5\x43\x3DF"+
+		"\n\x43\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3E5\n\x43\x3\x43\x3\x43\x3"+
+		"\x43\x3\x43\x5\x43\x3EB\n\x43\x3\x43\x3\x43\x3\x43\x3\x43\x3\x43\x3\x43"+
+		"\x3\x43\x3\x43\x3\x43\x5\x43\x3F6\n\x43\x3\x43\x5\x43\x3F9\n\x43\x3\x43"+
+		"\x5\x43\x3FC\n\x43\x3\x43\x3\x43\x3\x43\x5\x43\x401\n\x43\x3\x44\x3\x44"+
+		"\x3\x44\x3\x44\x5\x44\x407\n\x44\x3\x44\x3\x44\x5\x44\x40B\n\x44\x3\x44"+
+		"\a\x44\x40E\n\x44\f\x44\xE\x44\x411\v\x44\x3\x45\x3\x45\x3\x46\x3\x46"+
+		"\x3\x46\x5\x46\x418\n\x46\x3G\x3G\x3H\x3H\x5H\x41E\nH\x3H\x3H\x5H\x422"+
+		"\nH\x3H\x3H\x3I\x3I\x3I\x3J\x3J\x3J\x3K\x3K\x5K\x42E\nK\x3K\x3K\x5K\x432"+
+		"\nK\x3K\x3K\x3L\x3L\x3M\x3M\x3N\x3N\x3N\x5N\x43D\nN\x3N\x3N\x3N\x3N\x3"+
+		"N\x3N\x3N\x3N\x3N\x5N\x448\nN\x3N\x3N\x3N\x3N\x3N\x5N\x44F\nN\x3N\x3N"+
+		"\x3N\x3N\x3N\x3N\x5N\x457\nN\x3O\x3O\x3O\x5O\x45C\nO\x3O\x3O\x3O\x3O\x3"+
+		"O\aO\x463\nO\fO\xEO\x466\vO\x3O\x3O\x3P\x3P\x5P\x46C\nP\x3P\x3P\x5P\x470"+
+		"\nP\x3P\x5P\x473\nP\x3P\x3P\x3Q\x3Q\x3R\x3R\x3R\x3R\x5R\x47D\nR\x3R\x3"+
+		"R\x5R\x481\nR\x3R\aR\x484\nR\fR\xER\x487\vR\x3S\x3S\x3S\x3S\x3T\x3T\x3"+
+		"T\x5T\x490\nT\x3T\x3T\x3T\x3T\x5T\x496\nT\x3T\x3T\x3U\x3U\x3V\x3V\x3V"+
+		"\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x3V\x5V\x4A7\nV\x3V\x3V\x3V\x3V\x5V\x4AD"+
+		"\nV\x3W\x3W\x3W\x3W\x5W\x4B3\nW\x3W\x3W\x5W\x4B7\nW\x3W\x3W\x3W\x3W\x3"+
+		"W\x3W\x3W\x3W\x3W\x3W\x5W\x4C3\nW\x3W\x3W\x5W\x4C7\nW\x3W\x3W\x3W\x3W"+
+		"\x5W\x4CD\nW\x3X\x3X\x3X\x5X\x4D2\nX\x3X\x3X\x5X\x4D6\nX\x3X\x3X\x5X\x4DA"+
+		"\nX\x3X\x3X\x5X\x4DE\nX\x3X\x5X\x4E1\nX\x3X\x5X\x4E4\nX\x3X\x5X\x4E7\n"+
+		"X\x3X\x5X\x4EA\nX\x3X\x3X\x5X\x4EE\nX\x3X\x3X\x3Y\x3Y\x3Z\x3Z\x3Z\x3Z"+
+		"\x3[\x3[\x3[\x3[\x3\\\x3\\\x3\\\x3\\\x3\\\x3\\\x3\\\x5\\\x503\n\\\x3\\"+
+		"\a\\\x506\n\\\f\\\xE\\\x509\v\\\x3\\\x5\\\x50C\n\\\x3\\\x3\\\x3]\x3]\x3"+
+		"]\x3]\x3]\x3]\x3]\x5]\x517\n]\x3]\x3]\x3]\x3]\x3]\x3]\x5]\x51F\n]\x3]"+
+		"\x5]\x522\n]\x5]\x524\n]\x3^\x3^\x3^\x5^\x529\n^\x3_\x3_\x5_\x52D\n_\x3"+
+		"`\x3`\x5`\x531\n`\x3`\x3`\x5`\x535\n`\x3`\x3`\x5`\x539\n`\x3`\x3`\x3`"+
+		"\x3`\x5`\x53F\n`\x3\x61\x3\x61\x5\x61\x543\n\x61\x3\x61\x3\x61\x5\x61"+
+		"\x547\n\x61\x3\x61\x3\x61\x3\x61\x5\x61\x54C\n\x61\x3\x61\x3\x61\x3\x62"+
+		"\x3\x62\x5\x62\x552\n\x62\x3\x62\x5\x62\x555\n\x62\x3\x63\x3\x63\x5\x63"+
+		"\x559\n\x63\x3\x63\x3\x63\x5\x63\x55D\n\x63\x3\x63\x5\x63\x560\n\x63\a"+
+		"\x63\x562\n\x63\f\x63\xE\x63\x565\v\x63\x3\x63\x3\x63\x5\x63\x569\n\x63"+
+		"\x5\x63\x56B\n\x63\x3\x63\x3\x63\x5\x63\x56F\n\x63\x3\x63\x3\x63\x5\x63"+
+		"\x573\n\x63\x3\x63\x5\x63\x576\n\x63\a\x63\x578\n\x63\f\x63\xE\x63\x57B"+
+		"\v\x63\x5\x63\x57D\n\x63\x3\x64\x3\x64\x3\x65\x3\x65\x3\x66\x3\x66\x3"+
+		"\x66\x3\x66\x3g\x3g\x5g\x589\ng\x3g\x3g\x5g\x58D\ng\x3g\x3g\x5g\x591\n"+
+		"g\x3g\x3g\x3h\x3h\x3h\x3h\x5h\x599\nh\x3h\x3h\x5h\x59D\nh\x3h\x3h\x3i"+
+		"\x3i\x5i\x5A3\ni\x3i\x3i\x5i\x5A7\ni\x3i\x3i\x5i\x5AB\ni\x3i\x3i\x3j\x3"+
+		"j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x3j\x5j\x5B9\nj\x3k\x3k\x3k\x3k\x3k\x3k"+
+		"\x3k\x3k\x5k\x5C3\nk\x3k\x3k\x5k\x5C7\nk\x3k\ak\x5CA\nk\fk\xEk\x5CD\v"+
+		"k\x3l\x3l\x3l\x3l\x3l\x3l\x3l\x3l\x5l\x5D7\nl\x3l\x3l\x5l\x5DB\nl\x3l"+
+		"\al\x5DE\nl\fl\xEl\x5E1\vl\x3m\x3m\x3m\x5m\x5E6\nm\x3m\x3m\x5m\x5EA\n"+
+		"m\x3m\x3m\x3m\x3m\x5m\x5F0\nm\x3m\x5m\x5F3\nm\x3m\x5m\x5F6\nm\x3m\x3m"+
+		"\x3m\x5m\x5FB\nm\x3m\x3m\x5m\x5FF\nm\x3m\x3m\x3n\x3n\x3n\x5n\x606\nn\x3"+
+		"n\x3n\x5n\x60A\nn\x3n\x3n\x3n\x3n\x5n\x610\nn\x3n\x5n\x613\nn\x3n\x3n"+
+		"\x5n\x617\nn\x3n\x3n\x3o\x3o\x3o\x5o\x61E\no\x3o\x3o\x5o\x622\no\x3o\x3"+
+		"o\x3o\x3o\x5o\x628\no\x3o\x5o\x62B\no\x3o\x3o\x5o\x62F\no\x3o\x3o\x3p"+
+		"\x3p\x3p\x3p\x5p\x637\np\x3p\x3p\x5p\x63B\np\x3p\x3p\x5p\x63F\np\x5p\x641"+
+		"\np\x3p\x5p\x644\np\x3q\x3q\x3q\x3q\x5q\x64A\nq\x3q\x3q\x5q\x64E\nq\x3"+
+		"q\x3q\x5q\x652\nq\x3q\aq\x655\nq\fq\xEq\x658\vq\x3r\x3r\x5r\x65C\nr\x3"+
+		"r\x3r\x5r\x660\nr\x3r\x3r\x5r\x664\nr\x3r\x3r\x3r\x3r\x5r\x66A\nr\x3s"+
+		"\x3s\x3s\x3s\x5s\x670\ns\x5s\x672\ns\x3t\x3t\x3u\x3u\x3u\x3u\x5u\x67A"+
+		"\nu\x3u\x3u\x5u\x67E\nu\x3u\x3u\x3v\x3v\x3w\x3w\x3w\x3w\x3w\x3w\x3w\a"+
+		"w\x68B\nw\fw\xEw\x68E\vw\x3w\x3w\x3x\x3x\x5x\x694\nx\x3x\x3x\x5x\x698"+
+		"\nx\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x3x\x5x\x6A3\nx\x3y\x3y\x3y\x3y\x3"+
+		"y\x5y\x6AA\ny\x3z\x3z\x3z\x5z\x6AF\nz\x3z\x3z\x5z\x6B3\nz\x3z\az\x6B6"+
+		"\nz\fz\xEz\x6B9\vz\x5z\x6BB\nz\x3{\x3{\x3{\x3{\x5{\x6C1\n{\x3{\x3{\x5"+
+		"{\x6C5\n{\x3{\x3{\x3|\x3|\x3|\x5|\x6CC\n|\x3|\x3|\x5|\x6D0\n|\x3|\x3|"+
+		"\x5|\x6D4\n|\x3|\x3|\x5|\x6D8\n|\x3|\x5|\x6DB\n|\x3|\x3|\x5|\x6DF\n|\x3"+
+		"|\x3|\x3}\x3}\x3~\x3~\x3~\x5~\x6E8\n~\x3~\x3~\x3~\x3~\x3~\a~\x6EF\n~\f"+
+		"~\xE~\x6F2\v~\x3~\x3~\x3\x7F\x3\x7F\x5\x7F\x6F8\n\x7F\x3\x7F\x3\x7F\x5"+
+		"\x7F\x6FC\n\x7F\x3\x7F\x5\x7F\x6FF\n\x7F\x3\x7F\x5\x7F\x702\n\x7F\x3\x7F"+
+		"\x5\x7F\x705\n\x7F\x3\x7F\x3\x7F\x3\x7F\x5\x7F\x70A\n\x7F\x3\x7F\x3\x7F"+
+		"\x3\x80\x3\x80\x3\x80\x5\x80\x711\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x716"+
+		"\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x71B\n\x80\x3\x80\x3\x80\x5\x80\x71F"+
+		"\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x725\n\x80\x3\x80\x3\x80\x3"+
+		"\x80\x5\x80\x72A\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x731"+
+		"\n\x80\x3\x80\x3\x80\x5\x80\x735\n\x80\x3\x80\x3\x80\x3\x80\x3\x80\x3"+
+		"\x80\x5\x80\x73C\n\x80\x3\x80\x3\x80\x5\x80\x740\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x744\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x749\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x74D\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x752\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x756\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x75B\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x75F\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x764\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x768\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x76D\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x771\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x776\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x77A\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x77F\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x783\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x788\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x78C\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x791\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x795\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x79A\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x79E\n\x80\x3\x80\x3\x80\x3\x80\x5\x80\x7A3\n\x80\x3\x80\x3\x80\x5"+
+		"\x80\x7A7\n\x80\x3\x80\a\x80\x7AA\n\x80\f\x80\xE\x80\x7AD\v\x80\x3\x81"+
+		"\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x3\x81\x5\x81\x7B7\n\x81\x3"+
+		"\x82\x3\x82\x3\x82\x5\x82\x7BC\n\x82\x3\x82\x3\x82\x3\x82\x5\x82\x7C1"+
+		"\n\x82\x3\x82\x3\x82\x3\x83\x3\x83\x5\x83\x7C7\n\x83\x3\x83\x3\x83\x5"+
+		"\x83\x7CB\n\x83\x3\x83\a\x83\x7CE\n\x83\f\x83\xE\x83\x7D1\v\x83\x3\x84"+
+		"\x3\x84\x5\x84\x7D5\n\x84\x3\x84\x5\x84\x7D8\n\x84\x3\x84\x3\x84\x5\x84"+
+		"\x7DC\n\x84\x3\x84\x3\x84\x5\x84\x7E0\n\x84\x5\x84\x7E2\n\x84\x3\x84\x3"+
+		"\x84\x5\x84\x7E6\n\x84\x5\x84\x7E8\n\x84\x3\x84\x3\x84\x3\x84\x5\x84\x7ED"+
+		"\n\x84\x3\x85\x3\x85\x3\x85\x3\x85\x3\x85\x5\x85\x7F4\n\x85\x3\x85\x3"+
+		"\x85\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x5\x86\x7FD\n\x86\x3\x86\x3\x86"+
+		"\x3\x87\x3\x87\x5\x87\x803\n\x87\x3\x87\x3\x87\x5\x87\x807\n\x87\x5\x87"+
+		"\x809\n\x87\x3\x87\x3\x87\x3\x87\x3\x87\x5\x87\x80F\n\x87\x5\x87\x811"+
+		"\n\x87\x3\x87\x3\x87\x5\x87\x815\n\x87\x3\x87\x3\x87\x5\x87\x819\n\x87"+
+		"\x3\x87\x6\x87\x81C\n\x87\r\x87\xE\x87\x81D\x3\x88\x3\x88\x5\x88\x822"+
+		"\n\x88\x3\x88\x3\x88\x5\x88\x826\n\x88\x5\x88\x828\n\x88\x3\x88\x3\x88"+
+		"\x3\x88\x3\x88\x5\x88\x82E\n\x88\x3\x88\x3\x88\x5\x88\x832\n\x88\x3\x88"+
+		"\x3\x88\x3\x89\x3\x89\x5\x89\x838\n\x89\x3\x89\x3\x89\x5\x89\x83C\n\x89"+
+		"\x3\x89\x3\x89\x5\x89\x840\n\x89\x3\x89\x3\x89\x5\x89\x844\n\x89\x3\x89"+
+		"\x3\x89\x3\x8A\x3\x8A\x3\x8B\x3\x8B\x3\x8B\x3\x8B\x3\x8C\x5\x8C\x84F\n"+
+		"\x8C\x3\x8C\x3\x8C\x3\x8C\x5\x8C\x854\n\x8C\x3\x8C\x5\x8C\x857\n\x8C\x3"+
+		"\x8C\x3\x8C\x5\x8C\x85B\n\x8C\x3\x8C\x3\x8C\x5\x8C\x85F\n\x8C\x3\x8C\x3"+
+		"\x8C\x5\x8C\x863\n\x8C\x3\x8C\x5\x8C\x866\n\x8C\x3\x8C\x3\x8C\x3\x8C\x3"+
+		"\x8C\a\x8C\x86C\n\x8C\f\x8C\xE\x8C\x86F\v\x8C\x3\x8C\x3\x8C\x5\x8C\x873"+
+		"\n\x8C\x3\x8C\x5\x8C\x876\n\x8C\x3\x8C\x3\x8C\x5\x8C\x87A\n\x8C\x3\x8C"+
+		"\x3\x8C\x5\x8C\x87E\n\x8C\x3\x8C\x3\x8C\x5\x8C\x882\n\x8C\x3\x8C\x5\x8C"+
+		"\x885\n\x8C\x3\x8C\x3\x8C\x3\x8C\x3\x8C\a\x8C\x88B\n\x8C\f\x8C\xE\x8C"+
+		"\x88E\v\x8C\x5\x8C\x890\n\x8C\x3\x8D\x3\x8D\x5\x8D\x894\n\x8D\x3\x8E\x5"+
+		"\x8E\x897\n\x8E\x3\x8E\x5\x8E\x89A\n\x8E\x3\x8E\x3\x8E\x5\x8E\x89E\n\x8E"+
+		"\x3\x8E\x3\x8E\x5\x8E\x8A2\n\x8E\x3\x8E\x3\x8E\x3\x8E\x5\x8E\x8A7\n\x8E"+
+		"\x3\x8E\x5\x8E\x8AA\n\x8E\x3\x8E\x5\x8E\x8AD\n\x8E\x3\x8E\x5\x8E\x8B0"+
+		"\n\x8E\x3\x8E\x3\x8E\x3\x8E\x3\x8E\a\x8E\x8B6\n\x8E\f\x8E\xE\x8E\x8B9"+
+		"\v\x8E\x3\x8F\x3\x8F\x3\x8F\x3\x8F\x5\x8F\x8BF\n\x8F\x3\x8F\x5\x8F\x8C2"+
+		"\n\x8F\x3\x8F\x3\x8F\x3\x8F\x3\x8F\a\x8F\x8C8\n\x8F\f\x8F\xE\x8F\x8CB"+
+		"\v\x8F\x3\x90\x3\x90\x3\x90\x3\x90\x5\x90\x8D1\n\x90\x3\x91\x3\x91\x5"+
+		"\x91\x8D5\n\x91\x3\x91\x5\x91\x8D8\n\x91\x3\x91\x5\x91\x8DB\n\x91\x3\x91"+
+		"\x5\x91\x8DE\n\x91\x3\x91\x3\x91\x3\x91\x3\x91\a\x91\x8E4\n\x91\f\x91"+
+		"\xE\x91\x8E7\v\x91\x3\x92\x3\x92\x5\x92\x8EB\n\x92\x3\x92\x5\x92\x8EE"+
+		"\n\x92\x3\x92\x5\x92\x8F1\n\x92\x3\x92\x3\x92\x5\x92\x8F5\n\x92\x3\x92"+
+		"\x3\x92\x5\x92\x8F9\n\x92\x5\x92\x8FB\n\x92\x3\x92\x3\x92\x5\x92\x8FF"+
+		"\n\x92\x3\x92\x5\x92\x902\n\x92\x3\x92\x5\x92\x905\n\x92\x3\x92\x3\x92"+
+		"\x3\x92\x3\x92\a\x92\x90B\n\x92\f\x92\xE\x92\x90E\v\x92\x3\x93\x3\x93"+
+		"\x5\x93\x912\n\x93\x3\x93\x5\x93\x915\n\x93\x3\x93\x5\x93\x918\n\x93\x3"+
+		"\x93\x5\x93\x91B\n\x93\x3\x93\x3\x93\x3\x93\x3\x93\a\x93\x921\n\x93\f"+
+		"\x93\xE\x93\x924\v\x93\x3\x94\x3\x94\x5\x94\x928\n\x94\x3\x94\x5\x94\x92B"+
+		"\n\x94\x3\x94\x5\x94\x92E\n\x94\x3\x94\x3\x94\x5\x94\x932\n\x94\x3\x94"+
+		"\x3\x94\x5\x94\x936\n\x94\x5\x94\x938\n\x94\x3\x94\x3\x94\x5\x94\x93C"+
+		"\n\x94\x3\x94\x5\x94\x93F\n\x94\x3\x94\x5\x94\x942\n\x94\x3\x94\x3\x94"+
+		"\x3\x94\x3\x94\a\x94\x948\n\x94\f\x94\xE\x94\x94B\v\x94\x3\x95\x3\x95"+
+		"\x5\x95\x94F\n\x95\x3\x95\x3\x95\x5\x95\x953\n\x95\x6\x95\x955\n\x95\r"+
+		"\x95\xE\x95\x956\x3\x95\x5\x95\x95A\n\x95\x3\x95\x5\x95\x95D\n\x95\x3"+
+		"\x95\x5\x95\x960\n\x95\x3\x95\x3\x95\x3\x95\x3\x95\a\x95\x966\n\x95\f"+
+		"\x95\xE\x95\x969\v\x95\x3\x96\x3\x96\x5\x96\x96D\n\x96\x3\x96\x3\x96\x5"+
+		"\x96\x971\n\x96\x3\x97\x5\x97\x974\n\x97\x3\x97\x3\x97\x3\x98\x5\x98\x979"+
+		"\n\x98\x3\x98\x5\x98\x97C\n\x98\x3\x98\x3\x98\x5\x98\x980\n\x98\a\x98"+
+		"\x982\n\x98\f\x98\xE\x98\x985\v\x98\x3\x98\x3\x98\x5\x98\x989\n\x98\x3"+
+		"\x98\x3\x98\x5\x98\x98D\n\x98\x3\x98\x5\x98\x990\n\x98\a\x98\x992\n\x98"+
+		"\f\x98\xE\x98\x995\v\x98\x3\x99\x5\x99\x998\n\x99\x3\x99\x3\x99\x5\x99"+
+		"\x99C\n\x99\x3\x99\x5\x99\x99F\n\x99\x3\x99\x3\x99\x3\x9A\x3\x9A\x5\x9A"+
+		"\x9A5\n\x9A\x3\x9A\x3\x9A\x5\x9A\x9A9\n\x9A\x3\x9B\x3\x9B\x5\x9B\x9AD"+
+		"\n\x9B\x3\x9B\x3\x9B\x5\x9B\x9B1\n\x9B\x3\x9B\x3\x9B\x5\x9B\x9B5\n\x9B"+
+		"\x3\x9B\a\x9B\x9B8\n\x9B\f\x9B\xE\x9B\x9BB\v\x9B\x5\x9B\x9BD\n\x9B\x3"+
+		"\x9B\x5\x9B\x9C0\n\x9B\x3\x9B\x3\x9B\x3\x9C\x3\x9C\x5\x9C\x9C6\n\x9C\x3"+
+		"\x9C\x3\x9C\x5\x9C\x9CA\n\x9C\x3\x9C\x3\x9C\x5\x9C\x9CE\n\x9C\x3\x9C\x3"+
+		"\x9C\x5\x9C\x9D2\n\x9C\x3\x9C\x5\x9C\x9D5\n\x9C\x3\x9C\x3\x9C\x5\x9C\x9D9"+
+		"\n\x9C\x3\x9C\x5\x9C\x9DC\n\x9C\x3\x9C\x5\x9C\x9DF\n\x9C\x3\x9C\x5\x9C"+
+		"\x9E2\n\x9C\x3\x9C\x5\x9C\x9E5\n\x9C\x3\x9C\x5\x9C\x9E8\n\x9C\x3\x9D\x3"+
+		"\x9D\x5\x9D\x9EC\n\x9D\x3\x9D\x3\x9D\x3\x9E\x3\x9E\x5\x9E\x9F2\n\x9E\x3"+
+		"\x9E\x3\x9E\x5\x9E\x9F6\n\x9E\x3\x9E\a\x9E\x9F9\n\x9E\f\x9E\xE\x9E\x9FC"+
+		"\v\x9E\x3\x9F\x3\x9F\x3\x9F\x3\x9F\x3\x9F\x5\x9F\xA03\n\x9F\x3\x9F\x3"+
+		"\x9F\x3\xA0\x3\xA0\x3\xA0\x5\xA0\xA0A\n\xA0\x3\xA1\x3\xA1\x5\xA1\xA0E"+
+		"\n\xA1\x3\xA2\x3\xA2\x5\xA2\xA12\n\xA2\x3\xA2\x3\xA2\x5\xA2\xA16\n\xA2"+
+		"\x3\xA2\x3\xA2\x5\xA2\xA1A\n\xA2\x3\xA2\x5\xA2\xA1D\n\xA2\x3\xA3\x3\xA3"+
+		"\x3\xA4\x3\xA4\x3\xA5\x3\xA5\x3\xA5\a\xA5\xA26\n\xA5\f\xA5\xE\xA5\xA29"+
+		"\v\xA5\x3\xA6\x3\xA6\x5\xA6\xA2D\n\xA6\x3\xA6\x3\xA6\x5\xA6\xA31\n\xA6"+
+		"\x3\xA7\x3\xA7\x5\xA7\xA35\n\xA7\x3\xA7\x3\xA7\x3\xA8\x3\xA8\x5\xA8\xA3B"+
+		"\n\xA8\x3\xA9\x3\xA9\x3\xAA\x3\xAA\x3\xAB\x3\xAB\x3\xAB\x3\xAB\x3\xAB"+
+		"\x3\xAB\x3\xAB\x3\xAB\x5\xAB\xA49\n\xAB\x3\xAC\x3\xAC\x3\xAD\x3\xAD\x5"+
+		"\xAD\xA4F\n\xAD\x3\xAD\x5\xAD\xA52\n\xAD\x3\xAD\x3\xAD\x5\xAD\xA56\n\xAD"+
+		"\x3\xAD\x5\xAD\xA59\n\xAD\x3\xAE\x3\xAE\x3\xAF\x3\xAF\x3\xB0\x3\xB0\x3"+
+		"\xB1\x3\xB1\x3\xB2\x3\xB2\x3\xB3\x5\xB3\xA66\n\xB3\x3\xB3\x5\xB3\xA69"+
+		"\n\xB3\x3\xB4\x3\xB4\x3\xB4\x5\xB4\xA6E\n\xB4\x3\xB4\x5\xB4\xA71\n\xB4"+
+		"\x3\xB4\x3\xB4\x5\xB4\xA75\n\xB4\x5\xB4\xA77\n\xB4\a\xB4\xA79\n\xB4\f"+
+		"\xB4\xE\xB4\xA7C\v\xB4\x3\xB4\x3\xB4\x3\xB4\x5\xB4\xA81\n\xB4\x3\xB5\x3"+
+		"\xB5\x3\xB5\x5\xB5\xA86\n\xB5\x3\xB6\x3\xB6\x5\xB6\xA8A\n\xB6\x3\xB6\x3"+
+		"\xB6\x3\xB7\x3\xB7\x3\xB7\x3\xB8\x3\xB8\a\xB8\xA93\n\xB8\f\xB8\xE\xB8"+
+		"\xA96\v\xB8\x3\xB9\x3\xB9\x3\xB9\x3\xB9\x5\xB9\xA9C\n\xB9\x6\xB9\xA9E"+
+		"\n\xB9\r\xB9\xE\xB9\xA9F\x3\xBA\x3\xBA\x5\xBA\xAA4\n\xBA\x3\xBB\x3\xBB"+
+		"\x3\xBC\x3\xBC\x3\xBC\x3\xBC\x3\xBC\x3\xBC\x5\xBC\xAAE\n\xBC\x3\xBC\x3"+
+		"\xBC\x5\xBC\xAB2\n\xBC\x3\xBC\x6\xBC\xAB5\n\xBC\r\xBC\xE\xBC\xAB6\x3\xBC"+
+		"\x5\xBC\xABA\n\xBC\x3\xBC\x3\xBC\x5\xBC\xABE\n\xBC\x3\xBC\x3\xBC\x5\xBC"+
+		"\xAC2\n\xBC\x3\xBC\x3\xBC\x5\xBC\xAC6\n\xBC\x3\xBC\x3\xBC\x5\xBC\xACA"+
+		"\n\xBC\x3\xBC\x3\xBC\x3\xBC\x5\xBC\xACF\n\xBC\x3\xBC\x3\xBC\x3\xBC\x5"+
+		"\xBC\xAD4\n\xBC\x3\xBC\x3\xBC\x5\xBC\xAD8\n\xBC\x3\xBC\x6\xBC\xADB\n\xBC"+
+		"\r\xBC\xE\xBC\xADC\x3\xBC\x5\xBC\xAE0\n\xBC\x3\xBC\x3\xBC\x5\xBC\xAE4"+
+		"\n\xBC\x3\xBD\x3\xBD\x3\xBE\x6\xBE\xAE9\n\xBE\r\xBE\xE\xBE\xAEA\x3\xBE"+
+		"\x2\x2\x3\xFE\xBF\x2\x2\x4\x2\x6\x2\b\x2\n\x2\f\x2\xE\x2\x10\x2\x12\x2"+
+		"\x14\x2\x16\x2\x18\x2\x1A\x2\x1C\x2\x1E\x2 \x2\"\x2$\x2&\x2(\x2*\x2,\x2"+
+		".\x2\x30\x2\x32\x2\x34\x2\x36\x2\x38\x2:\x2<\x2>\x2@\x2\x42\x2\x44\x2"+
+		"\x46\x2H\x2J\x2L\x2N\x2P\x2R\x2T\x2V\x2X\x2Z\x2\\\x2^\x2`\x2\x62\x2\x64"+
+		"\x2\x66\x2h\x2j\x2l\x2n\x2p\x2r\x2t\x2v\x2x\x2z\x2|\x2~\x2\x80\x2\x82"+
+		"\x2\x84\x2\x86\x2\x88\x2\x8A\x2\x8C\x2\x8E\x2\x90\x2\x92\x2\x94\x2\x96"+
+		"\x2\x98\x2\x9A\x2\x9C\x2\x9E\x2\xA0\x2\xA2\x2\xA4\x2\xA6\x2\xA8\x2\xAA"+
+		"\x2\xAC\x2\xAE\x2\xB0\x2\xB2\x2\xB4\x2\xB6\x2\xB8\x2\xBA\x2\xBC\x2\xBE"+
+		"\x2\xC0\x2\xC2\x2\xC4\x2\xC6\x2\xC8\x2\xCA\x2\xCC\x2\xCE\x2\xD0\x2\xD2"+
+		"\x2\xD4\x2\xD6\x2\xD8\x2\xDA\x2\xDC\x2\xDE\x2\xE0\x2\xE2\x2\xE4\x2\xE6"+
+		"\x2\xE8\x2\xEA\x2\xEC\x2\xEE\x2\xF0\x2\xF2\x2\xF4\x2\xF6\x2\xF8\x2\xFA"+
+		"\x2\xFC\x2\xFE\x2\x100\x2\x102\x2\x104\x2\x106\x2\x108\x2\x10A\x2\x10C"+
+		"\x2\x10E\x2\x110\x2\x112\x2\x114\x2\x116\x2\x118\x2\x11A\x2\x11C\x2\x11E"+
+		"\x2\x120\x2\x122\x2\x124\x2\x126\x2\x128\x2\x12A\x2\x12C\x2\x12E\x2\x130"+
+		"\x2\x132\x2\x134\x2\x136\x2\x138\x2\x13A\x2\x13C\x2\x13E\x2\x140\x2\x142"+
+		"\x2\x144\x2\x146\x2\x148\x2\x14A\x2\x14C\x2\x14E\x2\x150\x2\x152\x2\x154"+
+		"\x2\x156\x2\x158\x2\x15A\x2\x15C\x2\x15E\x2\x160\x2\x162\x2\x164\x2\x166"+
+		"\x2\x168\x2\x16A\x2\x16C\x2\x16E\x2\x170\x2\x172\x2\x174\x2\x176\x2\x178"+
+		"\x2\x17A\x2\x2\x1A\x5\x2;;\x45\x45\xBC\xBC\a\x2\x38\x38;;{{\x9B\x9B\xA6"+
+		"\xA6\x4\x2\xA8\xA9\xCB\xCB\x4\x2\x85\x87\xB3\xB3\x4\x2))++\x4\x2rr\xBA"+
+		"\xBA\x3\x2HT\x4\x2\xC3\xC3\xC7\xC7\x3\x2jn\x3\x2\x92\x93\x4\x2\xCE\xCE"+
+		"\xD7\xD7\x4\x2\xD6\xD6\xD9\xD9\a\x2||\x83\x83\xD0\xD3\xD5\xD5\xD8\xD8"+
+		"\x3\x2,-\x4\x2=>\x9C\x9C\x3\x2=>\r\x2\x13\x13\x1F <<??\x46\x46WW}}\x7F"+
+		"\x7F\xB4\xB4\xB9\xB9\xC4\xC4\x3\x2\xE4\xE7\x5\x2,,.\x32\xDA\xDA\x6\x2"+
+		"pptt\x9F\x9F\xA4\xA4&\x2\x3\f\xE\x17\x19#%%\'(\x33\x38:?\x42\x43\x45\x46"+
 		"WW``\x63\x64\x66\x66hhjossxxz\x7F\x82\x87\x89\x8B\x8D\x90\x92\x92\x94"+
 		"\x95\x9A\x9D\xA5\xA6\xA8\xA9\xAB\xAC\xB0\xB0\xB3\xB5\xB7\xB7\xB9\xB9\xBB"+
 		"\xBF\xC1\xC5\xC8\xC8\xCA\xCC\xF1\xF7\x1E\x2\x18\x18$$@\x41\x44\x44GVY"+
 		"Z\x65\x65ggiiprtwyy\x80\x81\x88\x88\x8C\x8C\x91\x91\x9E\x9F\xA4\xA4\xA7"+
 		"\xA7\xAA\xAA\xAD\xAF\xB1\xB2\xB6\xB6\xB8\xB8\xBA\xBA\xC0\xC0\xC6\xC7\xC9"+
-		"\xC9\x3\x2\xE9\xE9\x4\x2\xEC\xEC\xEF\xEF\xBFE\x2\x176\x3\x2\x2\x2\x4\x179"+
-		"\x3\x2\x2\x2\x6\x192\x3\x2\x2\x2\b\x19D\x3\x2\x2\x2\n\x1AF\x3\x2\x2\x2"+
-		"\f\x1C7\x3\x2\x2\x2\xE\x1CB\x3\x2\x2\x2\x10\x1E0\x3\x2\x2\x2\x12\x1EB"+
-		"\x3\x2\x2\x2\x14\x1ED\x3\x2\x2\x2\x16\x1FD\x3\x2\x2\x2\x18\x1FF\x3\x2"+
-		"\x2\x2\x1A\x217\x3\x2\x2\x2\x1C\x219\x3\x2\x2\x2\x1E\x21B\x3\x2\x2\x2"+
-		" \x249\x3\x2\x2\x2\"\x258\x3\x2\x2\x2$\x25A\x3\x2\x2\x2&\x275\x3\x2\x2"+
-		"\x2(\x277\x3\x2\x2\x2*\x27B\x3\x2\x2\x2,\x27D\x3\x2\x2\x2.\x281\x3\x2"+
-		"\x2\x2\x30\x283\x3\x2\x2\x2\x32\x285\x3\x2\x2\x2\x34\x28F\x3\x2\x2\x2"+
-		"\x36\x293\x3\x2\x2\x2\x38\x295\x3\x2\x2\x2:\x298\x3\x2\x2\x2<\x29A\x3"+
-		"\x2\x2\x2>\x2A0\x3\x2\x2\x2@\x2A2\x3\x2\x2\x2\x42\x2B0\x3\x2\x2\x2\x44"+
-		"\x2BC\x3\x2\x2\x2\x46\x2BE\x3\x2\x2\x2H\x2D5\x3\x2\x2\x2J\x2D7\x3\x2\x2"+
-		"\x2L\x2D9\x3\x2\x2\x2N\x2DB\x3\x2\x2\x2P\x2E8\x3\x2\x2\x2R\x2F4\x3\x2"+
-		"\x2\x2T\x2F6\x3\x2\x2\x2V\x302\x3\x2\x2\x2X\x304\x3\x2\x2\x2Z\x311\x3"+
-		"\x2\x2\x2\\\x323\x3\x2\x2\x2^\x328\x3\x2\x2\x2`\x32A\x3\x2\x2\x2\x62\x32C"+
-		"\x3\x2\x2\x2\x64\x32E\x3\x2\x2\x2\x66\x33C\x3\x2\x2\x2h\x33E\x3\x2\x2"+
-		"\x2j\x345\x3\x2\x2\x2l\x34F\x3\x2\x2\x2n\x351\x3\x2\x2\x2p\x35E\x3\x2"+
-		"\x2\x2r\x36A\x3\x2\x2\x2t\x378\x3\x2\x2\x2v\x37A\x3\x2\x2\x2x\x390\x3"+
-		"\x2\x2\x2z\x392\x3\x2\x2\x2|\x394\x3\x2\x2\x2~\x3AA\x3\x2\x2\x2\x80\x3AF"+
-		"\x3\x2\x2\x2\x82\x3C1\x3\x2\x2\x2\x84\x3D6\x3\x2\x2\x2\x86\x3FA\x3\x2"+
-		"\x2\x2\x88\x40A\x3\x2\x2\x2\x8A\x40F\x3\x2\x2\x2\x8C\x411\x3\x2\x2\x2"+
-		"\x8E\x413\x3\x2\x2\x2\x90\x41D\x3\x2\x2\x2\x92\x420\x3\x2\x2\x2\x94\x423"+
-		"\x3\x2\x2\x2\x96\x42D\x3\x2\x2\x2\x98\x42F\x3\x2\x2\x2\x9A\x44E\x3\x2"+
-		"\x2\x2\x9C\x453\x3\x2\x2\x2\x9E\x461\x3\x2\x2\x2\xA0\x46E\x3\x2\x2\x2"+
-		"\xA2\x470\x3\x2\x2\x2\xA4\x480\x3\x2\x2\x2\xA6\x487\x3\x2\x2\x2\xA8\x491"+
-		"\x3\x2\x2\x2\xAA\x493\x3\x2\x2\x2\xAC\x4A6\x3\x2\x2\x2\xAE\x4C9\x3\x2"+
-		"\x2\x2\xB0\x4E9\x3\x2\x2\x2\xB2\x4EB\x3\x2\x2\x2\xB4\x4EF\x3\x2\x2\x2"+
-		"\xB6\x4F3\x3\x2\x2\x2\xB8\x51B\x3\x2\x2\x2\xBA\x51D\x3\x2\x2\x2\xBC\x524"+
-		"\x3\x2\x2\x2\xBE\x526\x3\x2\x2\x2\xC0\x538\x3\x2\x2\x2\xC2\x547\x3\x2"+
-		"\x2\x2\xC4\x574\x3\x2\x2\x2\xC6\x576\x3\x2\x2\x2\xC8\x578\x3\x2\x2\x2"+
-		"\xCA\x57A\x3\x2\x2\x2\xCC\x580\x3\x2\x2\x2\xCE\x58C\x3\x2\x2\x2\xD0\x598"+
-		"\x3\x2\x2\x2\xD2\x5A6\x3\x2\x2\x2\xD4\x5B2\x3\x2\x2\x2\xD6\x5C6\x3\x2"+
-		"\x2\x2\xD8\x5DD\x3\x2\x2\x2\xDA\x5FD\x3\x2\x2\x2\xDC\x615\x3\x2\x2\x2"+
-		"\xDE\x62A\x3\x2\x2\x2\xE0\x63D\x3\x2\x2\x2\xE2\x651\x3\x2\x2\x2\xE4\x663"+
-		"\x3\x2\x2\x2\xE6\x66B\x3\x2\x2\x2\xE8\x66D\x3\x2\x2\x2\xEA\x679\x3\x2"+
-		"\x2\x2\xEC\x67B\x3\x2\x2\x2\xEE\x69A\x3\x2\x2\x2\xF0\x69C\x3\x2\x2\x2"+
-		"\xF2\x6B2\x3\x2\x2\x2\xF4\x6B4\x3\x2\x2\x2\xF6\x6C3\x3\x2\x2\x2\xF8\x6DA"+
-		"\x3\x2\x2\x2\xFA\x6DF\x3\x2\x2\x2\xFC\x6ED\x3\x2\x2\x2\xFE\x733\x3\x2"+
-		"\x2\x2\x100\x7A6\x3\x2\x2\x2\x102\x7B3\x3\x2\x2\x2\x104\x7BC\x3\x2\x2"+
-		"\x2\x106\x7CA\x3\x2\x2\x2\x108\x7E6\x3\x2\x2\x2\x10A\x7EF\x3\x2\x2\x2"+
-		"\x10C\x7F8\x3\x2\x2\x2\x10E\x7FA\x3\x2\x2\x2\x110\x840\x3\x2\x2\x2\x112"+
-		"\x844\x3\x2\x2\x2\x114\x847\x3\x2\x2\x2\x116\x86B\x3\x2\x2\x2\x118\x881"+
-		"\x3\x2\x2\x2\x11A\x883\x3\x2\x2\x2\x11C\x89B\x3\x2\x2\x2\x11E\x8C0\x3"+
-		"\x2\x2\x2\x120\x8D8\x3\x2\x2\x2\x122\x8FF\x3\x2\x2\x2\x124\x91B\x3\x2"+
-		"\x2\x2\x126\x924\x3\x2\x2\x2\x128\x934\x3\x2\x2\x2\x12A\x948\x3\x2\x2"+
-		"\x2\x12C\x953\x3\x2\x2\x2\x12E\x95B\x3\x2\x2\x2\x130\x976\x3\x2\x2\x2"+
-		"\x132\x99A\x3\x2\x2\x2\x134\x9A0\x3\x2\x2\x2\x136\x9B3\x3\x2\x2\x2\x138"+
-		"\x9BA\x3\x2\x2\x2\x13A\x9BE\x3\x2\x2\x2\x13C\x9C0\x3\x2\x2\x2\x13E\x9CF"+
-		"\x3\x2\x2\x2\x140\x9D1\x3\x2\x2\x2\x142\x9D3\x3\x2\x2\x2\x144\x9DB\x3"+
-		"\x2\x2\x2\x146\x9E3\x3\x2\x2\x2\x148\x9EB\x3\x2\x2\x2\x14A\x9ED\x3\x2"+
-		"\x2\x2\x14C\x9EF\x3\x2\x2\x2\x14E\x9F9\x3\x2\x2\x2\x150\x9FB\x3\x2\x2"+
-		"\x2\x152\x9FF\x3\x2\x2\x2\x154\xA0B\x3\x2\x2\x2\x156\xA0D\x3\x2\x2\x2"+
-		"\x158\xA0F\x3\x2\x2\x2\x15A\xA11\x3\x2\x2\x2\x15C\xA13\x3\x2\x2\x2\x15E"+
-		"\xA16\x3\x2\x2\x2\x160\xA31\x3\x2\x2\x2\x162\xA36\x3\x2\x2\x2\x164\xA38"+
-		"\x3\x2\x2\x2\x166\xA3E\x3\x2\x2\x2\x168\xA45\x3\x2\x2\x2\x16A\xA48\x3"+
-		"\x2\x2\x2\x16C\xA52\x3\x2\x2\x2\x16E\xA56\x3\x2\x2\x2\x170\xA94\x3\x2"+
-		"\x2\x2\x172\xA96\x3\x2\x2\x2\x174\xA99\x3\x2\x2\x2\x176\x177\x5\x4\x3"+
-		"\x2\x177\x3\x3\x2\x2\x2\x178\x17A\x5\x174\xBB\x2\x179\x178\x3\x2\x2\x2"+
-		"\x179\x17A\x3\x2\x2\x2\x17A\x17B\x3\x2\x2\x2\x17B\x17F\x5\x160\xB1\x2"+
-		"\x17C\x17D\x5\x6\x4\x2\x17D\x17E\x5\x160\xB1\x2\x17E\x180\x3\x2\x2\x2"+
-		"\x17F\x17C\x3\x2\x2\x2\x17F\x180\x3\x2\x2\x2\x180\x182\x3\x2\x2\x2\x181"+
-		"\x183\x5\b\x5\x2\x182\x181\x3\x2\x2\x2\x182\x183\x3\x2\x2\x2\x183\x184"+
-		"\x3\x2\x2\x2\x184\x186\x5\x160\xB1\x2\x185\x187\x5\f\a\x2\x186\x185\x3"+
-		"\x2\x2\x2\x186\x187\x3\x2\x2\x2\x187\x188\x3\x2\x2\x2\x188\x18A\x5\x160"+
-		"\xB1\x2\x189\x18B\x5\xE\b\x2\x18A\x189\x3\x2\x2\x2\x18A\x18B\x3\x2\x2"+
-		"\x2\x18B\x18C\x3\x2\x2\x2\x18C\x18E\x5\x160\xB1\x2\x18D\x18F\x5\x14\v"+
-		"\x2\x18E\x18D\x3\x2\x2\x2\x18E\x18F\x3\x2\x2\x2\x18F\x190\x3\x2\x2\x2"+
-		"\x190\x191\x5\x160\xB1\x2\x191\x5\x3\x2\x2\x2\x192\x193\a\xC5\x2\x2\x193"+
-		"\x194\x5\x174\xBB\x2\x194\x196\x5\x150\xA9\x2\x195\x197\x5\x174\xBB\x2"+
-		"\x196\x195\x3\x2\x2\x2\x196\x197\x3\x2\x2\x2\x197\x199\x3\x2\x2\x2\x198"+
-		"\x19A\a\x42\x2\x2\x199\x198\x3\x2\x2\x2\x199\x19A\x3\x2\x2\x2\x19A\x19B"+
-		"\x3\x2\x2\x2\x19B\x19C\x5\x160\xB1\x2\x19C\a\x3\x2\x2\x2\x19D\x1A5\a:"+
-		"\x2\x2\x19E\x19F\x5\x174\xBB\x2\x19F\x1A0\a\xED\x2\x2\x1A0\x1A1\x5\x174"+
-		"\xBB\x2\x1A1\x1A3\x5\x138\x9D\x2\x1A2\x1A4\x5\x174\xBB\x2\x1A3\x1A2\x3"+
-		"\x2\x2\x2\x1A3\x1A4\x3\x2\x2\x2\x1A4\x1A6\x3\x2\x2\x2\x1A5\x19E\x3\x2"+
-		"\x2\x2\x1A5\x1A6\x3\x2\x2\x2\x1A6\x1A7\x3\x2\x2\x2\x1A7\x1A9\x5\x160\xB1"+
-		"\x2\x1A8\x1AA\x5\n\x6\x2\x1A9\x1A8\x3\x2\x2\x2\x1AA\x1AB\x3\x2\x2\x2\x1AB"+
-		"\x1A9\x3\x2\x2\x2\x1AB\x1AC\x3\x2\x2\x2\x1AC\x1AD\x3\x2\x2\x2\x1AD\x1AE"+
-		"\a\x64\x2\x2\x1AE\t\x3\x2\x2\x2\x1AF\x1B3\x5\x138\x9D\x2\x1B0\x1B2\x5"+
-		"\x174\xBB\x2\x1B1\x1B0\x3\x2\x2\x2\x1B2\x1B5\x3\x2\x2\x2\x1B3\x1B1\x3"+
-		"\x2\x2\x2\x1B3\x1B4\x3\x2\x2\x2\x1B4\x1B6\x3\x2\x2\x2\x1B5\x1B3\x3\x2"+
-		"\x2\x2\x1B6\x1BA\a\xD0\x2\x2\x1B7\x1B9\x5\x174\xBB\x2\x1B8\x1B7\x3\x2"+
-		"\x2\x2\x1B9\x1BC\x3\x2\x2\x2\x1BA\x1B8\x3\x2\x2\x2\x1BA\x1BB\x3\x2\x2"+
-		"\x2\x1BB\x1BD\x3\x2\x2\x2\x1BC\x1BA\x3\x2\x2\x2\x1BD\x1C0\x5\xFE\x80\x2"+
-		"\x1BE\x1BF\a*\x2\x2\x1BF\x1C1\x5\x150\xA9\x2\x1C0\x1BE\x3\x2\x2\x2\x1C0"+
-		"\x1C1\x3\x2\x2\x2\x1C1\x1C2\x3\x2\x2\x2\x1C2\x1C3\x5\x160\xB1\x2\x1C3"+
-		"\v\x3\x2\x2\x2\x1C4\x1C5\x5\x18\r\x2\x1C5\x1C6\x5\x160\xB1\x2\x1C6\x1C8"+
-		"\x3\x2\x2\x2\x1C7\x1C4\x3\x2\x2\x2\x1C8\x1C9\x3\x2\x2\x2\x1C9\x1C7\x3"+
-		"\x2\x2\x2\x1C9\x1CA\x3\x2\x2\x2\x1CA\r\x3\x2\x2\x2\x1CB\x1D1\x5\x12\n"+
-		"\x2\x1CC\x1CD\x5\x160\xB1\x2\x1CD\x1CE\x5\x12\n\x2\x1CE\x1D0\x3\x2\x2"+
-		"\x2\x1CF\x1CC\x3\x2\x2\x2\x1D0\x1D3\x3\x2\x2\x2\x1D1\x1CF\x3\x2\x2\x2"+
-		"\x1D1\x1D2\x3\x2\x2\x2\x1D2\x1D4\x3\x2\x2\x2\x1D3\x1D1\x3\x2\x2\x2\x1D4"+
-		"\x1D5\x5\x160\xB1\x2\x1D5\xF\x3\x2\x2\x2\x1D6\x1D7\a\x96\x2\x2\x1D7\x1D8"+
-		"\x5\x174\xBB\x2\x1D8\x1D9\x5\x150\xA9\x2\x1D9\x1E1\x3\x2\x2\x2\x1DA\x1DB"+
-		"\a\x98\x2\x2\x1DB\x1DC\x5\x174\xBB\x2\x1DC\x1DD\t\x2\x2\x2\x1DD\x1E1\x3"+
-		"\x2\x2\x2\x1DE\x1E1\a\x97\x2\x2\x1DF\x1E1\a\x99\x2\x2\x1E0\x1D6\x3\x2"+
-		"\x2\x2\x1E0\x1DA\x3\x2\x2\x2\x1E0\x1DE\x3\x2\x2\x2\x1E0\x1DF\x3\x2\x2"+
-		"\x2\x1E1\x11\x3\x2\x2\x2\x1E2\x1EC\x5\x84\x43\x2\x1E3\x1EC\x5\x86\x44"+
-		"\x2\x1E4\x1EC\x5\x9CO\x2\x1E5\x1EC\x5\xA6T\x2\x1E6\x1EC\x5\x80\x41\x2"+
-		"\x1E7\x1EC\x5\xCA\x66\x2\x1E8\x1EC\x5\x102\x82\x2\x1E9\x1EC\x5\x10\t\x2"+
-		"\x1EA\x1EC\x5\xFA~\x2\x1EB\x1E2\x3\x2\x2\x2\x1EB\x1E3\x3\x2\x2\x2\x1EB"+
-		"\x1E4\x3\x2\x2\x2\x1EB\x1E5\x3\x2\x2\x2\x1EB\x1E6\x3\x2\x2\x2\x1EB\x1E7"+
-		"\x3\x2\x2\x2\x1EB\x1E8\x3\x2\x2\x2\x1EB\x1E9\x3\x2\x2\x2\x1EB\x1EA\x3"+
-		"\x2\x2\x2\x1EC\x13\x3\x2\x2\x2\x1ED\x1F3\x5\x16\f\x2\x1EE\x1EF\x5\x160"+
-		"\xB1\x2\x1EF\x1F0\x5\x16\f\x2\x1F0\x1F2\x3\x2\x2\x2\x1F1\x1EE\x3\x2\x2"+
-		"\x2\x1F2\x1F5\x3\x2\x2\x2\x1F3\x1F1\x3\x2\x2\x2\x1F3\x1F4\x3\x2\x2\x2"+
-		"\x1F4\x1F6\x3\x2\x2\x2\x1F5\x1F3\x3\x2\x2\x2\x1F6\x1F7\x5\x160\xB1\x2"+
-		"\x1F7\x15\x3\x2\x2\x2\x1F8\x1FE\x5\xAEX\x2\x1F9\x1FE\x5\xD8m\x2\x1FA\x1FE"+
-		"\x5\xDAn\x2\x1FB\x1FE\x5\xDCo\x2\x1FC\x1FE\x5\xF6|\x2\x1FD\x1F8\x3\x2"+
-		"\x2\x2\x1FD\x1F9\x3\x2\x2\x2\x1FD\x1FA\x3\x2\x2\x2\x1FD\x1FB\x3\x2\x2"+
-		"\x2\x1FD\x1FC\x3\x2\x2\x2\x1FE\x17\x3\x2\x2\x2\x1FF\x200\a\x37\x2\x2\x200"+
-		"\x201\x5\x174\xBB\x2\x201\x203\x5\x1A\xE\x2\x202\x204\x5\x174\xBB\x2\x203"+
-		"\x202\x3\x2\x2\x2\x203\x204\x3\x2\x2\x2\x204\x205\x3\x2\x2\x2\x205\x207"+
-		"\a\xD0\x2\x2\x206\x208\x5\x174\xBB\x2\x207\x206\x3\x2\x2\x2\x207\x208"+
-		"\x3\x2\x2\x2\x208\x209\x3\x2\x2\x2\x209\x214\x5\x1C\xF\x2\x20A\x20C\x5"+
-		"\x174\xBB\x2\x20B\x20A\x3\x2\x2\x2\x20B\x20C\x3\x2\x2\x2\x20C\x20D\x3"+
-		"\x2\x2\x2\x20D\x20F\a)\x2\x2\x20E\x210\x5\x174\xBB\x2\x20F\x20E\x3\x2"+
-		"\x2\x2\x20F\x210\x3\x2\x2\x2\x210\x211\x3\x2\x2\x2\x211\x213\x5\x1C\xF"+
-		"\x2\x212\x20B\x3\x2\x2\x2\x213\x216\x3\x2\x2\x2\x214\x212\x3\x2\x2\x2"+
-		"\x214\x215\x3\x2\x2\x2\x215\x19\x3\x2\x2\x2\x216\x214\x3\x2\x2\x2\x217"+
-		"\x218\x5\x118\x8D\x2\x218\x1B\x3\x2\x2\x2\x219\x21A\x5\xFE\x80\x2\x21A"+
-		"\x1D\x3\x2\x2\x2\x21B\x221\x5 \x11\x2\x21C\x21D\x5\x160\xB1\x2\x21D\x21E"+
-		"\x5 \x11\x2\x21E\x220\x3\x2\x2\x2\x21F\x21C\x3\x2\x2\x2\x220\x223\x3\x2"+
-		"\x2\x2\x221\x21F\x3\x2\x2\x2\x221\x222\x3\x2\x2\x2\x222\x224\x3\x2\x2"+
-		"\x2\x223\x221\x3\x2\x2\x2\x224\x225\x5\x160\xB1\x2\x225\x1F\x3\x2\x2\x2"+
-		"\x226\x24A\x5\x146\xA4\x2\x227\x24A\x5\"\x12\x2\x228\x24A\x5\x18\r\x2"+
-		"\x229\x24A\x5\x80\x41\x2\x22A\x24A\x5\x9AN\x2\x22B\x24A\x5\xA0Q\x2\x22C"+
-		"\x24A\x5\xA2R\x2\x22D\x24A\x5\xA4S\x2\x22E\x24A\x5\xA8U\x2\x22F\x24A\x5"+
-		"\x10E\x88\x2\x230\x24A\x5\xAAV\x2\x231\x24A\x5\xACW\x2\x232\x24A\x5\xB2"+
-		"Z\x2\x233\x24A\x5\xB4[\x2\x234\x24A\x5\xB6\\\x2\x235\x24A\x5\xBC_\x2\x236"+
-		"\x24A\x5\xCA\x66\x2\x237\x24A\x5\xCCg\x2\x238\x24A\x5\xCEh\x2\x239\x24A"+
-		"\x5\xD0i\x2\x23A\x24A\x5\xD2j\x2\x23B\x24A\x5\xD4k\x2\x23C\x24A\x5\xD6"+
-		"l\x2\x23D\x24A\x5\xDEp\x2\x23E\x24A\x5\xE0q\x2\x23F\x24A\x5\xE4s\x2\x240"+
-		"\x24A\x5\xE6t\x2\x241\x24A\x5\xE8u\x2\x242\x24A\x5\xECw\x2\x243\x24A\x5"+
-		"\xF4{\x2\x244\x24A\x5\xEAv\x2\x245\x24A\x5\x102\x82\x2\x246\x24A\x5\x108"+
-		"\x85\x2\x247\x24A\x5\x10A\x86\x2\x248\x24A\x5\x112\x8A\x2\x249\x226\x3"+
-		"\x2\x2\x2\x249\x227\x3\x2\x2\x2\x249\x228\x3\x2\x2\x2\x249\x229\x3\x2"+
-		"\x2\x2\x249\x22A\x3\x2\x2\x2\x249\x22B\x3\x2\x2\x2\x249\x22C\x3\x2\x2"+
-		"\x2\x249\x22D\x3\x2\x2\x2\x249\x22E\x3\x2\x2\x2\x249\x22F\x3\x2\x2\x2"+
-		"\x249\x230\x3\x2\x2\x2\x249\x231\x3\x2\x2\x2\x249\x232\x3\x2\x2\x2\x249"+
-		"\x233\x3\x2\x2\x2\x249\x234\x3\x2\x2\x2\x249\x235\x3\x2\x2\x2\x249\x236"+
-		"\x3\x2\x2\x2\x249\x237\x3\x2\x2\x2\x249\x238\x3\x2\x2\x2\x249\x239\x3"+
-		"\x2\x2\x2\x249\x23A\x3\x2\x2\x2\x249\x23B\x3\x2\x2\x2\x249\x23C\x3\x2"+
-		"\x2\x2\x249\x23D\x3\x2\x2\x2\x249\x23E\x3\x2\x2\x2\x249\x23F\x3\x2\x2"+
-		"\x2\x249\x240\x3\x2\x2\x2\x249\x241\x3\x2\x2\x2\x249\x242\x3\x2\x2\x2"+
-		"\x249\x243\x3\x2\x2\x2\x249\x244\x3\x2\x2\x2\x249\x245\x3\x2\x2\x2\x249"+
-		"\x246\x3\x2\x2\x2\x249\x247\x3\x2\x2\x2\x249\x248\x3\x2\x2\x2\x24A!\x3"+
-		"\x2\x2\x2\x24B\x259\x5$\x13\x2\x24C\x259\x5> \x2\x24D\x259\x5<\x1F\x2"+
-		"\x24E\x259\x5\x42\"\x2\x24F\x259\x5\x46$\x2\x250\x259\x5N(\x2\x251\x259"+
-		"\x5P)\x2\x252\x259\x5T+\x2\x253\x259\x5X-\x2\x254\x259\x5n\x38\x2\x255"+
-		"\x259\x5p\x39\x2\x256\x259\x5v<\x2\x257\x259\x5|?\x2\x258\x24B\x3\x2\x2"+
-		"\x2\x258\x24C\x3\x2\x2\x2\x258\x24D\x3\x2\x2\x2\x258\x24E\x3\x2\x2\x2"+
-		"\x258\x24F\x3\x2\x2\x2\x258\x250\x3\x2\x2\x2\x258\x251\x3\x2\x2\x2\x258"+
-		"\x252\x3\x2\x2\x2\x258\x253\x3\x2\x2\x2\x258\x254\x3\x2\x2\x2\x258\x255"+
-		"\x3\x2\x2\x2\x258\x256\x3\x2\x2\x2\x258\x257\x3\x2\x2\x2\x259#\x3\x2\x2"+
-		"\x2\x25A\x25B\a\x94\x2\x2\x25B\x25C\x5\x174\xBB\x2\x25C\x260\x5&\x14\x2"+
-		"\x25D\x25E\x5\x174\xBB\x2\x25E\x25F\x5(\x15\x2\x25F\x261\x3\x2\x2\x2\x260"+
-		"\x25D\x3\x2\x2\x2\x260\x261\x3\x2\x2\x2\x261\x265\x3\x2\x2\x2\x262\x263"+
-		"\x5\x174\xBB\x2\x263\x264\x5,\x17\x2\x264\x266\x3\x2\x2\x2\x265\x262\x3"+
-		"\x2\x2\x2\x265\x266\x3\x2\x2\x2\x266\x26A\x3\x2\x2\x2\x267\x268\x5\x174"+
-		"\xBB\x2\x268\x269\x5\x30\x19\x2\x269\x26B\x3\x2\x2\x2\x26A\x267\x3\x2"+
-		"\x2\x2\x26A\x26B\x3\x2\x2\x2\x26B\x26C\x3\x2\x2\x2\x26C\x26D\x5\x174\xBB"+
-		"\x2\x26D\x26E\a\x39\x2\x2\x26E\x26F\x5\x174\xBB\x2\x26F\x273\x5\x36\x1C"+
-		"\x2\x270\x271\x5\x174\xBB\x2\x271\x272\x5\x32\x1A\x2\x272\x274\x3\x2\x2"+
-		"\x2\x273\x270\x3\x2\x2\x2\x273\x274\x3\x2\x2\x2\x274%\x3\x2\x2\x2\x275"+
-		"\x276\x5\xFE\x80\x2\x276\'\x3\x2\x2\x2\x277\x278\aq\x2\x2\x278\x279\x5"+
-		"\x174\xBB\x2\x279\x27A\x5*\x16\x2\x27A)\x3\x2\x2\x2\x27B\x27C\t\x3\x2"+
-		"\x2\x27C+\x3\x2\x2\x2\x27D\x27E\a\x33\x2\x2\x27E\x27F\x5\x174\xBB\x2\x27F"+
-		"\x280\x5.\x18\x2\x280-\x3\x2\x2\x2\x281\x282\t\x4\x2\x2\x282/\x3\x2\x2"+
-		"\x2\x283\x284\t\x5\x2\x2\x284\x31\x3\x2\x2\x2\x285\x287\a\x1D\x2\x2\x286"+
-		"\x288\x5\x174\xBB\x2\x287\x286\x3\x2\x2\x2\x287\x288\x3\x2\x2\x2\x288"+
-		"\x289\x3\x2\x2\x2\x289\x28B\a\xD0\x2\x2\x28A\x28C\x5\x174\xBB\x2\x28B"+
-		"\x28A\x3\x2\x2\x2\x28B\x28C\x3\x2\x2\x2\x28C\x28D\x3\x2\x2\x2\x28D\x28E"+
-		"\x5\x34\x1B\x2\x28E\x33\x3\x2\x2\x2\x28F\x290\x5\xFE\x80\x2\x290\x35\x3"+
-		"\x2\x2\x2\x291\x294\x5\x38\x1D\x2\x292\x294\x5:\x1E\x2\x293\x291\x3\x2"+
-		"\x2\x2\x293\x292\x3\x2\x2\x2\x294\x37\x3\x2\x2\x2\x295\x296\a.\x2\x2\x296"+
-		"\x297\x5\xFE\x80\x2\x297\x39\x3\x2\x2\x2\x298\x299\x5\xFE\x80\x2\x299"+
-		";\x3\x2\x2\x2\x29A\x29E\a\x43\x2\x2\x29B\x29C\x5\x174\xBB\x2\x29C\x29D"+
-		"\x5@!\x2\x29D\x29F\x3\x2\x2\x2\x29E\x29B\x3\x2\x2\x2\x29E\x29F\x3\x2\x2"+
-		"\x2\x29F=\x3\x2\x2\x2\x2A0\x2A1\a\xAC\x2\x2\x2A1?\x3\x2\x2\x2\x2A2\x2AD"+
-		"\x5\x36\x1C\x2\x2A3\x2A5\x5\x174\xBB\x2\x2A4\x2A3\x3\x2\x2\x2\x2A4\x2A5"+
-		"\x3\x2\x2\x2\x2A5\x2A6\x3\x2\x2\x2\x2A6\x2A8\a)\x2\x2\x2A7\x2A9\x5\x174"+
-		"\xBB\x2\x2A8\x2A7\x3\x2\x2\x2\x2A8\x2A9\x3\x2\x2\x2\x2A9\x2AA\x3\x2\x2"+
-		"\x2\x2AA\x2AC\x5\x36\x1C\x2\x2AB\x2A4\x3\x2\x2\x2\x2AC\x2AF\x3\x2\x2\x2"+
-		"\x2AD\x2AB\x3\x2\x2\x2\x2AD\x2AE\x3\x2\x2\x2\x2AE\x41\x3\x2\x2\x2\x2AF"+
-		"\x2AD\x3\x2\x2\x2\x2B0\x2B1\a\xB0\x2\x2\x2B1\x2B2\x5\x174\xBB\x2\x2B2"+
-		"\x2B4\x5\x36\x1C\x2\x2B3\x2B5\x5\x174\xBB\x2\x2B4\x2B3\x3\x2\x2\x2\x2B4"+
-		"\x2B5\x3\x2\x2\x2\x2B5\x2B6\x3\x2\x2\x2\x2B6\x2B8\a)\x2\x2\x2B7\x2B9\x5"+
-		"\x174\xBB\x2\x2B8\x2B7\x3\x2\x2\x2\x2B8\x2B9\x3\x2\x2\x2\x2B9\x2BA\x3"+
-		"\x2\x2\x2\x2BA\x2BB\x5\x44#\x2\x2BB\x43\x3\x2\x2\x2\x2BC\x2BD\x5\xFE\x80"+
-		"\x2\x2BD\x45\x3\x2\x2\x2\x2BE\x2BF\a~\x2\x2\x2BF\x2C0\x5\x174\xBB\x2\x2C0"+
-		"\x2C9\x5\x36\x1C\x2\x2C1\x2C3\x5\x174\xBB\x2\x2C2\x2C1\x3\x2\x2\x2\x2C2"+
-		"\x2C3\x3\x2\x2\x2\x2C3\x2C4\x3\x2\x2\x2\x2C4\x2C6\a)\x2\x2\x2C5\x2C7\x5"+
-		"\x174\xBB\x2\x2C6\x2C5\x3\x2\x2\x2\x2C6\x2C7\x3\x2\x2\x2\x2C7\x2C8\x3"+
-		"\x2\x2\x2\x2C8\x2CA\x5H%\x2\x2C9\x2C2\x3\x2\x2\x2\x2C9\x2CA\x3\x2\x2\x2"+
-		"\x2CAG\x3\x2\x2\x2\x2CB\x2D6\x5J&\x2\x2CC\x2CD\x5J&\x2\x2CD\x2CE\x5\x174"+
-		"\xBB\x2\x2CE\x2D0\x3\x2\x2\x2\x2CF\x2CC\x3\x2\x2\x2\x2CF\x2D0\x3\x2\x2"+
-		"\x2\x2D0\x2D1\x3\x2\x2\x2\x2D1\x2D2\a\xBE\x2\x2\x2D2\x2D3\x5\x174\xBB"+
-		"\x2\x2D3\x2D4\x5L\'\x2\x2D4\x2D6\x3\x2\x2\x2\x2D5\x2CB\x3\x2\x2\x2\x2D5"+
-		"\x2CF\x3\x2\x2\x2\x2D6I\x3\x2\x2\x2\x2D7\x2D8\x5\xFE\x80\x2\x2D8K\x3\x2"+
-		"\x2\x2\x2D9\x2DA\x5\xFE\x80\x2\x2DAM\x3\x2\x2\x2\x2DB\x2DC\a\xC2\x2\x2"+
-		"\x2DC\x2DD\x5\x174\xBB\x2\x2DD\x2E6\x5\x36\x1C\x2\x2DE\x2E0\x5\x174\xBB"+
-		"\x2\x2DF\x2DE\x3\x2\x2\x2\x2DF\x2E0\x3\x2\x2\x2\x2E0\x2E1\x3\x2\x2\x2"+
-		"\x2E1\x2E3\a)\x2\x2\x2E2\x2E4\x5\x174\xBB\x2\x2E3\x2E2\x3\x2\x2\x2\x2E3"+
-		"\x2E4\x3\x2\x2\x2\x2E4\x2E5\x3\x2\x2\x2\x2E5\x2E7\x5H%\x2\x2E6\x2DF\x3"+
-		"\x2\x2\x2\x2E6\x2E7\x3\x2\x2\x2\x2E7O\x3\x2\x2\x2\x2E8\x2E9\a\x84\x2\x2"+
-		"\x2E9\x2EA\x5\x174\xBB\x2\x2EA\x2EC\x5\x38\x1D\x2\x2EB\x2ED\x5\x174\xBB"+
-		"\x2\x2EC\x2EB\x3\x2\x2\x2\x2EC\x2ED\x3\x2\x2\x2\x2ED\x2EE\x3\x2\x2\x2"+
-		"\x2EE\x2F0\a)\x2\x2\x2EF\x2F1\x5\x174\xBB\x2\x2F0\x2EF\x3\x2\x2\x2\x2F0"+
-		"\x2F1\x3\x2\x2\x2\x2F1\x2F2\x3\x2\x2\x2\x2F2\x2F3\x5R*\x2\x2F3Q\x3\x2"+
-		"\x2\x2\x2F4\x2F5\x5\xFE\x80\x2\x2F5S\x3\x2\x2\x2\x2F6\x2F7\a\xC8\x2\x2"+
-		"\x2F7\x2F8\x5\x174\xBB\x2\x2F8\x2FA\x5\x38\x1D\x2\x2F9\x2FB\x5\x174\xBB"+
-		"\x2\x2FA\x2F9\x3\x2\x2\x2\x2FA\x2FB\x3\x2\x2\x2\x2FB\x2FC\x3\x2\x2\x2"+
-		"\x2FC\x2FE\a)\x2\x2\x2FD\x2FF\x5\x174\xBB\x2\x2FE\x2FD\x3\x2\x2\x2\x2FE"+
-		"\x2FF\x3\x2\x2\x2\x2FF\x300\x3\x2\x2\x2\x300\x301\x5V,\x2\x301U\x3\x2"+
-		"\x2\x2\x302\x303\x5\xFE\x80\x2\x303W\x3\x2\x2\x2\x304\x305\a\x9E\x2\x2"+
-		"\x305\x306\x5\x174\xBB\x2\x306\x308\x5\x38\x1D\x2\x307\x309\x5\x174\xBB"+
-		"\x2\x308\x307\x3\x2\x2\x2\x308\x309\x3\x2\x2\x2\x309\x30A\x3\x2\x2\x2"+
-		"\x30A\x30F\a)\x2\x2\x30B\x30D\x5\x174\xBB\x2\x30C\x30B\x3\x2\x2\x2\x30C"+
-		"\x30D\x3\x2\x2\x2\x30D\x30E\x3\x2\x2\x2\x30E\x310\x5Z.\x2\x30F\x30C\x3"+
-		"\x2\x2\x2\x30F\x310\x3\x2\x2\x2\x310Y\x3\x2\x2\x2\x311\x318\x5\\/\x2\x312"+
-		"\x314\x5\x174\xBB\x2\x313\x312\x3\x2\x2\x2\x313\x314\x3\x2\x2\x2\x314"+
-		"\x315\x3\x2\x2\x2\x315\x317\x5\\/\x2\x316\x313\x3\x2\x2\x2\x317\x31A\x3"+
-		"\x2\x2\x2\x318\x316\x3\x2\x2\x2\x318\x319\x3\x2\x2\x2\x319[\x3\x2\x2\x2"+
-		"\x31A\x318\x3\x2\x2\x2\x31B\x324\x5^\x30\x2\x31C\x324\x5`\x31\x2\x31D"+
-		"\x31F\x5^\x30\x2\x31E\x320\x5\x174\xBB\x2\x31F\x31E\x3\x2\x2\x2\x31F\x320"+
-		"\x3\x2\x2\x2\x320\x321\x3\x2\x2\x2\x321\x322\x5`\x31\x2\x322\x324\x3\x2"+
-		"\x2\x2\x323\x31B\x3\x2\x2\x2\x323\x31C\x3\x2\x2\x2\x323\x31D\x3\x2\x2"+
-		"\x2\x324]\x3\x2\x2\x2\x325\x329\x5\x64\x33\x2\x326\x329\x5h\x35\x2\x327"+
-		"\x329\x5\x62\x32\x2\x328\x325\x3\x2\x2\x2\x328\x326\x3\x2\x2\x2\x328\x327"+
-		"\x3\x2\x2\x2\x329_\x3\x2\x2\x2\x32A\x32B\t\x6\x2\x2\x32B\x61\x3\x2\x2"+
-		"\x2\x32C\x32D\x5\xFE\x80\x2\x32D\x63\x3\x2\x2\x2\x32E\x330\a\xB5\x2\x2"+
-		"\x32F\x331\x5\x174\xBB\x2\x330\x32F\x3\x2\x2\x2\x330\x331\x3\x2\x2\x2"+
-		"\x331\x332\x3\x2\x2\x2\x332\x334\a\xD4\x2\x2\x333\x335\x5\x174\xBB\x2"+
-		"\x334\x333\x3\x2\x2\x2\x334\x335\x3\x2\x2\x2\x335\x336\x3\x2\x2\x2\x336"+
-		"\x338\x5\x66\x34\x2\x337\x339\x5\x174\xBB\x2\x338\x337\x3\x2\x2\x2\x338"+
-		"\x339\x3\x2\x2\x2\x339\x33A\x3\x2\x2\x2\x33A\x33B\a\xDB\x2\x2\x33B\x65"+
-		"\x3\x2\x2\x2\x33C\x33D\x5\xFE\x80\x2\x33Dg\x3\x2\x2\x2\x33E\x343\a\xBB"+
-		"\x2\x2\x33F\x341\x5\x174\xBB\x2\x340\x33F\x3\x2\x2\x2\x340\x341\x3\x2"+
-		"\x2\x2\x341\x342\x3\x2\x2\x2\x342\x344\x5j\x36\x2\x343\x340\x3\x2\x2\x2"+
-		"\x343\x344\x3\x2\x2\x2\x344i\x3\x2\x2\x2\x345\x347\a\xD4\x2\x2\x346\x348"+
-		"\x5\x174\xBB\x2\x347\x346\x3\x2\x2\x2\x347\x348\x3\x2\x2\x2\x348\x349"+
-		"\x3\x2\x2\x2\x349\x34B\x5l\x37\x2\x34A\x34C\x5\x174\xBB\x2\x34B\x34A\x3"+
-		"\x2\x2\x2\x34B\x34C\x3\x2\x2\x2\x34C\x34D\x3\x2\x2\x2\x34D\x34E\a\xDB"+
-		"\x2\x2\x34Ek\x3\x2\x2\x2\x34F\x350\x5\xFE\x80\x2\x350m\x3\x2\x2\x2\x351"+
-		"\x352\a\xCB\x2\x2\x352\x353\x5\x174\xBB\x2\x353\x355\x5\x38\x1D\x2\x354"+
-		"\x356\x5\x174\xBB\x2\x355\x354\x3\x2\x2\x2\x355\x356\x3\x2\x2\x2\x356"+
-		"\x357\x3\x2\x2\x2\x357\x35C\a)\x2\x2\x358\x35A\x5\x174\xBB\x2\x359\x358"+
-		"\x3\x2\x2\x2\x359\x35A\x3\x2\x2\x2\x35A\x35B\x3\x2\x2\x2\x35B\x35D\x5"+
-		"Z.\x2\x35C\x359\x3\x2\x2\x2\x35C\x35D\x3\x2\x2\x2\x35Do\x3\x2\x2\x2\x35E"+
-		"\x35F\a{\x2\x2\x35F\x360\x5\x174\xBB\x2\x360\x362\x5\x38\x1D\x2\x361\x363"+
-		"\x5\x174\xBB\x2\x362\x361\x3\x2\x2\x2\x362\x363\x3\x2\x2\x2\x363\x364"+
-		"\x3\x2\x2\x2\x364\x366\a)\x2\x2\x365\x367\x5\x174\xBB\x2\x366\x365\x3"+
-		"\x2\x2\x2\x366\x367\x3\x2\x2\x2\x367\x368\x3\x2\x2\x2\x368\x369\x5r:\x2"+
-		"\x369q\x3\x2\x2\x2\x36A\x375\x5t;\x2\x36B\x36D\x5\x174\xBB\x2\x36C\x36B"+
-		"\x3\x2\x2\x2\x36C\x36D\x3\x2\x2\x2\x36D\x36E\x3\x2\x2\x2\x36E\x370\a)"+
-		"\x2\x2\x36F\x371\x5\x174\xBB\x2\x370\x36F\x3\x2\x2\x2\x370\x371\x3\x2"+
-		"\x2\x2\x371\x372\x3\x2\x2\x2\x372\x374\x5t;\x2\x373\x36C\x3\x2\x2\x2\x374"+
-		"\x377\x3\x2\x2\x2\x375\x373\x3\x2\x2\x2\x375\x376\x3\x2\x2\x2\x376s\x3"+
-		"\x2\x2\x2\x377\x375\x3\x2\x2\x2\x378\x379\x5\xFE\x80\x2\x379u\x3\x2\x2"+
-		"\x2\x37A\x37B\a\xA5\x2\x2\x37B\x37C\x5\x174\xBB\x2\x37C\x37E\x5\x36\x1C"+
-		"\x2\x37D\x37F\x5\x174\xBB\x2\x37E\x37D\x3\x2\x2\x2\x37E\x37F\x3\x2\x2"+
-		"\x2\x37F\x380\x3\x2\x2\x2\x380\x382\a)\x2\x2\x381\x383\x5\x174\xBB\x2"+
-		"\x382\x381\x3\x2\x2\x2\x382\x383\x3\x2\x2\x2\x383\x385\x3\x2\x2\x2\x384"+
-		"\x386\x5x=\x2\x385\x384\x3\x2\x2\x2\x385\x386\x3\x2\x2\x2\x386\x388\x3"+
-		"\x2\x2\x2\x387\x389\x5\x174\xBB\x2\x388\x387\x3\x2\x2\x2\x388\x389\x3"+
-		"\x2\x2\x2\x389\x38A\x3\x2\x2\x2\x38A\x38C\a)\x2\x2\x38B\x38D\x5\x174\xBB"+
-		"\x2\x38C\x38B\x3\x2\x2\x2\x38C\x38D\x3\x2\x2\x2\x38D\x38E\x3\x2\x2\x2"+
-		"\x38E\x38F\x5z>\x2\x38Fw\x3\x2\x2\x2\x390\x391\x5\xFE\x80\x2\x391y\x3"+
-		"\x2\x2\x2\x392\x393\x5\xFE\x80\x2\x393{\x3\x2\x2\x2\x394\x395\as\x2\x2"+
-		"\x395\x396\x5\x174\xBB\x2\x396\x398\x5\x36\x1C\x2\x397\x399\x5\x174\xBB"+
-		"\x2\x398\x397\x3\x2\x2\x2\x398\x399\x3\x2\x2\x2\x399\x39A\x3\x2\x2\x2"+
-		"\x39A\x39C\a)\x2\x2\x39B\x39D\x5\x174\xBB\x2\x39C\x39B\x3\x2\x2\x2\x39C"+
-		"\x39D\x3\x2\x2\x2\x39D\x39F\x3\x2\x2\x2\x39E\x3A0\x5x=\x2\x39F\x39E\x3"+
-		"\x2\x2\x2\x39F\x3A0\x3\x2\x2\x2\x3A0\x3A2\x3\x2\x2\x2\x3A1\x3A3\x5\x174"+
-		"\xBB\x2\x3A2\x3A1\x3\x2\x2\x2\x3A2\x3A3\x3\x2\x2\x2\x3A3\x3A4\x3\x2\x2"+
-		"\x2\x3A4\x3A6\a)\x2\x2\x3A5\x3A7\x5\x174\xBB\x2\x3A6\x3A5\x3\x2\x2\x2"+
-		"\x3A6\x3A7\x3\x2\x2\x2\x3A7\x3A8\x3\x2\x2\x2\x3A8\x3A9\x5~@\x2\x3A9}\x3"+
-		"\x2\x2\x2\x3AA\x3AB\x5\xFE\x80\x2\x3AB\x7F\x3\x2\x2\x2\x3AC\x3AD\x5\x156"+
-		"\xAC\x2\x3AD\x3AE\x5\x174\xBB\x2\x3AE\x3B0\x3\x2\x2\x2\x3AF\x3AC\x3\x2"+
-		"\x2\x2\x3AF\x3B0\x3\x2\x2\x2\x3B0\x3B1\x3\x2\x2\x2\x3B1\x3B2\a\x44\x2"+
-		"\x2\x3B2\x3B3\x5\x174\xBB\x2\x3B3\x3BE\x5\x82\x42\x2\x3B4\x3B6\x5\x174"+
-		"\xBB\x2\x3B5\x3B4\x3\x2\x2\x2\x3B5\x3B6\x3\x2\x2\x2\x3B6\x3B7\x3\x2\x2"+
-		"\x2\x3B7\x3B9\a)\x2\x2\x3B8\x3BA\x5\x174\xBB\x2\x3B9\x3B8\x3\x2\x2\x2"+
-		"\x3B9\x3BA\x3\x2\x2\x2\x3BA\x3BB\x3\x2\x2\x2\x3BB\x3BD\x5\x82\x42\x2\x3BC"+
-		"\x3B5\x3\x2\x2\x2\x3BD\x3C0\x3\x2\x2\x2\x3BE\x3BC\x3\x2\x2\x2\x3BE\x3BF"+
-		"\x3\x2\x2\x2\x3BF\x81\x3\x2\x2\x2\x3C0\x3BE\x3\x2\x2\x2\x3C1\x3C3\x5\x13A"+
-		"\x9E\x2\x3C2\x3C4\x5\x154\xAB\x2\x3C3\x3C2\x3\x2\x2\x2\x3C3\x3C4\x3\x2"+
-		"\x2\x2\x3C4\x3C8\x3\x2\x2\x2\x3C5\x3C6\x5\x174\xBB\x2\x3C6\x3C7\x5\x13C"+
-		"\x9F\x2\x3C7\x3C9\x3\x2\x2\x2\x3C8\x3C5\x3\x2\x2\x2\x3C8\x3C9\x3\x2\x2"+
-		"\x2\x3C9\x3CB\x3\x2\x2\x2\x3CA\x3CC\x5\x174\xBB\x2\x3CB\x3CA\x3\x2\x2"+
-		"\x2\x3CB\x3CC\x3\x2\x2\x2\x3CC\x3CD\x3\x2\x2\x2\x3CD\x3CF\a\xD0\x2\x2"+
-		"\x3CE\x3D0\x5\x174\xBB\x2\x3CF\x3CE\x3\x2\x2\x2\x3CF\x3D0\x3\x2\x2\x2"+
-		"\x3D0\x3D1\x3\x2\x2\x2\x3D1\x3D2\x5\xFE\x80\x2\x3D2\x83\x3\x2\x2\x2\x3D3"+
-		"\x3D4\x5\x156\xAC\x2\x3D4\x3D5\x5\x174\xBB\x2\x3D5\x3D7\x3\x2\x2\x2\x3D6"+
-		"\x3D3\x3\x2\x2\x2\x3D6\x3D7\x3\x2\x2\x2\x3D7\x3D8\x3\x2\x2\x2\x3D8\x3D9"+
-		"\aG\x2\x2\x3D9\x3DC\x5\x174\xBB\x2\x3DA\x3DB\a\xA3\x2\x2\x3DB\x3DD\x5"+
-		"\x174\xBB\x2\x3DC\x3DA\x3\x2\x2\x2\x3DC\x3DD\x3\x2\x2\x2\x3DD\x3DE\x3"+
-		"\x2\x2\x2\x3DE\x3DF\t\a\x2\x2\x3DF\x3E0\x5\x174\xBB\x2\x3E0\x3E2\x5\x13A"+
-		"\x9E\x2\x3E1\x3E3\x5\x154\xAB\x2\x3E2\x3E1\x3\x2\x2\x2\x3E2\x3E3\x3\x2"+
-		"\x2\x2\x3E3\x3E4\x3\x2\x2\x2\x3E4\x3E5\x5\x174\xBB\x2\x3E5\x3E6\a\x82"+
-		"\x2\x2\x3E6\x3E7\x5\x174\xBB\x2\x3E7\x3ED\a\xE3\x2\x2\x3E8\x3E9\x5\x174"+
-		"\xBB\x2\x3E9\x3EA\a\x35\x2\x2\x3EA\x3EB\x5\x174\xBB\x2\x3EB\x3EC\a\xE3"+
-		"\x2\x2\x3EC\x3EE\x3\x2\x2\x2\x3ED\x3E8\x3\x2\x2\x2\x3ED\x3EE\x3\x2\x2"+
-		"\x2\x3EE\x3F3\x3\x2\x2\x2\x3EF\x3F1\x5\x174\xBB\x2\x3F0\x3EF\x3\x2\x2"+
-		"\x2\x3F0\x3F1\x3\x2\x2\x2\x3F1\x3F2\x3\x2\x2\x2\x3F2\x3F4\x5\x12E\x98"+
-		"\x2\x3F3\x3F0\x3\x2\x2\x2\x3F3\x3F4\x3\x2\x2\x2\x3F4\x3F8\x3\x2\x2\x2"+
-		"\x3F5\x3F6\x5\x174\xBB\x2\x3F6\x3F7\x5\x13C\x9F\x2\x3F7\x3F9\x3\x2\x2"+
-		"\x2\x3F8\x3F5\x3\x2\x2\x2\x3F8\x3F9\x3\x2\x2\x2\x3F9\x85\x3\x2\x2\x2\x3FA"+
-		"\x3FB\x5\x88\x45\x2\x3FB\x3FC\x5\x174\xBB\x2\x3FC\x407\x5\x8A\x46\x2\x3FD"+
-		"\x3FF\x5\x174\xBB\x2\x3FE\x3FD\x3\x2\x2\x2\x3FE\x3FF\x3\x2\x2\x2\x3FF"+
-		"\x400\x3\x2\x2\x2\x400\x402\a)\x2\x2\x401\x403\x5\x174\xBB\x2\x402\x401"+
-		"\x3\x2\x2\x2\x402\x403\x3\x2\x2\x2\x403\x404\x3\x2\x2\x2\x404\x406\x5"+
-		"\x8A\x46\x2\x405\x3FE\x3\x2\x2\x2\x406\x409\x3\x2\x2\x2\x407\x405\x3\x2"+
-		"\x2\x2\x407\x408\x3\x2\x2\x2\x408\x87\x3\x2\x2\x2\x409\x407\x3\x2\x2\x2"+
-		"\x40A\x40B\t\b\x2\x2\x40B\x89\x3\x2\x2\x2\x40C\x410\x5\x8CG\x2\x40D\x410"+
-		"\x5\x8EH\x2\x40E\x410\x5\x94K\x2\x40F\x40C\x3\x2\x2\x2\x40F\x40D\x3\x2"+
-		"\x2\x2\x40F\x40E\x3\x2\x2\x2\x410\x8B\x3\x2\x2\x2\x411\x412\x5\x138\x9D"+
-		"\x2\x412\x8D\x3\x2\x2\x2\x413\x415\x5\x90I\x2\x414\x416\x5\x174\xBB\x2"+
-		"\x415\x414\x3\x2\x2\x2\x415\x416\x3\x2\x2\x2\x416\x417\x3\x2\x2\x2\x417"+
-		"\x419\a\xD6\x2\x2\x418\x41A\x5\x174\xBB\x2\x419\x418\x3\x2\x2\x2\x419"+
-		"\x41A\x3\x2\x2\x2\x41A\x41B\x3\x2\x2\x2\x41B\x41C\x5\x92J\x2\x41C\x8F"+
-		"\x3\x2\x2\x2\x41D\x41E\x6I\x2\x2\x41E\x41F\x5\x138\x9D\x2\x41F\x91\x3"+
-		"\x2\x2\x2\x420\x421\x6J\x3\x2\x421\x422\x5\x138\x9D\x2\x422\x93\x3\x2"+
-		"\x2\x2\x423\x425\x5\x96L\x2\x424\x426\x5\x174\xBB\x2\x425\x424\x3\x2\x2"+
-		"\x2\x425\x426\x3\x2\x2\x2\x426\x427\x3\x2\x2\x2\x427\x429\a\xD6\x2\x2"+
-		"\x428\x42A\x5\x174\xBB\x2\x429\x428\x3\x2\x2\x2\x429\x42A\x3\x2\x2\x2"+
-		"\x42A\x42B\x3\x2\x2\x2\x42B\x42C\x5\x98M\x2\x42C\x95\x3\x2\x2\x2\x42D"+
-		"\x42E\x5\x138\x9D\x2\x42E\x97\x3\x2\x2\x2\x42F\x430\x5\x138\x9D\x2\x430"+
-		"\x99\x3\x2\x2\x2\x431\x432\aV\x2\x2\x432\x434\x5\x160\xB1\x2\x433\x435"+
-		"\x5\x1E\x10\x2\x434\x433\x3\x2\x2\x2\x434\x435\x3\x2\x2\x2\x435\x436\x3"+
-		"\x2\x2\x2\x436\x437\a\x80\x2\x2\x437\x44F\x3\x2\x2\x2\x438\x439\aV\x2"+
-		"\x2\x439\x43A\x5\x174\xBB\x2\x43A\x43B\t\t\x2\x2\x43B\x43C\x5\x174\xBB"+
-		"\x2\x43C\x43D\x5\xFE\x80\x2\x43D\x43F\x5\x160\xB1\x2\x43E\x440\x5\x1E"+
-		"\x10\x2\x43F\x43E\x3\x2\x2\x2\x43F\x440\x3\x2\x2\x2\x440\x441\x3\x2\x2"+
-		"\x2\x441\x442\a\x80\x2\x2\x442\x44F\x3\x2\x2\x2\x443\x444\aV\x2\x2\x444"+
-		"\x446\x5\x160\xB1\x2\x445\x447\x5\x1E\x10\x2\x446\x445\x3\x2\x2\x2\x446"+
-		"\x447\x3\x2\x2\x2\x447\x448\x3\x2\x2\x2\x448\x449\a\x80\x2\x2\x449\x44A"+
-		"\x5\x174\xBB\x2\x44A\x44B\t\t\x2\x2\x44B\x44C\x5\x174\xBB\x2\x44C\x44D"+
-		"\x5\xFE\x80\x2\x44D\x44F\x3\x2\x2\x2\x44E\x431\x3\x2\x2\x2\x44E\x438\x3"+
-		"\x2\x2\x2\x44E\x443\x3\x2\x2\x2\x44F\x9B\x3\x2\x2\x2\x450\x451\x5\x156"+
-		"\xAC\x2\x451\x452\x5\x174\xBB\x2\x452\x454\x3\x2\x2\x2\x453\x450\x3\x2"+
-		"\x2\x2\x453\x454\x3\x2\x2\x2\x454\x455\x3\x2\x2\x2\x455\x456\a\x65\x2"+
-		"\x2\x456\x457\x5\x174\xBB\x2\x457\x458\x5\x13A\x9E\x2\x458\x45C\x5\x160"+
-		"\xB1\x2\x459\x45B\x5\x9EP\x2\x45A\x459\x3\x2\x2\x2\x45B\x45E\x3\x2\x2"+
-		"\x2\x45C\x45A\x3\x2\x2\x2\x45C\x45D\x3\x2\x2\x2\x45D\x45F\x3\x2\x2\x2"+
-		"\x45E\x45C\x3\x2\x2\x2\x45F\x460\a\\\x2\x2\x460\x9D\x3\x2\x2\x2\x461\x46A"+
-		"\x5\x13A\x9E\x2\x462\x464\x5\x174\xBB\x2\x463\x462\x3\x2\x2\x2\x463\x464"+
-		"\x3\x2\x2\x2\x464\x465\x3\x2\x2\x2\x465\x467\a\xD0\x2\x2\x466\x468\x5"+
-		"\x174\xBB\x2\x467\x466\x3\x2\x2\x2\x467\x468\x3\x2\x2\x2\x468\x469\x3"+
-		"\x2\x2\x2\x469\x46B\x5\xFE\x80\x2\x46A\x463\x3\x2\x2\x2\x46A\x46B\x3\x2"+
-		"\x2\x2\x46B\x46C\x3\x2\x2\x2\x46C\x46D\x5\x160\xB1\x2\x46D\x9F\x3\x2\x2"+
-		"\x2\x46E\x46F\a\x64\x2\x2\x46F\xA1\x3\x2\x2\x2\x470\x471\ag\x2\x2\x471"+
-		"\x472\x5\x174\xBB\x2\x472\x47D\x5\xFE\x80\x2\x473\x475\x5\x174\xBB\x2"+
-		"\x474\x473\x3\x2\x2\x2\x474\x475\x3\x2\x2\x2\x475\x476\x3\x2\x2\x2\x476"+
-		"\x478\a)\x2\x2\x477\x479\x5\x174\xBB\x2\x478\x477\x3\x2\x2\x2\x478\x479"+
-		"\x3\x2\x2\x2\x479\x47A\x3\x2\x2\x2\x47A\x47C\x5\xFE\x80\x2\x47B\x474\x3"+
-		"\x2\x2\x2\x47C\x47F\x3\x2\x2\x2\x47D\x47B\x3\x2\x2\x2\x47D\x47E\x3\x2"+
-		"\x2\x2\x47E\xA3\x3\x2\x2\x2\x47F\x47D\x3\x2\x2\x2\x480\x481\ah\x2\x2\x481"+
-		"\x482\x5\x174\xBB\x2\x482\x483\x5\xFE\x80\x2\x483\xA5\x3\x2\x2\x2\x484"+
-		"\x485\x5\x156\xAC\x2\x485\x486\x5\x174\xBB\x2\x486\x488\x3\x2\x2\x2\x487"+
-		"\x484\x3\x2\x2\x2\x487\x488\x3\x2\x2\x2\x488\x489\x3\x2\x2\x2\x489\x48A"+
-		"\ai\x2\x2\x48A\x48B\x5\x174\xBB\x2\x48B\x48D\x5\x13A\x9E\x2\x48C\x48E"+
-		"\x5\x174\xBB\x2\x48D\x48C\x3\x2\x2\x2\x48D\x48E\x3\x2\x2\x2\x48E\x48F"+
-		"\x3\x2\x2\x2\x48F\x490\x5\x12E\x98\x2\x490\xA7\x3\x2\x2\x2\x491\x492\t"+
-		"\n\x2\x2\x492\xA9\x3\x2\x2\x2\x493\x494\aq\x2\x2\x494\x495\x5\x174\xBB"+
-		"\x2\x495\x496\aX\x2\x2\x496\x497\x5\x174\xBB\x2\x497\x498\x5\xFE\x80\x2"+
-		"\x498\x499\x5\x174\xBB\x2\x499\x49A\az\x2\x2\x49A\x49B\x5\x174\xBB\x2"+
-		"\x49B\x49C\x5\xFE\x80\x2\x49C\x49E\x5\x160\xB1\x2\x49D\x49F\x5\x1E\x10"+
-		"\x2\x49E\x49D\x3\x2\x2\x2\x49E\x49F\x3\x2\x2\x2\x49F\x4A0\x3\x2\x2\x2"+
-		"\x4A0\x4A4\a\x8C\x2\x2\x4A1\x4A2\x5\x174\xBB\x2\x4A2\x4A3\x5\xFE\x80\x2"+
-		"\x4A3\x4A5\x3\x2\x2\x2\x4A4\x4A1\x3\x2\x2\x2\x4A4\x4A5\x3\x2\x2\x2\x4A5"+
-		"\xAB\x3\x2\x2\x2\x4A6\x4A7\aq\x2\x2\x4A7\x4A8\x5\x174\xBB\x2\x4A8\x4AA"+
-		"\x5\xFE\x80\x2\x4A9\x4AB\x5\x174\xBB\x2\x4AA\x4A9\x3\x2\x2\x2\x4AA\x4AB"+
-		"\x3\x2\x2\x2\x4AB\x4AC\x3\x2\x2\x2\x4AC\x4AE\a\xD0\x2\x2\x4AD\x4AF\x5"+
-		"\x174\xBB\x2\x4AE\x4AD\x3\x2\x2\x2\x4AE\x4AF\x3\x2\x2\x2\x4AF\x4B0\x3"+
-		"\x2\x2\x2\x4B0\x4B1\x5\xFE\x80\x2\x4B1\x4B2\x5\x174\xBB\x2\x4B2\x4B3\a"+
-		"\xBE\x2\x2\x4B3\x4B4\x5\x174\xBB\x2\x4B4\x4BA\x5\xFE\x80\x2\x4B5\x4B6"+
-		"\x5\x174\xBB\x2\x4B6\x4B7\a\xB7\x2\x2\x4B7\x4B8\x5\x174\xBB\x2\x4B8\x4B9"+
-		"\x5\xFE\x80\x2\x4B9\x4BB\x3\x2\x2\x2\x4BA\x4B5\x3\x2\x2\x2\x4BA\x4BB\x3"+
-		"\x2\x2\x2\x4BB\x4BC\x3\x2\x2\x2\x4BC\x4BE\x5\x160\xB1\x2\x4BD\x4BF\x5"+
-		"\x1E\x10\x2\x4BE\x4BD\x3\x2\x2\x2\x4BE\x4BF\x3\x2\x2\x2\x4BF\x4C0\x3\x2"+
-		"\x2\x2\x4C0\x4C4\a\x8C\x2\x2\x4C1\x4C2\x5\x174\xBB\x2\x4C2\x4C3\x5\xFE"+
-		"\x80\x2\x4C3\x4C5\x3\x2\x2\x2\x4C4\x4C1\x3\x2\x2\x2\x4C4\x4C5\x3\x2\x2"+
-		"\x2\x4C5\xAD\x3\x2\x2\x2\x4C6\x4C7\x5\x156\xAC\x2\x4C7\x4C8\x5\x174\xBB"+
-		"\x2\x4C8\x4CA\x3\x2\x2\x2\x4C9\x4C6\x3\x2\x2\x2\x4C9\x4CA\x3\x2\x2\x2"+
-		"\x4CA\x4CD\x3\x2\x2\x2\x4CB\x4CC\a\xB6\x2\x2\x4CC\x4CE\x5\x174\xBB\x2"+
-		"\x4CD\x4CB\x3\x2\x2\x2\x4CD\x4CE\x3\x2\x2\x2\x4CE\x4CF\x3\x2\x2\x2\x4CF"+
-		"\x4D1\ar\x2\x2\x4D0\x4D2\x5\x174\xBB\x2\x4D1\x4D0\x3\x2\x2\x2\x4D1\x4D2"+
-		"\x3\x2\x2\x2\x4D2\x4D3\x3\x2\x2\x2\x4D3\x4D5\x5\xB0Y\x2\x4D4\x4D6\x5\x154"+
-		"\xAB\x2\x4D5\x4D4\x3\x2\x2\x2\x4D5\x4D6\x3\x2\x2\x2\x4D6\x4DB\x3\x2\x2"+
-		"\x2\x4D7\x4D9\x5\x174\xBB\x2\x4D8\x4D7\x3\x2\x2\x2\x4D8\x4D9\x3\x2\x2"+
-		"\x2\x4D9\x4DA\x3\x2\x2\x2\x4DA\x4DC\x5\x12E\x98\x2\x4DB\x4D8\x3\x2\x2"+
-		"\x2\x4DB\x4DC\x3\x2\x2\x2\x4DC\x4E1\x3\x2\x2\x2\x4DD\x4DF\x5\x174\xBB"+
-		"\x2\x4DE\x4DD\x3\x2\x2\x2\x4DE\x4DF\x3\x2\x2\x2\x4DF\x4E0\x3\x2\x2\x2"+
-		"\x4E0\x4E2\x5\x13C\x9F\x2\x4E1\x4DE\x3\x2\x2\x2\x4E1\x4E2\x3\x2\x2\x2"+
-		"\x4E2\x4E3\x3\x2\x2\x2\x4E3\x4E5\x5\x160\xB1\x2\x4E4\x4E6\x5\x1E\x10\x2"+
-		"\x4E5\x4E4\x3\x2\x2\x2\x4E5\x4E6\x3\x2\x2\x2\x4E6\x4E7\x3\x2\x2\x2\x4E7"+
-		"\x4E8\a]\x2\x2\x4E8\xAF\x3\x2\x2\x2\x4E9\x4EA\x5\x13A\x9E\x2\x4EA\xB1"+
-		"\x3\x2\x2\x2\x4EB\x4EC\au\x2\x2\x4EC\x4ED\x5\x174\xBB\x2\x4ED\x4EE\x5"+
-		"\xFE\x80\x2\x4EE\xB3\x3\x2\x2\x2\x4EF\x4F0\av\x2\x2\x4F0\x4F1\x5\x174"+
-		"\xBB\x2\x4F1\x4F2\x5\xFE\x80\x2\x4F2\xB5\x3\x2\x2\x2\x4F3\x4F4\aw\x2\x2"+
-		"\x4F4\x4F5\x5\x174\xBB\x2\x4F5\x4F6\x5\xC8\x65\x2\x4F6\x4F7\x5\x174\xBB"+
-		"\x2\x4F7\x4F8\a\xBD\x2\x2\x4F8\x4FA\x5\x160\xB1\x2\x4F9\x4FB\x5\x1E\x10"+
-		"\x2\x4FA\x4F9\x3\x2\x2\x2\x4FA\x4FB\x3\x2\x2\x2\x4FB\x4FF\x3\x2\x2\x2"+
-		"\x4FC\x4FE\x5\xB8]\x2\x4FD\x4FC\x3\x2\x2\x2\x4FE\x501\x3\x2\x2\x2\x4FF"+
-		"\x4FD\x3\x2\x2\x2\x4FF\x500\x3\x2\x2\x2\x500\x503\x3\x2\x2\x2\x501\x4FF"+
-		"\x3\x2\x2\x2\x502\x504\x5\xBA^\x2\x503\x502\x3\x2\x2\x2\x503\x504\x3\x2"+
-		"\x2\x2\x504\x505\x3\x2\x2\x2\x505\x506\a^\x2\x2\x506\xB7\x3\x2\x2\x2\x507"+
-		"\x508\aZ\x2\x2\x508\x509\x5\x174\xBB\x2\x509\x50A\x5\xC8\x65\x2\x50A\x50B"+
-		"\x5\x174\xBB\x2\x50B\x50C\a\xBD\x2\x2\x50C\x50E\x5\x160\xB1\x2\x50D\x50F"+
-		"\x5\x1E\x10\x2\x50E\x50D\x3\x2\x2\x2\x50E\x50F\x3\x2\x2\x2\x50F\x51C\x3"+
-		"\x2\x2\x2\x510\x511\aZ\x2\x2\x511\x512\x5\x174\xBB\x2\x512\x513\x5\xC8"+
-		"\x65\x2\x513\x514\x5\x174\xBB\x2\x514\x516\a\xBD\x2\x2\x515\x517\x5\x174"+
-		"\xBB\x2\x516\x515\x3\x2\x2\x2\x516\x517\x3\x2\x2\x2\x517\x519\x3\x2\x2"+
-		"\x2\x518\x51A\x5\x1E\x10\x2\x519\x518\x3\x2\x2\x2\x519\x51A\x3\x2\x2\x2"+
-		"\x51A\x51C\x3\x2\x2\x2\x51B\x507\x3\x2\x2\x2\x51B\x510\x3\x2\x2\x2\x51C"+
-		"\xB9\x3\x2\x2\x2\x51D\x51E\aY\x2\x2\x51E\x520\x5\x160\xB1\x2\x51F\x521"+
-		"\x5\x1E\x10\x2\x520\x51F\x3\x2\x2\x2\x520\x521\x3\x2\x2\x2\x521\xBB\x3"+
-		"\x2\x2\x2\x522\x525\x5\xBE`\x2\x523\x525\x5\xC0\x61\x2\x524\x522\x3\x2"+
-		"\x2\x2\x524\x523\x3\x2\x2\x2\x525\xBD\x3\x2\x2\x2\x526\x528\aw\x2\x2\x527"+
-		"\x529\x5\x174\xBB\x2\x528\x527\x3\x2\x2\x2\x528\x529\x3\x2\x2\x2\x529"+
-		"\x52A\x3\x2\x2\x2\x52A\x52C\x5\xC8\x65\x2\x52B\x52D\x5\x174\xBB\x2\x52C"+
-		"\x52B\x3\x2\x2\x2\x52C\x52D\x3\x2\x2\x2\x52D\x52E\x3\x2\x2\x2\x52E\x530"+
-		"\a\xBD\x2\x2\x52F\x531\x5\x174\xBB\x2\x530\x52F\x3\x2\x2\x2\x530\x531"+
-		"\x3\x2\x2\x2\x531\x532\x3\x2\x2\x2\x532\x536\x5\xC4\x63\x2\x533\x534\x5"+
-		"\x174\xBB\x2\x534\x535\x5\xC2\x62\x2\x535\x537\x3\x2\x2\x2\x536\x533\x3"+
-		"\x2\x2\x2\x536\x537\x3\x2\x2\x2\x537\xBF\x3\x2\x2\x2\x538\x53A\aw\x2\x2"+
-		"\x539\x53B\x5\x174\xBB\x2\x53A\x539\x3\x2\x2\x2\x53A\x53B\x3\x2\x2\x2"+
-		"\x53B\x53C\x3\x2\x2\x2\x53C\x53E\x5\xC8\x65\x2\x53D\x53F\x5\x174\xBB\x2"+
-		"\x53E\x53D\x3\x2\x2\x2\x53E\x53F\x3\x2\x2\x2\x53F\x540\x3\x2\x2\x2\x540"+
-		"\x541\a\xBD\x2\x2\x541\x543\x5\x160\xB1\x2\x542\x544\x5\x174\xBB\x2\x543"+
-		"\x542\x3\x2\x2\x2\x543\x544\x3\x2\x2\x2\x544\x545\x3\x2\x2\x2\x545\x546"+
-		"\x5\xC2\x62\x2\x546\xC1\x3\x2\x2\x2\x547\x549\aY\x2\x2\x548\x54A\x5\x174"+
-		"\xBB\x2\x549\x548\x3\x2\x2\x2\x549\x54A\x3\x2\x2\x2\x54A\x54C\x3\x2\x2"+
-		"\x2\x54B\x54D\x5\xC4\x63\x2\x54C\x54B\x3\x2\x2\x2\x54C\x54D\x3\x2\x2\x2"+
-		"\x54D\xC3\x3\x2\x2\x2\x54E\x55B\x5\x14C\xA7\x2\x54F\x551\x5\x174\xBB\x2"+
-		"\x550\x54F\x3\x2\x2\x2\x550\x551\x3\x2\x2\x2\x551\x552\x3\x2\x2\x2\x552"+
-		"\x554\a*\x2\x2\x553\x555\x5\x174\xBB\x2\x554\x553\x3\x2\x2\x2\x554\x555"+
-		"\x3\x2\x2\x2\x555\x557\x3\x2\x2\x2\x556\x558\x5\xC6\x64\x2\x557\x556\x3"+
-		"\x2\x2\x2\x557\x558\x3\x2\x2\x2\x558\x55A\x3\x2\x2\x2\x559\x550\x3\x2"+
-		"\x2\x2\x55A\x55D\x3\x2\x2\x2\x55B\x559\x3\x2\x2\x2\x55B\x55C\x3\x2\x2"+
-		"\x2\x55C\x575\x3\x2\x2\x2\x55D\x55B\x3\x2\x2\x2\x55E\x560\a*\x2\x2\x55F"+
-		"\x561\x5\x174\xBB\x2\x560\x55F\x3\x2\x2\x2\x560\x561\x3\x2\x2\x2\x561"+
-		"\x563\x3\x2\x2\x2\x562\x55E\x3\x2\x2\x2\x562\x563\x3\x2\x2\x2\x563\x564"+
-		"\x3\x2\x2\x2\x564\x571\x5\xC6\x64\x2\x565\x567\x5\x174\xBB\x2\x566\x565"+
-		"\x3\x2\x2\x2\x566\x567\x3\x2\x2\x2\x567\x568\x3\x2\x2\x2\x568\x56A\a*"+
-		"\x2\x2\x569\x56B\x5\x174\xBB\x2\x56A\x569\x3\x2\x2\x2\x56A\x56B\x3\x2"+
-		"\x2\x2\x56B\x56D\x3\x2\x2\x2\x56C\x56E\x5\xC6\x64\x2\x56D\x56C\x3\x2\x2"+
-		"\x2\x56D\x56E\x3\x2\x2\x2\x56E\x570\x3\x2\x2\x2\x56F\x566\x3\x2\x2\x2"+
-		"\x570\x573\x3\x2\x2\x2\x571\x56F\x3\x2\x2\x2\x571\x572\x3\x2\x2\x2\x572"+
-		"\x575\x3\x2\x2\x2\x573\x571\x3\x2\x2\x2\x574\x54E\x3\x2\x2\x2\x574\x562"+
-		"\x3\x2\x2\x2\x575\xC5\x3\x2\x2\x2\x576\x577\x5 \x11\x2\x577\xC7\x3\x2"+
-		"\x2\x2\x578\x579\x5\xFE\x80\x2\x579\xC9\x3\x2\x2\x2\x57A\x57B\ay\x2\x2"+
-		"\x57B\x57C\x5\x174\xBB\x2\x57C\x57D\x5\xFE\x80\x2\x57D\xCB\x3\x2\x2\x2"+
-		"\x57E\x57F\a\x81\x2\x2\x57F\x581\x5\x174\xBB\x2\x580\x57E\x3\x2\x2\x2"+
-		"\x580\x581\x3\x2\x2\x2\x581\x582\x3\x2\x2\x2\x582\x584\x5\xFE\x80\x2\x583"+
-		"\x585\x5\x174\xBB\x2\x584\x583\x3\x2\x2\x2\x584\x585\x3\x2\x2\x2\x585"+
-		"\x586\x3\x2\x2\x2\x586\x588\a\xD0\x2\x2\x587\x589\x5\x174\xBB\x2\x588"+
-		"\x587\x3\x2\x2\x2\x588\x589\x3\x2\x2\x2\x589\x58A\x3\x2\x2\x2\x58A\x58B"+
-		"\x5\xFE\x80\x2\x58B\xCD\x3\x2\x2\x2\x58C\x58D\a\x88\x2\x2\x58D\x58E\x5"+
-		"\x174\xBB\x2\x58E\x590\x5\xFE\x80\x2\x58F\x591\x5\x174\xBB\x2\x590\x58F"+
-		"\x3\x2\x2\x2\x590\x591\x3\x2\x2\x2\x591\x592\x3\x2\x2\x2\x592\x594\a\xD0"+
-		"\x2\x2\x593\x595\x5\x174\xBB\x2\x594\x593\x3\x2\x2\x2\x594\x595\x3\x2"+
-		"\x2\x2\x595\x596\x3\x2\x2\x2\x596\x597\x5\xFE\x80\x2\x597\xCF\x3\x2\x2"+
-		"\x2\x598\x59A\a\x8A\x2\x2\x599\x59B\x5\x174\xBB\x2\x59A\x599\x3\x2\x2"+
-		"\x2\x59A\x59B\x3\x2\x2\x2\x59B\x59C\x3\x2\x2\x2\x59C\x59E\a\xD4\x2\x2"+
-		"\x59D\x59F\x5\x174\xBB\x2\x59E\x59D\x3\x2\x2\x2\x59E\x59F\x3\x2\x2\x2"+
-		"\x59F\x5A0\x3\x2\x2\x2\x5A0\x5A2\x5\x128\x95\x2\x5A1\x5A3\x5\x174\xBB"+
-		"\x2\x5A2\x5A1\x3\x2\x2\x2\x5A2\x5A3\x3\x2\x2\x2\x5A3\x5A4\x3\x2\x2\x2"+
-		"\x5A4\x5A5\a\xDB\x2\x2\x5A5\xD1\x3\x2\x2\x2\x5A6\x5A7\t\v\x2\x2\x5A7\x5B0"+
-		"\x5\x174\xBB\x2\x5A8\x5A9\av\x2\x2\x5A9\x5AA\x5\x174\xBB\x2\x5AA\x5AB"+
-		"\x5\xFE\x80\x2\x5AB\x5B1\x3\x2\x2\x2\x5AC\x5AD\a\xAD\x2\x2\x5AD\x5AE\x5"+
-		"\x174\xBB\x2\x5AE\x5AF\a\x8C\x2\x2\x5AF\x5B1\x3\x2\x2\x2\x5B0\x5A8\x3"+
-		"\x2\x2\x2\x5B0\x5AC\x3\x2\x2\x2\x5B1\xD3\x3\x2\x2\x2\x5B2\x5B3\a\x91\x2"+
-		"\x2\x5B3\x5B4\x5\x174\xBB\x2\x5B4\x5B5\x5\xFE\x80\x2\x5B5\x5B6\x5\x174"+
-		"\xBB\x2\x5B6\x5B7\av\x2\x2\x5B7\x5B8\x5\x174\xBB\x2\x5B8\x5C3\x5\xFE\x80"+
-		"\x2\x5B9\x5BB\x5\x174\xBB\x2\x5BA\x5B9\x3\x2\x2\x2\x5BA\x5BB\x3\x2\x2"+
-		"\x2\x5BB\x5BC\x3\x2\x2\x2\x5BC\x5BE\a)\x2\x2\x5BD\x5BF\x5\x174\xBB\x2"+
-		"\x5BE\x5BD\x3\x2\x2\x2\x5BE\x5BF\x3\x2\x2\x2\x5BF\x5C0\x3\x2\x2\x2\x5C0"+
-		"\x5C2\x5\xFE\x80\x2\x5C1\x5BA\x3\x2\x2\x2\x5C2\x5C5\x3\x2\x2\x2\x5C3\x5C1"+
-		"\x3\x2\x2\x2\x5C3\x5C4\x3\x2\x2\x2\x5C4\xD5\x3\x2\x2\x2\x5C5\x5C3\x3\x2"+
-		"\x2\x2\x5C6\x5C7\a\x91\x2\x2\x5C7\x5C8\x5\x174\xBB\x2\x5C8\x5C9\x5\xFE"+
-		"\x80\x2\x5C9\x5CA\x5\x174\xBB\x2\x5CA\x5CB\au\x2\x2\x5CB\x5CC\x5\x174"+
-		"\xBB\x2\x5CC\x5D7\x5\xFE\x80\x2\x5CD\x5CF\x5\x174\xBB\x2\x5CE\x5CD\x3"+
-		"\x2\x2\x2\x5CE\x5CF\x3\x2\x2\x2\x5CF\x5D0\x3\x2\x2\x2\x5D0\x5D2\a)\x2"+
-		"\x2\x5D1\x5D3\x5\x174\xBB\x2\x5D2\x5D1\x3\x2\x2\x2\x5D2\x5D3\x3\x2\x2"+
-		"\x2\x5D3\x5D4\x3\x2\x2\x2\x5D4\x5D6\x5\xFE\x80\x2\x5D5\x5CE\x3\x2\x2\x2"+
-		"\x5D6\x5D9\x3\x2\x2\x2\x5D7\x5D5\x3\x2\x2\x2\x5D7\x5D8\x3\x2\x2\x2\x5D8"+
-		"\xD7\x3\x2\x2\x2\x5D9\x5D7\x3\x2\x2\x2\x5DA\x5DB\x5\x156\xAC\x2\x5DB\x5DC"+
-		"\x5\x174\xBB\x2\x5DC\x5DE\x3\x2\x2\x2\x5DD\x5DA\x3\x2\x2\x2\x5DD\x5DE"+
-		"\x3\x2\x2\x2\x5DE\x5E1\x3\x2\x2\x2\x5DF\x5E0\a\xB6\x2\x2\x5E0\x5E2\x5"+
-		"\x174\xBB\x2\x5E1\x5DF\x3\x2\x2\x2\x5E1\x5E2\x3\x2\x2\x2\x5E2\x5E3\x3"+
-		"\x2\x2\x2\x5E3\x5E4\a\xA0\x2\x2\x5E4\x5E5\x5\x174\xBB\x2\x5E5\x5E7\x5"+
-		"\xB0Y\x2\x5E6\x5E8\x5\x154\xAB\x2\x5E7\x5E6\x3\x2\x2\x2\x5E7\x5E8\x3\x2"+
-		"\x2\x2\x5E8\x5ED\x3\x2\x2\x2\x5E9\x5EB\x5\x174\xBB\x2\x5EA\x5E9\x3\x2"+
-		"\x2\x2\x5EA\x5EB\x3\x2\x2\x2\x5EB\x5EC\x3\x2\x2\x2\x5EC\x5EE\x5\x12E\x98"+
-		"\x2\x5ED\x5EA\x3\x2\x2\x2\x5ED\x5EE\x3\x2\x2\x2\x5EE\x5F2\x3\x2\x2\x2"+
-		"\x5EF\x5F0\x5\x174\xBB\x2\x5F0\x5F1\x5\x13C\x9F\x2\x5F1\x5F3\x3\x2\x2"+
-		"\x2\x5F2\x5EF\x3\x2\x2\x2\x5F2\x5F3\x3\x2\x2\x2\x5F3\x5F4\x3\x2\x2\x2"+
-		"\x5F4\x5F6\x5\x160\xB1\x2\x5F5\x5F7\x5\x1E\x10\x2\x5F6\x5F5\x3\x2\x2\x2"+
-		"\x5F6\x5F7\x3\x2\x2\x2\x5F7\x5F8\x3\x2\x2\x2\x5F8\x5F9\a_\x2\x2\x5F9\xD9"+
-		"\x3\x2\x2\x2\x5FA\x5FB\x5\x156\xAC\x2\x5FB\x5FC\x5\x174\xBB\x2\x5FC\x5FE"+
-		"\x3\x2\x2\x2\x5FD\x5FA\x3\x2\x2\x2\x5FD\x5FE\x3\x2\x2\x2\x5FE\x601\x3"+
-		"\x2\x2\x2\x5FF\x600\a\xB6\x2\x2\x600\x602\x5\x174\xBB\x2\x601\x5FF\x3"+
-		"\x2\x2\x2\x601\x602\x3\x2\x2\x2\x602\x603\x3\x2\x2\x2\x603\x604\a\xA2"+
-		"\x2\x2\x604\x605\x5\x174\xBB\x2\x605\x60A\x5\xF8}\x2\x606\x608\x5\x174"+
-		"\xBB\x2\x607\x606\x3\x2\x2\x2\x607\x608\x3\x2\x2\x2\x608\x609\x3\x2\x2"+
-		"\x2\x609\x60B\x5\x12E\x98\x2\x60A\x607\x3\x2\x2\x2\x60A\x60B\x3\x2\x2"+
-		"\x2\x60B\x60C\x3\x2\x2\x2\x60C\x60E\x5\x160\xB1\x2\x60D\x60F\x5\x1E\x10"+
-		"\x2\x60E\x60D\x3\x2\x2\x2\x60E\x60F\x3\x2\x2\x2\x60F\x610\x3\x2\x2\x2"+
-		"\x610\x611\a_\x2\x2\x611\xDB\x3\x2\x2\x2\x612\x613\x5\x156\xAC\x2\x613"+
-		"\x614\x5\x174\xBB\x2\x614\x616\x3\x2\x2\x2\x615\x612\x3\x2\x2\x2\x615"+
-		"\x616\x3\x2\x2\x2\x616\x619\x3\x2\x2\x2\x617\x618\a\xB6\x2\x2\x618\x61A"+
-		"\x5\x174\xBB\x2\x619\x617\x3\x2\x2\x2\x619\x61A\x3\x2\x2\x2\x61A\x61B"+
-		"\x3\x2\x2\x2\x61B\x61C\a\xA1\x2\x2\x61C\x61D\x5\x174\xBB\x2\x61D\x622"+
-		"\x5\xF8}\x2\x61E\x620\x5\x174\xBB\x2\x61F\x61E\x3\x2\x2\x2\x61F\x620\x3"+
-		"\x2\x2\x2\x620\x621\x3\x2\x2\x2\x621\x623\x5\x12E\x98\x2\x622\x61F\x3"+
-		"\x2\x2\x2\x622\x623\x3\x2\x2\x2\x623\x624\x3\x2\x2\x2\x624\x626\x5\x160"+
-		"\xB1\x2\x625\x627\x5\x1E\x10\x2\x626\x625\x3\x2\x2\x2\x626\x627\x3\x2"+
-		"\x2\x2\x627\x628\x3\x2\x2\x2\x628\x629\a_\x2\x2\x629\xDD\x3\x2\x2\x2\x62A"+
-		"\x62B\a\xA7\x2\x2\x62B\x62C\x5\x174\xBB\x2\x62C\x63B\x5\x13A\x9E\x2\x62D"+
-		"\x62F\x5\x174\xBB\x2\x62E\x62D\x3\x2\x2\x2\x62E\x62F\x3\x2\x2\x2\x62F"+
-		"\x630\x3\x2\x2\x2\x630\x632\a\xD4\x2\x2\x631\x633\x5\x174\xBB\x2\x632"+
-		"\x631\x3\x2\x2\x2\x632\x633\x3\x2\x2\x2\x633\x638\x3\x2\x2\x2\x634\x636"+
-		"\x5\x128\x95\x2\x635\x637\x5\x174\xBB\x2\x636\x635\x3\x2\x2\x2\x636\x637"+
-		"\x3\x2\x2\x2\x637\x639\x3\x2\x2\x2\x638\x634\x3\x2\x2\x2\x638\x639\x3"+
-		"\x2\x2\x2\x639\x63A\x3\x2\x2\x2\x63A\x63C\a\xDB\x2\x2\x63B\x62E\x3\x2"+
-		"\x2\x2\x63B\x63C\x3\x2\x2\x2\x63C\xDF\x3\x2\x2\x2\x63D\x63E\a\xAA\x2\x2"+
-		"\x63E\x641\x5\x174\xBB\x2\x63F\x640\a\x9D\x2\x2\x640\x642\x5\x174\xBB"+
-		"\x2\x641\x63F\x3\x2\x2\x2\x641\x642\x3\x2\x2\x2\x642\x643\x3\x2\x2\x2"+
-		"\x643\x64E\x5\xE2r\x2\x644\x646\x5\x174\xBB\x2\x645\x644\x3\x2\x2\x2\x645"+
-		"\x646\x3\x2\x2\x2\x646\x647\x3\x2\x2\x2\x647\x649\a)\x2\x2\x648\x64A\x5"+
-		"\x174\xBB\x2\x649\x648\x3\x2\x2\x2\x649\x64A\x3\x2\x2\x2\x64A\x64B\x3"+
-		"\x2\x2\x2\x64B\x64D\x5\xE2r\x2\x64C\x645\x3\x2\x2\x2\x64D\x650\x3\x2\x2"+
-		"\x2\x64E\x64C\x3\x2\x2\x2\x64E\x64F\x3\x2\x2\x2\x64F\xE1\x3\x2\x2\x2\x650"+
-		"\x64E\x3\x2\x2\x2\x651\x653\x5\x118\x8D\x2\x652\x654\x5\x174\xBB\x2\x653"+
-		"\x652\x3\x2\x2\x2\x653\x654\x3\x2\x2\x2\x654\x655\x3\x2\x2\x2\x655\x657"+
-		"\a\xD4\x2\x2\x656\x658\x5\x174\xBB\x2\x657\x656\x3\x2\x2\x2\x657\x658"+
-		"\x3\x2\x2\x2\x658\x659\x3\x2\x2\x2\x659\x65B\x5\x134\x9B\x2\x65A\x65C"+
-		"\x5\x174\xBB\x2\x65B\x65A\x3\x2\x2\x2\x65B\x65C\x3\x2\x2\x2\x65C\x65D"+
-		"\x3\x2\x2\x2\x65D\x661\a\xDB\x2\x2\x65E\x65F\x5\x174\xBB\x2\x65F\x660"+
-		"\x5\x13C\x9F\x2\x660\x662\x3\x2\x2\x2\x661\x65E\x3\x2\x2\x2\x661\x662"+
-		"\x3\x2\x2\x2\x662\xE3\x3\x2\x2\x2\x663\x669\a\xAD\x2\x2\x664\x667\x5\x174"+
-		"\xBB\x2\x665\x668\a\x8C\x2\x2\x666\x668\x5\xFE\x80\x2\x667\x665\x3\x2"+
-		"\x2\x2\x667\x666\x3\x2\x2\x2\x668\x66A\x3\x2\x2\x2\x669\x664\x3\x2\x2"+
-		"\x2\x669\x66A\x3\x2\x2\x2\x66A\xE5\x3\x2\x2\x2\x66B\x66C\a\xAE\x2\x2\x66C"+
-		"\xE7\x3\x2\x2\x2\x66D\x66E\a\xAF\x2\x2\x66E\x66F\x5\x174\xBB\x2\x66F\x671"+
-		"\x5\xFE\x80\x2\x670\x672\x5\x174\xBB\x2\x671\x670\x3\x2\x2\x2\x671\x672"+
-		"\x3\x2\x2\x2\x672\x673\x3\x2\x2\x2\x673\x675\a\xD0\x2\x2\x674\x676\x5"+
-		"\x174\xBB\x2\x675\x674\x3\x2\x2\x2\x675\x676\x3\x2\x2\x2\x676\x677\x3"+
-		"\x2\x2\x2\x677\x678\x5\xFE\x80\x2\x678\xE9\x3\x2\x2\x2\x679\x67A\a\xB8"+
-		"\x2\x2\x67A\xEB\x3\x2\x2\x2\x67B\x67C\a\xB1\x2\x2\x67C\x67D\x5\x174\xBB"+
-		"\x2\x67D\x67E\a\x41\x2\x2\x67E\x67F\x5\x174\xBB\x2\x67F\x680\x5\xFE\x80"+
-		"\x2\x680\x684\x5\x160\xB1\x2\x681\x683\x5\xF0y\x2\x682\x681\x3\x2\x2\x2"+
-		"\x683\x686\x3\x2\x2\x2\x684\x682\x3\x2\x2\x2\x684\x685\x3\x2\x2\x2\x685"+
-		"\x687\x3\x2\x2\x2\x686\x684\x3\x2\x2\x2\x687\x688\a`\x2\x2\x688\xED\x3"+
-		"\x2\x2\x2\x689\x68B\a|\x2\x2\x68A\x68C\x5\x174\xBB\x2\x68B\x68A\x3\x2"+
-		"\x2\x2\x68B\x68C\x3\x2\x2\x2\x68C\x68D\x3\x2\x2\x2\x68D\x68F\x5\x140\xA1"+
-		"\x2\x68E\x690\x5\x174\xBB\x2\x68F\x68E\x3\x2\x2\x2\x68F\x690\x3\x2\x2"+
-		"\x2\x690\x691\x3\x2\x2\x2\x691\x692\x5\xFE\x80\x2\x692\x69B\x3\x2\x2\x2"+
-		"\x693\x694\x5\xFE\x80\x2\x694\x695\x5\x174\xBB\x2\x695\x696\a\xBE\x2\x2"+
-		"\x696\x697\x5\x174\xBB\x2\x697\x698\x5\xFE\x80\x2\x698\x69B\x3\x2\x2\x2"+
-		"\x699\x69B\x5\xFE\x80\x2\x69A\x689\x3\x2\x2\x2\x69A\x693\x3\x2\x2\x2\x69A"+
-		"\x699\x3\x2\x2\x2\x69B\xEF\x3\x2\x2\x2\x69C\x69D\a\x41\x2\x2\x69D\x69E"+
-		"\x5\x174\xBB\x2\x69E\x69F\x5\xF2z\x2\x69F\x6A1\x5\x160\xB1\x2\x6A0\x6A2"+
-		"\x5\x1E\x10\x2\x6A1\x6A0\x3\x2\x2\x2\x6A1\x6A2\x3\x2\x2\x2\x6A2\xF1\x3"+
-		"\x2\x2\x2\x6A3\x6B3\aY\x2\x2\x6A4\x6AF\x5\xEEx\x2\x6A5\x6A7\x5\x174\xBB"+
-		"\x2\x6A6\x6A5\x3\x2\x2\x2\x6A6\x6A7\x3\x2\x2\x2\x6A7\x6A8\x3\x2\x2\x2"+
-		"\x6A8\x6AA\a)\x2\x2\x6A9\x6AB\x5\x174\xBB\x2\x6AA\x6A9\x3\x2\x2\x2\x6AA"+
-		"\x6AB\x3\x2\x2\x2\x6AB\x6AC\x3\x2\x2\x2\x6AC\x6AE\x5\xEEx\x2\x6AD\x6A6"+
-		"\x3\x2\x2\x2\x6AE\x6B1\x3\x2\x2\x2\x6AF\x6AD\x3\x2\x2\x2\x6AF\x6B0\x3"+
-		"\x2\x2\x2\x6B0\x6B3\x3\x2\x2\x2\x6B1\x6AF\x3\x2\x2\x2\x6B2\x6A3\x3\x2"+
-		"\x2\x2\x6B2\x6A4\x3\x2\x2\x2\x6B3\xF3\x3\x2\x2\x2\x6B4\x6B5\a\xB2\x2\x2"+
-		"\x6B5\x6B6\x5\x174\xBB\x2\x6B6\x6B8\x5\xFE\x80\x2\x6B7\x6B9\x5\x174\xBB"+
-		"\x2\x6B8\x6B7\x3\x2\x2\x2\x6B8\x6B9\x3\x2\x2\x2\x6B9\x6BA\x3\x2\x2\x2"+
-		"\x6BA\x6BC\a\xD0\x2\x2\x6BB\x6BD\x5\x174\xBB\x2\x6BC\x6BB\x3\x2\x2\x2"+
-		"\x6BC\x6BD\x3\x2\x2\x2\x6BD\x6BE\x3\x2\x2\x2\x6BE\x6BF\x5\xFE\x80\x2\x6BF"+
-		"\xF5\x3\x2\x2\x2\x6C0\x6C1\x5\x156\xAC\x2\x6C1\x6C2\x5\x174\xBB\x2\x6C2"+
-		"\x6C4\x3\x2\x2\x2\x6C3\x6C0\x3\x2\x2\x2\x6C3\x6C4\x3\x2\x2\x2\x6C4\x6C7"+
-		"\x3\x2\x2\x2\x6C5\x6C6\a\xB6\x2\x2\x6C6\x6C8\x5\x174\xBB\x2\x6C7\x6C5"+
-		"\x3\x2\x2\x2\x6C7\x6C8\x3\x2\x2\x2\x6C8\x6C9\x3\x2\x2\x2\x6C9\x6CB\a\xBA"+
-		"\x2\x2\x6CA\x6CC\x5\x174\xBB\x2\x6CB\x6CA\x3\x2\x2\x2\x6CB\x6CC\x3\x2"+
-		"\x2\x2\x6CC\x6CD\x3\x2\x2\x2\x6CD\x6D2\x5\xF8}\x2\x6CE\x6D0\x5\x174\xBB"+
-		"\x2\x6CF\x6CE\x3\x2\x2\x2\x6CF\x6D0\x3\x2\x2\x2\x6D0\x6D1\x3\x2\x2\x2"+
-		"\x6D1\x6D3\x5\x12E\x98\x2\x6D2\x6CF\x3\x2\x2\x2\x6D2\x6D3\x3\x2\x2\x2"+
-		"\x6D3\x6D4\x3\x2\x2\x2\x6D4\x6D6\x5\x160\xB1\x2\x6D5\x6D7\x5\x1E\x10\x2"+
-		"\x6D6\x6D5\x3\x2\x2\x2\x6D6\x6D7\x3\x2\x2\x2\x6D7\x6D8\x3\x2\x2\x2\x6D8"+
-		"\x6D9\a\x61\x2\x2\x6D9\xF7\x3\x2\x2\x2\x6DA\x6DB\x5\x13A\x9E\x2\x6DB\xF9"+
-		"\x3\x2\x2\x2\x6DC\x6DD\x5\x156\xAC\x2\x6DD\x6DE\x5\x174\xBB\x2\x6DE\x6E0"+
-		"\x3\x2\x2\x2\x6DF\x6DC\x3\x2\x2\x2\x6DF\x6E0\x3\x2\x2\x2\x6E0\x6E1\x3"+
-		"\x2\x2\x2\x6E1\x6E2\a\xC0\x2\x2\x6E2\x6E3\x5\x174\xBB\x2\x6E3\x6E4\x5"+
-		"\x13A\x9E\x2\x6E4\x6E8\x5\x160\xB1\x2\x6E5\x6E7\x5\xFC\x7F\x2\x6E6\x6E5"+
-		"\x3\x2\x2\x2\x6E7\x6EA\x3\x2\x2\x2\x6E8\x6E6\x3\x2\x2\x2\x6E8\x6E9\x3"+
-		"\x2\x2\x2\x6E9\x6EB\x3\x2\x2\x2\x6EA\x6E8\x3\x2\x2\x2\x6EB\x6EC\a\x62"+
-		"\x2\x2\x6EC\xFB\x3\x2\x2\x2\x6ED\x6FC\x5\x13A\x9E\x2\x6EE\x6F0\x5\x174"+
-		"\xBB\x2\x6EF\x6EE\x3\x2\x2\x2\x6EF\x6F0\x3\x2\x2\x2\x6F0\x6F1\x3\x2\x2"+
-		"\x2\x6F1\x6F6\a\xD4\x2\x2\x6F2\x6F4\x5\x174\xBB\x2\x6F3\x6F2\x3\x2\x2"+
-		"\x2\x6F3\x6F4\x3\x2\x2\x2\x6F4\x6F5\x3\x2\x2\x2\x6F5\x6F7\x5\x134\x9B"+
-		"\x2\x6F6\x6F3\x3\x2\x2\x2\x6F6\x6F7\x3\x2\x2\x2\x6F7\x6F9\x3\x2\x2\x2"+
-		"\x6F8\x6FA\x5\x174\xBB\x2\x6F9\x6F8\x3\x2\x2\x2\x6F9\x6FA\x3\x2\x2\x2"+
-		"\x6FA\x6FB\x3\x2\x2\x2\x6FB\x6FD\a\xDB\x2\x2\x6FC\x6EF\x3\x2\x2\x2\x6FC"+
-		"\x6FD\x3\x2\x2\x2\x6FD\x701\x3\x2\x2\x2\x6FE\x6FF\x5\x174\xBB\x2\x6FF"+
-		"\x700\x5\x13C\x9F\x2\x700\x702\x3\x2\x2\x2\x701\x6FE\x3\x2\x2\x2\x701"+
-		"\x702\x3\x2\x2\x2\x702\x703\x3\x2\x2\x2\x703\x704\x5\x160\xB1\x2\x704"+
-		"\xFD\x3\x2\x2\x2\x705\x706\b\x80\x1\x2\x706\x708\a\x8D\x2\x2\x707\x709"+
-		"\x5\x174\xBB\x2\x708\x707\x3\x2\x2\x2\x708\x709\x3\x2\x2\x2\x709\x70A"+
-		"\x3\x2\x2\x2\x70A\x734\x5\xFE\x80\x16\x70B\x70D\a\x34\x2\x2\x70C\x70E"+
-		"\x5\x174\xBB\x2\x70D\x70C\x3\x2\x2\x2\x70D\x70E\x3\x2\x2\x2\x70E\x70F"+
-		"\x3\x2\x2\x2\x70F\x734\x5\xFE\x80\x13\x710\x712\x5\x138\x9D\x2\x711\x713"+
-		"\x5\x174\xBB\x2\x712\x711\x3\x2\x2\x2\x712\x713\x3\x2\x2\x2\x713\x714"+
-		"\x3\x2\x2\x2\x714\x716\a\xCD\x2\x2\x715\x717\x5\x174\xBB\x2\x716\x715"+
-		"\x3\x2\x2\x2\x716\x717\x3\x2\x2\x2\x717\x718\x3\x2\x2\x2\x718\x719\x5"+
-		"\xFE\x80\x12\x719\x734\x3\x2\x2\x2\x71A\x71C\a\xD6\x2\x2\x71B\x71D\x5"+
-		"\x174\xBB\x2\x71C\x71B\x3\x2\x2\x2\x71C\x71D\x3\x2\x2\x2\x71D\x71E\x3"+
-		"\x2\x2\x2\x71E\x734\x5\xFE\x80\x10\x71F\x721\a\x8E\x2\x2\x720\x722\x5"+
-		"\x174\xBB\x2\x721\x720\x3\x2\x2\x2\x721\x722\x3\x2\x2\x2\x722\x723\x3"+
-		"\x2\x2\x2\x723\x734\x5\xFE\x80\t\x724\x734\x5\x14E\xA8\x2\x725\x734\x5"+
-		"\x118\x8D\x2\x726\x728\a\xD4\x2\x2\x727\x729\x5\x174\xBB\x2\x728\x727"+
-		"\x3\x2\x2\x2\x728\x729\x3\x2\x2\x2\x729\x72A\x3\x2\x2\x2\x72A\x72C\x5"+
-		"\xFE\x80\x2\x72B\x72D\x5\x174\xBB\x2\x72C\x72B\x3\x2\x2\x2\x72C\x72D\x3"+
-		"\x2\x2\x2\x72D\x72E\x3\x2\x2\x2\x72E\x72F\a\xDB\x2\x2\x72F\x734\x3\x2"+
-		"\x2\x2\x730\x734\x5\x100\x81\x2\x731\x734\x5\xD0i\x2\x732\x734\x5\x38"+
-		"\x1D\x2\x733\x705\x3\x2\x2\x2\x733\x70B\x3\x2\x2\x2\x733\x710\x3\x2\x2"+
-		"\x2\x733\x71A\x3\x2\x2\x2\x733\x71F\x3\x2\x2\x2\x733\x724\x3\x2\x2\x2"+
-		"\x733\x725\x3\x2\x2\x2\x733\x726\x3\x2\x2\x2\x733\x730\x3\x2\x2\x2\x733"+
-		"\x731\x3\x2\x2\x2\x733\x732\x3\x2\x2\x2\x734\x7A3\x3\x2\x2\x2\x735\x737"+
-		"\f\x11\x2\x2\x736\x738\x5\x174\xBB\x2\x737\x736\x3\x2\x2\x2\x737\x738"+
-		"\x3\x2\x2\x2\x738\x739\x3\x2\x2\x2\x739\x73B\a\xDA\x2\x2\x73A\x73C\x5"+
-		"\x174\xBB\x2\x73B\x73A\x3\x2\x2\x2\x73B\x73C\x3\x2\x2\x2\x73C\x73D\x3"+
-		"\x2\x2\x2\x73D\x7A2\x5\xFE\x80\x12\x73E\x740\f\xF\x2\x2\x73F\x741\x5\x174"+
-		"\xBB\x2\x740\x73F\x3\x2\x2\x2\x740\x741\x3\x2\x2\x2\x741\x742\x3\x2\x2"+
-		"\x2\x742\x744\t\f\x2\x2\x743\x745\x5\x174\xBB\x2\x744\x743\x3\x2\x2\x2"+
-		"\x744\x745\x3\x2\x2\x2\x745\x746\x3\x2\x2\x2\x746\x7A2\x5\xFE\x80\x10"+
-		"\x747\x749\f\xE\x2\x2\x748\x74A\x5\x174\xBB\x2\x749\x748\x3\x2\x2\x2\x749"+
-		"\x74A\x3\x2\x2\x2\x74A\x74B\x3\x2\x2\x2\x74B\x74D\a\xCF\x2\x2\x74C\x74E"+
-		"\x5\x174\xBB\x2\x74D\x74C\x3\x2\x2\x2\x74D\x74E\x3\x2\x2\x2\x74E\x74F"+
-		"\x3\x2\x2\x2\x74F\x7A2\x5\xFE\x80\xF\x750\x752\f\r\x2\x2\x751\x753\x5"+
-		"\x174\xBB\x2\x752\x751\x3\x2\x2\x2\x752\x753\x3\x2\x2\x2\x753\x754\x3"+
-		"\x2\x2\x2\x754\x756\a\x8B\x2\x2\x755\x757\x5\x174\xBB\x2\x756\x755\x3"+
-		"\x2\x2\x2\x756\x757\x3\x2\x2\x2\x757\x758\x3\x2\x2\x2\x758\x7A2\x5\xFE"+
-		"\x80\xE\x759\x75B\f\f\x2\x2\x75A\x75C\x5\x174\xBB\x2\x75B\x75A\x3\x2\x2"+
-		"\x2\x75B\x75C\x3\x2\x2\x2\x75C\x75D\x3\x2\x2\x2\x75D\x75F\t\r\x2\x2\x75E"+
-		"\x760\x5\x174\xBB\x2\x75F\x75E\x3\x2\x2\x2\x75F\x760\x3\x2\x2\x2\x760"+
-		"\x761\x3\x2\x2\x2\x761\x7A2\x5\xFE\x80\r\x762\x764\f\v\x2\x2\x763\x765"+
-		"\x5\x174\xBB\x2\x764\x763\x3\x2\x2\x2\x764\x765\x3\x2\x2\x2\x765\x766"+
-		"\x3\x2\x2\x2\x766\x768\a\x32\x2\x2\x767\x769\x5\x174\xBB\x2\x768\x767"+
-		"\x3\x2\x2\x2\x768\x769\x3\x2\x2\x2\x769\x76A\x3\x2\x2\x2\x76A\x7A2\x5"+
-		"\xFE\x80\f\x76B\x76D\f\n\x2\x2\x76C\x76E\x5\x174\xBB\x2\x76D\x76C\x3\x2"+
-		"\x2\x2\x76D\x76E\x3\x2\x2\x2\x76E\x76F\x3\x2\x2\x2\x76F\x771\t\xE\x2\x2"+
-		"\x770\x772\x5\x174\xBB\x2\x771\x770\x3\x2\x2\x2\x771\x772\x3\x2\x2\x2"+
-		"\x772\x773\x3\x2\x2\x2\x773\x7A2\x5\xFE\x80\v\x774\x776\f\b\x2\x2\x775"+
-		"\x777\x5\x174\xBB\x2\x776\x775\x3\x2\x2\x2\x776\x777\x3\x2\x2\x2\x777"+
-		"\x778\x3\x2\x2\x2\x778\x77A\a\x36\x2\x2\x779\x77B\x5\x174\xBB\x2\x77A"+
-		"\x779\x3\x2\x2\x2\x77A\x77B\x3\x2\x2\x2\x77B\x77C\x3\x2\x2\x2\x77C\x7A2"+
-		"\x5\xFE\x80\t\x77D\x77F\f\a\x2\x2\x77E\x780\x5\x174\xBB\x2\x77F\x77E\x3"+
-		"\x2\x2\x2\x77F\x780\x3\x2\x2\x2\x780\x781\x3\x2\x2\x2\x781\x783\a\x9A"+
-		"\x2\x2\x782\x784\x5\x174\xBB\x2\x783\x782\x3\x2\x2\x2\x783\x784\x3\x2"+
-		"\x2\x2\x784\x785\x3\x2\x2\x2\x785\x7A2\x5\xFE\x80\b\x786\x788\f\x6\x2"+
-		"\x2\x787\x789\x5\x174\xBB\x2\x788\x787\x3\x2\x2\x2\x788\x789\x3\x2\x2"+
-		"\x2\x789\x78A\x3\x2\x2\x2\x78A\x78C\a\xCC\x2\x2\x78B\x78D\x5\x174\xBB"+
-		"\x2\x78C\x78B\x3\x2\x2\x2\x78C\x78D\x3\x2\x2\x2\x78D\x78E\x3\x2\x2\x2"+
-		"\x78E\x7A2\x5\xFE\x80\a\x78F\x791\f\x5\x2\x2\x790\x792\x5\x174\xBB\x2"+
-		"\x791\x790\x3\x2\x2\x2\x791\x792\x3\x2\x2\x2\x792\x793\x3\x2\x2\x2\x793"+
-		"\x795\a\x66\x2\x2\x794\x796\x5\x174\xBB\x2\x795\x794\x3\x2\x2\x2\x795"+
-		"\x796\x3\x2\x2\x2\x796\x797\x3\x2\x2\x2\x797\x7A2\x5\xFE\x80\x6\x798\x79A"+
-		"\f\x4\x2\x2\x799\x79B\x5\x174\xBB\x2\x79A\x799\x3\x2\x2\x2\x79A\x79B\x3"+
-		"\x2\x2\x2\x79B\x79C\x3\x2\x2\x2\x79C\x79E\ax\x2\x2\x79D\x79F\x5\x174\xBB"+
-		"\x2\x79E\x79D\x3\x2\x2\x2\x79E\x79F\x3\x2\x2\x2\x79F\x7A0\x3\x2\x2\x2"+
-		"\x7A0\x7A2\x5\xFE\x80\x5\x7A1\x735\x3\x2\x2\x2\x7A1\x73E\x3\x2\x2\x2\x7A1"+
-		"\x747\x3\x2\x2\x2\x7A1\x750\x3\x2\x2\x2\x7A1\x759\x3\x2\x2\x2\x7A1\x762"+
-		"\x3\x2\x2\x2\x7A1\x76B\x3\x2\x2\x2\x7A1\x774\x3\x2\x2\x2\x7A1\x77D\x3"+
-		"\x2\x2\x2\x7A1\x786\x3\x2\x2\x2\x7A1\x78F\x3\x2\x2\x2\x7A1\x798\x3\x2"+
-		"\x2\x2\x7A2\x7A5\x3\x2\x2\x2\x7A3\x7A1\x3\x2\x2\x2\x7A3\x7A4\x3\x2\x2"+
-		"\x2\x7A4\xFF\x3\x2\x2\x2\x7A5\x7A3\x3\x2\x2\x2\x7A6\x7A7\a\xC1\x2\x2\x7A7"+
-		"\x7A8\x5\x174\xBB\x2\x7A8\x7AE\x5\xFE\x80\x2\x7A9\x7AA\x5\x174\xBB\x2"+
-		"\x7AA\x7AB\a|\x2\x2\x7AB\x7AC\x5\x174\xBB\x2\x7AC\x7AD\x5\x152\xAA\x2"+
-		"\x7AD\x7AF\x3\x2\x2\x2\x7AE\x7A9\x3\x2\x2\x2\x7AE\x7AF\x3\x2\x2\x2\x7AF"+
-		"\x101\x3\x2\x2\x2\x7B0\x7B4\aU\x2\x2\x7B1\x7B4\a\xB6\x2\x2\x7B2\x7B4\x5"+
-		"\x156\xAC\x2\x7B3\x7B0\x3\x2\x2\x2\x7B3\x7B1\x3\x2\x2\x2\x7B3\x7B2\x3"+
-		"\x2\x2\x2\x7B4\x7B5\x3\x2\x2\x2\x7B5\x7B8\x5\x174\xBB\x2\x7B6\x7B7\a\xCA"+
-		"\x2\x2\x7B7\x7B9\x5\x174\xBB\x2\x7B8\x7B6\x3\x2\x2\x2\x7B8\x7B9\x3\x2"+
-		"\x2\x2\x7B9\x7BA\x3\x2\x2\x2\x7BA\x7BB\x5\x104\x83\x2\x7BB\x103\x3\x2"+
-		"\x2\x2\x7BC\x7C7\x5\x106\x84\x2\x7BD\x7BF\x5\x174\xBB\x2\x7BE\x7BD\x3"+
-		"\x2\x2\x2\x7BE\x7BF\x3\x2\x2\x2\x7BF\x7C0\x3\x2\x2\x2\x7C0\x7C2\a)\x2"+
-		"\x2\x7C1\x7C3\x5\x174\xBB\x2\x7C2\x7C1\x3\x2\x2\x2\x7C2\x7C3\x3\x2\x2"+
-		"\x2\x7C3\x7C4\x3\x2\x2\x2\x7C4\x7C6\x5\x106\x84\x2\x7C5\x7BE\x3\x2\x2"+
-		"\x2\x7C6\x7C9\x3\x2\x2\x2\x7C7\x7C5\x3\x2\x2\x2\x7C7\x7C8\x3\x2\x2\x2"+
-		"\x7C8\x105\x3\x2\x2\x2\x7C9\x7C7\x3\x2\x2\x2\x7CA\x7CC\x5\x13A\x9E\x2"+
-		"\x7CB\x7CD\x5\x154\xAB\x2\x7CC\x7CB\x3\x2\x2\x2\x7CC\x7CD\x3\x2\x2\x2"+
-		"\x7CD\x7DF\x3\x2\x2\x2\x7CE\x7D0\x5\x174\xBB\x2\x7CF\x7CE\x3\x2\x2\x2"+
-		"\x7CF\x7D0\x3\x2\x2\x2\x7D0\x7D1\x3\x2\x2\x2\x7D1\x7D3\a\xD4\x2\x2\x7D2"+
-		"\x7D4\x5\x174\xBB\x2\x7D3\x7D2\x3\x2\x2\x2\x7D3\x7D4\x3\x2\x2\x2\x7D4"+
-		"\x7D9\x3\x2\x2\x2\x7D5\x7D7\x5\x134\x9B\x2\x7D6\x7D8\x5\x174\xBB\x2\x7D7"+
-		"\x7D6\x3\x2\x2\x2\x7D7\x7D8\x3\x2\x2\x2\x7D8\x7DA\x3\x2\x2\x2\x7D9\x7D5"+
-		"\x3\x2\x2\x2\x7D9\x7DA\x3\x2\x2\x2\x7DA\x7DB\x3\x2\x2\x2\x7DB\x7DD\a\xDB"+
-		"\x2\x2\x7DC\x7DE\x5\x174\xBB\x2\x7DD\x7DC\x3\x2\x2\x2\x7DD\x7DE\x3\x2"+
-		"\x2\x2\x7DE\x7E0\x3\x2\x2\x2\x7DF\x7CF\x3\x2\x2\x2\x7DF\x7E0\x3\x2\x2"+
-		"\x2\x7E0\x7E4\x3\x2\x2\x2\x7E1\x7E2\x5\x174\xBB\x2\x7E2\x7E3\x5\x13C\x9F"+
-		"\x2\x7E3\x7E5\x3\x2\x2\x2\x7E4\x7E1\x3\x2\x2\x2\x7E4\x7E5\x3\x2\x2\x2"+
-		"\x7E5\x107\x3\x2\x2\x2\x7E6\x7E7\a\xC7\x2\x2\x7E7\x7E8\x5\x174\xBB\x2"+
-		"\x7E8\x7E9\x5\xFE\x80\x2\x7E9\x7EB\x5\x160\xB1\x2\x7EA\x7EC\x5\x1E\x10"+
-		"\x2\x7EB\x7EA\x3\x2\x2\x2\x7EB\x7EC\x3\x2\x2\x2\x7EC\x7ED\x3\x2\x2\x2"+
-		"\x7ED\x7EE\a\xC6\x2\x2\x7EE\x109\x3\x2\x2\x2\x7EF\x7F0\a\xC9\x2\x2\x7F0"+
-		"\x7F1\x5\x174\xBB\x2\x7F1\x7F2\x5\x10C\x87\x2\x7F2\x7F4\x5\x160\xB1\x2"+
-		"\x7F3\x7F5\x5\x1E\x10\x2\x7F4\x7F3\x3\x2\x2\x2\x7F4\x7F5\x3\x2\x2\x2\x7F5"+
-		"\x7F6\x3\x2\x2\x2\x7F6\x7F7\a\x63\x2\x2\x7F7\x10B\x3\x2\x2\x2\x7F8\x7F9"+
-		"\x5\xFE\x80\x2\x7F9\x10D\x3\x2\x2\x2\x7FA\x7FB\a@\x2\x2\x7FB\x7FC\x5\x174"+
-		"\xBB\x2\x7FC\x7FD\x5\x110\x89\x2\x7FD\x10F\x3\x2\x2\x2\x7FE\x800\x5\x118"+
-		"\x8D\x2\x7FF\x7FE\x3\x2\x2\x2\x7FF\x800\x3\x2\x2\x2\x800\x801\x3\x2\x2"+
-		"\x2\x801\x802\a-\x2\x2\x802\x804\x5\x13A\x9E\x2\x803\x805\x5\x154\xAB"+
-		"\x2\x804\x803\x3\x2\x2\x2\x804\x805\x3\x2\x2\x2\x805\x813\x3\x2\x2\x2"+
-		"\x806\x808\x5\x174\xBB\x2\x807\x806\x3\x2\x2\x2\x807\x808\x3\x2\x2\x2"+
-		"\x808\x809\x3\x2\x2\x2\x809\x80B\a\xD4\x2\x2\x80A\x80C\x5\x174\xBB\x2"+
-		"\x80B\x80A\x3\x2\x2\x2\x80B\x80C\x3\x2\x2\x2\x80C\x80D\x3\x2\x2\x2\x80D"+
-		"\x80F\x5\x128\x95\x2\x80E\x810\x5\x174\xBB\x2\x80F\x80E\x3\x2\x2\x2\x80F"+
-		"\x810\x3\x2\x2\x2\x810\x811\x3\x2\x2\x2\x811\x812\a\xDB\x2\x2\x812\x814"+
-		"\x3\x2\x2\x2\x813\x807\x3\x2\x2\x2\x813\x814\x3\x2\x2\x2\x814\x81E\x3"+
-		"\x2\x2\x2\x815\x817\x5\x174\xBB\x2\x816\x815\x3\x2\x2\x2\x816\x817\x3"+
-		"\x2\x2\x2\x817\x818\x3\x2\x2\x2\x818\x819\a\xD4\x2\x2\x819\x81A\x5\x134"+
-		"\x9B\x2\x81A\x81B\a\xDB\x2\x2\x81B\x81D\x3\x2\x2\x2\x81C\x816\x3\x2\x2"+
-		"\x2\x81D\x820\x3\x2\x2\x2\x81E\x81C\x3\x2\x2\x2\x81E\x81F\x3\x2\x2\x2"+
-		"\x81F\x841\x3\x2\x2\x2\x820\x81E\x3\x2\x2\x2\x821\x823\x5\x13A\x9E\x2"+
-		"\x822\x824\x5\x154\xAB\x2\x823\x822\x3\x2\x2\x2\x823\x824\x3\x2\x2\x2"+
-		"\x824\x832\x3\x2\x2\x2\x825\x827\x5\x174\xBB\x2\x826\x825\x3\x2\x2\x2"+
-		"\x826\x827\x3\x2\x2\x2\x827\x828\x3\x2\x2\x2\x828\x82A\a\xD4\x2\x2\x829"+
-		"\x82B\x5\x174\xBB\x2\x82A\x829\x3\x2\x2\x2\x82A\x82B\x3\x2\x2\x2\x82B"+
-		"\x82C\x3\x2\x2\x2\x82C\x82E\x5\x128\x95\x2\x82D\x82F\x5\x174\xBB\x2\x82E"+
-		"\x82D\x3\x2\x2\x2\x82E\x82F\x3\x2\x2\x2\x82F\x830\x3\x2\x2\x2\x830\x831"+
-		"\a\xDB\x2\x2\x831\x833\x3\x2\x2\x2\x832\x826\x3\x2\x2\x2\x832\x833\x3"+
-		"\x2\x2\x2\x833\x83D\x3\x2\x2\x2\x834\x836\x5\x174\xBB\x2\x835\x834\x3"+
-		"\x2\x2\x2\x835\x836\x3\x2\x2\x2\x836\x837\x3\x2\x2\x2\x837\x838\a\xD4"+
-		"\x2\x2\x838\x839\x5\x134\x9B\x2\x839\x83A\a\xDB\x2\x2\x83A\x83C\x3\x2"+
-		"\x2\x2\x83B\x835\x3\x2\x2\x2\x83C\x83F\x3\x2\x2\x2\x83D\x83B\x3\x2\x2"+
-		"\x2\x83D\x83E\x3\x2\x2\x2\x83E\x841\x3\x2\x2\x2\x83F\x83D\x3\x2\x2\x2"+
-		"\x840\x7FF\x3\x2\x2\x2\x840\x821\x3\x2\x2\x2\x841\x111\x3\x2\x2\x2\x842"+
-		"\x845\x5\x114\x8B\x2\x843\x845\x5\x116\x8C\x2\x844\x842\x3\x2\x2\x2\x844"+
-		"\x843\x3\x2\x2\x2\x845\x113\x3\x2\x2\x2\x846\x848\x5\x118\x8D\x2\x847"+
-		"\x846\x3\x2\x2\x2\x847\x848\x3\x2\x2\x2\x848\x84A\x3\x2\x2\x2\x849\x84B"+
-		"\x5\x174\xBB\x2\x84A\x849\x3\x2\x2\x2\x84A\x84B\x3\x2\x2\x2\x84B\x84C"+
-		"\x3\x2\x2\x2\x84C\x84E\a-\x2\x2\x84D\x84F\x5\x174\xBB\x2\x84E\x84D\x3"+
-		"\x2\x2\x2\x84E\x84F\x3\x2\x2\x2\x84F\x850\x3\x2\x2\x2\x850\x852\x5\x138"+
-		"\x9D\x2\x851\x853\x5\x154\xAB\x2\x852\x851\x3\x2\x2\x2\x852\x853\x3\x2"+
-		"\x2\x2\x853\x857\x3\x2\x2\x2\x854\x855\x5\x174\xBB\x2\x855\x856\x5\x128"+
-		"\x95\x2\x856\x858\x3\x2\x2\x2\x857\x854\x3\x2\x2\x2\x857\x858\x3\x2\x2"+
-		"\x2\x858\x85D\x3\x2\x2\x2\x859\x85B\x5\x174\xBB\x2\x85A\x859\x3\x2\x2"+
-		"\x2\x85A\x85B\x3\x2\x2\x2\x85B\x85C\x3\x2\x2\x2\x85C\x85E\x5\x12C\x97"+
-		"\x2\x85D\x85A\x3\x2\x2\x2\x85D\x85E\x3\x2\x2\x2\x85E\x868\x3\x2\x2\x2"+
-		"\x85F\x861\x5\x174\xBB\x2\x860\x85F\x3\x2\x2\x2\x860\x861\x3\x2\x2\x2"+
-		"\x861\x862\x3\x2\x2\x2\x862\x863\a\xD4\x2\x2\x863\x864\x5\x134\x9B\x2"+
-		"\x864\x865\a\xDB\x2\x2\x865\x867\x3\x2\x2\x2\x866\x860\x3\x2\x2\x2\x867"+
-		"\x86A\x3\x2\x2\x2\x868\x866\x3\x2\x2\x2\x868\x869\x3\x2\x2\x2\x869\x115"+
-		"\x3\x2\x2\x2\x86A\x868\x3\x2\x2\x2\x86B\x86F\x5\x13A\x9E\x2\x86C\x86D"+
-		"\x5\x174\xBB\x2\x86D\x86E\x5\x128\x95\x2\x86E\x870\x3\x2\x2\x2\x86F\x86C"+
-		"\x3\x2\x2\x2\x86F\x870\x3\x2\x2\x2\x870\x87A\x3\x2\x2\x2\x871\x873\x5"+
-		"\x174\xBB\x2\x872\x871\x3\x2\x2\x2\x872\x873\x3\x2\x2\x2\x873\x874\x3"+
-		"\x2\x2\x2\x874\x875\a\xD4\x2\x2\x875\x876\x5\x134\x9B\x2\x876\x877\a\xDB"+
-		"\x2\x2\x877\x879\x3\x2\x2\x2\x878\x872\x3\x2\x2\x2\x879\x87C\x3\x2\x2"+
-		"\x2\x87A\x878\x3\x2\x2\x2\x87A\x87B\x3\x2\x2\x2\x87B\x117\x3\x2\x2\x2"+
-		"\x87C\x87A\x3\x2\x2\x2\x87D\x882\x5\x122\x92\x2\x87E\x882\x5\x11A\x8E"+
-		"\x2\x87F\x882\x5\x11C\x8F\x2\x880\x882\x5\x126\x94\x2\x881\x87D\x3\x2"+
-		"\x2\x2\x881\x87E\x3\x2\x2\x2\x881\x87F\x3\x2\x2\x2\x881\x880\x3\x2\x2"+
-		"\x2\x882\x119\x3\x2\x2\x2\x883\x885\x5\x13A\x9E\x2\x884\x886\x5\x154\xAB"+
-		"\x2\x885\x884\x3\x2\x2\x2\x885\x886\x3\x2\x2\x2\x886\x88B\x3\x2\x2\x2"+
-		"\x887\x889\x5\x174\xBB\x2\x888\x887\x3\x2\x2\x2\x888\x889\x3\x2\x2\x2"+
-		"\x889\x88A\x3\x2\x2\x2\x88A\x88C\x5\x12C\x97\x2\x88B\x888\x3\x2\x2\x2"+
-		"\x88B\x88C\x3\x2\x2\x2\x88C\x896\x3\x2\x2\x2\x88D\x88F\x5\x174\xBB\x2"+
-		"\x88E\x88D\x3\x2\x2\x2\x88E\x88F\x3\x2\x2\x2\x88F\x890\x3\x2\x2\x2\x890"+
-		"\x891\a\xD4\x2\x2\x891\x892\x5\x134\x9B\x2\x892\x893\a\xDB\x2\x2\x893"+
-		"\x895\x3\x2\x2\x2\x894\x88E\x3\x2\x2\x2\x895\x898\x3\x2\x2\x2\x896\x894"+
-		"\x3\x2\x2\x2\x896\x897\x3\x2\x2\x2\x897\x11B\x3\x2\x2\x2\x898\x896\x3"+
-		"\x2\x2\x2\x899\x89C\x5\x13A\x9E\x2\x89A\x89C\x5\x13E\xA0\x2\x89B\x899"+
-		"\x3\x2\x2\x2\x89B\x89A\x3\x2\x2\x2\x89C\x89E\x3\x2\x2\x2\x89D\x89F\x5"+
-		"\x154\xAB\x2\x89E\x89D\x3\x2\x2\x2\x89E\x89F\x3\x2\x2\x2\x89F\x8A1\x3"+
-		"\x2\x2\x2\x8A0\x8A2\x5\x174\xBB\x2\x8A1\x8A0\x3\x2\x2\x2\x8A1\x8A2\x3"+
-		"\x2\x2\x2\x8A2\x8A3\x3\x2\x2\x2\x8A3\x8A5\a\xD4\x2\x2\x8A4\x8A6\x5\x174"+
-		"\xBB\x2\x8A5\x8A4\x3\x2\x2\x2\x8A5\x8A6\x3\x2\x2\x2\x8A6\x8AB\x3\x2\x2"+
-		"\x2\x8A7\x8A9\x5\x128\x95\x2\x8A8\x8AA\x5\x174\xBB\x2\x8A9\x8A8\x3\x2"+
-		"\x2\x2\x8A9\x8AA\x3\x2\x2\x2\x8AA\x8AC\x3\x2\x2\x2\x8AB\x8A7\x3\x2\x2"+
-		"\x2\x8AB\x8AC\x3\x2\x2\x2\x8AC\x8AD\x3\x2\x2\x2\x8AD\x8B2\a\xDB\x2\x2"+
-		"\x8AE\x8B0\x5\x174\xBB\x2\x8AF\x8AE\x3\x2\x2\x2\x8AF\x8B0\x3\x2\x2\x2"+
-		"\x8B0\x8B1\x3\x2\x2\x2\x8B1\x8B3\x5\x12C\x97\x2\x8B2\x8AF\x3\x2\x2\x2"+
-		"\x8B2\x8B3\x3\x2\x2\x2\x8B3\x8BD\x3\x2\x2\x2\x8B4\x8B6\x5\x174\xBB\x2"+
-		"\x8B5\x8B4\x3\x2\x2\x2\x8B5\x8B6\x3\x2\x2\x2\x8B6\x8B7\x3\x2\x2\x2\x8B7"+
-		"\x8B8\a\xD4\x2\x2\x8B8\x8B9\x5\x134\x9B\x2\x8B9\x8BA\a\xDB\x2\x2\x8BA"+
-		"\x8BC\x3\x2\x2\x2\x8BB\x8B5\x3\x2\x2\x2\x8BC\x8BF\x3\x2\x2\x2\x8BD\x8BB"+
-		"\x3\x2\x2\x2\x8BD\x8BE\x3\x2\x2\x2\x8BE\x11D\x3\x2\x2\x2\x8BF\x8BD\x3"+
-		"\x2\x2\x2\x8C0\x8C2\x5\x138\x9D\x2\x8C1\x8C3\x5\x154\xAB\x2\x8C2\x8C1"+
-		"\x3\x2\x2\x2\x8C2\x8C3\x3\x2\x2\x2\x8C3\x8C8\x3\x2\x2\x2\x8C4\x8C6\x5"+
-		"\x174\xBB\x2\x8C5\x8C4\x3\x2\x2\x2\x8C5\x8C6\x3\x2\x2\x2\x8C6\x8C7\x3"+
-		"\x2\x2\x2\x8C7\x8C9\x5\x12C\x97\x2\x8C8\x8C5\x3\x2\x2\x2\x8C8\x8C9\x3"+
-		"\x2\x2\x2\x8C9\x8D3\x3\x2\x2\x2\x8CA\x8CC\x5\x174\xBB\x2\x8CB\x8CA\x3"+
-		"\x2\x2\x2\x8CB\x8CC\x3\x2\x2\x2\x8CC\x8CD\x3\x2\x2\x2\x8CD\x8CE\a\xD4"+
-		"\x2\x2\x8CE\x8CF\x5\x134\x9B\x2\x8CF\x8D0\a\xDB\x2\x2\x8D0\x8D2\x3\x2"+
-		"\x2\x2\x8D1\x8CB\x3\x2\x2\x2\x8D2\x8D5\x3\x2\x2\x2\x8D3\x8D1\x3\x2\x2"+
-		"\x2\x8D3\x8D4\x3\x2\x2\x2\x8D4\x11F\x3\x2\x2\x2\x8D5\x8D3\x3\x2\x2\x2"+
-		"\x8D6\x8D9\x5\x138\x9D\x2\x8D7\x8D9\x5\x13E\xA0\x2\x8D8\x8D6\x3\x2\x2"+
-		"\x2\x8D8\x8D7\x3\x2\x2\x2\x8D9\x8DB\x3\x2\x2\x2\x8DA\x8DC\x5\x154\xAB"+
-		"\x2\x8DB\x8DA\x3\x2\x2\x2\x8DB\x8DC\x3\x2\x2\x2\x8DC\x8DE\x3\x2\x2\x2"+
-		"\x8DD\x8DF\x5\x174\xBB\x2\x8DE\x8DD\x3\x2\x2\x2\x8DE\x8DF\x3\x2\x2\x2"+
-		"\x8DF\x8E0\x3\x2\x2\x2\x8E0\x8E2\a\xD4\x2\x2\x8E1\x8E3\x5\x174\xBB\x2"+
-		"\x8E2\x8E1\x3\x2\x2\x2\x8E2\x8E3\x3\x2\x2\x2\x8E3\x8E8\x3\x2\x2\x2\x8E4"+
-		"\x8E6\x5\x128\x95\x2\x8E5\x8E7\x5\x174\xBB\x2\x8E6\x8E5\x3\x2\x2\x2\x8E6"+
-		"\x8E7\x3\x2\x2\x2\x8E7\x8E9\x3\x2\x2\x2\x8E8\x8E4\x3\x2\x2\x2\x8E8\x8E9"+
-		"\x3\x2\x2\x2\x8E9\x8EA\x3\x2\x2\x2\x8EA\x8EF\a\xDB\x2\x2\x8EB\x8ED\x5"+
-		"\x174\xBB\x2\x8EC\x8EB\x3\x2\x2\x2\x8EC\x8ED\x3\x2\x2\x2\x8ED\x8EE\x3"+
-		"\x2\x2\x2\x8EE\x8F0\x5\x12C\x97\x2\x8EF\x8EC\x3\x2\x2\x2\x8EF\x8F0\x3"+
-		"\x2\x2\x2\x8F0\x8FA\x3\x2\x2\x2\x8F1\x8F3\x5\x174\xBB\x2\x8F2\x8F1\x3"+
-		"\x2\x2\x2\x8F2\x8F3\x3\x2\x2\x2\x8F3\x8F4\x3\x2\x2\x2\x8F4\x8F5\a\xD4"+
-		"\x2\x2\x8F5\x8F6\x5\x134\x9B\x2\x8F6\x8F7\a\xDB\x2\x2\x8F7\x8F9\x3\x2"+
-		"\x2\x2\x8F8\x8F2\x3\x2\x2\x2\x8F9\x8FC\x3\x2\x2\x2\x8FA\x8F8\x3\x2\x2"+
-		"\x2\x8FA\x8FB\x3\x2\x2\x2\x8FB\x121\x3\x2\x2\x2\x8FC\x8FA\x3\x2\x2\x2"+
-		"\x8FD\x900\x5\x11A\x8E\x2\x8FE\x900\x5\x11C\x8F\x2\x8FF\x8FD\x3\x2\x2"+
-		"\x2\x8FF\x8FE\x3\x2\x2\x2\x8FF\x900\x3\x2\x2\x2\x900\x905\x3\x2\x2\x2"+
-		"\x901\x903\x5\x124\x93\x2\x902\x904\x5\x174\xBB\x2\x903\x902\x3\x2\x2"+
-		"\x2\x903\x904\x3\x2\x2\x2\x904\x906\x3\x2\x2\x2\x905\x901\x3\x2\x2\x2"+
-		"\x906\x907\x3\x2\x2\x2\x907\x905\x3\x2\x2\x2\x907\x908\x3\x2\x2\x2\x908"+
-		"\x90D\x3\x2\x2\x2\x909\x90B\x5\x174\xBB\x2\x90A\x909\x3\x2\x2\x2\x90A"+
-		"\x90B\x3\x2\x2\x2\x90B\x90C\x3\x2\x2\x2\x90C\x90E\x5\x12C\x97\x2\x90D"+
-		"\x90A\x3\x2\x2\x2\x90D\x90E\x3\x2\x2\x2\x90E\x918\x3\x2\x2\x2\x90F\x911"+
-		"\x5\x174\xBB\x2\x910\x90F\x3\x2\x2\x2\x910\x911\x3\x2\x2\x2\x911\x912"+
-		"\x3\x2\x2\x2\x912\x913\a\xD4\x2\x2\x913\x914\x5\x134\x9B\x2\x914\x915"+
-		"\a\xDB\x2\x2\x915\x917\x3\x2\x2\x2\x916\x910\x3\x2\x2\x2\x917\x91A\x3"+
-		"\x2\x2\x2\x918\x916\x3\x2\x2\x2\x918\x919\x3\x2\x2\x2\x919\x123\x3\x2"+
-		"\x2\x2\x91A\x918\x3\x2\x2\x2\x91B\x91D\t\xF\x2\x2\x91C\x91E\x5\x174\xBB"+
-		"\x2\x91D\x91C\x3\x2\x2\x2\x91D\x91E\x3\x2\x2\x2\x91E\x921\x3\x2\x2\x2"+
-		"\x91F\x922\x5\x11E\x90\x2\x920\x922\x5\x120\x91\x2\x921\x91F\x3\x2\x2"+
-		"\x2\x921\x920\x3\x2\x2\x2\x922\x125\x3\x2\x2\x2\x923\x925\x5\x174\xBB"+
-		"\x2\x924\x923\x3\x2\x2\x2\x924\x925\x3\x2\x2\x2\x925\x926\x3\x2\x2\x2"+
-		"\x926\x927\x5\x12C\x97\x2\x927\x127\x3\x2\x2\x2\x928\x92A\x5\x12A\x96"+
-		"\x2\x929\x928\x3\x2\x2\x2\x929\x92A\x3\x2\x2\x2\x92A\x92C\x3\x2\x2\x2"+
-		"\x92B\x92D\x5\x174\xBB\x2\x92C\x92B\x3\x2\x2\x2\x92C\x92D\x3\x2\x2\x2"+
-		"\x92D\x92E\x3\x2\x2\x2\x92E\x930\t\x6\x2\x2\x92F\x931\x5\x174\xBB\x2\x930"+
-		"\x92F\x3\x2\x2\x2\x930\x931\x3\x2\x2\x2\x931\x933\x3\x2\x2\x2\x932\x929"+
-		"\x3\x2\x2\x2\x933\x936\x3\x2\x2\x2\x934\x932\x3\x2\x2\x2\x934\x935\x3"+
-		"\x2\x2\x2\x935\x937\x3\x2\x2\x2\x936\x934\x3\x2\x2\x2\x937\x944\x5\x12A"+
-		"\x96\x2\x938\x93A\x5\x174\xBB\x2\x939\x938\x3\x2\x2\x2\x939\x93A\x3\x2"+
-		"\x2\x2\x93A\x93B\x3\x2\x2\x2\x93B\x93D\t\x6\x2\x2\x93C\x93E\x5\x174\xBB"+
-		"\x2\x93D\x93C\x3\x2\x2\x2\x93D\x93E\x3\x2\x2\x2\x93E\x940\x3\x2\x2\x2"+
-		"\x93F\x941\x5\x12A\x96\x2\x940\x93F\x3\x2\x2\x2\x940\x941\x3\x2\x2\x2"+
-		"\x941\x943\x3\x2\x2\x2\x942\x939\x3\x2\x2\x2\x943\x946\x3\x2\x2\x2\x944"+
-		"\x942\x3\x2\x2\x2\x944\x945\x3\x2\x2\x2\x945\x129\x3\x2\x2\x2\x946\x944"+
-		"\x3\x2\x2\x2\x947\x949\a\xD4\x2\x2\x948\x947\x3\x2\x2\x2\x948\x949\x3"+
-		"\x2\x2\x2\x949\x94C\x3\x2\x2\x2\x94A\x94B\t\x10\x2\x2\x94B\x94D\x5\x174"+
-		"\xBB\x2\x94C\x94A\x3\x2\x2\x2\x94C\x94D\x3\x2\x2\x2\x94D\x94F\x3\x2\x2"+
-		"\x2\x94E\x950\a\xDB\x2\x2\x94F\x94E\x3\x2\x2\x2\x94F\x950\x3\x2\x2\x2"+
-		"\x950\x951\x3\x2\x2\x2\x951\x952\x5\xFE\x80\x2\x952\x12B\x3\x2\x2\x2\x953"+
-		"\x955\a,\x2\x2\x954\x956\x5\x174\xBB\x2\x955\x954\x3\x2\x2\x2\x955\x956"+
-		"\x3\x2\x2\x2\x956\x957\x3\x2\x2\x2\x957\x959\x5\x138\x9D\x2\x958\x95A"+
-		"\x5\x154\xAB\x2\x959\x958\x3\x2\x2\x2\x959\x95A\x3\x2\x2\x2\x95A\x12D"+
-		"\x3\x2\x2\x2\x95B\x96D\a\xD4\x2\x2\x95C\x95E\x5\x174\xBB\x2\x95D\x95C"+
-		"\x3\x2\x2\x2\x95D\x95E\x3\x2\x2\x2\x95E\x95F\x3\x2\x2\x2\x95F\x96A\x5"+
-		"\x130\x99\x2\x960\x962\x5\x174\xBB\x2\x961\x960\x3\x2\x2\x2\x961\x962"+
-		"\x3\x2\x2\x2\x962\x963\x3\x2\x2\x2\x963\x965\a)\x2\x2\x964\x966\x5\x174"+
-		"\xBB\x2\x965\x964\x3\x2\x2\x2\x965\x966\x3\x2\x2\x2\x966\x967\x3\x2\x2"+
-		"\x2\x967\x969\x5\x130\x99\x2\x968\x961\x3\x2\x2\x2\x969\x96C\x3\x2\x2"+
-		"\x2\x96A\x968\x3\x2\x2\x2\x96A\x96B\x3\x2\x2\x2\x96B\x96E\x3\x2\x2\x2"+
-		"\x96C\x96A\x3\x2\x2\x2\x96D\x95D\x3\x2\x2\x2\x96D\x96E\x3\x2\x2\x2\x96E"+
-		"\x970\x3\x2\x2\x2\x96F\x971\x5\x174\xBB\x2\x970\x96F\x3\x2\x2\x2\x970"+
-		"\x971\x3\x2\x2\x2\x971\x972\x3\x2\x2\x2\x972\x973\a\xDB\x2\x2\x973\x12F"+
-		"\x3\x2\x2\x2\x974\x975\a\x95\x2\x2\x975\x977\x5\x174\xBB\x2\x976\x974"+
-		"\x3\x2\x2\x2\x976\x977\x3\x2\x2\x2\x977\x97A\x3\x2\x2\x2\x978\x979\t\x11"+
-		"\x2\x2\x979\x97B\x5\x174\xBB\x2\x97A\x978\x3\x2\x2\x2\x97A\x97B\x3\x2"+
-		"\x2\x2\x97B\x97E\x3\x2\x2\x2\x97C\x97D\a\x9C\x2\x2\x97D\x97F\x5\x174\xBB"+
-		"\x2\x97E\x97C\x3\x2\x2\x2\x97E\x97F\x3\x2\x2\x2\x97F\x980\x3\x2\x2\x2"+
-		"\x980\x982\x5\x138\x9D\x2\x981\x983\x5\x154\xAB\x2\x982\x981\x3\x2\x2"+
-		"\x2\x982\x983\x3\x2\x2\x2\x983\x98C\x3\x2\x2\x2\x984\x986\x5\x174\xBB"+
-		"\x2\x985\x984\x3\x2\x2\x2\x985\x986\x3\x2\x2\x2\x986\x987\x3\x2\x2\x2"+
-		"\x987\x989\a\xD4\x2\x2\x988\x98A\x5\x174\xBB\x2\x989\x988\x3\x2\x2\x2"+
-		"\x989\x98A\x3\x2\x2\x2\x98A\x98B\x3\x2\x2\x2\x98B\x98D\a\xDB\x2\x2\x98C"+
-		"\x985\x3\x2\x2\x2\x98C\x98D\x3\x2\x2\x2\x98D\x992\x3\x2\x2\x2\x98E\x990"+
-		"\x5\x174\xBB\x2\x98F\x98E\x3\x2\x2\x2\x98F\x990\x3\x2\x2\x2\x990\x991"+
-		"\x3\x2\x2\x2\x991\x993\x5\x13C\x9F\x2\x992\x98F\x3\x2\x2\x2\x992\x993"+
-		"\x3\x2\x2\x2\x993\x998\x3\x2\x2\x2\x994\x996\x5\x174\xBB\x2\x995\x994"+
-		"\x3\x2\x2\x2\x995\x996\x3\x2\x2\x2\x996\x997\x3\x2\x2\x2\x997\x999\x5"+
-		"\x132\x9A\x2\x998\x995\x3\x2\x2\x2\x998\x999\x3\x2\x2\x2\x999\x131\x3"+
-		"\x2\x2\x2\x99A\x99C\a\xD0\x2\x2\x99B\x99D\x5\x174\xBB\x2\x99C\x99B\x3"+
-		"\x2\x2\x2\x99C\x99D\x3\x2\x2\x2\x99D\x99E\x3\x2\x2\x2\x99E\x99F\x5\xFE"+
-		"\x80\x2\x99F\x133\x3\x2\x2\x2\x9A0\x9AB\x5\x136\x9C\x2\x9A1\x9A3\x5\x174"+
-		"\xBB\x2\x9A2\x9A1\x3\x2\x2\x2\x9A2\x9A3\x3\x2\x2\x2\x9A3\x9A4\x3\x2\x2"+
-		"\x2\x9A4\x9A6\a)\x2\x2\x9A5\x9A7\x5\x174\xBB\x2\x9A6\x9A5\x3\x2\x2\x2"+
-		"\x9A6\x9A7\x3\x2\x2\x2\x9A7\x9A8\x3\x2\x2\x2\x9A8\x9AA\x5\x136\x9C\x2"+
-		"\x9A9\x9A2\x3\x2\x2\x2\x9AA\x9AD\x3\x2\x2\x2\x9AB\x9A9\x3\x2\x2\x2\x9AB"+
-		"\x9AC\x3\x2\x2\x2\x9AC\x135\x3\x2\x2\x2\x9AD\x9AB\x3\x2\x2\x2\x9AE\x9AF"+
-		"\x5\xFE\x80\x2\x9AF\x9B0\x5\x174\xBB\x2\x9B0\x9B1\a\xBE\x2\x2\x9B1\x9B2"+
-		"\x5\x174\xBB\x2\x9B2\x9B4\x3\x2\x2\x2\x9B3\x9AE\x3\x2\x2\x2\x9B3\x9B4"+
-		"\x3\x2\x2\x2\x9B4\x9B5\x3\x2\x2\x2\x9B5\x9B6\x5\xFE\x80\x2\x9B6\x137\x3"+
-		"\x2\x2\x2\x9B7\x9BB\x5\x13A\x9E\x2\x9B8\x9BB\x5\x15C\xAF\x2\x9B9\x9BB"+
-		"\x5\x15A\xAE\x2\x9BA\x9B7\x3\x2\x2\x2\x9BA\x9B8\x3\x2\x2\x2\x9BA\x9B9"+
-		"\x3\x2\x2\x2\x9BB\x139\x3\x2\x2\x2\x9BC\x9BF\a\xEE\x2\x2\x9BD\x9BF\x5"+
-		"\x158\xAD\x2\x9BE\x9BC\x3\x2\x2\x2\x9BE\x9BD\x3\x2\x2\x2\x9BF\x13B\x3"+
-		"\x2\x2\x2\x9C0\x9C2\a\x39\x2\x2\x9C1\x9C3\x5\x174\xBB\x2\x9C2\x9C1\x3"+
-		"\x2\x2\x2\x9C2\x9C3\x3\x2\x2\x2\x9C3\x9C6\x3\x2\x2\x2\x9C4\x9C5\a\x8D"+
-		"\x2\x2\x9C5\x9C7\x5\x174\xBB\x2\x9C6\x9C4\x3\x2\x2\x2\x9C6\x9C7\x3\x2"+
-		"\x2\x2\x9C7\x9C8\x3\x2\x2\x2\x9C8\x9CD\x5\x152\xAA\x2\x9C9\x9CB\x5\x174"+
-		"\xBB\x2\x9CA\x9C9\x3\x2\x2\x2\x9CA\x9CB\x3\x2\x2\x2\x9CB\x9CC\x3\x2\x2"+
-		"\x2\x9CC\x9CE\x5\x144\xA3\x2\x9CD\x9CA\x3\x2\x2\x2\x9CD\x9CE\x3\x2\x2"+
-		"\x2\x9CE\x13D\x3\x2\x2\x2\x9CF\x9D0\t\x12\x2\x2\x9D0\x13F\x3\x2\x2\x2"+
-		"\x9D1\x9D2\t\xE\x2\x2\x9D2\x141\x3\x2\x2\x2\x9D3\x9D8\x5\x13A\x9E\x2\x9D4"+
-		"\x9D5\t\xF\x2\x2\x9D5\x9D7\x5\x13A\x9E\x2\x9D6\x9D4\x3\x2\x2\x2\x9D7\x9DA"+
-		"\x3\x2\x2\x2\x9D8\x9D6\x3\x2\x2\x2\x9D8\x9D9\x3\x2\x2\x2\x9D9\x143\x3"+
-		"\x2\x2\x2\x9DA\x9D8\x3\x2\x2\x2\x9DB\x9DD\a\xD7\x2\x2\x9DC\x9DE\x5\x174"+
-		"\xBB\x2\x9DD\x9DC\x3\x2\x2\x2\x9DD\x9DE\x3\x2\x2\x2\x9DE\x9E1\x3\x2\x2"+
-		"\x2\x9DF\x9E2\x5\x150\xA9\x2\x9E0\x9E2\x5\x13A\x9E\x2\x9E1\x9DF\x3\x2"+
-		"\x2\x2\x9E1\x9E0\x3\x2\x2\x2\x9E2\x145\x3\x2\x2\x2\x9E3\x9E5\x5\x148\xA5"+
-		"\x2\x9E4\x9E6\x5\x174\xBB\x2\x9E5\x9E4\x3\x2\x2\x2\x9E5\x9E6\x3\x2\x2"+
-		"\x2\x9E6\x9E7\x3\x2\x2\x2\x9E7\x9E8\a*\x2\x2\x9E8\x147\x3\x2\x2\x2\x9E9"+
-		"\x9EC\x5\x14A\xA6\x2\x9EA\x9EC\x5\x14C\xA7\x2\x9EB\x9E9\x3\x2\x2\x2\x9EB"+
-		"\x9EA\x3\x2\x2\x2\x9EC\x149\x3\x2\x2\x2\x9ED\x9EE\x5\x138\x9D\x2\x9EE"+
-		"\x14B\x3\x2\x2\x2\x9EF\x9F0\x5\x150\xA9\x2\x9F0\x14D\x3\x2\x2\x2\x9F1"+
-		"\x9FA\x5\x150\xA9\x2\x9F2\x9FA\a\xE8\x2\x2\x9F3\x9FA\a\xE3\x2\x2\x9F4"+
-		"\x9FA\a\xBF\x2\x2\x9F5\x9FA\ao\x2\x2\x9F6\x9FA\a\x8F\x2\x2\x9F7\x9FA\a"+
-		"\x90\x2\x2\x9F8\x9FA\a[\x2\x2\x9F9\x9F1\x3\x2\x2\x2\x9F9\x9F2\x3\x2\x2"+
-		"\x2\x9F9\x9F3\x3\x2\x2\x2\x9F9\x9F4\x3\x2\x2\x2\x9F9\x9F5\x3\x2\x2\x2"+
-		"\x9F9\x9F6\x3\x2\x2\x2\x9F9\x9F7\x3\x2\x2\x2\x9F9\x9F8\x3\x2\x2\x2\x9FA"+
-		"\x14F\x3\x2\x2\x2\x9FB\x9FC\t\x13\x2\x2\x9FC\x151\x3\x2\x2\x2\x9FD\xA00"+
-		"\x5\x13E\xA0\x2\x9FE\xA00\x5\x142\xA2\x2\x9FF\x9FD\x3\x2\x2\x2\x9FF\x9FE"+
-		"\x3\x2\x2\x2\xA00\xA09\x3\x2\x2\x2\xA01\xA03\x5\x174\xBB\x2\xA02\xA01"+
-		"\x3\x2\x2\x2\xA02\xA03\x3\x2\x2\x2\xA03\xA04\x3\x2\x2\x2\xA04\xA06\a\xD4"+
-		"\x2\x2\xA05\xA07\x5\x174\xBB\x2\xA06\xA05\x3\x2\x2\x2\xA06\xA07\x3\x2"+
-		"\x2\x2\xA07\xA08\x3\x2\x2\x2\xA08\xA0A\a\xDB\x2\x2\xA09\xA02\x3\x2\x2"+
-		"\x2\xA09\xA0A\x3\x2\x2\x2\xA0A\x153\x3\x2\x2\x2\xA0B\xA0C\t\x14\x2\x2"+
-		"\xA0C\x155\x3\x2\x2\x2\xA0D\xA0E\t\x15\x2\x2\xA0E\x157\x3\x2\x2\x2\xA0F"+
-		"\xA10\t\x16\x2\x2\xA10\x159\x3\x2\x2\x2\xA11\xA12\a\x39\x2\x2\xA12\x15B"+
-		"\x3\x2\x2\x2\xA13\xA14\t\x17\x2\x2\xA14\x15D\x3\x2\x2\x2\xA15\xA17\x5"+
-		"\x174\xBB\x2\xA16\xA15\x3\x2\x2\x2\xA16\xA17\x3\x2\x2\x2\xA17\xA19\x3"+
-		"\x2\x2\x2\xA18\xA1A\x5\x162\xB2\x2\xA19\xA18\x3\x2\x2\x2\xA19\xA1A\x3"+
-		"\x2\x2\x2\xA1A\x15F\x3\x2\x2\x2\xA1B\xA1C\x5\x15E\xB0\x2\xA1C\xA1E\a\xE9"+
-		"\x2\x2\xA1D\xA1F\x5\x174\xBB\x2\xA1E\xA1D\x3\x2\x2\x2\xA1E\xA1F\x3\x2"+
-		"\x2\x2\xA1F\xA28\x3\x2\x2\x2\xA20\xA22\x5\x174\xBB\x2\xA21\xA20\x3\x2"+
-		"\x2\x2\xA21\xA22\x3\x2\x2\x2\xA22\xA23\x3\x2\x2\x2\xA23\xA25\a*\x2\x2"+
-		"\xA24\xA26\x5\x174\xBB\x2\xA25\xA24\x3\x2\x2\x2\xA25\xA26\x3\x2\x2\x2"+
-		"\xA26\xA28\x3\x2\x2\x2\xA27\xA1B\x3\x2\x2\x2\xA27\xA21\x3\x2\x2\x2\xA28"+
-		"\xA2A\x3\x2\x2\x2\xA29\xA27\x3\x2\x2\x2\xA2A\xA2D\x3\x2\x2\x2\xA2B\xA29"+
-		"\x3\x2\x2\x2\xA2B\xA2C\x3\x2\x2\x2\xA2C\xA32\x3\x2\x2\x2\xA2D\xA2B\x3"+
-		"\x2\x2\x2\xA2E\xA2F\x5\x15E\xB0\x2\xA2F\xA30\a\x2\x2\x3\xA30\xA32\x3\x2"+
-		"\x2\x2\xA31\xA2B\x3\x2\x2\x2\xA31\xA2E\x3\x2\x2\x2\xA32\x161\x3\x2\x2"+
-		"\x2\xA33\xA37\x5\x16A\xB6\x2\xA34\xA37\x5\x166\xB4\x2\xA35\xA37\x5\x164"+
-		"\xB3\x2\xA36\xA33\x3\x2\x2\x2\xA36\xA34\x3\x2\x2\x2\xA36\xA35\x3\x2\x2"+
-		"\x2\xA37\x163\x3\x2\x2\x2\xA38\xA3A\a\xAB\x2\x2\xA39\xA3B\x5\x174\xBB"+
-		"\x2\xA3A\xA39\x3\x2\x2\x2\xA3A\xA3B\x3\x2\x2\x2\xA3B\xA3C\x3\x2\x2\x2"+
-		"\xA3C\xA3D\x5\x168\xB5\x2\xA3D\x165\x3\x2\x2\x2\xA3E\xA3F\a\xEA\x2\x2"+
-		"\xA3F\xA40\x5\x168\xB5\x2\xA40\x167\x3\x2\x2\x2\xA41\xA44\a\xEF\x2\x2"+
-		"\xA42\xA44\n\x18\x2\x2\xA43\xA41\x3\x2\x2\x2\xA43\xA42\x3\x2\x2\x2\xA44"+
-		"\xA47\x3\x2\x2\x2\xA45\xA43\x3\x2\x2\x2\xA45\xA46\x3\x2\x2\x2\xA46\x169"+
-		"\x3\x2\x2\x2\xA47\xA45\x3\x2\x2\x2\xA48\xA4E\a\xEA\x2\x2\xA49\xA4A\a/"+
-		"\x2\x2\xA4A\xA4C\x5\x16C\xB7\x2\xA4B\xA4D\x5\x174\xBB\x2\xA4C\xA4B\x3"+
-		"\x2\x2\x2\xA4C\xA4D\x3\x2\x2\x2\xA4D\xA4F\x3\x2\x2\x2\xA4E\xA49\x3\x2"+
-		"\x2\x2\xA4F\xA50\x3\x2\x2\x2\xA50\xA4E\x3\x2\x2\x2\xA50\xA51\x3\x2\x2"+
-		"\x2\xA51\x16B\x3\x2\x2\x2\xA52\xA54\x5\x16E\xB8\x2\xA53\xA55\x5\x170\xB9"+
-		"\x2\xA54\xA53\x3\x2\x2\x2\xA54\xA55\x3\x2\x2\x2\xA55\x16D\x3\x2\x2\x2"+
-		"\xA56\xA57\x5\x138\x9D\x2\xA57\x16F\x3\x2\x2\x2\xA58\xA59\x5\x174\xBB"+
-		"\x2\xA59\xA5A\x5\x172\xBA\x2\xA5A\xA95\x3\x2\x2\x2\xA5B\xA5C\x5\x174\xBB"+
-		"\x2\xA5C\xA65\x5\x172\xBA\x2\xA5D\xA5F\x5\x174\xBB\x2\xA5E\xA5D\x3\x2"+
-		"\x2\x2\xA5E\xA5F\x3\x2\x2\x2\xA5F\xA60\x3\x2\x2\x2\xA60\xA62\a)\x2\x2"+
-		"\xA61\xA63\x5\x174\xBB\x2\xA62\xA61\x3\x2\x2\x2\xA62\xA63\x3\x2\x2\x2"+
-		"\xA63\xA64\x3\x2\x2\x2\xA64\xA66\x5\x172\xBA\x2\xA65\xA5E\x3\x2\x2\x2"+
-		"\xA66\xA67\x3\x2\x2\x2\xA67\xA65\x3\x2\x2\x2\xA67\xA68\x3\x2\x2\x2\xA68"+
-		"\xA95\x3\x2\x2\x2\xA69\xA6B\x5\x174\xBB\x2\xA6A\xA69\x3\x2\x2\x2\xA6A"+
-		"\xA6B\x3\x2\x2\x2\xA6B\xA6C\x3\x2\x2\x2\xA6C\xA6E\a\xD4\x2\x2\xA6D\xA6F"+
-		"\x5\x174\xBB\x2\xA6E\xA6D\x3\x2\x2\x2\xA6E\xA6F\x3\x2\x2\x2\xA6F\xA70"+
-		"\x3\x2\x2\x2\xA70\xA95\a\xDB\x2\x2\xA71\xA73\x5\x174\xBB\x2\xA72\xA71"+
-		"\x3\x2\x2\x2\xA72\xA73\x3\x2\x2\x2\xA73\xA74\x3\x2\x2\x2\xA74\xA76\a\xD4"+
-		"\x2\x2\xA75\xA77\x5\x174\xBB\x2\xA76\xA75\x3\x2\x2\x2\xA76\xA77\x3\x2"+
-		"\x2\x2\xA77\xA78\x3\x2\x2\x2\xA78\xA7A\x5\x172\xBA\x2\xA79\xA7B\x5\x174"+
-		"\xBB\x2\xA7A\xA79\x3\x2\x2\x2\xA7A\xA7B\x3\x2\x2\x2\xA7B\xA7C\x3\x2\x2"+
-		"\x2\xA7C\xA7D\a\xDB\x2\x2\xA7D\xA95\x3\x2\x2\x2\xA7E\xA80\x5\x174\xBB"+
-		"\x2\xA7F\xA7E\x3\x2\x2\x2\xA7F\xA80\x3\x2\x2\x2\xA80\xA81\x3\x2\x2\x2"+
-		"\xA81\xA82\a\xD4\x2\x2\xA82\xA8B\x5\x172\xBA\x2\xA83\xA85\x5\x174\xBB"+
-		"\x2\xA84\xA83\x3\x2\x2\x2\xA84\xA85\x3\x2\x2\x2\xA85\xA86\x3\x2\x2\x2"+
-		"\xA86\xA88\a)\x2\x2\xA87\xA89\x5\x174\xBB\x2\xA88\xA87\x3\x2\x2\x2\xA88"+
-		"\xA89\x3\x2\x2\x2\xA89\xA8A\x3\x2\x2\x2\xA8A\xA8C\x5\x172\xBA\x2\xA8B"+
-		"\xA84\x3\x2\x2\x2\xA8C\xA8D\x3\x2\x2\x2\xA8D\xA8B\x3\x2\x2\x2\xA8D\xA8E"+
-		"\x3\x2\x2\x2\xA8E\xA90\x3\x2\x2\x2\xA8F\xA91\x5\x174\xBB\x2\xA90\xA8F"+
-		"\x3\x2\x2\x2\xA90\xA91\x3\x2\x2\x2\xA91\xA92\x3\x2\x2\x2\xA92\xA93\a\xDB"+
-		"\x2\x2\xA93\xA95\x3\x2\x2\x2\xA94\xA58\x3\x2\x2\x2\xA94\xA5B\x3\x2\x2"+
-		"\x2\xA94\xA6A\x3\x2\x2\x2\xA94\xA72\x3\x2\x2\x2\xA94\xA7F\x3\x2\x2\x2"+
-		"\xA95\x171\x3\x2\x2\x2\xA96\xA97\x5\xFE\x80\x2\xA97\x173\x3\x2\x2\x2\xA98"+
-		"\xA9A\t\x19\x2\x2\xA99\xA98\x3\x2\x2\x2\xA9A\xA9B\x3\x2\x2\x2\xA9B\xA99"+
-		"\x3\x2\x2\x2\xA9B\xA9C\x3\x2\x2\x2\xA9C\x175\x3\x2\x2\x2\x1BE\x179\x17F"+
-		"\x182\x186\x18A\x18E\x196\x199\x1A3\x1A5\x1AB\x1B3\x1BA\x1C0\x1C9\x1D1"+
-		"\x1E0\x1EB\x1F3\x1FD\x203\x207\x20B\x20F\x214\x221\x249\x258\x260\x265"+
-		"\x26A\x273\x287\x28B\x293\x29E\x2A4\x2A8\x2AD\x2B4\x2B8\x2C2\x2C6\x2C9"+
-		"\x2CF\x2D5\x2DF\x2E3\x2E6\x2EC\x2F0\x2FA\x2FE\x308\x30C\x30F\x313\x318"+
-		"\x31F\x323\x328\x330\x334\x338\x340\x343\x347\x34B\x355\x359\x35C\x362"+
-		"\x366\x36C\x370\x375\x37E\x382\x385\x388\x38C\x398\x39C\x39F\x3A2\x3A6"+
-		"\x3AF\x3B5\x3B9\x3BE\x3C3\x3C8\x3CB\x3CF\x3D6\x3DC\x3E2\x3ED\x3F0\x3F3"+
-		"\x3F8\x3FE\x402\x407\x40F\x415\x419\x425\x429\x434\x43F\x446\x44E\x453"+
-		"\x45C\x463\x467\x46A\x474\x478\x47D\x487\x48D\x49E\x4A4\x4AA\x4AE\x4BA"+
-		"\x4BE\x4C4\x4C9\x4CD\x4D1\x4D5\x4D8\x4DB\x4DE\x4E1\x4E5\x4FA\x4FF\x503"+
-		"\x50E\x516\x519\x51B\x520\x524\x528\x52C\x530\x536\x53A\x53E\x543\x549"+
-		"\x54C\x550\x554\x557\x55B\x560\x562\x566\x56A\x56D\x571\x574\x580\x584"+
-		"\x588\x590\x594\x59A\x59E\x5A2\x5B0\x5BA\x5BE\x5C3\x5CE\x5D2\x5D7\x5DD"+
-		"\x5E1\x5E7\x5EA\x5ED\x5F2\x5F6\x5FD\x601\x607\x60A\x60E\x615\x619\x61F"+
-		"\x622\x626\x62E\x632\x636\x638\x63B\x641\x645\x649\x64E\x653\x657\x65B"+
-		"\x661\x667\x669\x671\x675\x684\x68B\x68F\x69A\x6A1\x6A6\x6AA\x6AF\x6B2"+
-		"\x6B8\x6BC\x6C3\x6C7\x6CB\x6CF\x6D2\x6D6\x6DF\x6E8\x6EF\x6F3\x6F6\x6F9"+
-		"\x6FC\x701\x708\x70D\x712\x716\x71C\x721\x728\x72C\x733\x737\x73B\x740"+
-		"\x744\x749\x74D\x752\x756\x75B\x75F\x764\x768\x76D\x771\x776\x77A\x77F"+
-		"\x783\x788\x78C\x791\x795\x79A\x79E\x7A1\x7A3\x7AE\x7B3\x7B8\x7BE\x7C2"+
-		"\x7C7\x7CC\x7CF\x7D3\x7D7\x7D9\x7DD\x7DF\x7E4\x7EB\x7F4\x7FF\x804\x807"+
-		"\x80B\x80F\x813\x816\x81E\x823\x826\x82A\x82E\x832\x835\x83D\x840\x844"+
-		"\x847\x84A\x84E\x852\x857\x85A\x85D\x860\x868\x86F\x872\x87A\x881\x885"+
-		"\x888\x88B\x88E\x896\x89B\x89E\x8A1\x8A5\x8A9\x8AB\x8AF\x8B2\x8B5\x8BD"+
-		"\x8C2\x8C5\x8C8\x8CB\x8D3\x8D8\x8DB\x8DE\x8E2\x8E6\x8E8\x8EC\x8EF\x8F2"+
-		"\x8FA\x8FF\x903\x907\x90A\x90D\x910\x918\x91D\x921\x924\x929\x92C\x930"+
-		"\x934\x939\x93D\x940\x944\x948\x94C\x94F\x955\x959\x95D\x961\x965\x96A"+
-		"\x96D\x970\x976\x97A\x97E\x982\x985\x989\x98C\x98F\x992\x995\x998\x99C"+
-		"\x9A2\x9A6\x9AB\x9B3\x9BA\x9BE\x9C2\x9C6\x9CA\x9CD\x9D8\x9DD\x9E1\x9E5"+
-		"\x9EB\x9F9\x9FF\xA02\xA06\xA09\xA16\xA19\xA1E\xA21\xA25\xA27\xA2B\xA31"+
-		"\xA36\xA3A\xA43\xA45\xA4C\xA50\xA54\xA5E\xA62\xA67\xA6A\xA6E\xA72\xA76"+
-		"\xA7A\xA7F\xA84\xA88\xA8D\xA90\xA94\xA9B";
+		"\xC9\x3\x2\xE9\xE9\x4\x2\xEC\xEC\xEF\xEF\xC5D\x2\x17C\x3\x2\x2\x2\x4\x17F"+
+		"\x3\x2\x2\x2\x6\x198\x3\x2\x2\x2\b\x1A3\x3\x2\x2\x2\n\x1B5\x3\x2\x2\x2"+
+		"\f\x1CD\x3\x2\x2\x2\xE\x1D1\x3\x2\x2\x2\x10\x1E6\x3\x2\x2\x2\x12\x1F1"+
+		"\x3\x2\x2\x2\x14\x1F3\x3\x2\x2\x2\x16\x203\x3\x2\x2\x2\x18\x205\x3\x2"+
+		"\x2\x2\x1A\x21D\x3\x2\x2\x2\x1C\x21F\x3\x2\x2\x2\x1E\x221\x3\x2\x2\x2"+
+		" \x251\x3\x2\x2\x2\"\x260\x3\x2\x2\x2$\x262\x3\x2\x2\x2&\x27D\x3\x2\x2"+
+		"\x2(\x27F\x3\x2\x2\x2*\x283\x3\x2\x2\x2,\x285\x3\x2\x2\x2.\x289\x3\x2"+
+		"\x2\x2\x30\x28B\x3\x2\x2\x2\x32\x28D\x3\x2\x2\x2\x34\x297\x3\x2\x2\x2"+
+		"\x36\x29B\x3\x2\x2\x2\x38\x29D\x3\x2\x2\x2:\x2A0\x3\x2\x2\x2<\x2A2\x3"+
+		"\x2\x2\x2>\x2A8\x3\x2\x2\x2@\x2AA\x3\x2\x2\x2\x42\x2B8\x3\x2\x2\x2\x44"+
+		"\x2C4\x3\x2\x2\x2\x46\x2C6\x3\x2\x2\x2H\x2DD\x3\x2\x2\x2J\x2DF\x3\x2\x2"+
+		"\x2L\x2E1\x3\x2\x2\x2N\x2E3\x3\x2\x2\x2P\x2F0\x3\x2\x2\x2R\x2FC\x3\x2"+
+		"\x2\x2T\x2FE\x3\x2\x2\x2V\x30A\x3\x2\x2\x2X\x30C\x3\x2\x2\x2Z\x319\x3"+
+		"\x2\x2\x2\\\x32B\x3\x2\x2\x2^\x330\x3\x2\x2\x2`\x332\x3\x2\x2\x2\x62\x334"+
+		"\x3\x2\x2\x2\x64\x336\x3\x2\x2\x2\x66\x344\x3\x2\x2\x2h\x346\x3\x2\x2"+
+		"\x2j\x34D\x3\x2\x2\x2l\x357\x3\x2\x2\x2n\x359\x3\x2\x2\x2p\x366\x3\x2"+
+		"\x2\x2r\x372\x3\x2\x2\x2t\x380\x3\x2\x2\x2v\x382\x3\x2\x2\x2x\x398\x3"+
+		"\x2\x2\x2z\x39A\x3\x2\x2\x2|\x39C\x3\x2\x2\x2~\x3B2\x3\x2\x2\x2\x80\x3B7"+
+		"\x3\x2\x2\x2\x82\x3C9\x3\x2\x2\x2\x84\x3DE\x3\x2\x2\x2\x86\x402\x3\x2"+
+		"\x2\x2\x88\x412\x3\x2\x2\x2\x8A\x417\x3\x2\x2\x2\x8C\x419\x3\x2\x2\x2"+
+		"\x8E\x41B\x3\x2\x2\x2\x90\x425\x3\x2\x2\x2\x92\x428\x3\x2\x2\x2\x94\x42B"+
+		"\x3\x2\x2\x2\x96\x435\x3\x2\x2\x2\x98\x437\x3\x2\x2\x2\x9A\x456\x3\x2"+
+		"\x2\x2\x9C\x45B\x3\x2\x2\x2\x9E\x469\x3\x2\x2\x2\xA0\x476\x3\x2\x2\x2"+
+		"\xA2\x478\x3\x2\x2\x2\xA4\x488\x3\x2\x2\x2\xA6\x48F\x3\x2\x2\x2\xA8\x499"+
+		"\x3\x2\x2\x2\xAA\x49B\x3\x2\x2\x2\xAC\x4AE\x3\x2\x2\x2\xAE\x4D1\x3\x2"+
+		"\x2\x2\xB0\x4F1\x3\x2\x2\x2\xB2\x4F3\x3\x2\x2\x2\xB4\x4F7\x3\x2\x2\x2"+
+		"\xB6\x4FB\x3\x2\x2\x2\xB8\x523\x3\x2\x2\x2\xBA\x525\x3\x2\x2\x2\xBC\x52C"+
+		"\x3\x2\x2\x2\xBE\x52E\x3\x2\x2\x2\xC0\x540\x3\x2\x2\x2\xC2\x54F\x3\x2"+
+		"\x2\x2\xC4\x57C\x3\x2\x2\x2\xC6\x57E\x3\x2\x2\x2\xC8\x580\x3\x2\x2\x2"+
+		"\xCA\x582\x3\x2\x2\x2\xCC\x588\x3\x2\x2\x2\xCE\x594\x3\x2\x2\x2\xD0\x5A0"+
+		"\x3\x2\x2\x2\xD2\x5AE\x3\x2\x2\x2\xD4\x5BA\x3\x2\x2\x2\xD6\x5CE\x3\x2"+
+		"\x2\x2\xD8\x5E5\x3\x2\x2\x2\xDA\x605\x3\x2\x2\x2\xDC\x61D\x3\x2\x2\x2"+
+		"\xDE\x632\x3\x2\x2\x2\xE0\x645\x3\x2\x2\x2\xE2\x659\x3\x2\x2\x2\xE4\x66B"+
+		"\x3\x2\x2\x2\xE6\x673\x3\x2\x2\x2\xE8\x675\x3\x2\x2\x2\xEA\x681\x3\x2"+
+		"\x2\x2\xEC\x683\x3\x2\x2\x2\xEE\x6A2\x3\x2\x2\x2\xF0\x6A4\x3\x2\x2\x2"+
+		"\xF2\x6BA\x3\x2\x2\x2\xF4\x6BC\x3\x2\x2\x2\xF6\x6CB\x3\x2\x2\x2\xF8\x6E2"+
+		"\x3\x2\x2\x2\xFA\x6E7\x3\x2\x2\x2\xFC\x6F5\x3\x2\x2\x2\xFE\x73B\x3\x2"+
+		"\x2\x2\x100\x7AE\x3\x2\x2\x2\x102\x7BB\x3\x2\x2\x2\x104\x7C4\x3\x2\x2"+
+		"\x2\x106\x7D2\x3\x2\x2\x2\x108\x7EE\x3\x2\x2\x2\x10A\x7F7\x3\x2\x2\x2"+
+		"\x10C\x808\x3\x2\x2\x2\x10E\x827\x3\x2\x2\x2\x110\x835\x3\x2\x2\x2\x112"+
+		"\x847\x3\x2\x2\x2\x114\x849\x3\x2\x2\x2\x116\x88F\x3\x2\x2\x2\x118\x893"+
+		"\x3\x2\x2\x2\x11A\x896\x3\x2\x2\x2\x11C\x8BA\x3\x2\x2\x2\x11E\x8D0\x3"+
+		"\x2\x2\x2\x120\x8D2\x3\x2\x2\x2\x122\x8EA\x3\x2\x2\x2\x124\x90F\x3\x2"+
+		"\x2\x2\x126\x927\x3\x2\x2\x2\x128\x94E\x3\x2\x2\x2\x12A\x96A\x3\x2\x2"+
+		"\x2\x12C\x973\x3\x2\x2\x2\x12E\x983\x3\x2\x2\x2\x130\x997\x3\x2\x2\x2"+
+		"\x132\x9A2\x3\x2\x2\x2\x134\x9AA\x3\x2\x2\x2\x136\x9C5\x3\x2\x2\x2\x138"+
+		"\x9E9\x3\x2\x2\x2\x13A\x9EF\x3\x2\x2\x2\x13C\xA02\x3\x2\x2\x2\x13E\xA09"+
+		"\x3\x2\x2\x2\x140\xA0D\x3\x2\x2\x2\x142\xA0F\x3\x2\x2\x2\x144\xA1E\x3"+
+		"\x2\x2\x2\x146\xA20\x3\x2\x2\x2\x148\xA22\x3\x2\x2\x2\x14A\xA2A\x3\x2"+
+		"\x2\x2\x14C\xA32\x3\x2\x2\x2\x14E\xA3A\x3\x2\x2\x2\x150\xA3C\x3\x2\x2"+
+		"\x2\x152\xA3E\x3\x2\x2\x2\x154\xA48\x3\x2\x2\x2\x156\xA4A\x3\x2\x2\x2"+
+		"\x158\xA4E\x3\x2\x2\x2\x15A\xA5A\x3\x2\x2\x2\x15C\xA5C\x3\x2\x2\x2\x15E"+
+		"\xA5E\x3\x2\x2\x2\x160\xA60\x3\x2\x2\x2\x162\xA62\x3\x2\x2\x2\x164\xA65"+
+		"\x3\x2\x2\x2\x166\xA80\x3\x2\x2\x2\x168\xA85\x3\x2\x2\x2\x16A\xA87\x3"+
+		"\x2\x2\x2\x16C\xA8D\x3\x2\x2\x2\x16E\xA94\x3\x2\x2\x2\x170\xA97\x3\x2"+
+		"\x2\x2\x172\xAA1\x3\x2\x2\x2\x174\xAA5\x3\x2\x2\x2\x176\xAE3\x3\x2\x2"+
+		"\x2\x178\xAE5\x3\x2\x2\x2\x17A\xAE8\x3\x2\x2\x2\x17C\x17D\x5\x4\x3\x2"+
+		"\x17D\x3\x3\x2\x2\x2\x17E\x180\x5\x17A\xBE\x2\x17F\x17E\x3\x2\x2\x2\x17F"+
+		"\x180\x3\x2\x2\x2\x180\x181\x3\x2\x2\x2\x181\x185\x5\x166\xB4\x2\x182"+
+		"\x183\x5\x6\x4\x2\x183\x184\x5\x166\xB4\x2\x184\x186\x3\x2\x2\x2\x185"+
+		"\x182\x3\x2\x2\x2\x185\x186\x3\x2\x2\x2\x186\x188\x3\x2\x2\x2\x187\x189"+
+		"\x5\b\x5\x2\x188\x187\x3\x2\x2\x2\x188\x189\x3\x2\x2\x2\x189\x18A\x3\x2"+
+		"\x2\x2\x18A\x18C\x5\x166\xB4\x2\x18B\x18D\x5\f\a\x2\x18C\x18B\x3\x2\x2"+
+		"\x2\x18C\x18D\x3\x2\x2\x2\x18D\x18E\x3\x2\x2\x2\x18E\x190\x5\x166\xB4"+
+		"\x2\x18F\x191\x5\xE\b\x2\x190\x18F\x3\x2\x2\x2\x190\x191\x3\x2\x2\x2\x191"+
+		"\x192\x3\x2\x2\x2\x192\x194\x5\x166\xB4\x2\x193\x195\x5\x14\v\x2\x194"+
+		"\x193\x3\x2\x2\x2\x194\x195\x3\x2\x2\x2\x195\x196\x3\x2\x2\x2\x196\x197"+
+		"\x5\x166\xB4\x2\x197\x5\x3\x2\x2\x2\x198\x199\a\xC5\x2\x2\x199\x19A\x5"+
+		"\x17A\xBE\x2\x19A\x19C\x5\x156\xAC\x2\x19B\x19D\x5\x17A\xBE\x2\x19C\x19B"+
+		"\x3\x2\x2\x2\x19C\x19D\x3\x2\x2\x2\x19D\x19F\x3\x2\x2\x2\x19E\x1A0\a\x42"+
+		"\x2\x2\x19F\x19E\x3\x2\x2\x2\x19F\x1A0\x3\x2\x2\x2\x1A0\x1A1\x3\x2\x2"+
+		"\x2\x1A1\x1A2\x5\x166\xB4\x2\x1A2\a\x3\x2\x2\x2\x1A3\x1AB\a:\x2\x2\x1A4"+
+		"\x1A5\x5\x17A\xBE\x2\x1A5\x1A6\a\xED\x2\x2\x1A6\x1A7\x5\x17A\xBE\x2\x1A7"+
+		"\x1A9\x5\x13E\xA0\x2\x1A8\x1AA\x5\x17A\xBE\x2\x1A9\x1A8\x3\x2\x2\x2\x1A9"+
+		"\x1AA\x3\x2\x2\x2\x1AA\x1AC\x3\x2\x2\x2\x1AB\x1A4\x3\x2\x2\x2\x1AB\x1AC"+
+		"\x3\x2\x2\x2\x1AC\x1AD\x3\x2\x2\x2\x1AD\x1AF\x5\x166\xB4\x2\x1AE\x1B0"+
+		"\x5\n\x6\x2\x1AF\x1AE\x3\x2\x2\x2\x1B0\x1B1\x3\x2\x2\x2\x1B1\x1AF\x3\x2"+
+		"\x2\x2\x1B1\x1B2\x3\x2\x2\x2\x1B2\x1B3\x3\x2\x2\x2\x1B3\x1B4\a\x64\x2"+
+		"\x2\x1B4\t\x3\x2\x2\x2\x1B5\x1B9\x5\x13E\xA0\x2\x1B6\x1B8\x5\x17A\xBE"+
+		"\x2\x1B7\x1B6\x3\x2\x2\x2\x1B8\x1BB\x3\x2\x2\x2\x1B9\x1B7\x3\x2\x2\x2"+
+		"\x1B9\x1BA\x3\x2\x2\x2\x1BA\x1BC\x3\x2\x2\x2\x1BB\x1B9\x3\x2\x2\x2\x1BC"+
+		"\x1C0\a\xD0\x2\x2\x1BD\x1BF\x5\x17A\xBE\x2\x1BE\x1BD\x3\x2\x2\x2\x1BF"+
+		"\x1C2\x3\x2\x2\x2\x1C0\x1BE\x3\x2\x2\x2\x1C0\x1C1\x3\x2\x2\x2\x1C1\x1C3"+
+		"\x3\x2\x2\x2\x1C2\x1C0\x3\x2\x2\x2\x1C3\x1C6\x5\xFE\x80\x2\x1C4\x1C5\a"+
+		"*\x2\x2\x1C5\x1C7\x5\x156\xAC\x2\x1C6\x1C4\x3\x2\x2\x2\x1C6\x1C7\x3\x2"+
+		"\x2\x2\x1C7\x1C8\x3\x2\x2\x2\x1C8\x1C9\x5\x166\xB4\x2\x1C9\v\x3\x2\x2"+
+		"\x2\x1CA\x1CB\x5\x18\r\x2\x1CB\x1CC\x5\x166\xB4\x2\x1CC\x1CE\x3\x2\x2"+
+		"\x2\x1CD\x1CA\x3\x2\x2\x2\x1CE\x1CF\x3\x2\x2\x2\x1CF\x1CD\x3\x2\x2\x2"+
+		"\x1CF\x1D0\x3\x2\x2\x2\x1D0\r\x3\x2\x2\x2\x1D1\x1D7\x5\x12\n\x2\x1D2\x1D3"+
+		"\x5\x166\xB4\x2\x1D3\x1D4\x5\x12\n\x2\x1D4\x1D6\x3\x2\x2\x2\x1D5\x1D2"+
+		"\x3\x2\x2\x2\x1D6\x1D9\x3\x2\x2\x2\x1D7\x1D5\x3\x2\x2\x2\x1D7\x1D8\x3"+
+		"\x2\x2\x2\x1D8\x1DA\x3\x2\x2\x2\x1D9\x1D7\x3\x2\x2\x2\x1DA\x1DB\x5\x166"+
+		"\xB4\x2\x1DB\xF\x3\x2\x2\x2\x1DC\x1DD\a\x96\x2\x2\x1DD\x1DE\x5\x17A\xBE"+
+		"\x2\x1DE\x1DF\x5\x156\xAC\x2\x1DF\x1E7\x3\x2\x2\x2\x1E0\x1E1\a\x98\x2"+
+		"\x2\x1E1\x1E2\x5\x17A\xBE\x2\x1E2\x1E3\t\x2\x2\x2\x1E3\x1E7\x3\x2\x2\x2"+
+		"\x1E4\x1E7\a\x97\x2\x2\x1E5\x1E7\a\x99\x2\x2\x1E6\x1DC\x3\x2\x2\x2\x1E6"+
+		"\x1E0\x3\x2\x2\x2\x1E6\x1E4\x3\x2\x2\x2\x1E6\x1E5\x3\x2\x2\x2\x1E7\x11"+
+		"\x3\x2\x2\x2\x1E8\x1F2\x5\x84\x43\x2\x1E9\x1F2\x5\x86\x44\x2\x1EA\x1F2"+
+		"\x5\x9CO\x2\x1EB\x1F2\x5\xA6T\x2\x1EC\x1F2\x5\x80\x41\x2\x1ED\x1F2\x5"+
+		"\xCA\x66\x2\x1EE\x1F2\x5\x102\x82\x2\x1EF\x1F2\x5\x10\t\x2\x1F0\x1F2\x5"+
+		"\xFA~\x2\x1F1\x1E8\x3\x2\x2\x2\x1F1\x1E9\x3\x2\x2\x2\x1F1\x1EA\x3\x2\x2"+
+		"\x2\x1F1\x1EB\x3\x2\x2\x2\x1F1\x1EC\x3\x2\x2\x2\x1F1\x1ED\x3\x2\x2\x2"+
+		"\x1F1\x1EE\x3\x2\x2\x2\x1F1\x1EF\x3\x2\x2\x2\x1F1\x1F0\x3\x2\x2\x2\x1F2"+
+		"\x13\x3\x2\x2\x2\x1F3\x1F9\x5\x16\f\x2\x1F4\x1F5\x5\x166\xB4\x2\x1F5\x1F6"+
+		"\x5\x16\f\x2\x1F6\x1F8\x3\x2\x2\x2\x1F7\x1F4\x3\x2\x2\x2\x1F8\x1FB\x3"+
+		"\x2\x2\x2\x1F9\x1F7\x3\x2\x2\x2\x1F9\x1FA\x3\x2\x2\x2\x1FA\x1FC\x3\x2"+
+		"\x2\x2\x1FB\x1F9\x3\x2\x2\x2\x1FC\x1FD\x5\x166\xB4\x2\x1FD\x15\x3\x2\x2"+
+		"\x2\x1FE\x204\x5\xAEX\x2\x1FF\x204\x5\xD8m\x2\x200\x204\x5\xDAn\x2\x201"+
+		"\x204\x5\xDCo\x2\x202\x204\x5\xF6|\x2\x203\x1FE\x3\x2\x2\x2\x203\x1FF"+
+		"\x3\x2\x2\x2\x203\x200\x3\x2\x2\x2\x203\x201\x3\x2\x2\x2\x203\x202\x3"+
+		"\x2\x2\x2\x204\x17\x3\x2\x2\x2\x205\x206\a\x37\x2\x2\x206\x207\x5\x17A"+
+		"\xBE\x2\x207\x209\x5\x1A\xE\x2\x208\x20A\x5\x17A\xBE\x2\x209\x208\x3\x2"+
+		"\x2\x2\x209\x20A\x3\x2\x2\x2\x20A\x20B\x3\x2\x2\x2\x20B\x20D\a\xD0\x2"+
+		"\x2\x20C\x20E\x5\x17A\xBE\x2\x20D\x20C\x3\x2\x2\x2\x20D\x20E\x3\x2\x2"+
+		"\x2\x20E\x20F\x3\x2\x2\x2\x20F\x21A\x5\x1C\xF\x2\x210\x212\x5\x17A\xBE"+
+		"\x2\x211\x210\x3\x2\x2\x2\x211\x212\x3\x2\x2\x2\x212\x213\x3\x2\x2\x2"+
+		"\x213\x215\a)\x2\x2\x214\x216\x5\x17A\xBE\x2\x215\x214\x3\x2\x2\x2\x215"+
+		"\x216\x3\x2\x2\x2\x216\x217\x3\x2\x2\x2\x217\x219\x5\x1C\xF\x2\x218\x211"+
+		"\x3\x2\x2\x2\x219\x21C\x3\x2\x2\x2\x21A\x218\x3\x2\x2\x2\x21A\x21B\x3"+
+		"\x2\x2\x2\x21B\x19\x3\x2\x2\x2\x21C\x21A\x3\x2\x2\x2\x21D\x21E\x5\x11E"+
+		"\x90\x2\x21E\x1B\x3\x2\x2\x2\x21F\x220\x5\xFE\x80\x2\x220\x1D\x3\x2\x2"+
+		"\x2\x221\x227\x5 \x11\x2\x222\x223\x5\x166\xB4\x2\x223\x224\x5 \x11\x2"+
+		"\x224\x226\x3\x2\x2\x2\x225\x222\x3\x2\x2\x2\x226\x229\x3\x2\x2\x2\x227"+
+		"\x225\x3\x2\x2\x2\x227\x228\x3\x2\x2\x2\x228\x22A\x3\x2\x2\x2\x229\x227"+
+		"\x3\x2\x2\x2\x22A\x22B\x5\x166\xB4\x2\x22B\x1F\x3\x2\x2\x2\x22C\x252\x5"+
+		"\x14C\xA7\x2\x22D\x252\x5\"\x12\x2\x22E\x252\x5\x18\r\x2\x22F\x252\x5"+
+		"\x80\x41\x2\x230\x252\x5\x9AN\x2\x231\x252\x5\xA0Q\x2\x232\x252\x5\xA2"+
+		"R\x2\x233\x252\x5\xA4S\x2\x234\x252\x5\xA8U\x2\x235\x252\x5\x114\x8B\x2"+
+		"\x236\x252\x5\xAAV\x2\x237\x252\x5\xACW\x2\x238\x252\x5\xB2Z\x2\x239\x252"+
+		"\x5\xB4[\x2\x23A\x252\x5\xB6\\\x2\x23B\x252\x5\xBC_\x2\x23C\x252\x5\xCA"+
+		"\x66\x2\x23D\x252\x5\xCCg\x2\x23E\x252\x5\xCEh\x2\x23F\x252\x5\xD0i\x2"+
+		"\x240\x252\x5\xD2j\x2\x241\x252\x5\xD4k\x2\x242\x252\x5\xD6l\x2\x243\x252"+
+		"\x5\xDEp\x2\x244\x252\x5\xE0q\x2\x245\x252\x5\xE4s\x2\x246\x252\x5\xE6"+
+		"t\x2\x247\x252\x5\xE8u\x2\x248\x252\x5\xECw\x2\x249\x252\x5\xF4{\x2\x24A"+
+		"\x252\x5\xEAv\x2\x24B\x252\x5\x102\x82\x2\x24C\x252\x5\x108\x85\x2\x24D"+
+		"\x252\x5\x10A\x86\x2\x24E\x252\x5\x10C\x87\x2\x24F\x252\x5\x10E\x88\x2"+
+		"\x250\x252\x5\x118\x8D\x2\x251\x22C\x3\x2\x2\x2\x251\x22D\x3\x2\x2\x2"+
+		"\x251\x22E\x3\x2\x2\x2\x251\x22F\x3\x2\x2\x2\x251\x230\x3\x2\x2\x2\x251"+
+		"\x231\x3\x2\x2\x2\x251\x232\x3\x2\x2\x2\x251\x233\x3\x2\x2\x2\x251\x234"+
+		"\x3\x2\x2\x2\x251\x235\x3\x2\x2\x2\x251\x236\x3\x2\x2\x2\x251\x237\x3"+
+		"\x2\x2\x2\x251\x238\x3\x2\x2\x2\x251\x239\x3\x2\x2\x2\x251\x23A\x3\x2"+
+		"\x2\x2\x251\x23B\x3\x2\x2\x2\x251\x23C\x3\x2\x2\x2\x251\x23D\x3\x2\x2"+
+		"\x2\x251\x23E\x3\x2\x2\x2\x251\x23F\x3\x2\x2\x2\x251\x240\x3\x2\x2\x2"+
+		"\x251\x241\x3\x2\x2\x2\x251\x242\x3\x2\x2\x2\x251\x243\x3\x2\x2\x2\x251"+
+		"\x244\x3\x2\x2\x2\x251\x245\x3\x2\x2\x2\x251\x246\x3\x2\x2\x2\x251\x247"+
+		"\x3\x2\x2\x2\x251\x248\x3\x2\x2\x2\x251\x249\x3\x2\x2\x2\x251\x24A\x3"+
+		"\x2\x2\x2\x251\x24B\x3\x2\x2\x2\x251\x24C\x3\x2\x2\x2\x251\x24D\x3\x2"+
+		"\x2\x2\x251\x24E\x3\x2\x2\x2\x251\x24F\x3\x2\x2\x2\x251\x250\x3\x2\x2"+
+		"\x2\x252!\x3\x2\x2\x2\x253\x261\x5$\x13\x2\x254\x261\x5> \x2\x255\x261"+
+		"\x5<\x1F\x2\x256\x261\x5\x42\"\x2\x257\x261\x5\x46$\x2\x258\x261\x5N("+
+		"\x2\x259\x261\x5P)\x2\x25A\x261\x5T+\x2\x25B\x261\x5X-\x2\x25C\x261\x5"+
+		"n\x38\x2\x25D\x261\x5p\x39\x2\x25E\x261\x5v<\x2\x25F\x261\x5|?\x2\x260"+
+		"\x253\x3\x2\x2\x2\x260\x254\x3\x2\x2\x2\x260\x255\x3\x2\x2\x2\x260\x256"+
+		"\x3\x2\x2\x2\x260\x257\x3\x2\x2\x2\x260\x258\x3\x2\x2\x2\x260\x259\x3"+
+		"\x2\x2\x2\x260\x25A\x3\x2\x2\x2\x260\x25B\x3\x2\x2\x2\x260\x25C\x3\x2"+
+		"\x2\x2\x260\x25D\x3\x2\x2\x2\x260\x25E\x3\x2\x2\x2\x260\x25F\x3\x2\x2"+
+		"\x2\x261#\x3\x2\x2\x2\x262\x263\a\x94\x2\x2\x263\x264\x5\x17A\xBE\x2\x264"+
+		"\x268\x5&\x14\x2\x265\x266\x5\x17A\xBE\x2\x266\x267\x5(\x15\x2\x267\x269"+
+		"\x3\x2\x2\x2\x268\x265\x3\x2\x2\x2\x268\x269\x3\x2\x2\x2\x269\x26D\x3"+
+		"\x2\x2\x2\x26A\x26B\x5\x17A\xBE\x2\x26B\x26C\x5,\x17\x2\x26C\x26E\x3\x2"+
+		"\x2\x2\x26D\x26A\x3\x2\x2\x2\x26D\x26E\x3\x2\x2\x2\x26E\x272\x3\x2\x2"+
+		"\x2\x26F\x270\x5\x17A\xBE\x2\x270\x271\x5\x30\x19\x2\x271\x273\x3\x2\x2"+
+		"\x2\x272\x26F\x3\x2\x2\x2\x272\x273\x3\x2\x2\x2\x273\x274\x3\x2\x2\x2"+
+		"\x274\x275\x5\x17A\xBE\x2\x275\x276\a\x39\x2\x2\x276\x277\x5\x17A\xBE"+
+		"\x2\x277\x27B\x5\x36\x1C\x2\x278\x279\x5\x17A\xBE\x2\x279\x27A\x5\x32"+
+		"\x1A\x2\x27A\x27C\x3\x2\x2\x2\x27B\x278\x3\x2\x2\x2\x27B\x27C\x3\x2\x2"+
+		"\x2\x27C%\x3\x2\x2\x2\x27D\x27E\x5\xFE\x80\x2\x27E\'\x3\x2\x2\x2\x27F"+
+		"\x280\aq\x2\x2\x280\x281\x5\x17A\xBE\x2\x281\x282\x5*\x16\x2\x282)\x3"+
+		"\x2\x2\x2\x283\x284\t\x3\x2\x2\x284+\x3\x2\x2\x2\x285\x286\a\x33\x2\x2"+
+		"\x286\x287\x5\x17A\xBE\x2\x287\x288\x5.\x18\x2\x288-\x3\x2\x2\x2\x289"+
+		"\x28A\t\x4\x2\x2\x28A/\x3\x2\x2\x2\x28B\x28C\t\x5\x2\x2\x28C\x31\x3\x2"+
+		"\x2\x2\x28D\x28F\a\x1D\x2\x2\x28E\x290\x5\x17A\xBE\x2\x28F\x28E\x3\x2"+
+		"\x2\x2\x28F\x290\x3\x2\x2\x2\x290\x291\x3\x2\x2\x2\x291\x293\a\xD0\x2"+
+		"\x2\x292\x294\x5\x17A\xBE\x2\x293\x292\x3\x2\x2\x2\x293\x294\x3\x2\x2"+
+		"\x2\x294\x295\x3\x2\x2\x2\x295\x296\x5\x34\x1B\x2\x296\x33\x3\x2\x2\x2"+
+		"\x297\x298\x5\xFE\x80\x2\x298\x35\x3\x2\x2\x2\x299\x29C\x5\x38\x1D\x2"+
+		"\x29A\x29C\x5:\x1E\x2\x29B\x299\x3\x2\x2\x2\x29B\x29A\x3\x2\x2\x2\x29C"+
+		"\x37\x3\x2\x2\x2\x29D\x29E\a.\x2\x2\x29E\x29F\x5\xFE\x80\x2\x29F\x39\x3"+
+		"\x2\x2\x2\x2A0\x2A1\x5\xFE\x80\x2\x2A1;\x3\x2\x2\x2\x2A2\x2A6\a\x43\x2"+
+		"\x2\x2A3\x2A4\x5\x17A\xBE\x2\x2A4\x2A5\x5@!\x2\x2A5\x2A7\x3\x2\x2\x2\x2A6"+
+		"\x2A3\x3\x2\x2\x2\x2A6\x2A7\x3\x2\x2\x2\x2A7=\x3\x2\x2\x2\x2A8\x2A9\a"+
+		"\xAC\x2\x2\x2A9?\x3\x2\x2\x2\x2AA\x2B5\x5\x36\x1C\x2\x2AB\x2AD\x5\x17A"+
+		"\xBE\x2\x2AC\x2AB\x3\x2\x2\x2\x2AC\x2AD\x3\x2\x2\x2\x2AD\x2AE\x3\x2\x2"+
+		"\x2\x2AE\x2B0\a)\x2\x2\x2AF\x2B1\x5\x17A\xBE\x2\x2B0\x2AF\x3\x2\x2\x2"+
+		"\x2B0\x2B1\x3\x2\x2\x2\x2B1\x2B2\x3\x2\x2\x2\x2B2\x2B4\x5\x36\x1C\x2\x2B3"+
+		"\x2AC\x3\x2\x2\x2\x2B4\x2B7\x3\x2\x2\x2\x2B5\x2B3\x3\x2\x2\x2\x2B5\x2B6"+
+		"\x3\x2\x2\x2\x2B6\x41\x3\x2\x2\x2\x2B7\x2B5\x3\x2\x2\x2\x2B8\x2B9\a\xB0"+
+		"\x2\x2\x2B9\x2BA\x5\x17A\xBE\x2\x2BA\x2BC\x5\x36\x1C\x2\x2BB\x2BD\x5\x17A"+
+		"\xBE\x2\x2BC\x2BB\x3\x2\x2\x2\x2BC\x2BD\x3\x2\x2\x2\x2BD\x2BE\x3\x2\x2"+
+		"\x2\x2BE\x2C0\a)\x2\x2\x2BF\x2C1\x5\x17A\xBE\x2\x2C0\x2BF\x3\x2\x2\x2"+
+		"\x2C0\x2C1\x3\x2\x2\x2\x2C1\x2C2\x3\x2\x2\x2\x2C2\x2C3\x5\x44#\x2\x2C3"+
+		"\x43\x3\x2\x2\x2\x2C4\x2C5\x5\xFE\x80\x2\x2C5\x45\x3\x2\x2\x2\x2C6\x2C7"+
+		"\a~\x2\x2\x2C7\x2C8\x5\x17A\xBE\x2\x2C8\x2D1\x5\x36\x1C\x2\x2C9\x2CB\x5"+
+		"\x17A\xBE\x2\x2CA\x2C9\x3\x2\x2\x2\x2CA\x2CB\x3\x2\x2\x2\x2CB\x2CC\x3"+
+		"\x2\x2\x2\x2CC\x2CE\a)\x2\x2\x2CD\x2CF\x5\x17A\xBE\x2\x2CE\x2CD\x3\x2"+
+		"\x2\x2\x2CE\x2CF\x3\x2\x2\x2\x2CF\x2D0\x3\x2\x2\x2\x2D0\x2D2\x5H%\x2\x2D1"+
+		"\x2CA\x3\x2\x2\x2\x2D1\x2D2\x3\x2\x2\x2\x2D2G\x3\x2\x2\x2\x2D3\x2DE\x5"+
+		"J&\x2\x2D4\x2D5\x5J&\x2\x2D5\x2D6\x5\x17A\xBE\x2\x2D6\x2D8\x3\x2\x2\x2"+
+		"\x2D7\x2D4\x3\x2\x2\x2\x2D7\x2D8\x3\x2\x2\x2\x2D8\x2D9\x3\x2\x2\x2\x2D9"+
+		"\x2DA\a\xBE\x2\x2\x2DA\x2DB\x5\x17A\xBE\x2\x2DB\x2DC\x5L\'\x2\x2DC\x2DE"+
+		"\x3\x2\x2\x2\x2DD\x2D3\x3\x2\x2\x2\x2DD\x2D7\x3\x2\x2\x2\x2DEI\x3\x2\x2"+
+		"\x2\x2DF\x2E0\x5\xFE\x80\x2\x2E0K\x3\x2\x2\x2\x2E1\x2E2\x5\xFE\x80\x2"+
+		"\x2E2M\x3\x2\x2\x2\x2E3\x2E4\a\xC2\x2\x2\x2E4\x2E5\x5\x17A\xBE\x2\x2E5"+
+		"\x2EE\x5\x36\x1C\x2\x2E6\x2E8\x5\x17A\xBE\x2\x2E7\x2E6\x3\x2\x2\x2\x2E7"+
+		"\x2E8\x3\x2\x2\x2\x2E8\x2E9\x3\x2\x2\x2\x2E9\x2EB\a)\x2\x2\x2EA\x2EC\x5"+
+		"\x17A\xBE\x2\x2EB\x2EA\x3\x2\x2\x2\x2EB\x2EC\x3\x2\x2\x2\x2EC\x2ED\x3"+
+		"\x2\x2\x2\x2ED\x2EF\x5H%\x2\x2EE\x2E7\x3\x2\x2\x2\x2EE\x2EF\x3\x2\x2\x2"+
+		"\x2EFO\x3\x2\x2\x2\x2F0\x2F1\a\x84\x2\x2\x2F1\x2F2\x5\x17A\xBE\x2\x2F2"+
+		"\x2F4\x5\x38\x1D\x2\x2F3\x2F5\x5\x17A\xBE\x2\x2F4\x2F3\x3\x2\x2\x2\x2F4"+
+		"\x2F5\x3\x2\x2\x2\x2F5\x2F6\x3\x2\x2\x2\x2F6\x2F8\a)\x2\x2\x2F7\x2F9\x5"+
+		"\x17A\xBE\x2\x2F8\x2F7\x3\x2\x2\x2\x2F8\x2F9\x3\x2\x2\x2\x2F9\x2FA\x3"+
+		"\x2\x2\x2\x2FA\x2FB\x5R*\x2\x2FBQ\x3\x2\x2\x2\x2FC\x2FD\x5\xFE\x80\x2"+
+		"\x2FDS\x3\x2\x2\x2\x2FE\x2FF\a\xC8\x2\x2\x2FF\x300\x5\x17A\xBE\x2\x300"+
+		"\x302\x5\x38\x1D\x2\x301\x303\x5\x17A\xBE\x2\x302\x301\x3\x2\x2\x2\x302"+
+		"\x303\x3\x2\x2\x2\x303\x304\x3\x2\x2\x2\x304\x306\a)\x2\x2\x305\x307\x5"+
+		"\x17A\xBE\x2\x306\x305\x3\x2\x2\x2\x306\x307\x3\x2\x2\x2\x307\x308\x3"+
+		"\x2\x2\x2\x308\x309\x5V,\x2\x309U\x3\x2\x2\x2\x30A\x30B\x5\xFE\x80\x2"+
+		"\x30BW\x3\x2\x2\x2\x30C\x30D\a\x9E\x2\x2\x30D\x30E\x5\x17A\xBE\x2\x30E"+
+		"\x310\x5\x38\x1D\x2\x30F\x311\x5\x17A\xBE\x2\x310\x30F\x3\x2\x2\x2\x310"+
+		"\x311\x3\x2\x2\x2\x311\x312\x3\x2\x2\x2\x312\x317\a)\x2\x2\x313\x315\x5"+
+		"\x17A\xBE\x2\x314\x313\x3\x2\x2\x2\x314\x315\x3\x2\x2\x2\x315\x316\x3"+
+		"\x2\x2\x2\x316\x318\x5Z.\x2\x317\x314\x3\x2\x2\x2\x317\x318\x3\x2\x2\x2"+
+		"\x318Y\x3\x2\x2\x2\x319\x320\x5\\/\x2\x31A\x31C\x5\x17A\xBE\x2\x31B\x31A"+
+		"\x3\x2\x2\x2\x31B\x31C\x3\x2\x2\x2\x31C\x31D\x3\x2\x2\x2\x31D\x31F\x5"+
+		"\\/\x2\x31E\x31B\x3\x2\x2\x2\x31F\x322\x3\x2\x2\x2\x320\x31E\x3\x2\x2"+
+		"\x2\x320\x321\x3\x2\x2\x2\x321[\x3\x2\x2\x2\x322\x320\x3\x2\x2\x2\x323"+
+		"\x32C\x5^\x30\x2\x324\x32C\x5`\x31\x2\x325\x327\x5^\x30\x2\x326\x328\x5"+
+		"\x17A\xBE\x2\x327\x326\x3\x2\x2\x2\x327\x328\x3\x2\x2\x2\x328\x329\x3"+
+		"\x2\x2\x2\x329\x32A\x5`\x31\x2\x32A\x32C\x3\x2\x2\x2\x32B\x323\x3\x2\x2"+
+		"\x2\x32B\x324\x3\x2\x2\x2\x32B\x325\x3\x2\x2\x2\x32C]\x3\x2\x2\x2\x32D"+
+		"\x331\x5\x64\x33\x2\x32E\x331\x5h\x35\x2\x32F\x331\x5\x62\x32\x2\x330"+
+		"\x32D\x3\x2\x2\x2\x330\x32E\x3\x2\x2\x2\x330\x32F\x3\x2\x2\x2\x331_\x3"+
+		"\x2\x2\x2\x332\x333\t\x6\x2\x2\x333\x61\x3\x2\x2\x2\x334\x335\x5\xFE\x80"+
+		"\x2\x335\x63\x3\x2\x2\x2\x336\x338\a\xB5\x2\x2\x337\x339\x5\x17A\xBE\x2"+
+		"\x338\x337\x3\x2\x2\x2\x338\x339\x3\x2\x2\x2\x339\x33A\x3\x2\x2\x2\x33A"+
+		"\x33C\a\xD4\x2\x2\x33B\x33D\x5\x17A\xBE\x2\x33C\x33B\x3\x2\x2\x2\x33C"+
+		"\x33D\x3\x2\x2\x2\x33D\x33E\x3\x2\x2\x2\x33E\x340\x5\x66\x34\x2\x33F\x341"+
+		"\x5\x17A\xBE\x2\x340\x33F\x3\x2\x2\x2\x340\x341\x3\x2\x2\x2\x341\x342"+
+		"\x3\x2\x2\x2\x342\x343\a\xDB\x2\x2\x343\x65\x3\x2\x2\x2\x344\x345\x5\xFE"+
+		"\x80\x2\x345g\x3\x2\x2\x2\x346\x34B\a\xBB\x2\x2\x347\x349\x5\x17A\xBE"+
+		"\x2\x348\x347\x3\x2\x2\x2\x348\x349\x3\x2\x2\x2\x349\x34A\x3\x2\x2\x2"+
+		"\x34A\x34C\x5j\x36\x2\x34B\x348\x3\x2\x2\x2\x34B\x34C\x3\x2\x2\x2\x34C"+
+		"i\x3\x2\x2\x2\x34D\x34F\a\xD4\x2\x2\x34E\x350\x5\x17A\xBE\x2\x34F\x34E"+
+		"\x3\x2\x2\x2\x34F\x350\x3\x2\x2\x2\x350\x351\x3\x2\x2\x2\x351\x353\x5"+
+		"l\x37\x2\x352\x354\x5\x17A\xBE\x2\x353\x352\x3\x2\x2\x2\x353\x354\x3\x2"+
+		"\x2\x2\x354\x355\x3\x2\x2\x2\x355\x356\a\xDB\x2\x2\x356k\x3\x2\x2\x2\x357"+
+		"\x358\x5\xFE\x80\x2\x358m\x3\x2\x2\x2\x359\x35A\a\xCB\x2\x2\x35A\x35B"+
+		"\x5\x17A\xBE\x2\x35B\x35D\x5\x38\x1D\x2\x35C\x35E\x5\x17A\xBE\x2\x35D"+
+		"\x35C\x3\x2\x2\x2\x35D\x35E\x3\x2\x2\x2\x35E\x35F\x3\x2\x2\x2\x35F\x364"+
+		"\a)\x2\x2\x360\x362\x5\x17A\xBE\x2\x361\x360\x3\x2\x2\x2\x361\x362\x3"+
+		"\x2\x2\x2\x362\x363\x3\x2\x2\x2\x363\x365\x5Z.\x2\x364\x361\x3\x2\x2\x2"+
+		"\x364\x365\x3\x2\x2\x2\x365o\x3\x2\x2\x2\x366\x367\a{\x2\x2\x367\x368"+
+		"\x5\x17A\xBE\x2\x368\x36A\x5\x38\x1D\x2\x369\x36B\x5\x17A\xBE\x2\x36A"+
+		"\x369\x3\x2\x2\x2\x36A\x36B\x3\x2\x2\x2\x36B\x36C\x3\x2\x2\x2\x36C\x36E"+
+		"\a)\x2\x2\x36D\x36F\x5\x17A\xBE\x2\x36E\x36D\x3\x2\x2\x2\x36E\x36F\x3"+
+		"\x2\x2\x2\x36F\x370\x3\x2\x2\x2\x370\x371\x5r:\x2\x371q\x3\x2\x2\x2\x372"+
+		"\x37D\x5t;\x2\x373\x375\x5\x17A\xBE\x2\x374\x373\x3\x2\x2\x2\x374\x375"+
+		"\x3\x2\x2\x2\x375\x376\x3\x2\x2\x2\x376\x378\a)\x2\x2\x377\x379\x5\x17A"+
+		"\xBE\x2\x378\x377\x3\x2\x2\x2\x378\x379\x3\x2\x2\x2\x379\x37A\x3\x2\x2"+
+		"\x2\x37A\x37C\x5t;\x2\x37B\x374\x3\x2\x2\x2\x37C\x37F\x3\x2\x2\x2\x37D"+
+		"\x37B\x3\x2\x2\x2\x37D\x37E\x3\x2\x2\x2\x37Es\x3\x2\x2\x2\x37F\x37D\x3"+
+		"\x2\x2\x2\x380\x381\x5\xFE\x80\x2\x381u\x3\x2\x2\x2\x382\x383\a\xA5\x2"+
+		"\x2\x383\x384\x5\x17A\xBE\x2\x384\x386\x5\x36\x1C\x2\x385\x387\x5\x17A"+
+		"\xBE\x2\x386\x385\x3\x2\x2\x2\x386\x387\x3\x2\x2\x2\x387\x388\x3\x2\x2"+
+		"\x2\x388\x38A\a)\x2\x2\x389\x38B\x5\x17A\xBE\x2\x38A\x389\x3\x2\x2\x2"+
+		"\x38A\x38B\x3\x2\x2\x2\x38B\x38D\x3\x2\x2\x2\x38C\x38E\x5x=\x2\x38D\x38C"+
+		"\x3\x2\x2\x2\x38D\x38E\x3\x2\x2\x2\x38E\x390\x3\x2\x2\x2\x38F\x391\x5"+
+		"\x17A\xBE\x2\x390\x38F\x3\x2\x2\x2\x390\x391\x3\x2\x2\x2\x391\x392\x3"+
+		"\x2\x2\x2\x392\x394\a)\x2\x2\x393\x395\x5\x17A\xBE\x2\x394\x393\x3\x2"+
+		"\x2\x2\x394\x395\x3\x2\x2\x2\x395\x396\x3\x2\x2\x2\x396\x397\x5z>\x2\x397"+
+		"w\x3\x2\x2\x2\x398\x399\x5\xFE\x80\x2\x399y\x3\x2\x2\x2\x39A\x39B\x5\xFE"+
+		"\x80\x2\x39B{\x3\x2\x2\x2\x39C\x39D\as\x2\x2\x39D\x39E\x5\x17A\xBE\x2"+
+		"\x39E\x3A0\x5\x36\x1C\x2\x39F\x3A1\x5\x17A\xBE\x2\x3A0\x39F\x3\x2\x2\x2"+
+		"\x3A0\x3A1\x3\x2\x2\x2\x3A1\x3A2\x3\x2\x2\x2\x3A2\x3A4\a)\x2\x2\x3A3\x3A5"+
+		"\x5\x17A\xBE\x2\x3A4\x3A3\x3\x2\x2\x2\x3A4\x3A5\x3\x2\x2\x2\x3A5\x3A7"+
+		"\x3\x2\x2\x2\x3A6\x3A8\x5x=\x2\x3A7\x3A6\x3\x2\x2\x2\x3A7\x3A8\x3\x2\x2"+
+		"\x2\x3A8\x3AA\x3\x2\x2\x2\x3A9\x3AB\x5\x17A\xBE\x2\x3AA\x3A9\x3\x2\x2"+
+		"\x2\x3AA\x3AB\x3\x2\x2\x2\x3AB\x3AC\x3\x2\x2\x2\x3AC\x3AE\a)\x2\x2\x3AD"+
+		"\x3AF\x5\x17A\xBE\x2\x3AE\x3AD\x3\x2\x2\x2\x3AE\x3AF\x3\x2\x2\x2\x3AF"+
+		"\x3B0\x3\x2\x2\x2\x3B0\x3B1\x5~@\x2\x3B1}\x3\x2\x2\x2\x3B2\x3B3\x5\xFE"+
+		"\x80\x2\x3B3\x7F\x3\x2\x2\x2\x3B4\x3B5\x5\x15C\xAF\x2\x3B5\x3B6\x5\x17A"+
+		"\xBE\x2\x3B6\x3B8\x3\x2\x2\x2\x3B7\x3B4\x3\x2\x2\x2\x3B7\x3B8\x3\x2\x2"+
+		"\x2\x3B8\x3B9\x3\x2\x2\x2\x3B9\x3BA\a\x44\x2\x2\x3BA\x3BB\x5\x17A\xBE"+
+		"\x2\x3BB\x3C6\x5\x82\x42\x2\x3BC\x3BE\x5\x17A\xBE\x2\x3BD\x3BC\x3\x2\x2"+
+		"\x2\x3BD\x3BE\x3\x2\x2\x2\x3BE\x3BF\x3\x2\x2\x2\x3BF\x3C1\a)\x2\x2\x3C0"+
+		"\x3C2\x5\x17A\xBE\x2\x3C1\x3C0\x3\x2\x2\x2\x3C1\x3C2\x3\x2\x2\x2\x3C2"+
+		"\x3C3\x3\x2\x2\x2\x3C3\x3C5\x5\x82\x42\x2\x3C4\x3BD\x3\x2\x2\x2\x3C5\x3C8"+
+		"\x3\x2\x2\x2\x3C6\x3C4\x3\x2\x2\x2\x3C6\x3C7\x3\x2\x2\x2\x3C7\x81\x3\x2"+
+		"\x2\x2\x3C8\x3C6\x3\x2\x2\x2\x3C9\x3CB\x5\x140\xA1\x2\x3CA\x3CC\x5\x15A"+
+		"\xAE\x2\x3CB\x3CA\x3\x2\x2\x2\x3CB\x3CC\x3\x2\x2\x2\x3CC\x3D0\x3\x2\x2"+
+		"\x2\x3CD\x3CE\x5\x17A\xBE\x2\x3CE\x3CF\x5\x142\xA2\x2\x3CF\x3D1\x3\x2"+
+		"\x2\x2\x3D0\x3CD\x3\x2\x2\x2\x3D0\x3D1\x3\x2\x2\x2\x3D1\x3D3\x3\x2\x2"+
+		"\x2\x3D2\x3D4\x5\x17A\xBE\x2\x3D3\x3D2\x3\x2\x2\x2\x3D3\x3D4\x3\x2\x2"+
+		"\x2\x3D4\x3D5\x3\x2\x2\x2\x3D5\x3D7\a\xD0\x2\x2\x3D6\x3D8\x5\x17A\xBE"+
+		"\x2\x3D7\x3D6\x3\x2\x2\x2\x3D7\x3D8\x3\x2\x2\x2\x3D8\x3D9\x3\x2\x2\x2"+
+		"\x3D9\x3DA\x5\xFE\x80\x2\x3DA\x83\x3\x2\x2\x2\x3DB\x3DC\x5\x15C\xAF\x2"+
+		"\x3DC\x3DD\x5\x17A\xBE\x2\x3DD\x3DF\x3\x2\x2\x2\x3DE\x3DB\x3\x2\x2\x2"+
+		"\x3DE\x3DF\x3\x2\x2\x2\x3DF\x3E0\x3\x2\x2\x2\x3E0\x3E1\aG\x2\x2\x3E1\x3E4"+
+		"\x5\x17A\xBE\x2\x3E2\x3E3\a\xA3\x2\x2\x3E3\x3E5\x5\x17A\xBE\x2\x3E4\x3E2"+
+		"\x3\x2\x2\x2\x3E4\x3E5\x3\x2\x2\x2\x3E5\x3E6\x3\x2\x2\x2\x3E6\x3E7\t\a"+
+		"\x2\x2\x3E7\x3E8\x5\x17A\xBE\x2\x3E8\x3EA\x5\x140\xA1\x2\x3E9\x3EB\x5"+
+		"\x15A\xAE\x2\x3EA\x3E9\x3\x2\x2\x2\x3EA\x3EB\x3\x2\x2\x2\x3EB\x3EC\x3"+
+		"\x2\x2\x2\x3EC\x3ED\x5\x17A\xBE\x2\x3ED\x3EE\a\x82\x2\x2\x3EE\x3EF\x5"+
+		"\x17A\xBE\x2\x3EF\x3F5\a\xE3\x2\x2\x3F0\x3F1\x5\x17A\xBE\x2\x3F1\x3F2"+
+		"\a\x35\x2\x2\x3F2\x3F3\x5\x17A\xBE\x2\x3F3\x3F4\a\xE3\x2\x2\x3F4\x3F6"+
+		"\x3\x2\x2\x2\x3F5\x3F0\x3\x2\x2\x2\x3F5\x3F6\x3\x2\x2\x2\x3F6\x3FB\x3"+
+		"\x2\x2\x2\x3F7\x3F9\x5\x17A\xBE\x2\x3F8\x3F7\x3\x2\x2\x2\x3F8\x3F9\x3"+
+		"\x2\x2\x2\x3F9\x3FA\x3\x2\x2\x2\x3FA\x3FC\x5\x134\x9B\x2\x3FB\x3F8\x3"+
+		"\x2\x2\x2\x3FB\x3FC\x3\x2\x2\x2\x3FC\x400\x3\x2\x2\x2\x3FD\x3FE\x5\x17A"+
+		"\xBE\x2\x3FE\x3FF\x5\x142\xA2\x2\x3FF\x401\x3\x2\x2\x2\x400\x3FD\x3\x2"+
+		"\x2\x2\x400\x401\x3\x2\x2\x2\x401\x85\x3\x2\x2\x2\x402\x403\x5\x88\x45"+
+		"\x2\x403\x404\x5\x17A\xBE\x2\x404\x40F\x5\x8A\x46\x2\x405\x407\x5\x17A"+
+		"\xBE\x2\x406\x405\x3\x2\x2\x2\x406\x407\x3\x2\x2\x2\x407\x408\x3\x2\x2"+
+		"\x2\x408\x40A\a)\x2\x2\x409\x40B\x5\x17A\xBE\x2\x40A\x409\x3\x2\x2\x2"+
+		"\x40A\x40B\x3\x2\x2\x2\x40B\x40C\x3\x2\x2\x2\x40C\x40E\x5\x8A\x46\x2\x40D"+
+		"\x406\x3\x2\x2\x2\x40E\x411\x3\x2\x2\x2\x40F\x40D\x3\x2\x2\x2\x40F\x410"+
+		"\x3\x2\x2\x2\x410\x87\x3\x2\x2\x2\x411\x40F\x3\x2\x2\x2\x412\x413\t\b"+
+		"\x2\x2\x413\x89\x3\x2\x2\x2\x414\x418\x5\x8CG\x2\x415\x418\x5\x8EH\x2"+
+		"\x416\x418\x5\x94K\x2\x417\x414\x3\x2\x2\x2\x417\x415\x3\x2\x2\x2\x417"+
+		"\x416\x3\x2\x2\x2\x418\x8B\x3\x2\x2\x2\x419\x41A\x5\x13E\xA0\x2\x41A\x8D"+
+		"\x3\x2\x2\x2\x41B\x41D\x5\x90I\x2\x41C\x41E\x5\x17A\xBE\x2\x41D\x41C\x3"+
+		"\x2\x2\x2\x41D\x41E\x3\x2\x2\x2\x41E\x41F\x3\x2\x2\x2\x41F\x421\a\xD6"+
+		"\x2\x2\x420\x422\x5\x17A\xBE\x2\x421\x420\x3\x2\x2\x2\x421\x422\x3\x2"+
+		"\x2\x2\x422\x423\x3\x2\x2\x2\x423\x424\x5\x92J\x2\x424\x8F\x3\x2\x2\x2"+
+		"\x425\x426\x6I\x2\x2\x426\x427\x5\x13E\xA0\x2\x427\x91\x3\x2\x2\x2\x428"+
+		"\x429\x6J\x3\x2\x429\x42A\x5\x13E\xA0\x2\x42A\x93\x3\x2\x2\x2\x42B\x42D"+
+		"\x5\x96L\x2\x42C\x42E\x5\x17A\xBE\x2\x42D\x42C\x3\x2\x2\x2\x42D\x42E\x3"+
+		"\x2\x2\x2\x42E\x42F\x3\x2\x2\x2\x42F\x431\a\xD6\x2\x2\x430\x432\x5\x17A"+
+		"\xBE\x2\x431\x430\x3\x2\x2\x2\x431\x432\x3\x2\x2\x2\x432\x433\x3\x2\x2"+
+		"\x2\x433\x434\x5\x98M\x2\x434\x95\x3\x2\x2\x2\x435\x436\x5\x13E\xA0\x2"+
+		"\x436\x97\x3\x2\x2\x2\x437\x438\x5\x13E\xA0\x2\x438\x99\x3\x2\x2\x2\x439"+
+		"\x43A\aV\x2\x2\x43A\x43C\x5\x166\xB4\x2\x43B\x43D\x5\x1E\x10\x2\x43C\x43B"+
+		"\x3\x2\x2\x2\x43C\x43D\x3\x2\x2\x2\x43D\x43E\x3\x2\x2\x2\x43E\x43F\a\x80"+
+		"\x2\x2\x43F\x457\x3\x2\x2\x2\x440\x441\aV\x2\x2\x441\x442\x5\x17A\xBE"+
+		"\x2\x442\x443\t\t\x2\x2\x443\x444\x5\x17A\xBE\x2\x444\x445\x5\xFE\x80"+
+		"\x2\x445\x447\x5\x166\xB4\x2\x446\x448\x5\x1E\x10\x2\x447\x446\x3\x2\x2"+
+		"\x2\x447\x448\x3\x2\x2\x2\x448\x449\x3\x2\x2\x2\x449\x44A\a\x80\x2\x2"+
+		"\x44A\x457\x3\x2\x2\x2\x44B\x44C\aV\x2\x2\x44C\x44E\x5\x166\xB4\x2\x44D"+
+		"\x44F\x5\x1E\x10\x2\x44E\x44D\x3\x2\x2\x2\x44E\x44F\x3\x2\x2\x2\x44F\x450"+
+		"\x3\x2\x2\x2\x450\x451\a\x80\x2\x2\x451\x452\x5\x17A\xBE\x2\x452\x453"+
+		"\t\t\x2\x2\x453\x454\x5\x17A\xBE\x2\x454\x455\x5\xFE\x80\x2\x455\x457"+
+		"\x3\x2\x2\x2\x456\x439\x3\x2\x2\x2\x456\x440\x3\x2\x2\x2\x456\x44B\x3"+
+		"\x2\x2\x2\x457\x9B\x3\x2\x2\x2\x458\x459\x5\x15C\xAF\x2\x459\x45A\x5\x17A"+
+		"\xBE\x2\x45A\x45C\x3\x2\x2\x2\x45B\x458\x3\x2\x2\x2\x45B\x45C\x3\x2\x2"+
+		"\x2\x45C\x45D\x3\x2\x2\x2\x45D\x45E\a\x65\x2\x2\x45E\x45F\x5\x17A\xBE"+
+		"\x2\x45F\x460\x5\x140\xA1\x2\x460\x464\x5\x166\xB4\x2\x461\x463\x5\x9E"+
+		"P\x2\x462\x461\x3\x2\x2\x2\x463\x466\x3\x2\x2\x2\x464\x462\x3\x2\x2\x2"+
+		"\x464\x465\x3\x2\x2\x2\x465\x467\x3\x2\x2\x2\x466\x464\x3\x2\x2\x2\x467"+
+		"\x468\a\\\x2\x2\x468\x9D\x3\x2\x2\x2\x469\x472\x5\x140\xA1\x2\x46A\x46C"+
+		"\x5\x17A\xBE\x2\x46B\x46A\x3\x2\x2\x2\x46B\x46C\x3\x2\x2\x2\x46C\x46D"+
+		"\x3\x2\x2\x2\x46D\x46F\a\xD0\x2\x2\x46E\x470\x5\x17A\xBE\x2\x46F\x46E"+
+		"\x3\x2\x2\x2\x46F\x470\x3\x2\x2\x2\x470\x471\x3\x2\x2\x2\x471\x473\x5"+
+		"\xFE\x80\x2\x472\x46B\x3\x2\x2\x2\x472\x473\x3\x2\x2\x2\x473\x474\x3\x2"+
+		"\x2\x2\x474\x475\x5\x166\xB4\x2\x475\x9F\x3\x2\x2\x2\x476\x477\a\x64\x2"+
+		"\x2\x477\xA1\x3\x2\x2\x2\x478\x479\ag\x2\x2\x479\x47A\x5\x17A\xBE\x2\x47A"+
+		"\x485\x5\xFE\x80\x2\x47B\x47D\x5\x17A\xBE\x2\x47C\x47B\x3\x2\x2\x2\x47C"+
+		"\x47D\x3\x2\x2\x2\x47D\x47E\x3\x2\x2\x2\x47E\x480\a)\x2\x2\x47F\x481\x5"+
+		"\x17A\xBE\x2\x480\x47F\x3\x2\x2\x2\x480\x481\x3\x2\x2\x2\x481\x482\x3"+
+		"\x2\x2\x2\x482\x484\x5\xFE\x80\x2\x483\x47C\x3\x2\x2\x2\x484\x487\x3\x2"+
+		"\x2\x2\x485\x483\x3\x2\x2\x2\x485\x486\x3\x2\x2\x2\x486\xA3\x3\x2\x2\x2"+
+		"\x487\x485\x3\x2\x2\x2\x488\x489\ah\x2\x2\x489\x48A\x5\x17A\xBE\x2\x48A"+
+		"\x48B\x5\xFE\x80\x2\x48B\xA5\x3\x2\x2\x2\x48C\x48D\x5\x15C\xAF\x2\x48D"+
+		"\x48E\x5\x17A\xBE\x2\x48E\x490\x3\x2\x2\x2\x48F\x48C\x3\x2\x2\x2\x48F"+
+		"\x490\x3\x2\x2\x2\x490\x491\x3\x2\x2\x2\x491\x492\ai\x2\x2\x492\x493\x5"+
+		"\x17A\xBE\x2\x493\x495\x5\x140\xA1\x2\x494\x496\x5\x17A\xBE\x2\x495\x494"+
+		"\x3\x2\x2\x2\x495\x496\x3\x2\x2\x2\x496\x497\x3\x2\x2\x2\x497\x498\x5"+
+		"\x134\x9B\x2\x498\xA7\x3\x2\x2\x2\x499\x49A\t\n\x2\x2\x49A\xA9\x3\x2\x2"+
+		"\x2\x49B\x49C\aq\x2\x2\x49C\x49D\x5\x17A\xBE\x2\x49D\x49E\aX\x2\x2\x49E"+
+		"\x49F\x5\x17A\xBE\x2\x49F\x4A0\x5\xFE\x80\x2\x4A0\x4A1\x5\x17A\xBE\x2"+
+		"\x4A1\x4A2\az\x2\x2\x4A2\x4A3\x5\x17A\xBE\x2\x4A3\x4A4\x5\xFE\x80\x2\x4A4"+
+		"\x4A6\x5\x166\xB4\x2\x4A5\x4A7\x5\x1E\x10\x2\x4A6\x4A5\x3\x2\x2\x2\x4A6"+
+		"\x4A7\x3\x2\x2\x2\x4A7\x4A8\x3\x2\x2\x2\x4A8\x4AC\a\x8C\x2\x2\x4A9\x4AA"+
+		"\x5\x17A\xBE\x2\x4AA\x4AB\x5\xFE\x80\x2\x4AB\x4AD\x3\x2\x2\x2\x4AC\x4A9"+
+		"\x3\x2\x2\x2\x4AC\x4AD\x3\x2\x2\x2\x4AD\xAB\x3\x2\x2\x2\x4AE\x4AF\aq\x2"+
+		"\x2\x4AF\x4B0\x5\x17A\xBE\x2\x4B0\x4B2\x5\xFE\x80\x2\x4B1\x4B3\x5\x17A"+
+		"\xBE\x2\x4B2\x4B1\x3\x2\x2\x2\x4B2\x4B3\x3\x2\x2\x2\x4B3\x4B4\x3\x2\x2"+
+		"\x2\x4B4\x4B6\a\xD0\x2\x2\x4B5\x4B7\x5\x17A\xBE\x2\x4B6\x4B5\x3\x2\x2"+
+		"\x2\x4B6\x4B7\x3\x2\x2\x2\x4B7\x4B8\x3\x2\x2\x2\x4B8\x4B9\x5\xFE\x80\x2"+
+		"\x4B9\x4BA\x5\x17A\xBE\x2\x4BA\x4BB\a\xBE\x2\x2\x4BB\x4BC\x5\x17A\xBE"+
+		"\x2\x4BC\x4C2\x5\xFE\x80\x2\x4BD\x4BE\x5\x17A\xBE\x2\x4BE\x4BF\a\xB7\x2"+
+		"\x2\x4BF\x4C0\x5\x17A\xBE\x2\x4C0\x4C1\x5\xFE\x80\x2\x4C1\x4C3\x3\x2\x2"+
+		"\x2\x4C2\x4BD\x3\x2\x2\x2\x4C2\x4C3\x3\x2\x2\x2\x4C3\x4C4\x3\x2\x2\x2"+
+		"\x4C4\x4C6\x5\x166\xB4\x2\x4C5\x4C7\x5\x1E\x10\x2\x4C6\x4C5\x3\x2\x2\x2"+
+		"\x4C6\x4C7\x3\x2\x2\x2\x4C7\x4C8\x3\x2\x2\x2\x4C8\x4CC\a\x8C\x2\x2\x4C9"+
+		"\x4CA\x5\x17A\xBE\x2\x4CA\x4CB\x5\xFE\x80\x2\x4CB\x4CD\x3\x2\x2\x2\x4CC"+
+		"\x4C9\x3\x2\x2\x2\x4CC\x4CD\x3\x2\x2\x2\x4CD\xAD\x3\x2\x2\x2\x4CE\x4CF"+
+		"\x5\x15C\xAF\x2\x4CF\x4D0\x5\x17A\xBE\x2\x4D0\x4D2\x3\x2\x2\x2\x4D1\x4CE"+
+		"\x3\x2\x2\x2\x4D1\x4D2\x3\x2\x2\x2\x4D2\x4D5\x3\x2\x2\x2\x4D3\x4D4\a\xB6"+
+		"\x2\x2\x4D4\x4D6\x5\x17A\xBE\x2\x4D5\x4D3\x3\x2\x2\x2\x4D5\x4D6\x3\x2"+
+		"\x2\x2\x4D6\x4D7\x3\x2\x2\x2\x4D7\x4D9\ar\x2\x2\x4D8\x4DA\x5\x17A\xBE"+
+		"\x2\x4D9\x4D8\x3\x2\x2\x2\x4D9\x4DA\x3\x2\x2\x2\x4DA\x4DB\x3\x2\x2\x2"+
+		"\x4DB\x4DD\x5\xB0Y\x2\x4DC\x4DE\x5\x15A\xAE\x2\x4DD\x4DC\x3\x2\x2\x2\x4DD"+
+		"\x4DE\x3\x2\x2\x2\x4DE\x4E3\x3\x2\x2\x2\x4DF\x4E1\x5\x17A\xBE\x2\x4E0"+
+		"\x4DF\x3\x2\x2\x2\x4E0\x4E1\x3\x2\x2\x2\x4E1\x4E2\x3\x2\x2\x2\x4E2\x4E4"+
+		"\x5\x134\x9B\x2\x4E3\x4E0\x3\x2\x2\x2\x4E3\x4E4\x3\x2\x2\x2\x4E4\x4E9"+
+		"\x3\x2\x2\x2\x4E5\x4E7\x5\x17A\xBE\x2\x4E6\x4E5\x3\x2\x2\x2\x4E6\x4E7"+
+		"\x3\x2\x2\x2\x4E7\x4E8\x3\x2\x2\x2\x4E8\x4EA\x5\x142\xA2\x2\x4E9\x4E6"+
+		"\x3\x2\x2\x2\x4E9\x4EA\x3\x2\x2\x2\x4EA\x4EB\x3\x2\x2\x2\x4EB\x4ED\x5"+
+		"\x166\xB4\x2\x4EC\x4EE\x5\x1E\x10\x2\x4ED\x4EC\x3\x2\x2\x2\x4ED\x4EE\x3"+
+		"\x2\x2\x2\x4EE\x4EF\x3\x2\x2\x2\x4EF\x4F0\a]\x2\x2\x4F0\xAF\x3\x2\x2\x2"+
+		"\x4F1\x4F2\x5\x140\xA1\x2\x4F2\xB1\x3\x2\x2\x2\x4F3\x4F4\au\x2\x2\x4F4"+
+		"\x4F5\x5\x17A\xBE\x2\x4F5\x4F6\x5\xFE\x80\x2\x4F6\xB3\x3\x2\x2\x2\x4F7"+
+		"\x4F8\av\x2\x2\x4F8\x4F9\x5\x17A\xBE\x2\x4F9\x4FA\x5\xFE\x80\x2\x4FA\xB5"+
+		"\x3\x2\x2\x2\x4FB\x4FC\aw\x2\x2\x4FC\x4FD\x5\x17A\xBE\x2\x4FD\x4FE\x5"+
+		"\xC8\x65\x2\x4FE\x4FF\x5\x17A\xBE\x2\x4FF\x500\a\xBD\x2\x2\x500\x502\x5"+
+		"\x166\xB4\x2\x501\x503\x5\x1E\x10\x2\x502\x501\x3\x2\x2\x2\x502\x503\x3"+
+		"\x2\x2\x2\x503\x507\x3\x2\x2\x2\x504\x506\x5\xB8]\x2\x505\x504\x3\x2\x2"+
+		"\x2\x506\x509\x3\x2\x2\x2\x507\x505\x3\x2\x2\x2\x507\x508\x3\x2\x2\x2"+
+		"\x508\x50B\x3\x2\x2\x2\x509\x507\x3\x2\x2\x2\x50A\x50C\x5\xBA^\x2\x50B"+
+		"\x50A\x3\x2\x2\x2\x50B\x50C\x3\x2\x2\x2\x50C\x50D\x3\x2\x2\x2\x50D\x50E"+
+		"\a^\x2\x2\x50E\xB7\x3\x2\x2\x2\x50F\x510\aZ\x2\x2\x510\x511\x5\x17A\xBE"+
+		"\x2\x511\x512\x5\xC8\x65\x2\x512\x513\x5\x17A\xBE\x2\x513\x514\a\xBD\x2"+
+		"\x2\x514\x516\x5\x166\xB4\x2\x515\x517\x5\x1E\x10\x2\x516\x515\x3\x2\x2"+
+		"\x2\x516\x517\x3\x2\x2\x2\x517\x524\x3\x2\x2\x2\x518\x519\aZ\x2\x2\x519"+
+		"\x51A\x5\x17A\xBE\x2\x51A\x51B\x5\xC8\x65\x2\x51B\x51C\x5\x17A\xBE\x2"+
+		"\x51C\x51E\a\xBD\x2\x2\x51D\x51F\x5\x17A\xBE\x2\x51E\x51D\x3\x2\x2\x2"+
+		"\x51E\x51F\x3\x2\x2\x2\x51F\x521\x3\x2\x2\x2\x520\x522\x5\x1E\x10\x2\x521"+
+		"\x520\x3\x2\x2\x2\x521\x522\x3\x2\x2\x2\x522\x524\x3\x2\x2\x2\x523\x50F"+
+		"\x3\x2\x2\x2\x523\x518\x3\x2\x2\x2\x524\xB9\x3\x2\x2\x2\x525\x526\aY\x2"+
+		"\x2\x526\x528\x5\x166\xB4\x2\x527\x529\x5\x1E\x10\x2\x528\x527\x3\x2\x2"+
+		"\x2\x528\x529\x3\x2\x2\x2\x529\xBB\x3\x2\x2\x2\x52A\x52D\x5\xBE`\x2\x52B"+
+		"\x52D\x5\xC0\x61\x2\x52C\x52A\x3\x2\x2\x2\x52C\x52B\x3\x2\x2\x2\x52D\xBD"+
+		"\x3\x2\x2\x2\x52E\x530\aw\x2\x2\x52F\x531\x5\x17A\xBE\x2\x530\x52F\x3"+
+		"\x2\x2\x2\x530\x531\x3\x2\x2\x2\x531\x532\x3\x2\x2\x2\x532\x534\x5\xC8"+
+		"\x65\x2\x533\x535\x5\x17A\xBE\x2\x534\x533\x3\x2\x2\x2\x534\x535\x3\x2"+
+		"\x2\x2\x535\x536\x3\x2\x2\x2\x536\x538\a\xBD\x2\x2\x537\x539\x5\x17A\xBE"+
+		"\x2\x538\x537\x3\x2\x2\x2\x538\x539\x3\x2\x2\x2\x539\x53A\x3\x2\x2\x2"+
+		"\x53A\x53E\x5\xC4\x63\x2\x53B\x53C\x5\x17A\xBE\x2\x53C\x53D\x5\xC2\x62"+
+		"\x2\x53D\x53F\x3\x2\x2\x2\x53E\x53B\x3\x2\x2\x2\x53E\x53F\x3\x2\x2\x2"+
+		"\x53F\xBF\x3\x2\x2\x2\x540\x542\aw\x2\x2\x541\x543\x5\x17A\xBE\x2\x542"+
+		"\x541\x3\x2\x2\x2\x542\x543\x3\x2\x2\x2\x543\x544\x3\x2\x2\x2\x544\x546"+
+		"\x5\xC8\x65\x2\x545\x547\x5\x17A\xBE\x2\x546\x545\x3\x2\x2\x2\x546\x547"+
+		"\x3\x2\x2\x2\x547\x548\x3\x2\x2\x2\x548\x549\a\xBD\x2\x2\x549\x54B\x5"+
+		"\x166\xB4\x2\x54A\x54C\x5\x17A\xBE\x2\x54B\x54A\x3\x2\x2\x2\x54B\x54C"+
+		"\x3\x2\x2\x2\x54C\x54D\x3\x2\x2\x2\x54D\x54E\x5\xC2\x62\x2\x54E\xC1\x3"+
+		"\x2\x2\x2\x54F\x551\aY\x2\x2\x550\x552\x5\x17A\xBE\x2\x551\x550\x3\x2"+
+		"\x2\x2\x551\x552\x3\x2\x2\x2\x552\x554\x3\x2\x2\x2\x553\x555\x5\xC4\x63"+
+		"\x2\x554\x553\x3\x2\x2\x2\x554\x555\x3\x2\x2\x2\x555\xC3\x3\x2\x2\x2\x556"+
+		"\x563\x5\x152\xAA\x2\x557\x559\x5\x17A\xBE\x2\x558\x557\x3\x2\x2\x2\x558"+
+		"\x559\x3\x2\x2\x2\x559\x55A\x3\x2\x2\x2\x55A\x55C\a*\x2\x2\x55B\x55D\x5"+
+		"\x17A\xBE\x2\x55C\x55B\x3\x2\x2\x2\x55C\x55D\x3\x2\x2\x2\x55D\x55F\x3"+
+		"\x2\x2\x2\x55E\x560\x5\xC6\x64\x2\x55F\x55E\x3\x2\x2\x2\x55F\x560\x3\x2"+
+		"\x2\x2\x560\x562\x3\x2\x2\x2\x561\x558\x3\x2\x2\x2\x562\x565\x3\x2\x2"+
+		"\x2\x563\x561\x3\x2\x2\x2\x563\x564\x3\x2\x2\x2\x564\x57D\x3\x2\x2\x2"+
+		"\x565\x563\x3\x2\x2\x2\x566\x568\a*\x2\x2\x567\x569\x5\x17A\xBE\x2\x568"+
+		"\x567\x3\x2\x2\x2\x568\x569\x3\x2\x2\x2\x569\x56B\x3\x2\x2\x2\x56A\x566"+
+		"\x3\x2\x2\x2\x56A\x56B\x3\x2\x2\x2\x56B\x56C\x3\x2\x2\x2\x56C\x579\x5"+
+		"\xC6\x64\x2\x56D\x56F\x5\x17A\xBE\x2\x56E\x56D\x3\x2\x2\x2\x56E\x56F\x3"+
+		"\x2\x2\x2\x56F\x570\x3\x2\x2\x2\x570\x572\a*\x2\x2\x571\x573\x5\x17A\xBE"+
+		"\x2\x572\x571\x3\x2\x2\x2\x572\x573\x3\x2\x2\x2\x573\x575\x3\x2\x2\x2"+
+		"\x574\x576\x5\xC6\x64\x2\x575\x574\x3\x2\x2\x2\x575\x576\x3\x2\x2\x2\x576"+
+		"\x578\x3\x2\x2\x2\x577\x56E\x3\x2\x2\x2\x578\x57B\x3\x2\x2\x2\x579\x577"+
+		"\x3\x2\x2\x2\x579\x57A\x3\x2\x2\x2\x57A\x57D\x3\x2\x2\x2\x57B\x579\x3"+
+		"\x2\x2\x2\x57C\x556\x3\x2\x2\x2\x57C\x56A\x3\x2\x2\x2\x57D\xC5\x3\x2\x2"+
+		"\x2\x57E\x57F\x5 \x11\x2\x57F\xC7\x3\x2\x2\x2\x580\x581\x5\xFE\x80\x2"+
+		"\x581\xC9\x3\x2\x2\x2\x582\x583\ay\x2\x2\x583\x584\x5\x17A\xBE\x2\x584"+
+		"\x585\x5\xFE\x80\x2\x585\xCB\x3\x2\x2\x2\x586\x587\a\x81\x2\x2\x587\x589"+
+		"\x5\x17A\xBE\x2\x588\x586\x3\x2\x2\x2\x588\x589\x3\x2\x2\x2\x589\x58A"+
+		"\x3\x2\x2\x2\x58A\x58C\x5\xFE\x80\x2\x58B\x58D\x5\x17A\xBE\x2\x58C\x58B"+
+		"\x3\x2\x2\x2\x58C\x58D\x3\x2\x2\x2\x58D\x58E\x3\x2\x2\x2\x58E\x590\a\xD0"+
+		"\x2\x2\x58F\x591\x5\x17A\xBE\x2\x590\x58F\x3\x2\x2\x2\x590\x591\x3\x2"+
+		"\x2\x2\x591\x592\x3\x2\x2\x2\x592\x593\x5\xFE\x80\x2\x593\xCD\x3\x2\x2"+
+		"\x2\x594\x595\a\x88\x2\x2\x595\x596\x5\x17A\xBE\x2\x596\x598\x5\xFE\x80"+
+		"\x2\x597\x599\x5\x17A\xBE\x2\x598\x597\x3\x2\x2\x2\x598\x599\x3\x2\x2"+
+		"\x2\x599\x59A\x3\x2\x2\x2\x59A\x59C\a\xD0\x2\x2\x59B\x59D\x5\x17A\xBE"+
+		"\x2\x59C\x59B\x3\x2\x2\x2\x59C\x59D\x3\x2\x2\x2\x59D\x59E\x3\x2\x2\x2"+
+		"\x59E\x59F\x5\xFE\x80\x2\x59F\xCF\x3\x2\x2\x2\x5A0\x5A2\a\x8A\x2\x2\x5A1"+
+		"\x5A3\x5\x17A\xBE\x2\x5A2\x5A1\x3\x2\x2\x2\x5A2\x5A3\x3\x2\x2\x2\x5A3"+
+		"\x5A4\x3\x2\x2\x2\x5A4\x5A6\a\xD4\x2\x2\x5A5\x5A7\x5\x17A\xBE\x2\x5A6"+
+		"\x5A5\x3\x2\x2\x2\x5A6\x5A7\x3\x2\x2\x2\x5A7\x5A8\x3\x2\x2\x2\x5A8\x5AA"+
+		"\x5\x12E\x98\x2\x5A9\x5AB\x5\x17A\xBE\x2\x5AA\x5A9\x3\x2\x2\x2\x5AA\x5AB"+
+		"\x3\x2\x2\x2\x5AB\x5AC\x3\x2\x2\x2\x5AC\x5AD\a\xDB\x2\x2\x5AD\xD1\x3\x2"+
+		"\x2\x2\x5AE\x5AF\t\v\x2\x2\x5AF\x5B8\x5\x17A\xBE\x2\x5B0\x5B1\av\x2\x2"+
+		"\x5B1\x5B2\x5\x17A\xBE\x2\x5B2\x5B3\x5\xFE\x80\x2\x5B3\x5B9\x3\x2\x2\x2"+
+		"\x5B4\x5B5\a\xAD\x2\x2\x5B5\x5B6\x5\x17A\xBE\x2\x5B6\x5B7\a\x8C\x2\x2"+
+		"\x5B7\x5B9\x3\x2\x2\x2\x5B8\x5B0\x3\x2\x2\x2\x5B8\x5B4\x3\x2\x2\x2\x5B9"+
+		"\xD3\x3\x2\x2\x2\x5BA\x5BB\a\x91\x2\x2\x5BB\x5BC\x5\x17A\xBE\x2\x5BC\x5BD"+
+		"\x5\xFE\x80\x2\x5BD\x5BE\x5\x17A\xBE\x2\x5BE\x5BF\av\x2\x2\x5BF\x5C0\x5"+
+		"\x17A\xBE\x2\x5C0\x5CB\x5\xFE\x80\x2\x5C1\x5C3\x5\x17A\xBE\x2\x5C2\x5C1"+
+		"\x3\x2\x2\x2\x5C2\x5C3\x3\x2\x2\x2\x5C3\x5C4\x3\x2\x2\x2\x5C4\x5C6\a)"+
+		"\x2\x2\x5C5\x5C7\x5\x17A\xBE\x2\x5C6\x5C5\x3\x2\x2\x2\x5C6\x5C7\x3\x2"+
+		"\x2\x2\x5C7\x5C8\x3\x2\x2\x2\x5C8\x5CA\x5\xFE\x80\x2\x5C9\x5C2\x3\x2\x2"+
+		"\x2\x5CA\x5CD\x3\x2\x2\x2\x5CB\x5C9\x3\x2\x2\x2\x5CB\x5CC\x3\x2\x2\x2"+
+		"\x5CC\xD5\x3\x2\x2\x2\x5CD\x5CB\x3\x2\x2\x2\x5CE\x5CF\a\x91\x2\x2\x5CF"+
+		"\x5D0\x5\x17A\xBE\x2\x5D0\x5D1\x5\xFE\x80\x2\x5D1\x5D2\x5\x17A\xBE\x2"+
+		"\x5D2\x5D3\au\x2\x2\x5D3\x5D4\x5\x17A\xBE\x2\x5D4\x5DF\x5\xFE\x80\x2\x5D5"+
+		"\x5D7\x5\x17A\xBE\x2\x5D6\x5D5\x3\x2\x2\x2\x5D6\x5D7\x3\x2\x2\x2\x5D7"+
+		"\x5D8\x3\x2\x2\x2\x5D8\x5DA\a)\x2\x2\x5D9\x5DB\x5\x17A\xBE\x2\x5DA\x5D9"+
+		"\x3\x2\x2\x2\x5DA\x5DB\x3\x2\x2\x2\x5DB\x5DC\x3\x2\x2\x2\x5DC\x5DE\x5"+
+		"\xFE\x80\x2\x5DD\x5D6\x3\x2\x2\x2\x5DE\x5E1\x3\x2\x2\x2\x5DF\x5DD\x3\x2"+
+		"\x2\x2\x5DF\x5E0\x3\x2\x2\x2\x5E0\xD7\x3\x2\x2\x2\x5E1\x5DF\x3\x2\x2\x2"+
+		"\x5E2\x5E3\x5\x15C\xAF\x2\x5E3\x5E4\x5\x17A\xBE\x2\x5E4\x5E6\x3\x2\x2"+
+		"\x2\x5E5\x5E2\x3\x2\x2\x2\x5E5\x5E6\x3\x2\x2\x2\x5E6\x5E9\x3\x2\x2\x2"+
+		"\x5E7\x5E8\a\xB6\x2\x2\x5E8\x5EA\x5\x17A\xBE\x2\x5E9\x5E7\x3\x2\x2\x2"+
+		"\x5E9\x5EA\x3\x2\x2\x2\x5EA\x5EB\x3\x2\x2\x2\x5EB\x5EC\a\xA0\x2\x2\x5EC"+
+		"\x5ED\x5\x17A\xBE\x2\x5ED\x5EF\x5\xB0Y\x2\x5EE\x5F0\x5\x15A\xAE\x2\x5EF"+
+		"\x5EE\x3\x2\x2\x2\x5EF\x5F0\x3\x2\x2\x2\x5F0\x5F5\x3\x2\x2\x2\x5F1\x5F3"+
+		"\x5\x17A\xBE\x2\x5F2\x5F1\x3\x2\x2\x2\x5F2\x5F3\x3\x2\x2\x2\x5F3\x5F4"+
+		"\x3\x2\x2\x2\x5F4\x5F6\x5\x134\x9B\x2\x5F5\x5F2\x3\x2\x2\x2\x5F5\x5F6"+
+		"\x3\x2\x2\x2\x5F6\x5FA\x3\x2\x2\x2\x5F7\x5F8\x5\x17A\xBE\x2\x5F8\x5F9"+
+		"\x5\x142\xA2\x2\x5F9\x5FB\x3\x2\x2\x2\x5FA\x5F7\x3\x2\x2\x2\x5FA\x5FB"+
+		"\x3\x2\x2\x2\x5FB\x5FC\x3\x2\x2\x2\x5FC\x5FE\x5\x166\xB4\x2\x5FD\x5FF"+
+		"\x5\x1E\x10\x2\x5FE\x5FD\x3\x2\x2\x2\x5FE\x5FF\x3\x2\x2\x2\x5FF\x600\x3"+
+		"\x2\x2\x2\x600\x601\a_\x2\x2\x601\xD9\x3\x2\x2\x2\x602\x603\x5\x15C\xAF"+
+		"\x2\x603\x604\x5\x17A\xBE\x2\x604\x606\x3\x2\x2\x2\x605\x602\x3\x2\x2"+
+		"\x2\x605\x606\x3\x2\x2\x2\x606\x609\x3\x2\x2\x2\x607\x608\a\xB6\x2\x2"+
+		"\x608\x60A\x5\x17A\xBE\x2\x609\x607\x3\x2\x2\x2\x609\x60A\x3\x2\x2\x2"+
+		"\x60A\x60B\x3\x2\x2\x2\x60B\x60C\a\xA2\x2\x2\x60C\x60D\x5\x17A\xBE\x2"+
+		"\x60D\x612\x5\xF8}\x2\x60E\x610\x5\x17A\xBE\x2\x60F\x60E\x3\x2\x2\x2\x60F"+
+		"\x610\x3\x2\x2\x2\x610\x611\x3\x2\x2\x2\x611\x613\x5\x134\x9B\x2\x612"+
+		"\x60F\x3\x2\x2\x2\x612\x613\x3\x2\x2\x2\x613\x614\x3\x2\x2\x2\x614\x616"+
+		"\x5\x166\xB4\x2\x615\x617\x5\x1E\x10\x2\x616\x615\x3\x2\x2\x2\x616\x617"+
+		"\x3\x2\x2\x2\x617\x618\x3\x2\x2\x2\x618\x619\a_\x2\x2\x619\xDB\x3\x2\x2"+
+		"\x2\x61A\x61B\x5\x15C\xAF\x2\x61B\x61C\x5\x17A\xBE\x2\x61C\x61E\x3\x2"+
+		"\x2\x2\x61D\x61A\x3\x2\x2\x2\x61D\x61E\x3\x2\x2\x2\x61E\x621\x3\x2\x2"+
+		"\x2\x61F\x620\a\xB6\x2\x2\x620\x622\x5\x17A\xBE\x2\x621\x61F\x3\x2\x2"+
+		"\x2\x621\x622\x3\x2\x2\x2\x622\x623\x3\x2\x2\x2\x623\x624\a\xA1\x2\x2"+
+		"\x624\x625\x5\x17A\xBE\x2\x625\x62A\x5\xF8}\x2\x626\x628\x5\x17A\xBE\x2"+
+		"\x627\x626\x3\x2\x2\x2\x627\x628\x3\x2\x2\x2\x628\x629\x3\x2\x2\x2\x629"+
+		"\x62B\x5\x134\x9B\x2\x62A\x627\x3\x2\x2\x2\x62A\x62B\x3\x2\x2\x2\x62B"+
+		"\x62C\x3\x2\x2\x2\x62C\x62E\x5\x166\xB4\x2\x62D\x62F\x5\x1E\x10\x2\x62E"+
+		"\x62D\x3\x2\x2\x2\x62E\x62F\x3\x2\x2\x2\x62F\x630\x3\x2\x2\x2\x630\x631"+
+		"\a_\x2\x2\x631\xDD\x3\x2\x2\x2\x632\x633\a\xA7\x2\x2\x633\x634\x5\x17A"+
+		"\xBE\x2\x634\x643\x5\x140\xA1\x2\x635\x637\x5\x17A\xBE\x2\x636\x635\x3"+
+		"\x2\x2\x2\x636\x637\x3\x2\x2\x2\x637\x638\x3\x2\x2\x2\x638\x63A\a\xD4"+
+		"\x2\x2\x639\x63B\x5\x17A\xBE\x2\x63A\x639\x3\x2\x2\x2\x63A\x63B\x3\x2"+
+		"\x2\x2\x63B\x640\x3\x2\x2\x2\x63C\x63E\x5\x12E\x98\x2\x63D\x63F\x5\x17A"+
+		"\xBE\x2\x63E\x63D\x3\x2\x2\x2\x63E\x63F\x3\x2\x2\x2\x63F\x641\x3\x2\x2"+
+		"\x2\x640\x63C\x3\x2\x2\x2\x640\x641\x3\x2\x2\x2\x641\x642\x3\x2\x2\x2"+
+		"\x642\x644\a\xDB\x2\x2\x643\x636\x3\x2\x2\x2\x643\x644\x3\x2\x2\x2\x644"+
+		"\xDF\x3\x2\x2\x2\x645\x646\a\xAA\x2\x2\x646\x649\x5\x17A\xBE\x2\x647\x648"+
+		"\a\x9D\x2\x2\x648\x64A\x5\x17A\xBE\x2\x649\x647\x3\x2\x2\x2\x649\x64A"+
+		"\x3\x2\x2\x2\x64A\x64B\x3\x2\x2\x2\x64B\x656\x5\xE2r\x2\x64C\x64E\x5\x17A"+
+		"\xBE\x2\x64D\x64C\x3\x2\x2\x2\x64D\x64E\x3\x2\x2\x2\x64E\x64F\x3\x2\x2"+
+		"\x2\x64F\x651\a)\x2\x2\x650\x652\x5\x17A\xBE\x2\x651\x650\x3\x2\x2\x2"+
+		"\x651\x652\x3\x2\x2\x2\x652\x653\x3\x2\x2\x2\x653\x655\x5\xE2r\x2\x654"+
+		"\x64D\x3\x2\x2\x2\x655\x658\x3\x2\x2\x2\x656\x654\x3\x2\x2\x2\x656\x657"+
+		"\x3\x2\x2\x2\x657\xE1\x3\x2\x2\x2\x658\x656\x3\x2\x2\x2\x659\x65B\x5\x11E"+
+		"\x90\x2\x65A\x65C\x5\x17A\xBE\x2\x65B\x65A\x3\x2\x2\x2\x65B\x65C\x3\x2"+
+		"\x2\x2\x65C\x65D\x3\x2\x2\x2\x65D\x65F\a\xD4\x2\x2\x65E\x660\x5\x17A\xBE"+
+		"\x2\x65F\x65E\x3\x2\x2\x2\x65F\x660\x3\x2\x2\x2\x660\x661\x3\x2\x2\x2"+
+		"\x661\x663\x5\x13A\x9E\x2\x662\x664\x5\x17A\xBE\x2\x663\x662\x3\x2\x2"+
+		"\x2\x663\x664\x3\x2\x2\x2\x664\x665\x3\x2\x2\x2\x665\x669\a\xDB\x2\x2"+
+		"\x666\x667\x5\x17A\xBE\x2\x667\x668\x5\x142\xA2\x2\x668\x66A\x3\x2\x2"+
+		"\x2\x669\x666\x3\x2\x2\x2\x669\x66A\x3\x2\x2\x2\x66A\xE3\x3\x2\x2\x2\x66B"+
+		"\x671\a\xAD\x2\x2\x66C\x66F\x5\x17A\xBE\x2\x66D\x670\a\x8C\x2\x2\x66E"+
+		"\x670\x5\xFE\x80\x2\x66F\x66D\x3\x2\x2\x2\x66F\x66E\x3\x2\x2\x2\x670\x672"+
+		"\x3\x2\x2\x2\x671\x66C\x3\x2\x2\x2\x671\x672\x3\x2\x2\x2\x672\xE5\x3\x2"+
+		"\x2\x2\x673\x674\a\xAE\x2\x2\x674\xE7\x3\x2\x2\x2\x675\x676\a\xAF\x2\x2"+
+		"\x676\x677\x5\x17A\xBE\x2\x677\x679\x5\xFE\x80\x2\x678\x67A\x5\x17A\xBE"+
+		"\x2\x679\x678\x3\x2\x2\x2\x679\x67A\x3\x2\x2\x2\x67A\x67B\x3\x2\x2\x2"+
+		"\x67B\x67D\a\xD0\x2\x2\x67C\x67E\x5\x17A\xBE\x2\x67D\x67C\x3\x2\x2\x2"+
+		"\x67D\x67E\x3\x2\x2\x2\x67E\x67F\x3\x2\x2\x2\x67F\x680\x5\xFE\x80\x2\x680"+
+		"\xE9\x3\x2\x2\x2\x681\x682\a\xB8\x2\x2\x682\xEB\x3\x2\x2\x2\x683\x684"+
+		"\a\xB1\x2\x2\x684\x685\x5\x17A\xBE\x2\x685\x686\a\x41\x2\x2\x686\x687"+
+		"\x5\x17A\xBE\x2\x687\x688\x5\xFE\x80\x2\x688\x68C\x5\x166\xB4\x2\x689"+
+		"\x68B\x5\xF0y\x2\x68A\x689\x3\x2\x2\x2\x68B\x68E\x3\x2\x2\x2\x68C\x68A"+
+		"\x3\x2\x2\x2\x68C\x68D\x3\x2\x2\x2\x68D\x68F\x3\x2\x2\x2\x68E\x68C\x3"+
+		"\x2\x2\x2\x68F\x690\a`\x2\x2\x690\xED\x3\x2\x2\x2\x691\x693\a|\x2\x2\x692"+
+		"\x694\x5\x17A\xBE\x2\x693\x692\x3\x2\x2\x2\x693\x694\x3\x2\x2\x2\x694"+
+		"\x695\x3\x2\x2\x2\x695\x697\x5\x146\xA4\x2\x696\x698\x5\x17A\xBE\x2\x697"+
+		"\x696\x3\x2\x2\x2\x697\x698\x3\x2\x2\x2\x698\x699\x3\x2\x2\x2\x699\x69A"+
+		"\x5\xFE\x80\x2\x69A\x6A3\x3\x2\x2\x2\x69B\x69C\x5\xFE\x80\x2\x69C\x69D"+
+		"\x5\x17A\xBE\x2\x69D\x69E\a\xBE\x2\x2\x69E\x69F\x5\x17A\xBE\x2\x69F\x6A0"+
+		"\x5\xFE\x80\x2\x6A0\x6A3\x3\x2\x2\x2\x6A1\x6A3\x5\xFE\x80\x2\x6A2\x691"+
+		"\x3\x2\x2\x2\x6A2\x69B\x3\x2\x2\x2\x6A2\x6A1\x3\x2\x2\x2\x6A3\xEF\x3\x2"+
+		"\x2\x2\x6A4\x6A5\a\x41\x2\x2\x6A5\x6A6\x5\x17A\xBE\x2\x6A6\x6A7\x5\xF2"+
+		"z\x2\x6A7\x6A9\x5\x166\xB4\x2\x6A8\x6AA\x5\x1E\x10\x2\x6A9\x6A8\x3\x2"+
+		"\x2\x2\x6A9\x6AA\x3\x2\x2\x2\x6AA\xF1\x3\x2\x2\x2\x6AB\x6BB\aY\x2\x2\x6AC"+
+		"\x6B7\x5\xEEx\x2\x6AD\x6AF\x5\x17A\xBE\x2\x6AE\x6AD\x3\x2\x2\x2\x6AE\x6AF"+
+		"\x3\x2\x2\x2\x6AF\x6B0\x3\x2\x2\x2\x6B0\x6B2\a)\x2\x2\x6B1\x6B3\x5\x17A"+
+		"\xBE\x2\x6B2\x6B1\x3\x2\x2\x2\x6B2\x6B3\x3\x2\x2\x2\x6B3\x6B4\x3\x2\x2"+
+		"\x2\x6B4\x6B6\x5\xEEx\x2\x6B5\x6AE\x3\x2\x2\x2\x6B6\x6B9\x3\x2\x2\x2\x6B7"+
+		"\x6B5\x3\x2\x2\x2\x6B7\x6B8\x3\x2\x2\x2\x6B8\x6BB\x3\x2\x2\x2\x6B9\x6B7"+
+		"\x3\x2\x2\x2\x6BA\x6AB\x3\x2\x2\x2\x6BA\x6AC\x3\x2\x2\x2\x6BB\xF3\x3\x2"+
+		"\x2\x2\x6BC\x6BD\a\xB2\x2\x2\x6BD\x6BE\x5\x17A\xBE\x2\x6BE\x6C0\x5\xFE"+
+		"\x80\x2\x6BF\x6C1\x5\x17A\xBE\x2\x6C0\x6BF\x3\x2\x2\x2\x6C0\x6C1\x3\x2"+
+		"\x2\x2\x6C1\x6C2\x3\x2\x2\x2\x6C2\x6C4\a\xD0\x2\x2\x6C3\x6C5\x5\x17A\xBE"+
+		"\x2\x6C4\x6C3\x3\x2\x2\x2\x6C4\x6C5\x3\x2\x2\x2\x6C5\x6C6\x3\x2\x2\x2"+
+		"\x6C6\x6C7\x5\xFE\x80\x2\x6C7\xF5\x3\x2\x2\x2\x6C8\x6C9\x5\x15C\xAF\x2"+
+		"\x6C9\x6CA\x5\x17A\xBE\x2\x6CA\x6CC\x3\x2\x2\x2\x6CB\x6C8\x3\x2\x2\x2"+
+		"\x6CB\x6CC\x3\x2\x2\x2\x6CC\x6CF\x3\x2\x2\x2\x6CD\x6CE\a\xB6\x2\x2\x6CE"+
+		"\x6D0\x5\x17A\xBE\x2\x6CF\x6CD\x3\x2\x2\x2\x6CF\x6D0\x3\x2\x2\x2\x6D0"+
+		"\x6D1\x3\x2\x2\x2\x6D1\x6D3\a\xBA\x2\x2\x6D2\x6D4\x5\x17A\xBE\x2\x6D3"+
+		"\x6D2\x3\x2\x2\x2\x6D3\x6D4\x3\x2\x2\x2\x6D4\x6D5\x3\x2\x2\x2\x6D5\x6DA"+
+		"\x5\xF8}\x2\x6D6\x6D8\x5\x17A\xBE\x2\x6D7\x6D6\x3\x2\x2\x2\x6D7\x6D8\x3"+
+		"\x2\x2\x2\x6D8\x6D9\x3\x2\x2\x2\x6D9\x6DB\x5\x134\x9B\x2\x6DA\x6D7\x3"+
+		"\x2\x2\x2\x6DA\x6DB\x3\x2\x2\x2\x6DB\x6DC\x3\x2\x2\x2\x6DC\x6DE\x5\x166"+
+		"\xB4\x2\x6DD\x6DF\x5\x1E\x10\x2\x6DE\x6DD\x3\x2\x2\x2\x6DE\x6DF\x3\x2"+
+		"\x2\x2\x6DF\x6E0\x3\x2\x2\x2\x6E0\x6E1\a\x61\x2\x2\x6E1\xF7\x3\x2\x2\x2"+
+		"\x6E2\x6E3\x5\x140\xA1\x2\x6E3\xF9\x3\x2\x2\x2\x6E4\x6E5\x5\x15C\xAF\x2"+
+		"\x6E5\x6E6\x5\x17A\xBE\x2\x6E6\x6E8\x3\x2\x2\x2\x6E7\x6E4\x3\x2\x2\x2"+
+		"\x6E7\x6E8\x3\x2\x2\x2\x6E8\x6E9\x3\x2\x2\x2\x6E9\x6EA\a\xC0\x2\x2\x6EA"+
+		"\x6EB\x5\x17A\xBE\x2\x6EB\x6EC\x5\x140\xA1\x2\x6EC\x6F0\x5\x166\xB4\x2"+
+		"\x6ED\x6EF\x5\xFC\x7F\x2\x6EE\x6ED\x3\x2\x2\x2\x6EF\x6F2\x3\x2\x2\x2\x6F0"+
+		"\x6EE\x3\x2\x2\x2\x6F0\x6F1\x3\x2\x2\x2\x6F1\x6F3\x3\x2\x2\x2\x6F2\x6F0"+
+		"\x3\x2\x2\x2\x6F3\x6F4\a\x62\x2\x2\x6F4\xFB\x3\x2\x2\x2\x6F5\x704\x5\x140"+
+		"\xA1\x2\x6F6\x6F8\x5\x17A\xBE\x2\x6F7\x6F6\x3\x2\x2\x2\x6F7\x6F8\x3\x2"+
+		"\x2\x2\x6F8\x6F9\x3\x2\x2\x2\x6F9\x6FE\a\xD4\x2\x2\x6FA\x6FC\x5\x17A\xBE"+
+		"\x2\x6FB\x6FA\x3\x2\x2\x2\x6FB\x6FC\x3\x2\x2\x2\x6FC\x6FD\x3\x2\x2\x2"+
+		"\x6FD\x6FF\x5\x13A\x9E\x2\x6FE\x6FB\x3\x2\x2\x2\x6FE\x6FF\x3\x2\x2\x2"+
+		"\x6FF\x701\x3\x2\x2\x2\x700\x702\x5\x17A\xBE\x2\x701\x700\x3\x2\x2\x2"+
+		"\x701\x702\x3\x2\x2\x2\x702\x703\x3\x2\x2\x2\x703\x705\a\xDB\x2\x2\x704"+
+		"\x6F7\x3\x2\x2\x2\x704\x705\x3\x2\x2\x2\x705\x709\x3\x2\x2\x2\x706\x707"+
+		"\x5\x17A\xBE\x2\x707\x708\x5\x142\xA2\x2\x708\x70A\x3\x2\x2\x2\x709\x706"+
+		"\x3\x2\x2\x2\x709\x70A\x3\x2\x2\x2\x70A\x70B\x3\x2\x2\x2\x70B\x70C\x5"+
+		"\x166\xB4\x2\x70C\xFD\x3\x2\x2\x2\x70D\x70E\b\x80\x1\x2\x70E\x710\a\x8D"+
+		"\x2\x2\x70F\x711\x5\x17A\xBE\x2\x710\x70F\x3\x2\x2\x2\x710\x711\x3\x2"+
+		"\x2\x2\x711\x712\x3\x2\x2\x2\x712\x73C\x5\xFE\x80\x16\x713\x715\a\x34"+
+		"\x2\x2\x714\x716\x5\x17A\xBE\x2\x715\x714\x3\x2\x2\x2\x715\x716\x3\x2"+
+		"\x2\x2\x716\x717\x3\x2\x2\x2\x717\x73C\x5\xFE\x80\x13\x718\x71A\x5\x13E"+
+		"\xA0\x2\x719\x71B\x5\x17A\xBE\x2\x71A\x719\x3\x2\x2\x2\x71A\x71B\x3\x2"+
+		"\x2\x2\x71B\x71C\x3\x2\x2\x2\x71C\x71E\a\xCD\x2\x2\x71D\x71F\x5\x17A\xBE"+
+		"\x2\x71E\x71D\x3\x2\x2\x2\x71E\x71F\x3\x2\x2\x2\x71F\x720\x3\x2\x2\x2"+
+		"\x720\x721\x5\xFE\x80\x12\x721\x73C\x3\x2\x2\x2\x722\x724\a\xD6\x2\x2"+
+		"\x723\x725\x5\x17A\xBE\x2\x724\x723\x3\x2\x2\x2\x724\x725\x3\x2\x2\x2"+
+		"\x725\x726\x3\x2\x2\x2\x726\x73C\x5\xFE\x80\x10\x727\x729\a\x8E\x2\x2"+
+		"\x728\x72A\x5\x17A\xBE\x2\x729\x728\x3\x2\x2\x2\x729\x72A\x3\x2\x2\x2"+
+		"\x72A\x72B\x3\x2\x2\x2\x72B\x73C\x5\xFE\x80\t\x72C\x73C\x5\x154\xAB\x2"+
+		"\x72D\x73C\x5\x11E\x90\x2\x72E\x730\a\xD4\x2\x2\x72F\x731\x5\x17A\xBE"+
+		"\x2\x730\x72F\x3\x2\x2\x2\x730\x731\x3\x2\x2\x2\x731\x732\x3\x2\x2\x2"+
+		"\x732\x734\x5\xFE\x80\x2\x733\x735\x5\x17A\xBE\x2\x734\x733\x3\x2\x2\x2"+
+		"\x734\x735\x3\x2\x2\x2\x735\x736\x3\x2\x2\x2\x736\x737\a\xDB\x2\x2\x737"+
+		"\x73C\x3\x2\x2\x2\x738\x73C\x5\x100\x81\x2\x739\x73C\x5\xD0i\x2\x73A\x73C"+
+		"\x5\x38\x1D\x2\x73B\x70D\x3\x2\x2\x2\x73B\x713\x3\x2\x2\x2\x73B\x718\x3"+
+		"\x2\x2\x2\x73B\x722\x3\x2\x2\x2\x73B\x727\x3\x2\x2\x2\x73B\x72C\x3\x2"+
+		"\x2\x2\x73B\x72D\x3\x2\x2\x2\x73B\x72E\x3\x2\x2\x2\x73B\x738\x3\x2\x2"+
+		"\x2\x73B\x739\x3\x2\x2\x2\x73B\x73A\x3\x2\x2\x2\x73C\x7AB\x3\x2\x2\x2"+
+		"\x73D\x73F\f\x11\x2\x2\x73E\x740\x5\x17A\xBE\x2\x73F\x73E\x3\x2\x2\x2"+
+		"\x73F\x740\x3\x2\x2\x2\x740\x741\x3\x2\x2\x2\x741\x743\a\xDA\x2\x2\x742"+
+		"\x744\x5\x17A\xBE\x2\x743\x742\x3\x2\x2\x2\x743\x744\x3\x2\x2\x2\x744"+
+		"\x745\x3\x2\x2\x2\x745\x7AA\x5\xFE\x80\x12\x746\x748\f\xF\x2\x2\x747\x749"+
+		"\x5\x17A\xBE\x2\x748\x747\x3\x2\x2\x2\x748\x749\x3\x2\x2\x2\x749\x74A"+
+		"\x3\x2\x2\x2\x74A\x74C\t\f\x2\x2\x74B\x74D\x5\x17A\xBE\x2\x74C\x74B\x3"+
+		"\x2\x2\x2\x74C\x74D\x3\x2\x2\x2\x74D\x74E\x3\x2\x2\x2\x74E\x7AA\x5\xFE"+
+		"\x80\x10\x74F\x751\f\xE\x2\x2\x750\x752\x5\x17A\xBE\x2\x751\x750\x3\x2"+
+		"\x2\x2\x751\x752\x3\x2\x2\x2\x752\x753\x3\x2\x2\x2\x753\x755\a\xCF\x2"+
+		"\x2\x754\x756\x5\x17A\xBE\x2\x755\x754\x3\x2\x2\x2\x755\x756\x3\x2\x2"+
+		"\x2\x756\x757\x3\x2\x2\x2\x757\x7AA\x5\xFE\x80\xF\x758\x75A\f\r\x2\x2"+
+		"\x759\x75B\x5\x17A\xBE\x2\x75A\x759\x3\x2\x2\x2\x75A\x75B\x3\x2\x2\x2"+
+		"\x75B\x75C\x3\x2\x2\x2\x75C\x75E\a\x8B\x2\x2\x75D\x75F\x5\x17A\xBE\x2"+
+		"\x75E\x75D\x3\x2\x2\x2\x75E\x75F\x3\x2\x2\x2\x75F\x760\x3\x2\x2\x2\x760"+
+		"\x7AA\x5\xFE\x80\xE\x761\x763\f\f\x2\x2\x762\x764\x5\x17A\xBE\x2\x763"+
+		"\x762\x3\x2\x2\x2\x763\x764\x3\x2\x2\x2\x764\x765\x3\x2\x2\x2\x765\x767"+
+		"\t\r\x2\x2\x766\x768\x5\x17A\xBE\x2\x767\x766\x3\x2\x2\x2\x767\x768\x3"+
+		"\x2\x2\x2\x768\x769\x3\x2\x2\x2\x769\x7AA\x5\xFE\x80\r\x76A\x76C\f\v\x2"+
+		"\x2\x76B\x76D\x5\x17A\xBE\x2\x76C\x76B\x3\x2\x2\x2\x76C\x76D\x3\x2\x2"+
+		"\x2\x76D\x76E\x3\x2\x2\x2\x76E\x770\a\x32\x2\x2\x76F\x771\x5\x17A\xBE"+
+		"\x2\x770\x76F\x3\x2\x2\x2\x770\x771\x3\x2\x2\x2\x771\x772\x3\x2\x2\x2"+
+		"\x772\x7AA\x5\xFE\x80\f\x773\x775\f\n\x2\x2\x774\x776\x5\x17A\xBE\x2\x775"+
+		"\x774\x3\x2\x2\x2\x775\x776\x3\x2\x2\x2\x776\x777\x3\x2\x2\x2\x777\x779"+
+		"\t\xE\x2\x2\x778\x77A\x5\x17A\xBE\x2\x779\x778\x3\x2\x2\x2\x779\x77A\x3"+
+		"\x2\x2\x2\x77A\x77B\x3\x2\x2\x2\x77B\x7AA\x5\xFE\x80\v\x77C\x77E\f\b\x2"+
+		"\x2\x77D\x77F\x5\x17A\xBE\x2\x77E\x77D\x3\x2\x2\x2\x77E\x77F\x3\x2\x2"+
+		"\x2\x77F\x780\x3\x2\x2\x2\x780\x782\a\x36\x2\x2\x781\x783\x5\x17A\xBE"+
+		"\x2\x782\x781\x3\x2\x2\x2\x782\x783\x3\x2\x2\x2\x783\x784\x3\x2\x2\x2"+
+		"\x784\x7AA\x5\xFE\x80\t\x785\x787\f\a\x2\x2\x786\x788\x5\x17A\xBE\x2\x787"+
+		"\x786\x3\x2\x2\x2\x787\x788\x3\x2\x2\x2\x788\x789\x3\x2\x2\x2\x789\x78B"+
+		"\a\x9A\x2\x2\x78A\x78C\x5\x17A\xBE\x2\x78B\x78A\x3\x2\x2\x2\x78B\x78C"+
+		"\x3\x2\x2\x2\x78C\x78D\x3\x2\x2\x2\x78D\x7AA\x5\xFE\x80\b\x78E\x790\f"+
+		"\x6\x2\x2\x78F\x791\x5\x17A\xBE\x2\x790\x78F\x3\x2\x2\x2\x790\x791\x3"+
+		"\x2\x2\x2\x791\x792\x3\x2\x2\x2\x792\x794\a\xCC\x2\x2\x793\x795\x5\x17A"+
+		"\xBE\x2\x794\x793\x3\x2\x2\x2\x794\x795\x3\x2\x2\x2\x795\x796\x3\x2\x2"+
+		"\x2\x796\x7AA\x5\xFE\x80\a\x797\x799\f\x5\x2\x2\x798\x79A\x5\x17A\xBE"+
+		"\x2\x799\x798\x3\x2\x2\x2\x799\x79A\x3\x2\x2\x2\x79A\x79B\x3\x2\x2\x2"+
+		"\x79B\x79D\a\x66\x2\x2\x79C\x79E\x5\x17A\xBE\x2\x79D\x79C\x3\x2\x2\x2"+
+		"\x79D\x79E\x3\x2\x2\x2\x79E\x79F\x3\x2\x2\x2\x79F\x7AA\x5\xFE\x80\x6\x7A0"+
+		"\x7A2\f\x4\x2\x2\x7A1\x7A3\x5\x17A\xBE\x2\x7A2\x7A1\x3\x2\x2\x2\x7A2\x7A3"+
+		"\x3\x2\x2\x2\x7A3\x7A4\x3\x2\x2\x2\x7A4\x7A6\ax\x2\x2\x7A5\x7A7\x5\x17A"+
+		"\xBE\x2\x7A6\x7A5\x3\x2\x2\x2\x7A6\x7A7\x3\x2\x2\x2\x7A7\x7A8\x3\x2\x2"+
+		"\x2\x7A8\x7AA\x5\xFE\x80\x5\x7A9\x73D\x3\x2\x2\x2\x7A9\x746\x3\x2\x2\x2"+
+		"\x7A9\x74F\x3\x2\x2\x2\x7A9\x758\x3\x2\x2\x2\x7A9\x761\x3\x2\x2\x2\x7A9"+
+		"\x76A\x3\x2\x2\x2\x7A9\x773\x3\x2\x2\x2\x7A9\x77C\x3\x2\x2\x2\x7A9\x785"+
+		"\x3\x2\x2\x2\x7A9\x78E\x3\x2\x2\x2\x7A9\x797\x3\x2\x2\x2\x7A9\x7A0\x3"+
+		"\x2\x2\x2\x7AA\x7AD\x3\x2\x2\x2\x7AB\x7A9\x3\x2\x2\x2\x7AB\x7AC\x3\x2"+
+		"\x2\x2\x7AC\xFF\x3\x2\x2\x2\x7AD\x7AB\x3\x2\x2\x2\x7AE\x7AF\a\xC1\x2\x2"+
+		"\x7AF\x7B0\x5\x17A\xBE\x2\x7B0\x7B6\x5\xFE\x80\x2\x7B1\x7B2\x5\x17A\xBE"+
+		"\x2\x7B2\x7B3\a|\x2\x2\x7B3\x7B4\x5\x17A\xBE\x2\x7B4\x7B5\x5\x158\xAD"+
+		"\x2\x7B5\x7B7\x3\x2\x2\x2\x7B6\x7B1\x3\x2\x2\x2\x7B6\x7B7\x3\x2\x2\x2"+
+		"\x7B7\x101\x3\x2\x2\x2\x7B8\x7BC\aU\x2\x2\x7B9\x7BC\a\xB6\x2\x2\x7BA\x7BC"+
+		"\x5\x15C\xAF\x2\x7BB\x7B8\x3\x2\x2\x2\x7BB\x7B9\x3\x2\x2\x2\x7BB\x7BA"+
+		"\x3\x2\x2\x2\x7BC\x7BD\x3\x2\x2\x2\x7BD\x7C0\x5\x17A\xBE\x2\x7BE\x7BF"+
+		"\a\xCA\x2\x2\x7BF\x7C1\x5\x17A\xBE\x2\x7C0\x7BE\x3\x2\x2\x2\x7C0\x7C1"+
+		"\x3\x2\x2\x2\x7C1\x7C2\x3\x2\x2\x2\x7C2\x7C3\x5\x104\x83\x2\x7C3\x103"+
+		"\x3\x2\x2\x2\x7C4\x7CF\x5\x106\x84\x2\x7C5\x7C7\x5\x17A\xBE\x2\x7C6\x7C5"+
+		"\x3\x2\x2\x2\x7C6\x7C7\x3\x2\x2\x2\x7C7\x7C8\x3\x2\x2\x2\x7C8\x7CA\a)"+
+		"\x2\x2\x7C9\x7CB\x5\x17A\xBE\x2\x7CA\x7C9\x3\x2\x2\x2\x7CA\x7CB\x3\x2"+
+		"\x2\x2\x7CB\x7CC\x3\x2\x2\x2\x7CC\x7CE\x5\x106\x84\x2\x7CD\x7C6\x3\x2"+
+		"\x2\x2\x7CE\x7D1\x3\x2\x2\x2\x7CF\x7CD\x3\x2\x2\x2\x7CF\x7D0\x3\x2\x2"+
+		"\x2\x7D0\x105\x3\x2\x2\x2\x7D1\x7CF\x3\x2\x2\x2\x7D2\x7D4\x5\x140\xA1"+
+		"\x2\x7D3\x7D5\x5\x15A\xAE\x2\x7D4\x7D3\x3\x2\x2\x2\x7D4\x7D5\x3\x2\x2"+
+		"\x2\x7D5\x7E7\x3\x2\x2\x2\x7D6\x7D8\x5\x17A\xBE\x2\x7D7\x7D6\x3\x2\x2"+
+		"\x2\x7D7\x7D8\x3\x2\x2\x2\x7D8\x7D9\x3\x2\x2\x2\x7D9\x7DB\a\xD4\x2\x2"+
+		"\x7DA\x7DC\x5\x17A\xBE\x2\x7DB\x7DA\x3\x2\x2\x2\x7DB\x7DC\x3\x2\x2\x2"+
+		"\x7DC\x7E1\x3\x2\x2\x2\x7DD\x7DF\x5\x13A\x9E\x2\x7DE\x7E0\x5\x17A\xBE"+
+		"\x2\x7DF\x7DE\x3\x2\x2\x2\x7DF\x7E0\x3\x2\x2\x2\x7E0\x7E2\x3\x2\x2\x2"+
+		"\x7E1\x7DD\x3\x2\x2\x2\x7E1\x7E2\x3\x2\x2\x2\x7E2\x7E3\x3\x2\x2\x2\x7E3"+
+		"\x7E5\a\xDB\x2\x2\x7E4\x7E6\x5\x17A\xBE\x2\x7E5\x7E4\x3\x2\x2\x2\x7E5"+
+		"\x7E6\x3\x2\x2\x2\x7E6\x7E8\x3\x2\x2\x2\x7E7\x7D7\x3\x2\x2\x2\x7E7\x7E8"+
+		"\x3\x2\x2\x2\x7E8\x7EC\x3\x2\x2\x2\x7E9\x7EA\x5\x17A\xBE\x2\x7EA\x7EB"+
+		"\x5\x142\xA2\x2\x7EB\x7ED\x3\x2\x2\x2\x7EC\x7E9\x3\x2\x2\x2\x7EC\x7ED"+
+		"\x3\x2\x2\x2\x7ED\x107\x3\x2\x2\x2\x7EE\x7EF\a\xC7\x2\x2\x7EF\x7F0\x5"+
+		"\x17A\xBE\x2\x7F0\x7F1\x5\xFE\x80\x2\x7F1\x7F3\x5\x166\xB4\x2\x7F2\x7F4"+
+		"\x5\x1E\x10\x2\x7F3\x7F2\x3\x2\x2\x2\x7F3\x7F4\x3\x2\x2\x2\x7F4\x7F5\x3"+
+		"\x2\x2\x2\x7F5\x7F6\a\xC6\x2\x2\x7F6\x109\x3\x2\x2\x2\x7F7\x7F8\a\xC9"+
+		"\x2\x2\x7F8\x7F9\x5\x17A\xBE\x2\x7F9\x7FA\x5\x112\x8A\x2\x7FA\x7FC\x5"+
+		"\x166\xB4\x2\x7FB\x7FD\x5\x1E\x10\x2\x7FC\x7FB\x3\x2\x2\x2\x7FC\x7FD\x3"+
+		"\x2\x2\x2\x7FD\x7FE\x3\x2\x2\x2\x7FE\x7FF\a\x63\x2\x2\x7FF\x10B\x3\x2"+
+		"\x2\x2\x800\x802\x5\xFE\x80\x2\x801\x803\x5\x17A\xBE\x2\x802\x801\x3\x2"+
+		"\x2\x2\x802\x803\x3\x2\x2\x2\x803\x804\x3\x2\x2\x2\x804\x806\a-\x2\x2"+
+		"\x805\x807\x5\x17A\xBE\x2\x806\x805\x3\x2\x2\x2\x806\x807\x3\x2\x2\x2"+
+		"\x807\x809\x3\x2\x2\x2\x808\x800\x3\x2\x2\x2\x808\x809\x3\x2\x2\x2\x809"+
+		"\x80A\x3\x2\x2\x2\x80A\x80B\a\r\x2\x2\x80B\x810\x5\x17A\xBE\x2\x80C\x80E"+
+		"\a\xB7\x2\x2\x80D\x80F\x5\x17A\xBE\x2\x80E\x80D\x3\x2\x2\x2\x80E\x80F"+
+		"\x3\x2\x2\x2\x80F\x811\x3\x2\x2\x2\x810\x80C\x3\x2\x2\x2\x810\x811\x3"+
+		"\x2\x2\x2\x811\x812\x3\x2\x2\x2\x812\x81B\x5\x110\x89\x2\x813\x815\x5"+
+		"\x17A\xBE\x2\x814\x813\x3\x2\x2\x2\x814\x815\x3\x2\x2\x2\x815\x816\x3"+
+		"\x2\x2\x2\x816\x818\a)\x2\x2\x817\x819\x5\x17A\xBE\x2\x818\x817\x3\x2"+
+		"\x2\x2\x818\x819\x3\x2\x2\x2\x819\x81A\x3\x2\x2\x2\x81A\x81C\x5\xFE\x80"+
+		"\x2\x81B\x814\x3\x2\x2\x2\x81C\x81D\x3\x2\x2\x2\x81D\x81B\x3\x2\x2\x2"+
+		"\x81D\x81E\x3\x2\x2\x2\x81E\x10D\x3\x2\x2\x2\x81F\x821\x5\xFE\x80\x2\x820"+
+		"\x822\x5\x17A\xBE\x2\x821\x820\x3\x2\x2\x2\x821\x822\x3\x2\x2\x2\x822"+
+		"\x823\x3\x2\x2\x2\x823\x825\a-\x2\x2\x824\x826\x5\x17A\xBE\x2\x825\x824"+
+		"\x3\x2\x2\x2\x825\x826\x3\x2\x2\x2\x826\x828\x3\x2\x2\x2\x827\x81F\x3"+
+		"\x2\x2\x2\x827\x828\x3\x2\x2\x2\x828\x829\x3\x2\x2\x2\x829\x82A\a&\x2"+
+		"\x2\x82A\x82B\x5\x17A\xBE\x2\x82B\x82D\x5\x110\x89\x2\x82C\x82E\x5\x17A"+
+		"\xBE\x2\x82D\x82C\x3\x2\x2\x2\x82D\x82E\x3\x2\x2\x2\x82E\x82F\x3\x2\x2"+
+		"\x2\x82F\x831\a\xD6\x2\x2\x830\x832\x5\x17A\xBE\x2\x831\x830\x3\x2\x2"+
+		"\x2\x831\x832\x3\x2\x2\x2\x832\x833\x3\x2\x2\x2\x833\x834\x5\x110\x89"+
+		"\x2\x834\x10F\x3\x2\x2\x2\x835\x837\a\xD4\x2\x2\x836\x838\x5\x17A\xBE"+
+		"\x2\x837\x836\x3\x2\x2\x2\x837\x838\x3\x2\x2\x2\x838\x839\x3\x2\x2\x2"+
+		"\x839\x83B\x5\xFE\x80\x2\x83A\x83C\x5\x17A\xBE\x2\x83B\x83A\x3\x2\x2\x2"+
+		"\x83B\x83C\x3\x2\x2\x2\x83C\x83D\x3\x2\x2\x2\x83D\x83F\a)\x2\x2\x83E\x840"+
+		"\x5\x17A\xBE\x2\x83F\x83E\x3\x2\x2\x2\x83F\x840\x3\x2\x2\x2\x840\x841"+
+		"\x3\x2\x2\x2\x841\x843\x5\xFE\x80\x2\x842\x844\x5\x17A\xBE\x2\x843\x842"+
+		"\x3\x2\x2\x2\x843\x844\x3\x2\x2\x2\x844\x845\x3\x2\x2\x2\x845\x846\a\xDB"+
+		"\x2\x2\x846\x111\x3\x2\x2\x2\x847\x848\x5\xFE\x80\x2\x848\x113\x3\x2\x2"+
+		"\x2\x849\x84A\a@\x2\x2\x84A\x84B\x5\x17A\xBE\x2\x84B\x84C\x5\x116\x8C"+
+		"\x2\x84C\x115\x3\x2\x2\x2\x84D\x84F\x5\x11E\x90\x2\x84E\x84D\x3\x2\x2"+
+		"\x2\x84E\x84F\x3\x2\x2\x2\x84F\x850\x3\x2\x2\x2\x850\x851\a-\x2\x2\x851"+
+		"\x853\x5\x140\xA1\x2\x852\x854\x5\x15A\xAE\x2\x853\x852\x3\x2\x2\x2\x853"+
+		"\x854\x3\x2\x2\x2\x854\x862\x3\x2\x2\x2\x855\x857\x5\x17A\xBE\x2\x856"+
+		"\x855\x3\x2\x2\x2\x856\x857\x3\x2\x2\x2\x857\x858\x3\x2\x2\x2\x858\x85A"+
+		"\a\xD4\x2\x2\x859\x85B\x5\x17A\xBE\x2\x85A\x859\x3\x2\x2\x2\x85A\x85B"+
+		"\x3\x2\x2\x2\x85B\x85C\x3\x2\x2\x2\x85C\x85E\x5\x12E\x98\x2\x85D\x85F"+
+		"\x5\x17A\xBE\x2\x85E\x85D\x3\x2\x2\x2\x85E\x85F\x3\x2\x2\x2\x85F\x860"+
+		"\x3\x2\x2\x2\x860\x861\a\xDB\x2\x2\x861\x863\x3\x2\x2\x2\x862\x856\x3"+
+		"\x2\x2\x2\x862\x863\x3\x2\x2\x2\x863\x86D\x3\x2\x2\x2\x864\x866\x5\x17A"+
+		"\xBE\x2\x865\x864\x3\x2\x2\x2\x865\x866\x3\x2\x2\x2\x866\x867\x3\x2\x2"+
+		"\x2\x867\x868\a\xD4\x2\x2\x868\x869\x5\x13A\x9E\x2\x869\x86A\a\xDB\x2"+
+		"\x2\x86A\x86C\x3\x2\x2\x2\x86B\x865\x3\x2\x2\x2\x86C\x86F\x3\x2\x2\x2"+
+		"\x86D\x86B\x3\x2\x2\x2\x86D\x86E\x3\x2\x2\x2\x86E\x890\x3\x2\x2\x2\x86F"+
+		"\x86D\x3\x2\x2\x2\x870\x872\x5\x140\xA1\x2\x871\x873\x5\x15A\xAE\x2\x872"+
+		"\x871\x3\x2\x2\x2\x872\x873\x3\x2\x2\x2\x873\x881\x3\x2\x2\x2\x874\x876"+
+		"\x5\x17A\xBE\x2\x875\x874\x3\x2\x2\x2\x875\x876\x3\x2\x2\x2\x876\x877"+
+		"\x3\x2\x2\x2\x877\x879\a\xD4\x2\x2\x878\x87A\x5\x17A\xBE\x2\x879\x878"+
+		"\x3\x2\x2\x2\x879\x87A\x3\x2\x2\x2\x87A\x87B\x3\x2\x2\x2\x87B\x87D\x5"+
+		"\x12E\x98\x2\x87C\x87E\x5\x17A\xBE\x2\x87D\x87C\x3\x2\x2\x2\x87D\x87E"+
+		"\x3\x2\x2\x2\x87E\x87F\x3\x2\x2\x2\x87F\x880\a\xDB\x2\x2\x880\x882\x3"+
+		"\x2\x2\x2\x881\x875\x3\x2\x2\x2\x881\x882\x3\x2\x2\x2\x882\x88C\x3\x2"+
+		"\x2\x2\x883\x885\x5\x17A\xBE\x2\x884\x883\x3\x2\x2\x2\x884\x885\x3\x2"+
+		"\x2\x2\x885\x886\x3\x2\x2\x2\x886\x887\a\xD4\x2\x2\x887\x888\x5\x13A\x9E"+
+		"\x2\x888\x889\a\xDB\x2\x2\x889\x88B\x3\x2\x2\x2\x88A\x884\x3\x2\x2\x2"+
+		"\x88B\x88E\x3\x2\x2\x2\x88C\x88A\x3\x2\x2\x2\x88C\x88D\x3\x2\x2\x2\x88D"+
+		"\x890\x3\x2\x2\x2\x88E\x88C\x3\x2\x2\x2\x88F\x84E\x3\x2\x2\x2\x88F\x870"+
+		"\x3\x2\x2\x2\x890\x117\x3\x2\x2\x2\x891\x894\x5\x11A\x8E\x2\x892\x894"+
+		"\x5\x11C\x8F\x2\x893\x891\x3\x2\x2\x2\x893\x892\x3\x2\x2\x2\x894\x119"+
+		"\x3\x2\x2\x2\x895\x897\x5\x11E\x90\x2\x896\x895\x3\x2\x2\x2\x896\x897"+
+		"\x3\x2\x2\x2\x897\x899\x3\x2\x2\x2\x898\x89A\x5\x17A\xBE\x2\x899\x898"+
+		"\x3\x2\x2\x2\x899\x89A\x3\x2\x2\x2\x89A\x89B\x3\x2\x2\x2\x89B\x89D\a-"+
+		"\x2\x2\x89C\x89E\x5\x17A\xBE\x2\x89D\x89C\x3\x2\x2\x2\x89D\x89E\x3\x2"+
+		"\x2\x2\x89E\x89F\x3\x2\x2\x2\x89F\x8A1\x5\x13E\xA0\x2\x8A0\x8A2\x5\x15A"+
+		"\xAE\x2\x8A1\x8A0\x3\x2\x2\x2\x8A1\x8A2\x3\x2\x2\x2\x8A2\x8A6\x3\x2\x2"+
+		"\x2\x8A3\x8A4\x5\x17A\xBE\x2\x8A4\x8A5\x5\x12E\x98\x2\x8A5\x8A7\x3\x2"+
+		"\x2\x2\x8A6\x8A3\x3\x2\x2\x2\x8A6\x8A7\x3\x2\x2\x2\x8A7\x8AC\x3\x2\x2"+
+		"\x2\x8A8\x8AA\x5\x17A\xBE\x2\x8A9\x8A8\x3\x2\x2\x2\x8A9\x8AA\x3\x2\x2"+
+		"\x2\x8AA\x8AB\x3\x2\x2\x2\x8AB\x8AD\x5\x132\x9A\x2\x8AC\x8A9\x3\x2\x2"+
+		"\x2\x8AC\x8AD\x3\x2\x2\x2\x8AD\x8B7\x3\x2\x2\x2\x8AE\x8B0\x5\x17A\xBE"+
+		"\x2\x8AF\x8AE\x3\x2\x2\x2\x8AF\x8B0\x3\x2\x2\x2\x8B0\x8B1\x3\x2\x2\x2"+
+		"\x8B1\x8B2\a\xD4\x2\x2\x8B2\x8B3\x5\x13A\x9E\x2\x8B3\x8B4\a\xDB\x2\x2"+
+		"\x8B4\x8B6\x3\x2\x2\x2\x8B5\x8AF\x3\x2\x2\x2\x8B6\x8B9\x3\x2\x2\x2\x8B7"+
+		"\x8B5\x3\x2\x2\x2\x8B7\x8B8\x3\x2\x2\x2\x8B8\x11B\x3\x2\x2\x2\x8B9\x8B7"+
+		"\x3\x2\x2\x2\x8BA\x8BE\x5\x140\xA1\x2\x8BB\x8BC\x5\x17A\xBE\x2\x8BC\x8BD"+
+		"\x5\x12E\x98\x2\x8BD\x8BF\x3\x2\x2\x2\x8BE\x8BB\x3\x2\x2\x2\x8BE\x8BF"+
+		"\x3\x2\x2\x2\x8BF\x8C9\x3\x2\x2\x2\x8C0\x8C2\x5\x17A\xBE\x2\x8C1\x8C0"+
+		"\x3\x2\x2\x2\x8C1\x8C2\x3\x2\x2\x2\x8C2\x8C3\x3\x2\x2\x2\x8C3\x8C4\a\xD4"+
+		"\x2\x2\x8C4\x8C5\x5\x13A\x9E\x2\x8C5\x8C6\a\xDB\x2\x2\x8C6\x8C8\x3\x2"+
+		"\x2\x2\x8C7\x8C1\x3\x2\x2\x2\x8C8\x8CB\x3\x2\x2\x2\x8C9\x8C7\x3\x2\x2"+
+		"\x2\x8C9\x8CA\x3\x2\x2\x2\x8CA\x11D\x3\x2\x2\x2\x8CB\x8C9\x3\x2\x2\x2"+
+		"\x8CC\x8D1\x5\x128\x95\x2\x8CD\x8D1\x5\x120\x91\x2\x8CE\x8D1\x5\x122\x92"+
+		"\x2\x8CF\x8D1\x5\x12C\x97\x2\x8D0\x8CC\x3\x2\x2\x2\x8D0\x8CD\x3\x2\x2"+
+		"\x2\x8D0\x8CE\x3\x2\x2\x2\x8D0\x8CF\x3\x2\x2\x2\x8D1\x11F\x3\x2\x2\x2"+
+		"\x8D2\x8D4\x5\x140\xA1\x2\x8D3\x8D5\x5\x15A\xAE\x2\x8D4\x8D3\x3\x2\x2"+
+		"\x2\x8D4\x8D5\x3\x2\x2\x2\x8D5\x8DA\x3\x2\x2\x2\x8D6\x8D8\x5\x17A\xBE"+
+		"\x2\x8D7\x8D6\x3\x2\x2\x2\x8D7\x8D8\x3\x2\x2\x2\x8D8\x8D9\x3\x2\x2\x2"+
+		"\x8D9\x8DB\x5\x132\x9A\x2\x8DA\x8D7\x3\x2\x2\x2\x8DA\x8DB\x3\x2\x2\x2"+
+		"\x8DB\x8E5\x3\x2\x2\x2\x8DC\x8DE\x5\x17A\xBE\x2\x8DD\x8DC\x3\x2\x2\x2"+
+		"\x8DD\x8DE\x3\x2\x2\x2\x8DE\x8DF\x3\x2\x2\x2\x8DF\x8E0\a\xD4\x2\x2\x8E0"+
+		"\x8E1\x5\x13A\x9E\x2\x8E1\x8E2\a\xDB\x2\x2\x8E2\x8E4\x3\x2\x2\x2\x8E3"+
+		"\x8DD\x3\x2\x2\x2\x8E4\x8E7\x3\x2\x2\x2\x8E5\x8E3\x3\x2\x2\x2\x8E5\x8E6"+
+		"\x3\x2\x2\x2\x8E6\x121\x3\x2\x2\x2\x8E7\x8E5\x3\x2\x2\x2\x8E8\x8EB\x5"+
+		"\x140\xA1\x2\x8E9\x8EB\x5\x144\xA3\x2\x8EA\x8E8\x3\x2\x2\x2\x8EA\x8E9"+
+		"\x3\x2\x2\x2\x8EB\x8ED\x3\x2\x2\x2\x8EC\x8EE\x5\x15A\xAE\x2\x8ED\x8EC"+
+		"\x3\x2\x2\x2\x8ED\x8EE\x3\x2\x2\x2\x8EE\x8F0\x3\x2\x2\x2\x8EF\x8F1\x5"+
+		"\x17A\xBE\x2\x8F0\x8EF\x3\x2\x2\x2\x8F0\x8F1\x3\x2\x2\x2\x8F1\x8F2\x3"+
+		"\x2\x2\x2\x8F2\x8F4\a\xD4\x2\x2\x8F3\x8F5\x5\x17A\xBE\x2\x8F4\x8F3\x3"+
+		"\x2\x2\x2\x8F4\x8F5\x3\x2\x2\x2\x8F5\x8FA\x3\x2\x2\x2\x8F6\x8F8\x5\x12E"+
+		"\x98\x2\x8F7\x8F9\x5\x17A\xBE\x2\x8F8\x8F7\x3\x2\x2\x2\x8F8\x8F9\x3\x2"+
+		"\x2\x2\x8F9\x8FB\x3\x2\x2\x2\x8FA\x8F6\x3\x2\x2\x2\x8FA\x8FB\x3\x2\x2"+
+		"\x2\x8FB\x8FC\x3\x2\x2\x2\x8FC\x901\a\xDB\x2\x2\x8FD\x8FF\x5\x17A\xBE"+
+		"\x2\x8FE\x8FD\x3\x2\x2\x2\x8FE\x8FF\x3\x2\x2\x2\x8FF\x900\x3\x2\x2\x2"+
+		"\x900\x902\x5\x132\x9A\x2\x901\x8FE\x3\x2\x2\x2\x901\x902\x3\x2\x2\x2"+
+		"\x902\x90C\x3\x2\x2\x2\x903\x905\x5\x17A\xBE\x2\x904\x903\x3\x2\x2\x2"+
+		"\x904\x905\x3\x2\x2\x2\x905\x906\x3\x2\x2\x2\x906\x907\a\xD4\x2\x2\x907"+
+		"\x908\x5\x13A\x9E\x2\x908\x909\a\xDB\x2\x2\x909\x90B\x3\x2\x2\x2\x90A"+
+		"\x904\x3\x2\x2\x2\x90B\x90E\x3\x2\x2\x2\x90C\x90A\x3\x2\x2\x2\x90C\x90D"+
+		"\x3\x2\x2\x2\x90D\x123\x3\x2\x2\x2\x90E\x90C\x3\x2\x2\x2\x90F\x911\x5"+
+		"\x13E\xA0\x2\x910\x912\x5\x15A\xAE\x2\x911\x910\x3\x2\x2\x2\x911\x912"+
+		"\x3\x2\x2\x2\x912\x917\x3\x2\x2\x2\x913\x915\x5\x17A\xBE\x2\x914\x913"+
+		"\x3\x2\x2\x2\x914\x915\x3\x2\x2\x2\x915\x916\x3\x2\x2\x2\x916\x918\x5"+
+		"\x132\x9A\x2\x917\x914\x3\x2\x2\x2\x917\x918\x3\x2\x2\x2\x918\x922\x3"+
+		"\x2\x2\x2\x919\x91B\x5\x17A\xBE\x2\x91A\x919\x3\x2\x2\x2\x91A\x91B\x3"+
+		"\x2\x2\x2\x91B\x91C\x3\x2\x2\x2\x91C\x91D\a\xD4\x2\x2\x91D\x91E\x5\x13A"+
+		"\x9E\x2\x91E\x91F\a\xDB\x2\x2\x91F\x921\x3\x2\x2\x2\x920\x91A\x3\x2\x2"+
+		"\x2\x921\x924\x3\x2\x2\x2\x922\x920\x3\x2\x2\x2\x922\x923\x3\x2\x2\x2"+
+		"\x923\x125\x3\x2\x2\x2\x924\x922\x3\x2\x2\x2\x925\x928\x5\x13E\xA0\x2"+
+		"\x926\x928\x5\x144\xA3\x2\x927\x925\x3\x2\x2\x2\x927\x926\x3\x2\x2\x2"+
+		"\x928\x92A\x3\x2\x2\x2\x929\x92B\x5\x15A\xAE\x2\x92A\x929\x3\x2\x2\x2"+
+		"\x92A\x92B\x3\x2\x2\x2\x92B\x92D\x3\x2\x2\x2\x92C\x92E\x5\x17A\xBE\x2"+
+		"\x92D\x92C\x3\x2\x2\x2\x92D\x92E\x3\x2\x2\x2\x92E\x92F\x3\x2\x2\x2\x92F"+
+		"\x931\a\xD4\x2\x2\x930\x932\x5\x17A\xBE\x2\x931\x930\x3\x2\x2\x2\x931"+
+		"\x932\x3\x2\x2\x2\x932\x937\x3\x2\x2\x2\x933\x935\x5\x12E\x98\x2\x934"+
+		"\x936\x5\x17A\xBE\x2\x935\x934\x3\x2\x2\x2\x935\x936\x3\x2\x2\x2\x936"+
+		"\x938\x3\x2\x2\x2\x937\x933\x3\x2\x2\x2\x937\x938\x3\x2\x2\x2\x938\x939"+
+		"\x3\x2\x2\x2\x939\x93E\a\xDB\x2\x2\x93A\x93C\x5\x17A\xBE\x2\x93B\x93A"+
+		"\x3\x2\x2\x2\x93B\x93C\x3\x2\x2\x2\x93C\x93D\x3\x2\x2\x2\x93D\x93F\x5"+
+		"\x132\x9A\x2\x93E\x93B\x3\x2\x2\x2\x93E\x93F\x3\x2\x2\x2\x93F\x949\x3"+
+		"\x2\x2\x2\x940\x942\x5\x17A\xBE\x2\x941\x940\x3\x2\x2\x2\x941\x942\x3"+
+		"\x2\x2\x2\x942\x943\x3\x2\x2\x2\x943\x944\a\xD4\x2\x2\x944\x945\x5\x13A"+
+		"\x9E\x2\x945\x946\a\xDB\x2\x2\x946\x948\x3\x2\x2\x2\x947\x941\x3\x2\x2"+
+		"\x2\x948\x94B\x3\x2\x2\x2\x949\x947\x3\x2\x2\x2\x949\x94A\x3\x2\x2\x2"+
+		"\x94A\x127\x3\x2\x2\x2\x94B\x949\x3\x2\x2\x2\x94C\x94F\x5\x120\x91\x2"+
+		"\x94D\x94F\x5\x122\x92\x2\x94E\x94C\x3\x2\x2\x2\x94E\x94D\x3\x2\x2\x2"+
+		"\x94E\x94F\x3\x2\x2\x2\x94F\x954\x3\x2\x2\x2\x950\x952\x5\x12A\x96\x2"+
+		"\x951\x953\x5\x17A\xBE\x2\x952\x951\x3\x2\x2\x2\x952\x953\x3\x2\x2\x2"+
+		"\x953\x955\x3\x2\x2\x2\x954\x950\x3\x2\x2\x2\x955\x956\x3\x2\x2\x2\x956"+
+		"\x954\x3\x2\x2\x2\x956\x957\x3\x2\x2\x2\x957\x95C\x3\x2\x2\x2\x958\x95A"+
+		"\x5\x17A\xBE\x2\x959\x958\x3\x2\x2\x2\x959\x95A\x3\x2\x2\x2\x95A\x95B"+
+		"\x3\x2\x2\x2\x95B\x95D\x5\x132\x9A\x2\x95C\x959\x3\x2\x2\x2\x95C\x95D"+
+		"\x3\x2\x2\x2\x95D\x967\x3\x2\x2\x2\x95E\x960\x5\x17A\xBE\x2\x95F\x95E"+
+		"\x3\x2\x2\x2\x95F\x960\x3\x2\x2\x2\x960\x961\x3\x2\x2\x2\x961\x962\a\xD4"+
+		"\x2\x2\x962\x963\x5\x13A\x9E\x2\x963\x964\a\xDB\x2\x2\x964\x966\x3\x2"+
+		"\x2\x2\x965\x95F\x3\x2\x2\x2\x966\x969\x3\x2\x2\x2\x967\x965\x3\x2\x2"+
+		"\x2\x967\x968\x3\x2\x2\x2\x968\x129\x3\x2\x2\x2\x969\x967\x3\x2\x2\x2"+
+		"\x96A\x96C\t\xF\x2\x2\x96B\x96D\x5\x17A\xBE\x2\x96C\x96B\x3\x2\x2\x2\x96C"+
+		"\x96D\x3\x2\x2\x2\x96D\x970\x3\x2\x2\x2\x96E\x971\x5\x124\x93\x2\x96F"+
+		"\x971\x5\x126\x94\x2\x970\x96E\x3\x2\x2\x2\x970\x96F\x3\x2\x2\x2\x971"+
+		"\x12B\x3\x2\x2\x2\x972\x974\x5\x17A\xBE\x2\x973\x972\x3\x2\x2\x2\x973"+
+		"\x974\x3\x2\x2\x2\x974\x975\x3\x2\x2\x2\x975\x976\x5\x132\x9A\x2\x976"+
+		"\x12D\x3\x2\x2\x2\x977\x979\x5\x130\x99\x2\x978\x977\x3\x2\x2\x2\x978"+
+		"\x979\x3\x2\x2\x2\x979\x97B\x3\x2\x2\x2\x97A\x97C\x5\x17A\xBE\x2\x97B"+
+		"\x97A\x3\x2\x2\x2\x97B\x97C\x3\x2\x2\x2\x97C\x97D\x3\x2\x2\x2\x97D\x97F"+
+		"\t\x6\x2\x2\x97E\x980\x5\x17A\xBE\x2\x97F\x97E\x3\x2\x2\x2\x97F\x980\x3"+
+		"\x2\x2\x2\x980\x982\x3\x2\x2\x2\x981\x978\x3\x2\x2\x2\x982\x985\x3\x2"+
+		"\x2\x2\x983\x981\x3\x2\x2\x2\x983\x984\x3\x2\x2\x2\x984\x986\x3\x2\x2"+
+		"\x2\x985\x983\x3\x2\x2\x2\x986\x993\x5\x130\x99\x2\x987\x989\x5\x17A\xBE"+
+		"\x2\x988\x987\x3\x2\x2\x2\x988\x989\x3\x2\x2\x2\x989\x98A\x3\x2\x2\x2"+
+		"\x98A\x98C\t\x6\x2\x2\x98B\x98D\x5\x17A\xBE\x2\x98C\x98B\x3\x2\x2\x2\x98C"+
+		"\x98D\x3\x2\x2\x2\x98D\x98F\x3\x2\x2\x2\x98E\x990\x5\x130\x99\x2\x98F"+
+		"\x98E\x3\x2\x2\x2\x98F\x990\x3\x2\x2\x2\x990\x992\x3\x2\x2\x2\x991\x988"+
+		"\x3\x2\x2\x2\x992\x995\x3\x2\x2\x2\x993\x991\x3\x2\x2\x2\x993\x994\x3"+
+		"\x2\x2\x2\x994\x12F\x3\x2\x2\x2\x995\x993\x3\x2\x2\x2\x996\x998\a\xD4"+
+		"\x2\x2\x997\x996\x3\x2\x2\x2\x997\x998\x3\x2\x2\x2\x998\x99B\x3\x2\x2"+
+		"\x2\x999\x99A\t\x10\x2\x2\x99A\x99C\x5\x17A\xBE\x2\x99B\x999\x3\x2\x2"+
+		"\x2\x99B\x99C\x3\x2\x2\x2\x99C\x99E\x3\x2\x2\x2\x99D\x99F\a\xDB\x2\x2"+
+		"\x99E\x99D\x3\x2\x2\x2\x99E\x99F\x3\x2\x2\x2\x99F\x9A0\x3\x2\x2\x2\x9A0"+
+		"\x9A1\x5\xFE\x80\x2\x9A1\x131\x3\x2\x2\x2\x9A2\x9A4\a,\x2\x2\x9A3\x9A5"+
+		"\x5\x17A\xBE\x2\x9A4\x9A3\x3\x2\x2\x2\x9A4\x9A5\x3\x2\x2\x2\x9A5\x9A6"+
+		"\x3\x2\x2\x2\x9A6\x9A8\x5\x13E\xA0\x2\x9A7\x9A9\x5\x15A\xAE\x2\x9A8\x9A7"+
+		"\x3\x2\x2\x2\x9A8\x9A9\x3\x2\x2\x2\x9A9\x133\x3\x2\x2\x2\x9AA\x9BC\a\xD4"+
+		"\x2\x2\x9AB\x9AD\x5\x17A\xBE\x2\x9AC\x9AB\x3\x2\x2\x2\x9AC\x9AD\x3\x2"+
+		"\x2\x2\x9AD\x9AE\x3\x2\x2\x2\x9AE\x9B9\x5\x136\x9C\x2\x9AF\x9B1\x5\x17A"+
+		"\xBE\x2\x9B0\x9AF\x3\x2\x2\x2\x9B0\x9B1\x3\x2\x2\x2\x9B1\x9B2\x3\x2\x2"+
+		"\x2\x9B2\x9B4\a)\x2\x2\x9B3\x9B5\x5\x17A\xBE\x2\x9B4\x9B3\x3\x2\x2\x2"+
+		"\x9B4\x9B5\x3\x2\x2\x2\x9B5\x9B6\x3\x2\x2\x2\x9B6\x9B8\x5\x136\x9C\x2"+
+		"\x9B7\x9B0\x3\x2\x2\x2\x9B8\x9BB\x3\x2\x2\x2\x9B9\x9B7\x3\x2\x2\x2\x9B9"+
+		"\x9BA\x3\x2\x2\x2\x9BA\x9BD\x3\x2\x2\x2\x9BB\x9B9\x3\x2\x2\x2\x9BC\x9AC"+
+		"\x3\x2\x2\x2\x9BC\x9BD\x3\x2\x2\x2\x9BD\x9BF\x3\x2\x2\x2\x9BE\x9C0\x5"+
+		"\x17A\xBE\x2\x9BF\x9BE\x3\x2\x2\x2\x9BF\x9C0\x3\x2\x2\x2\x9C0\x9C1\x3"+
+		"\x2\x2\x2\x9C1\x9C2\a\xDB\x2\x2\x9C2\x135\x3\x2\x2\x2\x9C3\x9C4\a\x95"+
+		"\x2\x2\x9C4\x9C6\x5\x17A\xBE\x2\x9C5\x9C3\x3\x2\x2\x2\x9C5\x9C6\x3\x2"+
+		"\x2\x2\x9C6\x9C9\x3\x2\x2\x2\x9C7\x9C8\t\x11\x2\x2\x9C8\x9CA\x5\x17A\xBE"+
+		"\x2\x9C9\x9C7\x3\x2\x2\x2\x9C9\x9CA\x3\x2\x2\x2\x9CA\x9CD\x3\x2\x2\x2"+
+		"\x9CB\x9CC\a\x9C\x2\x2\x9CC\x9CE\x5\x17A\xBE\x2\x9CD\x9CB\x3\x2\x2\x2"+
+		"\x9CD\x9CE\x3\x2\x2\x2\x9CE\x9CF\x3\x2\x2\x2\x9CF\x9D1\x5\x13E\xA0\x2"+
+		"\x9D0\x9D2\x5\x15A\xAE\x2\x9D1\x9D0\x3\x2\x2\x2\x9D1\x9D2\x3\x2\x2\x2"+
+		"\x9D2\x9DB\x3\x2\x2\x2\x9D3\x9D5\x5\x17A\xBE\x2\x9D4\x9D3\x3\x2\x2\x2"+
+		"\x9D4\x9D5\x3\x2\x2\x2\x9D5\x9D6\x3\x2\x2\x2\x9D6\x9D8\a\xD4\x2\x2\x9D7"+
+		"\x9D9\x5\x17A\xBE\x2\x9D8\x9D7\x3\x2\x2\x2\x9D8\x9D9\x3\x2\x2\x2\x9D9"+
+		"\x9DA\x3\x2\x2\x2\x9DA\x9DC\a\xDB\x2\x2\x9DB\x9D4\x3\x2\x2\x2\x9DB\x9DC"+
+		"\x3\x2\x2\x2\x9DC\x9E1\x3\x2\x2\x2\x9DD\x9DF\x5\x17A\xBE\x2\x9DE\x9DD"+
+		"\x3\x2\x2\x2\x9DE\x9DF\x3\x2\x2\x2\x9DF\x9E0\x3\x2\x2\x2\x9E0\x9E2\x5"+
+		"\x142\xA2\x2\x9E1\x9DE\x3\x2\x2\x2\x9E1\x9E2\x3\x2\x2\x2\x9E2\x9E7\x3"+
+		"\x2\x2\x2\x9E3\x9E5\x5\x17A\xBE\x2\x9E4\x9E3\x3\x2\x2\x2\x9E4\x9E5\x3"+
+		"\x2\x2\x2\x9E5\x9E6\x3\x2\x2\x2\x9E6\x9E8\x5\x138\x9D\x2\x9E7\x9E4\x3"+
+		"\x2\x2\x2\x9E7\x9E8\x3\x2\x2\x2\x9E8\x137\x3\x2\x2\x2\x9E9\x9EB\a\xD0"+
+		"\x2\x2\x9EA\x9EC\x5\x17A\xBE\x2\x9EB\x9EA\x3\x2\x2\x2\x9EB\x9EC\x3\x2"+
+		"\x2\x2\x9EC\x9ED\x3\x2\x2\x2\x9ED\x9EE\x5\xFE\x80\x2\x9EE\x139\x3\x2\x2"+
+		"\x2\x9EF\x9FA\x5\x13C\x9F\x2\x9F0\x9F2\x5\x17A\xBE\x2\x9F1\x9F0\x3\x2"+
+		"\x2\x2\x9F1\x9F2\x3\x2\x2\x2\x9F2\x9F3\x3\x2\x2\x2\x9F3\x9F5\a)\x2\x2"+
+		"\x9F4\x9F6\x5\x17A\xBE\x2\x9F5\x9F4\x3\x2\x2\x2\x9F5\x9F6\x3\x2\x2\x2"+
+		"\x9F6\x9F7\x3\x2\x2\x2\x9F7\x9F9\x5\x13C\x9F\x2\x9F8\x9F1\x3\x2\x2\x2"+
+		"\x9F9\x9FC\x3\x2\x2\x2\x9FA\x9F8\x3\x2\x2\x2\x9FA\x9FB\x3\x2\x2\x2\x9FB"+
+		"\x13B\x3\x2\x2\x2\x9FC\x9FA\x3\x2\x2\x2\x9FD\x9FE\x5\xFE\x80\x2\x9FE\x9FF"+
+		"\x5\x17A\xBE\x2\x9FF\xA00\a\xBE\x2\x2\xA00\xA01\x5\x17A\xBE\x2\xA01\xA03"+
+		"\x3\x2\x2\x2\xA02\x9FD\x3\x2\x2\x2\xA02\xA03\x3\x2\x2\x2\xA03\xA04\x3"+
+		"\x2\x2\x2\xA04\xA05\x5\xFE\x80\x2\xA05\x13D\x3\x2\x2\x2\xA06\xA0A\x5\x140"+
+		"\xA1\x2\xA07\xA0A\x5\x162\xB2\x2\xA08\xA0A\x5\x160\xB1\x2\xA09\xA06\x3"+
+		"\x2\x2\x2\xA09\xA07\x3\x2\x2\x2\xA09\xA08\x3\x2\x2\x2\xA0A\x13F\x3\x2"+
+		"\x2\x2\xA0B\xA0E\a\xEE\x2\x2\xA0C\xA0E\x5\x15E\xB0\x2\xA0D\xA0B\x3\x2"+
+		"\x2\x2\xA0D\xA0C\x3\x2\x2\x2\xA0E\x141\x3\x2\x2\x2\xA0F\xA11\a\x39\x2"+
+		"\x2\xA10\xA12\x5\x17A\xBE\x2\xA11\xA10\x3\x2\x2\x2\xA11\xA12\x3\x2\x2"+
+		"\x2\xA12\xA15\x3\x2\x2\x2\xA13\xA14\a\x8D\x2\x2\xA14\xA16\x5\x17A\xBE"+
+		"\x2\xA15\xA13\x3\x2\x2\x2\xA15\xA16\x3\x2\x2\x2\xA16\xA17\x3\x2\x2\x2"+
+		"\xA17\xA1C\x5\x158\xAD\x2\xA18\xA1A\x5\x17A\xBE\x2\xA19\xA18\x3\x2\x2"+
+		"\x2\xA19\xA1A\x3\x2\x2\x2\xA1A\xA1B\x3\x2\x2\x2\xA1B\xA1D\x5\x14A\xA6"+
+		"\x2\xA1C\xA19\x3\x2\x2\x2\xA1C\xA1D\x3\x2\x2\x2\xA1D\x143\x3\x2\x2\x2"+
+		"\xA1E\xA1F\t\x12\x2\x2\xA1F\x145\x3\x2\x2\x2\xA20\xA21\t\xE\x2\x2\xA21"+
+		"\x147\x3\x2\x2\x2\xA22\xA27\x5\x140\xA1\x2\xA23\xA24\t\xF\x2\x2\xA24\xA26"+
+		"\x5\x140\xA1\x2\xA25\xA23\x3\x2\x2\x2\xA26\xA29\x3\x2\x2\x2\xA27\xA25"+
+		"\x3\x2\x2\x2\xA27\xA28\x3\x2\x2\x2\xA28\x149\x3\x2\x2\x2\xA29\xA27\x3"+
+		"\x2\x2\x2\xA2A\xA2C\a\xD7\x2\x2\xA2B\xA2D\x5\x17A\xBE\x2\xA2C\xA2B\x3"+
+		"\x2\x2\x2\xA2C\xA2D\x3\x2\x2\x2\xA2D\xA30\x3\x2\x2\x2\xA2E\xA31\x5\x156"+
+		"\xAC\x2\xA2F\xA31\x5\x140\xA1\x2\xA30\xA2E\x3\x2\x2\x2\xA30\xA2F\x3\x2"+
+		"\x2\x2\xA31\x14B\x3\x2\x2\x2\xA32\xA34\x5\x14E\xA8\x2\xA33\xA35\x5\x17A"+
+		"\xBE\x2\xA34\xA33\x3\x2\x2\x2\xA34\xA35\x3\x2\x2\x2\xA35\xA36\x3\x2\x2"+
+		"\x2\xA36\xA37\a*\x2\x2\xA37\x14D\x3\x2\x2\x2\xA38\xA3B\x5\x150\xA9\x2"+
+		"\xA39\xA3B\x5\x152\xAA\x2\xA3A\xA38\x3\x2\x2\x2\xA3A\xA39\x3\x2\x2\x2"+
+		"\xA3B\x14F\x3\x2\x2\x2\xA3C\xA3D\x5\x13E\xA0\x2\xA3D\x151\x3\x2\x2\x2"+
+		"\xA3E\xA3F\x5\x156\xAC\x2\xA3F\x153\x3\x2\x2\x2\xA40\xA49\x5\x156\xAC"+
+		"\x2\xA41\xA49\a\xE8\x2\x2\xA42\xA49\a\xE3\x2\x2\xA43\xA49\a\xBF\x2\x2"+
+		"\xA44\xA49\ao\x2\x2\xA45\xA49\a\x8F\x2\x2\xA46\xA49\a\x90\x2\x2\xA47\xA49"+
+		"\a[\x2\x2\xA48\xA40\x3\x2\x2\x2\xA48\xA41\x3\x2\x2\x2\xA48\xA42\x3\x2"+
+		"\x2\x2\xA48\xA43\x3\x2\x2\x2\xA48\xA44\x3\x2\x2\x2\xA48\xA45\x3\x2\x2"+
+		"\x2\xA48\xA46\x3\x2\x2\x2\xA48\xA47\x3\x2\x2\x2\xA49\x155\x3\x2\x2\x2"+
+		"\xA4A\xA4B\t\x13\x2\x2\xA4B\x157\x3\x2\x2\x2\xA4C\xA4F\x5\x144\xA3\x2"+
+		"\xA4D\xA4F\x5\x148\xA5\x2\xA4E\xA4C\x3\x2\x2\x2\xA4E\xA4D\x3\x2\x2\x2"+
+		"\xA4F\xA58\x3\x2\x2\x2\xA50\xA52\x5\x17A\xBE\x2\xA51\xA50\x3\x2\x2\x2"+
+		"\xA51\xA52\x3\x2\x2\x2\xA52\xA53\x3\x2\x2\x2\xA53\xA55\a\xD4\x2\x2\xA54"+
+		"\xA56\x5\x17A\xBE\x2\xA55\xA54\x3\x2\x2\x2\xA55\xA56\x3\x2\x2\x2\xA56"+
+		"\xA57\x3\x2\x2\x2\xA57\xA59\a\xDB\x2\x2\xA58\xA51\x3\x2\x2\x2\xA58\xA59"+
+		"\x3\x2\x2\x2\xA59\x159\x3\x2\x2\x2\xA5A\xA5B\t\x14\x2\x2\xA5B\x15B\x3"+
+		"\x2\x2\x2\xA5C\xA5D\t\x15\x2\x2\xA5D\x15D\x3\x2\x2\x2\xA5E\xA5F\t\x16"+
+		"\x2\x2\xA5F\x15F\x3\x2\x2\x2\xA60\xA61\a\x39\x2\x2\xA61\x161\x3\x2\x2"+
+		"\x2\xA62\xA63\t\x17\x2\x2\xA63\x163\x3\x2\x2\x2\xA64\xA66\x5\x17A\xBE"+
+		"\x2\xA65\xA64\x3\x2\x2\x2\xA65\xA66\x3\x2\x2\x2\xA66\xA68\x3\x2\x2\x2"+
+		"\xA67\xA69\x5\x168\xB5\x2\xA68\xA67\x3\x2\x2\x2\xA68\xA69\x3\x2\x2\x2"+
+		"\xA69\x165\x3\x2\x2\x2\xA6A\xA6B\x5\x164\xB3\x2\xA6B\xA6D\a\xE9\x2\x2"+
+		"\xA6C\xA6E\x5\x17A\xBE\x2\xA6D\xA6C\x3\x2\x2\x2\xA6D\xA6E\x3\x2\x2\x2"+
+		"\xA6E\xA77\x3\x2\x2\x2\xA6F\xA71\x5\x17A\xBE\x2\xA70\xA6F\x3\x2\x2\x2"+
+		"\xA70\xA71\x3\x2\x2\x2\xA71\xA72\x3\x2\x2\x2\xA72\xA74\a*\x2\x2\xA73\xA75"+
+		"\x5\x17A\xBE\x2\xA74\xA73\x3\x2\x2\x2\xA74\xA75\x3\x2\x2\x2\xA75\xA77"+
+		"\x3\x2\x2\x2\xA76\xA6A\x3\x2\x2\x2\xA76\xA70\x3\x2\x2\x2\xA77\xA79\x3"+
+		"\x2\x2\x2\xA78\xA76\x3\x2\x2\x2\xA79\xA7C\x3\x2\x2\x2\xA7A\xA78\x3\x2"+
+		"\x2\x2\xA7A\xA7B\x3\x2\x2\x2\xA7B\xA81\x3\x2\x2\x2\xA7C\xA7A\x3\x2\x2"+
+		"\x2\xA7D\xA7E\x5\x164\xB3\x2\xA7E\xA7F\a\x2\x2\x3\xA7F\xA81\x3\x2\x2\x2"+
+		"\xA80\xA7A\x3\x2\x2\x2\xA80\xA7D\x3\x2\x2\x2\xA81\x167\x3\x2\x2\x2\xA82"+
+		"\xA86\x5\x170\xB9\x2\xA83\xA86\x5\x16C\xB7\x2\xA84\xA86\x5\x16A\xB6\x2"+
+		"\xA85\xA82\x3\x2\x2\x2\xA85\xA83\x3\x2\x2\x2\xA85\xA84\x3\x2\x2\x2\xA86"+
+		"\x169\x3\x2\x2\x2\xA87\xA89\a\xAB\x2\x2\xA88\xA8A\x5\x17A\xBE\x2\xA89"+
+		"\xA88\x3\x2\x2\x2\xA89\xA8A\x3\x2\x2\x2\xA8A\xA8B\x3\x2\x2\x2\xA8B\xA8C"+
+		"\x5\x16E\xB8\x2\xA8C\x16B\x3\x2\x2\x2\xA8D\xA8E\a\xEA\x2\x2\xA8E\xA8F"+
+		"\x5\x16E\xB8\x2\xA8F\x16D\x3\x2\x2\x2\xA90\xA93\a\xEF\x2\x2\xA91\xA93"+
+		"\n\x18\x2\x2\xA92\xA90\x3\x2\x2\x2\xA92\xA91\x3\x2\x2\x2\xA93\xA96\x3"+
+		"\x2\x2\x2\xA94\xA92\x3\x2\x2\x2\xA94\xA95\x3\x2\x2\x2\xA95\x16F\x3\x2"+
+		"\x2\x2\xA96\xA94\x3\x2\x2\x2\xA97\xA9D\a\xEA\x2\x2\xA98\xA99\a/\x2\x2"+
+		"\xA99\xA9B\x5\x172\xBA\x2\xA9A\xA9C\x5\x17A\xBE\x2\xA9B\xA9A\x3\x2\x2"+
+		"\x2\xA9B\xA9C\x3\x2\x2\x2\xA9C\xA9E\x3\x2\x2\x2\xA9D\xA98\x3\x2\x2\x2"+
+		"\xA9E\xA9F\x3\x2\x2\x2\xA9F\xA9D\x3\x2\x2\x2\xA9F\xAA0\x3\x2\x2\x2\xAA0"+
+		"\x171\x3\x2\x2\x2\xAA1\xAA3\x5\x174\xBB\x2\xAA2\xAA4\x5\x176\xBC\x2\xAA3"+
+		"\xAA2\x3\x2\x2\x2\xAA3\xAA4\x3\x2\x2\x2\xAA4\x173\x3\x2\x2\x2\xAA5\xAA6"+
+		"\x5\x13E\xA0\x2\xAA6\x175\x3\x2\x2\x2\xAA7\xAA8\x5\x17A\xBE\x2\xAA8\xAA9"+
+		"\x5\x178\xBD\x2\xAA9\xAE4\x3\x2\x2\x2\xAAA\xAAB\x5\x17A\xBE\x2\xAAB\xAB4"+
+		"\x5\x178\xBD\x2\xAAC\xAAE\x5\x17A\xBE\x2\xAAD\xAAC\x3\x2\x2\x2\xAAD\xAAE"+
+		"\x3\x2\x2\x2\xAAE\xAAF\x3\x2\x2\x2\xAAF\xAB1\a)\x2\x2\xAB0\xAB2\x5\x17A"+
+		"\xBE\x2\xAB1\xAB0\x3\x2\x2\x2\xAB1\xAB2\x3\x2\x2\x2\xAB2\xAB3\x3\x2\x2"+
+		"\x2\xAB3\xAB5\x5\x178\xBD\x2\xAB4\xAAD\x3\x2\x2\x2\xAB5\xAB6\x3\x2\x2"+
+		"\x2\xAB6\xAB4\x3\x2\x2\x2\xAB6\xAB7\x3\x2\x2\x2\xAB7\xAE4\x3\x2\x2\x2"+
+		"\xAB8\xABA\x5\x17A\xBE\x2\xAB9\xAB8\x3\x2\x2\x2\xAB9\xABA\x3\x2\x2\x2"+
+		"\xABA\xABB\x3\x2\x2\x2\xABB\xABD\a\xD4\x2\x2\xABC\xABE\x5\x17A\xBE\x2"+
+		"\xABD\xABC\x3\x2\x2\x2\xABD\xABE\x3\x2\x2\x2\xABE\xABF\x3\x2\x2\x2\xABF"+
+		"\xAE4\a\xDB\x2\x2\xAC0\xAC2\x5\x17A\xBE\x2\xAC1\xAC0\x3\x2\x2\x2\xAC1"+
+		"\xAC2\x3\x2\x2\x2\xAC2\xAC3\x3\x2\x2\x2\xAC3\xAC5\a\xD4\x2\x2\xAC4\xAC6"+
+		"\x5\x17A\xBE\x2\xAC5\xAC4\x3\x2\x2\x2\xAC5\xAC6\x3\x2\x2\x2\xAC6\xAC7"+
+		"\x3\x2\x2\x2\xAC7\xAC9\x5\x178\xBD\x2\xAC8\xACA\x5\x17A\xBE\x2\xAC9\xAC8"+
+		"\x3\x2\x2\x2\xAC9\xACA\x3\x2\x2\x2\xACA\xACB\x3\x2\x2\x2\xACB\xACC\a\xDB"+
+		"\x2\x2\xACC\xAE4\x3\x2\x2\x2\xACD\xACF\x5\x17A\xBE\x2\xACE\xACD\x3\x2"+
+		"\x2\x2\xACE\xACF\x3\x2\x2\x2\xACF\xAD0\x3\x2\x2\x2\xAD0\xAD1\a\xD4\x2"+
+		"\x2\xAD1\xADA\x5\x178\xBD\x2\xAD2\xAD4\x5\x17A\xBE\x2\xAD3\xAD2\x3\x2"+
+		"\x2\x2\xAD3\xAD4\x3\x2\x2\x2\xAD4\xAD5\x3\x2\x2\x2\xAD5\xAD7\a)\x2\x2"+
+		"\xAD6\xAD8\x5\x17A\xBE\x2\xAD7\xAD6\x3\x2\x2\x2\xAD7\xAD8\x3\x2\x2\x2"+
+		"\xAD8\xAD9\x3\x2\x2\x2\xAD9\xADB\x5\x178\xBD\x2\xADA\xAD3\x3\x2\x2\x2"+
+		"\xADB\xADC\x3\x2\x2\x2\xADC\xADA\x3\x2\x2\x2\xADC\xADD\x3\x2\x2\x2\xADD"+
+		"\xADF\x3\x2\x2\x2\xADE\xAE0\x5\x17A\xBE\x2\xADF\xADE\x3\x2\x2\x2\xADF"+
+		"\xAE0\x3\x2\x2\x2\xAE0\xAE1\x3\x2\x2\x2\xAE1\xAE2\a\xDB\x2\x2\xAE2\xAE4"+
+		"\x3\x2\x2\x2\xAE3\xAA7\x3\x2\x2\x2\xAE3\xAAA\x3\x2\x2\x2\xAE3\xAB9\x3"+
+		"\x2\x2\x2\xAE3\xAC1\x3\x2\x2\x2\xAE3\xACE\x3\x2\x2\x2\xAE4\x177\x3\x2"+
+		"\x2\x2\xAE5\xAE6\x5\xFE\x80\x2\xAE6\x179\x3\x2\x2\x2\xAE7\xAE9\t\x19\x2"+
+		"\x2\xAE8\xAE7\x3\x2\x2\x2\xAE9\xAEA\x3\x2\x2\x2\xAEA\xAE8\x3\x2\x2\x2"+
+		"\xAEA\xAEB\x3\x2\x2\x2\xAEB\x17B\x3\x2\x2\x2\x1CF\x17F\x185\x188\x18C"+
+		"\x190\x194\x19C\x19F\x1A9\x1AB\x1B1\x1B9\x1C0\x1C6\x1CF\x1D7\x1E6\x1F1"+
+		"\x1F9\x203\x209\x20D\x211\x215\x21A\x227\x251\x260\x268\x26D\x272\x27B"+
+		"\x28F\x293\x29B\x2A6\x2AC\x2B0\x2B5\x2BC\x2C0\x2CA\x2CE\x2D1\x2D7\x2DD"+
+		"\x2E7\x2EB\x2EE\x2F4\x2F8\x302\x306\x310\x314\x317\x31B\x320\x327\x32B"+
+		"\x330\x338\x33C\x340\x348\x34B\x34F\x353\x35D\x361\x364\x36A\x36E\x374"+
+		"\x378\x37D\x386\x38A\x38D\x390\x394\x3A0\x3A4\x3A7\x3AA\x3AE\x3B7\x3BD"+
+		"\x3C1\x3C6\x3CB\x3D0\x3D3\x3D7\x3DE\x3E4\x3EA\x3F5\x3F8\x3FB\x400\x406"+
+		"\x40A\x40F\x417\x41D\x421\x42D\x431\x43C\x447\x44E\x456\x45B\x464\x46B"+
+		"\x46F\x472\x47C\x480\x485\x48F\x495\x4A6\x4AC\x4B2\x4B6\x4C2\x4C6\x4CC"+
+		"\x4D1\x4D5\x4D9\x4DD\x4E0\x4E3\x4E6\x4E9\x4ED\x502\x507\x50B\x516\x51E"+
+		"\x521\x523\x528\x52C\x530\x534\x538\x53E\x542\x546\x54B\x551\x554\x558"+
+		"\x55C\x55F\x563\x568\x56A\x56E\x572\x575\x579\x57C\x588\x58C\x590\x598"+
+		"\x59C\x5A2\x5A6\x5AA\x5B8\x5C2\x5C6\x5CB\x5D6\x5DA\x5DF\x5E5\x5E9\x5EF"+
+		"\x5F2\x5F5\x5FA\x5FE\x605\x609\x60F\x612\x616\x61D\x621\x627\x62A\x62E"+
+		"\x636\x63A\x63E\x640\x643\x649\x64D\x651\x656\x65B\x65F\x663\x669\x66F"+
+		"\x671\x679\x67D\x68C\x693\x697\x6A2\x6A9\x6AE\x6B2\x6B7\x6BA\x6C0\x6C4"+
+		"\x6CB\x6CF\x6D3\x6D7\x6DA\x6DE\x6E7\x6F0\x6F7\x6FB\x6FE\x701\x704\x709"+
+		"\x710\x715\x71A\x71E\x724\x729\x730\x734\x73B\x73F\x743\x748\x74C\x751"+
+		"\x755\x75A\x75E\x763\x767\x76C\x770\x775\x779\x77E\x782\x787\x78B\x790"+
+		"\x794\x799\x79D\x7A2\x7A6\x7A9\x7AB\x7B6\x7BB\x7C0\x7C6\x7CA\x7CF\x7D4"+
+		"\x7D7\x7DB\x7DF\x7E1\x7E5\x7E7\x7EC\x7F3\x7FC\x802\x806\x808\x80E\x810"+
+		"\x814\x818\x81D\x821\x825\x827\x82D\x831\x837\x83B\x83F\x843\x84E\x853"+
+		"\x856\x85A\x85E\x862\x865\x86D\x872\x875\x879\x87D\x881\x884\x88C\x88F"+
+		"\x893\x896\x899\x89D\x8A1\x8A6\x8A9\x8AC\x8AF\x8B7\x8BE\x8C1\x8C9\x8D0"+
+		"\x8D4\x8D7\x8DA\x8DD\x8E5\x8EA\x8ED\x8F0\x8F4\x8F8\x8FA\x8FE\x901\x904"+
+		"\x90C\x911\x914\x917\x91A\x922\x927\x92A\x92D\x931\x935\x937\x93B\x93E"+
+		"\x941\x949\x94E\x952\x956\x959\x95C\x95F\x967\x96C\x970\x973\x978\x97B"+
+		"\x97F\x983\x988\x98C\x98F\x993\x997\x99B\x99E\x9A4\x9A8\x9AC\x9B0\x9B4"+
+		"\x9B9\x9BC\x9BF\x9C5\x9C9\x9CD\x9D1\x9D4\x9D8\x9DB\x9DE\x9E1\x9E4\x9E7"+
+		"\x9EB\x9F1\x9F5\x9FA\xA02\xA09\xA0D\xA11\xA15\xA19\xA1C\xA27\xA2C\xA30"+
+		"\xA34\xA3A\xA48\xA4E\xA51\xA55\xA58\xA65\xA68\xA6D\xA70\xA74\xA76\xA7A"+
+		"\xA80\xA85\xA89\xA92\xA94\xA9B\xA9F\xAA3\xAAD\xAB1\xAB6\xAB9\xABD\xAC1"+
+		"\xAC5\xAC9\xACE\xAD3\xAD7\xADC\xADF\xAE3\xAEA";
 	public static readonly ATN _ATN =
 		new ATNDeserializer().Deserialize(_serializedATN.ToCharArray());
 }

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -121,6 +121,8 @@ blockStmt :
 	| variableStmt
 	| whileWendStmt
 	| withStmt
+    | circleSpecialForm
+    | scaleSpecialForm
 	| implicitCallStmt_InBlock
 ;
 
@@ -497,6 +499,11 @@ withStmt :
 	END_WITH
 ;
 
+// Special forms with special syntax, only available in a report.
+circleSpecialForm : (valueStmt whiteSpace? DOT whiteSpace?)? CIRCLE whiteSpace (STEP whiteSpace?)? tuple (whiteSpace? COMMA whiteSpace? valueStmt)+;
+scaleSpecialForm : (valueStmt whiteSpace? DOT whiteSpace?)? SCALE whiteSpace tuple whiteSpace? MINUS whiteSpace? tuple;
+tuple : LPAREN whiteSpace? valueStmt whiteSpace? COMMA whiteSpace? valueStmt whiteSpace? RPAREN;
+
 withStmtExpression : valueStmt;
 
 explicitCallStmt : CALL whiteSpace explicitCallStmtExpression;
@@ -599,7 +606,6 @@ keyword :
      | CDBL
      | CDEC
      | CINT
-     | CIRCLE
      | CLASS
      | CLNG
      | CLNGLNG
@@ -653,7 +659,6 @@ keyword :
      | PSET
      | REM
      | RMDIR
-     | SCALE
      | SENDKEYS
      | SETATTR
      | SGN

--- a/Rubberduck.Parsing/Grammar/VBAParserBaseListener.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserBaseListener.cs
@@ -34,108 +34,30 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 [System.CLSCompliant(false)]
 public partial class VBAParserBaseListener : IVBAParserListener {
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterListOrLabel([NotNull] VBAParser.ListOrLabelContext context) { }
+	public virtual void EnterTabNumber([NotNull] VBAParser.TabNumberContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitListOrLabel([NotNull] VBAParser.ListOrLabelContext context) { }
+	public virtual void ExitTabNumber([NotNull] VBAParser.TabNumberContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.spcClause"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterSeekStmt([NotNull] VBAParser.SeekStmtContext context) { }
+	public virtual void EnterSpcClause([NotNull] VBAParser.SpcClauseContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.spcClause"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitSeekStmt([NotNull] VBAParser.SeekStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.fileNumber"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterFileNumber([NotNull] VBAParser.FileNumberContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitFileNumber([NotNull] VBAParser.FileNumberContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.constStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterConstStmt([NotNull] VBAParser.ConstStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.constStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitConstStmt([NotNull] VBAParser.ConstStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { }
+	public virtual void ExitSpcClause([NotNull] VBAParser.SpcClauseContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.ECS_ProcedureCall"/>.
@@ -151,19 +73,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitECS_ProcedureCall([NotNull] VBAParser.ECS_ProcedureCallContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.type"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterType([NotNull] VBAParser.TypeContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.type"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitType([NotNull] VBAParser.TypeContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.rsetStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -175,19 +84,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitRsetStmt([NotNull] VBAParser.RsetStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.inputStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterInputStmt([NotNull] VBAParser.InputStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitInputStmt([NotNull] VBAParser.InputStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.vsAdd"/>.
@@ -216,19 +112,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitLsetStmt([NotNull] VBAParser.LsetStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.declareStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterDeclareStmt([NotNull] VBAParser.DeclareStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.implicitCallStmt_InBlock"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -242,32 +125,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitImplicitCallStmt_InBlock([NotNull] VBAParser.ImplicitCallStmt_InBlockContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.resetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterResetStmt([NotNull] VBAParser.ResetStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitResetStmt([NotNull] VBAParser.ResetStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsNew"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsNew([NotNull] VBAParser.VsNewContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsNew"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsNew([NotNull] VBAParser.VsNewContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.remComment"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -279,32 +136,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitRemComment([NotNull] VBAParser.RemCommentContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.block"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterBlock([NotNull] VBAParser.BlockContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.block"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitBlock([NotNull] VBAParser.BlockContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.setStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterSetStmt([NotNull] VBAParser.SetStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.setStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitSetStmt([NotNull] VBAParser.SetStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.vsNegation"/>.
@@ -333,19 +164,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitLetterSpec([NotNull] VBAParser.LetterSpecContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.fieldLength"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -370,19 +188,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitECS_MemberCall([NotNull] VBAParser.ECS_MemberCallContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.identifier"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterIdentifier([NotNull] VBAParser.IdentifierContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.identifier"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitIdentifier([NotNull] VBAParser.IdentifierContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.dictionaryCallStmt"/>.
@@ -422,32 +227,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitRedimSubStmt([NotNull] VBAParser.RedimSubStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterAttributeStmt([NotNull] VBAParser.AttributeStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.module"/>.
@@ -502,32 +281,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitVsICS([NotNull] VBAParser.VsICSContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.moduleDeclarations"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -539,32 +292,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitModuleDeclarations([NotNull] VBAParser.ModuleDeclarationsContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.iCS_B_MemberProcedureCall"/>.
@@ -580,17 +307,30 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitICS_B_MemberProcedureCall([NotNull] VBAParser.ICS_B_MemberProcedureCallContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterOutputList([NotNull] VBAParser.OutputListContext context) { }
+	public virtual void EnterInputList([NotNull] VBAParser.InputListContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitOutputList([NotNull] VBAParser.OutputListContext context) { }
+	public virtual void ExitInputList([NotNull] VBAParser.InputListContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsMarkedFileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsMarkedFileNumber([NotNull] VBAParser.VsMarkedFileNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsMarkedFileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsMarkedFileNumber([NotNull] VBAParser.VsMarkedFileNumberContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.selectCaseStmt"/>.
@@ -604,19 +344,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitSelectCaseStmt([NotNull] VBAParser.SelectCaseStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsIntDiv"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsIntDiv([NotNull] VBAParser.VsIntDivContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsIntDiv"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsIntDiv([NotNull] VBAParser.VsIntDivContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.moduleBody"/>.
@@ -645,30 +372,17 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitLetterRange([NotNull] VBAParser.LetterRangeContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.access"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterDefDirective([NotNull] VBAParser.DefDirectiveContext context) { }
+	public virtual void EnterAccess([NotNull] VBAParser.AccessContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.access"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitDefDirective([NotNull] VBAParser.DefDirectiveContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.caseCondSelection"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.caseCondSelection"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context) { }
+	public virtual void ExitAccess([NotNull] VBAParser.AccessContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.widthStmt"/>.
@@ -710,6 +424,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitArgCall([NotNull] VBAParser.ArgCallContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.endRecordNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterEndRecordNumber([NotNull] VBAParser.EndRecordNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.endRecordNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitEndRecordNumber([NotNull] VBAParser.EndRecordNumberContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.annotationName"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -721,19 +448,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitAnnotationName([NotNull] VBAParser.AnnotationNameContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeHint"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterTypeHint([NotNull] VBAParser.TypeHintContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeHint"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitTypeHint([NotNull] VBAParser.TypeHintContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.constSubStmt"/>.
@@ -762,19 +476,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitEndOfStatement([NotNull] VBAParser.EndOfStatementContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.elseBlock"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterElseBlock([NotNull] VBAParser.ElseBlockContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitElseBlock([NotNull] VBAParser.ElseBlockContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.optionCompareStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -788,17 +489,17 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitOptionCompareStmt([NotNull] VBAParser.OptionCompareStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.lineWidth"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterRedimStmt([NotNull] VBAParser.RedimStmtContext context) { }
+	public virtual void EnterLineWidth([NotNull] VBAParser.LineWidthContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.lineWidth"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { }
+	public virtual void ExitLineWidth([NotNull] VBAParser.LineWidthContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.literal"/>.
@@ -853,19 +554,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitErrorStmt([NotNull] VBAParser.ErrorStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsAddressOf([NotNull] VBAParser.VsAddressOfContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.arg"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -905,19 +593,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitEventStmt([NotNull] VBAParser.EventStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.firstLetter"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterFirstLetter([NotNull] VBAParser.FirstLetterContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitFirstLetter([NotNull] VBAParser.FirstLetterContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.lockStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -929,19 +604,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitLockStmt([NotNull] VBAParser.LockStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.optionExplicitStmt"/>.
@@ -983,32 +645,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitVsNot([NotNull] VBAParser.VsNotContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.endOfLine"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterEndOfLine([NotNull] VBAParser.EndOfLineContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitEndOfLine([NotNull] VBAParser.EndOfLineContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.startRule"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterStartRule([NotNull] VBAParser.StartRuleContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.startRule"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitStartRule([NotNull] VBAParser.StartRuleContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.writeStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1020,32 +656,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitWriteStmt([NotNull] VBAParser.WriteStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsAnd"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsAnd([NotNull] VBAParser.VsAndContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsAnd"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsAnd([NotNull] VBAParser.VsAndContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.endStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterEndStmt([NotNull] VBAParser.EndStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.endStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitEndStmt([NotNull] VBAParser.EndStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.annotationList"/>.
@@ -1074,32 +684,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitSingleLetter([NotNull] VBAParser.SingleLetterContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsAmp"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsAmp([NotNull] VBAParser.VsAmpContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsAmp"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsAmp([NotNull] VBAParser.VsAmpContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.ifStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1126,56 +710,17 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitSubroutineName([NotNull] VBAParser.SubroutineNameContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.inputVariable"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterForNextStmt([NotNull] VBAParser.ForNextStmtContext context) { }
+	public virtual void EnterInputVariable([NotNull] VBAParser.InputVariableContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.inputVariable"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitForNextStmt([NotNull] VBAParser.ForNextStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.caseCondTo"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterCaseCondTo([NotNull] VBAParser.CaseCondToContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.caseCondTo"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitCaseCondTo([NotNull] VBAParser.CaseCondToContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsImp"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsImp([NotNull] VBAParser.VsImpContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsImp"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsImp([NotNull] VBAParser.VsImpContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context) { }
+	public virtual void ExitInputVariable([NotNull] VBAParser.InputVariableContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.forEachStmt"/>.
@@ -1191,19 +736,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitForEachStmt([NotNull] VBAParser.ForEachStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.exitStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterExitStmt([NotNull] VBAParser.ExitStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitExitStmt([NotNull] VBAParser.ExitStmtContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.numberLiteral"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1215,19 +747,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitNumberLiteral([NotNull] VBAParser.NumberLiteralContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.argList"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterArgList([NotNull] VBAParser.ArgListContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.argList"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitArgList([NotNull] VBAParser.ArgListContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.singleLineIfStmt"/>.
@@ -1243,32 +762,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitSingleLineIfStmt([NotNull] VBAParser.SingleLineIfStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsStruct"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsStruct([NotNull] VBAParser.VsStructContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsStruct"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsStruct([NotNull] VBAParser.VsStructContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.subscripts"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterSubscripts([NotNull] VBAParser.SubscriptsContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.subscripts"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitSubscripts([NotNull] VBAParser.SubscriptsContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.lastLetter"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1282,6 +775,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitLastLetter([NotNull] VBAParser.LastLetterContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.spcNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterSpcNumber([NotNull] VBAParser.SpcNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.spcNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitSpcNumber([NotNull] VBAParser.SpcNumberContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.letStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1293,19 +799,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitLetStmt([NotNull] VBAParser.LetStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.subStmt"/>.
@@ -1347,19 +840,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitVsRelational([NotNull] VBAParser.VsRelationalContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.lineInputStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1373,17 +853,30 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitLineInputStmt([NotNull] VBAParser.LineInputStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.outputExpression"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterTypeStmt([NotNull] VBAParser.TypeStmtContext context) { }
+	public virtual void EnterOutputExpression([NotNull] VBAParser.OutputExpressionContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.outputExpression"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitTypeStmt([NotNull] VBAParser.TypeStmtContext context) { }
+	public virtual void ExitOutputExpression([NotNull] VBAParser.OutputExpressionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.tabClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterTabClause([NotNull] VBAParser.TabClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.tabClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitTabClause([NotNull] VBAParser.TabClauseContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -1412,30 +905,17 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitICS_S_MemberCall([NotNull] VBAParser.ICS_S_MemberCallContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.outputList_Expression"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.fileNumberList"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterOutputList_Expression([NotNull] VBAParser.OutputList_ExpressionContext context) { }
+	public virtual void EnterFileNumberList([NotNull] VBAParser.FileNumberListContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.outputList_Expression"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.fileNumberList"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitOutputList_Expression([NotNull] VBAParser.OutputList_ExpressionContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context) { }
+	public virtual void ExitFileNumberList([NotNull] VBAParser.FileNumberListContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.optionPrivateModuleStmt"/>.
@@ -1451,19 +931,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitOptionPrivateModuleStmt([NotNull] VBAParser.OptionPrivateModuleStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.putStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterPutStmt([NotNull] VBAParser.PutStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.putStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitPutStmt([NotNull] VBAParser.PutStmtContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.keyword"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1475,32 +942,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitKeyword([NotNull] VBAParser.KeywordContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.annotationArg"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterAnnotationArg([NotNull] VBAParser.AnnotationArgContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.vsAssign"/>.
@@ -1516,19 +957,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitVsAssign([NotNull] VBAParser.VsAssignContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.variableStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVariableStmt([NotNull] VBAParser.VariableStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVariableStmt([NotNull] VBAParser.VariableStmtContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.elseIfBlock"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1540,19 +968,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitElseIfBlock([NotNull] VBAParser.ElseIfBlockContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.subscript"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterSubscript([NotNull] VBAParser.SubscriptContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.subscript"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitSubscript([NotNull] VBAParser.SubscriptContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.visibility"/>.
@@ -1594,45 +1009,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitVsTypeOf([NotNull] VBAParser.VsTypeOfContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.caseCondValue"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterCaseCondValue([NotNull] VBAParser.CaseCondValueContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.caseCondValue"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.functionStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1644,6 +1020,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitFunctionStmt([NotNull] VBAParser.FunctionStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.recordRange"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterRecordRange([NotNull] VBAParser.RecordRangeContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.recordRange"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitRecordRange([NotNull] VBAParser.RecordRangeContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.returnStmt"/>.
@@ -1685,97 +1074,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitUniversalLetterRange([NotNull] VBAParser.UniversalLetterRangeContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsMod"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsMod([NotNull] VBAParser.VsModContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsMod"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsMod([NotNull] VBAParser.VsModContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsOr"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsOr([NotNull] VBAParser.VsOrContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsOr"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsOr([NotNull] VBAParser.VsOrContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.caseCondElse"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterCaseCondElse([NotNull] VBAParser.CaseCondElseContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.caseCondElse"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.getStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterGetStmt([NotNull] VBAParser.GetStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.getStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitGetStmt([NotNull] VBAParser.GetStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterSameLineStatement([NotNull] VBAParser.SameLineStatementContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.ifWithEmptyThen"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1787,6 +1085,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitIfWithEmptyThen([NotNull] VBAParser.IfWithEmptyThenContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.modeClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterModeClause([NotNull] VBAParser.ModeClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.modeClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitModeClause([NotNull] VBAParser.ModeClauseContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.annotationArgList"/>.
@@ -1826,45 +1137,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitOnGoToStmt([NotNull] VBAParser.OnGoToStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.argsCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterArgsCall([NotNull] VBAParser.ArgsCallContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.argsCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitArgsCall([NotNull] VBAParser.ArgsCallContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.upperCaseA"/>.
@@ -1997,17 +1269,17 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitStopStmt([NotNull] VBAParser.StopStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.variableName"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void EnterIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context) { }
+	public virtual void EnterVariableName([NotNull] VBAParser.VariableNameContext context) { }
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.variableName"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	public virtual void ExitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context) { }
+	public virtual void ExitVariableName([NotNull] VBAParser.VariableNameContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.whiteSpace"/>.
@@ -2036,45 +1308,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitSC_Case([NotNull] VBAParser.SC_CaseContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.functionName"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterFunctionName([NotNull] VBAParser.FunctionNameContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.functionName"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitFunctionName([NotNull] VBAParser.FunctionNameContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVariableListStmt([NotNull] VBAParser.VariableListStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.statementLabel"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterStatementLabel([NotNull] VBAParser.StatementLabelContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitStatementLabel([NotNull] VBAParser.StatementLabelContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.upperCaseZ"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -2086,45 +1319,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitUpperCaseZ([NotNull] VBAParser.UpperCaseZContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterUnlockStmt([NotNull] VBAParser.UnlockStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.vsXor"/>.
@@ -2179,19 +1373,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitMidStmt([NotNull] VBAParser.MidStmtContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.vsPow"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -2242,6 +1423,1293 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitDoLoopStmt([NotNull] VBAParser.DoLoopStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsLiteral"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsLiteral([NotNull] VBAParser.VsLiteralContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsLiteral"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsLiteral([NotNull] VBAParser.VsLiteralContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.comment"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterComment([NotNull] VBAParser.CommentContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.comment"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitComment([NotNull] VBAParser.CommentContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsMid"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsMid([NotNull] VBAParser.VsMidContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsMid"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsMid([NotNull] VBAParser.VsMidContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterSeekStmt([NotNull] VBAParser.SeekStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitSeekStmt([NotNull] VBAParser.SeekStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterListOrLabel([NotNull] VBAParser.ListOrLabelContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitListOrLabel([NotNull] VBAParser.ListOrLabelContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.fileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterFileNumber([NotNull] VBAParser.FileNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitFileNumber([NotNull] VBAParser.FileNumberContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.constStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterConstStmt([NotNull] VBAParser.ConstStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.constStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitConstStmt([NotNull] VBAParser.ConstStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.type"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterType([NotNull] VBAParser.TypeContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.type"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitType([NotNull] VBAParser.TypeContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.inputStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterInputStmt([NotNull] VBAParser.InputStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitInputStmt([NotNull] VBAParser.InputStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.declareStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterDeclareStmt([NotNull] VBAParser.DeclareStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.resetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterResetStmt([NotNull] VBAParser.ResetStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitResetStmt([NotNull] VBAParser.ResetStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsNew"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsNew([NotNull] VBAParser.VsNewContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsNew"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsNew([NotNull] VBAParser.VsNewContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.@lock"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterLock([NotNull] VBAParser.LockContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.@lock"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitLock([NotNull] VBAParser.LockContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.block"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterBlock([NotNull] VBAParser.BlockContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.block"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitBlock([NotNull] VBAParser.BlockContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.fileMode"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterFileMode([NotNull] VBAParser.FileModeContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.fileMode"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitFileMode([NotNull] VBAParser.FileModeContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.setStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterSetStmt([NotNull] VBAParser.SetStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.setStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitSetStmt([NotNull] VBAParser.SetStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.identifier"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterIdentifier([NotNull] VBAParser.IdentifierContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.identifier"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitIdentifier([NotNull] VBAParser.IdentifierContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterAttributeStmt([NotNull] VBAParser.AttributeStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterOutputList([NotNull] VBAParser.OutputListContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitOutputList([NotNull] VBAParser.OutputListContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsIntDiv"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsIntDiv([NotNull] VBAParser.VsIntDivContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsIntDiv"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsIntDiv([NotNull] VBAParser.VsIntDivContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterDefDirective([NotNull] VBAParser.DefDirectiveContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitDefDirective([NotNull] VBAParser.DefDirectiveContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.caseCondSelection"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.caseCondSelection"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeHint"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterTypeHint([NotNull] VBAParser.TypeHintContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeHint"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitTypeHint([NotNull] VBAParser.TypeHintContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.fileStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterFileStmt([NotNull] VBAParser.FileStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.fileStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitFileStmt([NotNull] VBAParser.FileStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.elseBlock"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterElseBlock([NotNull] VBAParser.ElseBlockContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitElseBlock([NotNull] VBAParser.ElseBlockContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterRedimStmt([NotNull] VBAParser.RedimStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsAddressOf([NotNull] VBAParser.VsAddressOfContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.recLength"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterRecLength([NotNull] VBAParser.RecLengthContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.recLength"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitRecLength([NotNull] VBAParser.RecLengthContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.unmarkedFileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterUnmarkedFileNumber([NotNull] VBAParser.UnmarkedFileNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.unmarkedFileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitUnmarkedFileNumber([NotNull] VBAParser.UnmarkedFileNumberContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.firstLetter"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterFirstLetter([NotNull] VBAParser.FirstLetterContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitFirstLetter([NotNull] VBAParser.FirstLetterContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.endOfLine"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterEndOfLine([NotNull] VBAParser.EndOfLineContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitEndOfLine([NotNull] VBAParser.EndOfLineContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.startRule"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterStartRule([NotNull] VBAParser.StartRuleContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.startRule"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitStartRule([NotNull] VBAParser.StartRuleContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsAnd"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsAnd([NotNull] VBAParser.VsAndContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsAnd"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsAnd([NotNull] VBAParser.VsAndContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.endStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterEndStmt([NotNull] VBAParser.EndStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.endStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitEndStmt([NotNull] VBAParser.EndStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsAmp"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsAmp([NotNull] VBAParser.VsAmpContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsAmp"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsAmp([NotNull] VBAParser.VsAmpContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterForNextStmt([NotNull] VBAParser.ForNextStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitForNextStmt([NotNull] VBAParser.ForNextStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.caseCondTo"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterCaseCondTo([NotNull] VBAParser.CaseCondToContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.caseCondTo"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitCaseCondTo([NotNull] VBAParser.CaseCondToContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsImp"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsImp([NotNull] VBAParser.VsImpContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsImp"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsImp([NotNull] VBAParser.VsImpContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.exitStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterExitStmt([NotNull] VBAParser.ExitStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitExitStmt([NotNull] VBAParser.ExitStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.argList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterArgList([NotNull] VBAParser.ArgListContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.argList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitArgList([NotNull] VBAParser.ArgListContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsStruct"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsStruct([NotNull] VBAParser.VsStructContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsStruct"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsStruct([NotNull] VBAParser.VsStructContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.data"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterData([NotNull] VBAParser.DataContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.data"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitData([NotNull] VBAParser.DataContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.subscripts"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterSubscripts([NotNull] VBAParser.SubscriptsContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.subscripts"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitSubscripts([NotNull] VBAParser.SubscriptsContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterTypeStmt([NotNull] VBAParser.TypeStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitTypeStmt([NotNull] VBAParser.TypeStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.putStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPutStmt([NotNull] VBAParser.PutStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.putStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPutStmt([NotNull] VBAParser.PutStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.annotationArg"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterAnnotationArg([NotNull] VBAParser.AnnotationArgContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.recordNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterRecordNumber([NotNull] VBAParser.RecordNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.recordNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitRecordNumber([NotNull] VBAParser.RecordNumberContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variableStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVariableStmt([NotNull] VBAParser.VariableStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVariableStmt([NotNull] VBAParser.VariableStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.subscript"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterSubscript([NotNull] VBAParser.SubscriptContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.subscript"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitSubscript([NotNull] VBAParser.SubscriptContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.outputClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterOutputClause([NotNull] VBAParser.OutputClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.outputClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitOutputClause([NotNull] VBAParser.OutputClauseContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.caseCondValue"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterCaseCondValue([NotNull] VBAParser.CaseCondValueContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.caseCondValue"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.startRecordNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterStartRecordNumber([NotNull] VBAParser.StartRecordNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.startRecordNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitStartRecordNumber([NotNull] VBAParser.StartRecordNumberContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsMod"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsMod([NotNull] VBAParser.VsModContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsMod"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsMod([NotNull] VBAParser.VsModContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.vsOr"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVsOr([NotNull] VBAParser.VsOrContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.vsOr"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVsOr([NotNull] VBAParser.VsOrContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.outputItem"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterOutputItem([NotNull] VBAParser.OutputItemContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.outputItem"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitOutputItem([NotNull] VBAParser.OutputItemContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.caseCondElse"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterCaseCondElse([NotNull] VBAParser.CaseCondElseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.caseCondElse"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.position"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPosition([NotNull] VBAParser.PositionContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.position"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPosition([NotNull] VBAParser.PositionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.getStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterGetStmt([NotNull] VBAParser.GetStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.getStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitGetStmt([NotNull] VBAParser.GetStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterSameLineStatement([NotNull] VBAParser.SameLineStatementContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.pathName"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPathName([NotNull] VBAParser.PathNameContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.pathName"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPathName([NotNull] VBAParser.PathNameContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.tabNumberClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterTabNumberClause([NotNull] VBAParser.TabNumberClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.tabNumberClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitTabNumberClause([NotNull] VBAParser.TabNumberClauseContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.charPosition"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterCharPosition([NotNull] VBAParser.CharPositionContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.charPosition"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitCharPosition([NotNull] VBAParser.CharPositionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.argsCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterArgsCall([NotNull] VBAParser.ArgsCallContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.argsCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitArgsCall([NotNull] VBAParser.ArgsCallContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterMarkedFileNumber([NotNull] VBAParser.MarkedFileNumberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitMarkedFileNumber([NotNull] VBAParser.MarkedFileNumberContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.accessClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterAccessClause([NotNull] VBAParser.AccessClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.accessClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitAccessClause([NotNull] VBAParser.AccessClauseContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.functionName"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterFunctionName([NotNull] VBAParser.FunctionNameContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.functionName"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitFunctionName([NotNull] VBAParser.FunctionNameContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVariableListStmt([NotNull] VBAParser.VariableListStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.statementLabel"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterStatementLabel([NotNull] VBAParser.StatementLabelContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitStatementLabel([NotNull] VBAParser.StatementLabelContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterUnlockStmt([NotNull] VBAParser.UnlockStmtContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.lenClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterLenClause([NotNull] VBAParser.LenClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.lenClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitLenClause([NotNull] VBAParser.LenClauseContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCall"/>.
@@ -2296,6 +2764,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitWithStmtExpression([NotNull] VBAParser.WithStmtExpressionContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variable"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterVariable([NotNull] VBAParser.VariableContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variable"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitVariable([NotNull] VBAParser.VariableContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.eraseStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -2322,32 +2803,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitCommentBody([NotNull] VBAParser.CommentBodyContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsLiteral"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsLiteral([NotNull] VBAParser.VsLiteralContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsLiteral"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsLiteral([NotNull] VBAParser.VsLiteralContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.vsEqv"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -2361,32 +2816,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitVsEqv([NotNull] VBAParser.VsEqvContext context) { }
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.comment"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterComment([NotNull] VBAParser.CommentContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.comment"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitComment([NotNull] VBAParser.CommentContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { }
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.unrestrictedIdentifier"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -2398,19 +2827,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitUnrestrictedIdentifier([NotNull] VBAParser.UnrestrictedIdentifierContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.vsMid"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterVsMid([NotNull] VBAParser.VsMidContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.vsMid"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitVsMid([NotNull] VBAParser.VsMidContext context) { }
 
 	/// <inheritdoc/>
 	/// <remarks>The default implementation does nothing.</remarks>

--- a/Rubberduck.Parsing/Grammar/VBAParserBaseListener.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserBaseListener.cs
@@ -580,6 +580,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitVsMult([NotNull] VBAParser.VsMultContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.scaleSpecialForm"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterScaleSpecialForm([NotNull] VBAParser.ScaleSpecialFormContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.scaleSpecialForm"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitScaleSpecialForm([NotNull] VBAParser.ScaleSpecialFormContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.eventStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -877,6 +890,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitTabClause([NotNull] VBAParser.TabClauseContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.circleSpecialForm"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterCircleSpecialForm([NotNull] VBAParser.CircleSpecialFormContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.circleSpecialForm"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitCircleSpecialForm([NotNull] VBAParser.CircleSpecialFormContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -1917,6 +1943,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.tuple"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterTuple([NotNull] VBAParser.TupleContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.tuple"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitTuple([NotNull] VBAParser.TupleContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.

--- a/Rubberduck.Parsing/Grammar/VBAParserBaseVisitor.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserBaseVisitor.cs
@@ -33,7 +33,7 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 [System.CLSCompliant(false)]
 public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Result>, IVBAParserVisitor<Result> {
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -41,10 +41,10 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitListOrLabel([NotNull] VBAParser.ListOrLabelContext context) { return VisitChildren(context); }
+	public virtual Result VisitTabNumber([NotNull] VBAParser.TabNumberContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.spcClause"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -52,73 +52,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitSeekStmt([NotNull] VBAParser.SeekStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitFileNumber([NotNull] VBAParser.FileNumberContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.constStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitConstStmt([NotNull] VBAParser.ConstStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { return VisitChildren(context); }
+	public virtual Result VisitSpcClause([NotNull] VBAParser.SpcClauseContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.ECS_ProcedureCall"/>.
@@ -132,17 +66,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitECS_ProcedureCall([NotNull] VBAParser.ECS_ProcedureCallContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.type"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitType([NotNull] VBAParser.TypeContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.rsetStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -152,17 +75,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitRsetStmt([NotNull] VBAParser.RsetStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitInputStmt([NotNull] VBAParser.InputStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.vsAdd"/>.
@@ -187,17 +99,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitLsetStmt([NotNull] VBAParser.LsetStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InBlock"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -209,28 +110,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitImplicitCallStmt_InBlock([NotNull] VBAParser.ImplicitCallStmt_InBlockContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitResetStmt([NotNull] VBAParser.ResetStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsNew"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsNew([NotNull] VBAParser.VsNewContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.remComment"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -240,28 +119,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitRemComment([NotNull] VBAParser.RemCommentContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.block"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitBlock([NotNull] VBAParser.BlockContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.setStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitSetStmt([NotNull] VBAParser.SetStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.vsNegation"/>.
@@ -286,17 +143,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitLetterSpec([NotNull] VBAParser.LetterSpecContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.fieldLength"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -317,17 +163,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitECS_MemberCall([NotNull] VBAParser.ECS_MemberCallContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.identifier"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitIdentifier([NotNull] VBAParser.IdentifierContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.dictionaryCallStmt"/>.
@@ -361,28 +196,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitRedimSubStmt([NotNull] VBAParser.RedimSubStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.module"/>.
@@ -429,28 +242,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitVsICS([NotNull] VBAParser.VsICSContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.moduleDeclarations"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -460,28 +251,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitModuleDeclarations([NotNull] VBAParser.ModuleDeclarationsContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.iCS_B_MemberProcedureCall"/>.
@@ -495,7 +264,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitICS_B_MemberProcedureCall([NotNull] VBAParser.ICS_B_MemberProcedureCallContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -503,7 +272,18 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitOutputList([NotNull] VBAParser.OutputListContext context) { return VisitChildren(context); }
+	public virtual Result VisitInputList([NotNull] VBAParser.InputListContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsMarkedFileNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsMarkedFileNumber([NotNull] VBAParser.VsMarkedFileNumberContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.selectCaseStmt"/>.
@@ -515,17 +295,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitSelectCaseStmt([NotNull] VBAParser.SelectCaseStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsIntDiv"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsIntDiv([NotNull] VBAParser.VsIntDivContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.moduleBody"/>.
@@ -550,7 +319,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitLetterRange([NotNull] VBAParser.LetterRangeContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.access"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -558,18 +327,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitDefDirective([NotNull] VBAParser.DefDirectiveContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.caseCondSelection"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context) { return VisitChildren(context); }
+	public virtual Result VisitAccess([NotNull] VBAParser.AccessContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.widthStmt"/>.
@@ -605,6 +363,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitArgCall([NotNull] VBAParser.ArgCallContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.endRecordNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitEndRecordNumber([NotNull] VBAParser.EndRecordNumberContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.annotationName"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -614,17 +383,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitAnnotationName([NotNull] VBAParser.AnnotationNameContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeHint"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitTypeHint([NotNull] VBAParser.TypeHintContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.constSubStmt"/>.
@@ -649,17 +407,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitEndOfStatement([NotNull] VBAParser.EndOfStatementContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitElseBlock([NotNull] VBAParser.ElseBlockContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.optionCompareStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -671,7 +418,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitOptionCompareStmt([NotNull] VBAParser.OptionCompareStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.lineWidth"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -679,7 +426,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { return VisitChildren(context); }
+	public virtual Result VisitLineWidth([NotNull] VBAParser.LineWidthContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.literal"/>.
@@ -726,17 +473,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitErrorStmt([NotNull] VBAParser.ErrorStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.arg"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -770,17 +506,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitEventStmt([NotNull] VBAParser.EventStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitFirstLetter([NotNull] VBAParser.FirstLetterContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.lockStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -790,17 +515,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitLockStmt([NotNull] VBAParser.LockStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.optionExplicitStmt"/>.
@@ -836,28 +550,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitVsNot([NotNull] VBAParser.VsNotContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitEndOfLine([NotNull] VBAParser.EndOfLineContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.startRule"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitStartRule([NotNull] VBAParser.StartRuleContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.writeStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -867,28 +559,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitWriteStmt([NotNull] VBAParser.WriteStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsAnd"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsAnd([NotNull] VBAParser.VsAndContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.endStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitEndStmt([NotNull] VBAParser.EndStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.annotationList"/>.
@@ -913,28 +583,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitSingleLetter([NotNull] VBAParser.SingleLetterContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsAmp"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsAmp([NotNull] VBAParser.VsAmpContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.ifStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -957,7 +605,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitSubroutineName([NotNull] VBAParser.SubroutineNameContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.inputVariable"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -965,40 +613,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitForNextStmt([NotNull] VBAParser.ForNextStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.caseCondTo"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitCaseCondTo([NotNull] VBAParser.CaseCondToContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsImp"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsImp([NotNull] VBAParser.VsImpContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context) { return VisitChildren(context); }
+	public virtual Result VisitInputVariable([NotNull] VBAParser.InputVariableContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.forEachStmt"/>.
@@ -1012,17 +627,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitForEachStmt([NotNull] VBAParser.ForEachStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitExitStmt([NotNull] VBAParser.ExitStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.numberLiteral"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1032,17 +636,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitNumberLiteral([NotNull] VBAParser.NumberLiteralContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.argList"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitArgList([NotNull] VBAParser.ArgListContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.singleLineIfStmt"/>.
@@ -1056,28 +649,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitSingleLineIfStmt([NotNull] VBAParser.SingleLineIfStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsStruct"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsStruct([NotNull] VBAParser.VsStructContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.subscripts"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitSubscripts([NotNull] VBAParser.SubscriptsContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.lastLetter"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1089,6 +660,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitLastLetter([NotNull] VBAParser.LastLetterContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.spcNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitSpcNumber([NotNull] VBAParser.SpcNumberContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.letStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1098,17 +680,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitLetStmt([NotNull] VBAParser.LetStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.subStmt"/>.
@@ -1144,17 +715,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitVsRelational([NotNull] VBAParser.VsRelationalContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.lineInputStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1166,7 +726,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitLineInputStmt([NotNull] VBAParser.LineInputStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.outputExpression"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -1174,7 +734,18 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitTypeStmt([NotNull] VBAParser.TypeStmtContext context) { return VisitChildren(context); }
+	public virtual Result VisitOutputExpression([NotNull] VBAParser.OutputExpressionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.tabClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitTabClause([NotNull] VBAParser.TabClauseContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -1199,7 +770,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitICS_S_MemberCall([NotNull] VBAParser.ICS_S_MemberCallContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.outputList_Expression"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.fileNumberList"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -1207,18 +778,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitOutputList_Expression([NotNull] VBAParser.OutputList_ExpressionContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context) { return VisitChildren(context); }
+	public virtual Result VisitFileNumberList([NotNull] VBAParser.FileNumberListContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.optionPrivateModuleStmt"/>.
@@ -1232,17 +792,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitOptionPrivateModuleStmt([NotNull] VBAParser.OptionPrivateModuleStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.putStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitPutStmt([NotNull] VBAParser.PutStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.keyword"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1252,28 +801,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitKeyword([NotNull] VBAParser.KeywordContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.vsAssign"/>.
@@ -1287,17 +814,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitVsAssign([NotNull] VBAParser.VsAssignContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVariableStmt([NotNull] VBAParser.VariableStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.elseIfBlock"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1307,17 +823,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitElseIfBlock([NotNull] VBAParser.ElseIfBlockContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.subscript"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitSubscript([NotNull] VBAParser.SubscriptContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.visibility"/>.
@@ -1353,39 +858,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitVsTypeOf([NotNull] VBAParser.VsTypeOfContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.caseCondValue"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.functionStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1395,6 +867,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitFunctionStmt([NotNull] VBAParser.FunctionStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.recordRange"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitRecordRange([NotNull] VBAParser.RecordRangeContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.returnStmt"/>.
@@ -1430,83 +913,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitUniversalLetterRange([NotNull] VBAParser.UniversalLetterRangeContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsMod"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsMod([NotNull] VBAParser.VsModContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsOr"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsOr([NotNull] VBAParser.VsOrContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.caseCondElse"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.getStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitGetStmt([NotNull] VBAParser.GetStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.ifWithEmptyThen"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1516,6 +922,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitIfWithEmptyThen([NotNull] VBAParser.IfWithEmptyThenContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.modeClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitModeClause([NotNull] VBAParser.ModeClauseContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.annotationArgList"/>.
@@ -1549,39 +966,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitOnGoToStmt([NotNull] VBAParser.OnGoToStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.argsCall"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitArgsCall([NotNull] VBAParser.ArgsCallContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.upperCaseA"/>.
@@ -1694,7 +1078,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitStopStmt([NotNull] VBAParser.StopStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.variableName"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
 	/// on <paramref name="context"/>.
@@ -1702,7 +1086,7 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	public virtual Result VisitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context) { return VisitChildren(context); }
+	public virtual Result VisitVariableName([NotNull] VBAParser.VariableNameContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.whiteSpace"/>.
@@ -1727,39 +1111,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitSC_Case([NotNull] VBAParser.SC_CaseContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.functionName"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitFunctionName([NotNull] VBAParser.FunctionNameContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitStatementLabel([NotNull] VBAParser.StatementLabelContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.upperCaseZ"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1769,39 +1120,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitUpperCaseZ([NotNull] VBAParser.UpperCaseZContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.vsXor"/>.
@@ -1848,17 +1166,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitMidStmt([NotNull] VBAParser.MidStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.vsPow"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1901,6 +1208,1095 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitDoLoopStmt([NotNull] VBAParser.DoLoopStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsLiteral"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsLiteral([NotNull] VBAParser.VsLiteralContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.comment"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitComment([NotNull] VBAParser.CommentContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsMid"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsMid([NotNull] VBAParser.VsMidContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitSeekStmt([NotNull] VBAParser.SeekStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitListOrLabel([NotNull] VBAParser.ListOrLabelContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitFileNumber([NotNull] VBAParser.FileNumberContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.constStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitConstStmt([NotNull] VBAParser.ConstStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.type"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitType([NotNull] VBAParser.TypeContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitInputStmt([NotNull] VBAParser.InputStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitResetStmt([NotNull] VBAParser.ResetStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsNew"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsNew([NotNull] VBAParser.VsNewContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.@lock"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitLock([NotNull] VBAParser.LockContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.block"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitBlock([NotNull] VBAParser.BlockContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.fileMode"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitFileMode([NotNull] VBAParser.FileModeContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.setStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitSetStmt([NotNull] VBAParser.SetStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.identifier"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitIdentifier([NotNull] VBAParser.IdentifierContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitOutputList([NotNull] VBAParser.OutputListContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsIntDiv"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsIntDiv([NotNull] VBAParser.VsIntDivContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitDefDirective([NotNull] VBAParser.DefDirectiveContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.caseCondSelection"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeHint"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitTypeHint([NotNull] VBAParser.TypeHintContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.fileStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitFileStmt([NotNull] VBAParser.FileStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitElseBlock([NotNull] VBAParser.ElseBlockContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.recLength"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitRecLength([NotNull] VBAParser.RecLengthContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.unmarkedFileNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitUnmarkedFileNumber([NotNull] VBAParser.UnmarkedFileNumberContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitFirstLetter([NotNull] VBAParser.FirstLetterContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitEndOfLine([NotNull] VBAParser.EndOfLineContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.startRule"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitStartRule([NotNull] VBAParser.StartRuleContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsAnd"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsAnd([NotNull] VBAParser.VsAndContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.endStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitEndStmt([NotNull] VBAParser.EndStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsAmp"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsAmp([NotNull] VBAParser.VsAmpContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitForNextStmt([NotNull] VBAParser.ForNextStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.caseCondTo"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitCaseCondTo([NotNull] VBAParser.CaseCondToContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsImp"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsImp([NotNull] VBAParser.VsImpContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitExitStmt([NotNull] VBAParser.ExitStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.argList"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitArgList([NotNull] VBAParser.ArgListContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsStruct"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsStruct([NotNull] VBAParser.VsStructContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.data"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitData([NotNull] VBAParser.DataContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.subscripts"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitSubscripts([NotNull] VBAParser.SubscriptsContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitTypeStmt([NotNull] VBAParser.TypeStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.putStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPutStmt([NotNull] VBAParser.PutStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.recordNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitRecordNumber([NotNull] VBAParser.RecordNumberContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVariableStmt([NotNull] VBAParser.VariableStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.subscript"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitSubscript([NotNull] VBAParser.SubscriptContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.outputClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitOutputClause([NotNull] VBAParser.OutputClauseContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.caseCondValue"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.startRecordNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitStartRecordNumber([NotNull] VBAParser.StartRecordNumberContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsMod"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsMod([NotNull] VBAParser.VsModContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.vsOr"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVsOr([NotNull] VBAParser.VsOrContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.outputItem"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitOutputItem([NotNull] VBAParser.OutputItemContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.caseCondElse"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.position"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPosition([NotNull] VBAParser.PositionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.getStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitGetStmt([NotNull] VBAParser.GetStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.pathName"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPathName([NotNull] VBAParser.PathNameContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.tabNumberClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitTabNumberClause([NotNull] VBAParser.TabNumberClauseContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.charPosition"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitCharPosition([NotNull] VBAParser.CharPositionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.argsCall"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitArgsCall([NotNull] VBAParser.ArgsCallContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitMarkedFileNumber([NotNull] VBAParser.MarkedFileNumberContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.accessClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitAccessClause([NotNull] VBAParser.AccessClauseContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.functionName"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitFunctionName([NotNull] VBAParser.FunctionNameContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitStatementLabel([NotNull] VBAParser.StatementLabelContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.lenClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitLenClause([NotNull] VBAParser.LenClauseContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCall"/>.
@@ -1947,6 +2343,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitWithStmtExpression([NotNull] VBAParser.WithStmtExpressionContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variable"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitVariable([NotNull] VBAParser.VariableContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.eraseStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1969,28 +2376,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitCommentBody([NotNull] VBAParser.CommentBodyContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsLiteral"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsLiteral([NotNull] VBAParser.VsLiteralContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.vsEqv"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -2002,28 +2387,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitVsEqv([NotNull] VBAParser.VsEqvContext context) { return VisitChildren(context); }
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.comment"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitComment([NotNull] VBAParser.CommentContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { return VisitChildren(context); }
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.unrestrictedIdentifier"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -2033,16 +2396,5 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitUnrestrictedIdentifier([NotNull] VBAParser.UnrestrictedIdentifierContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.vsMid"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitVsMid([NotNull] VBAParser.VsMidContext context) { return VisitChildren(context); }
 }
 } // namespace Rubberduck.Parsing.Grammar

--- a/Rubberduck.Parsing/Grammar/VBAParserBaseVisitor.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserBaseVisitor.cs
@@ -495,6 +495,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitVsMult([NotNull] VBAParser.VsMultContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.scaleSpecialForm"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitScaleSpecialForm([NotNull] VBAParser.ScaleSpecialFormContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.eventStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -746,6 +757,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitTabClause([NotNull] VBAParser.TabClauseContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.circleSpecialForm"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitCircleSpecialForm([NotNull] VBAParser.CircleSpecialFormContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -1626,6 +1648,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.tuple"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitTuple([NotNull] VBAParser.TupleContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.vsAddressOf"/>.

--- a/Rubberduck.Parsing/Grammar/VBAParserListener.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserListener.cs
@@ -30,92 +30,26 @@ using IToken = Antlr4.Runtime.IToken;
 [System.CLSCompliant(false)]
 public interface IVBAParserListener : IParseTreeListener {
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterListOrLabel([NotNull] VBAParser.ListOrLabelContext context);
+	void EnterTabNumber([NotNull] VBAParser.TabNumberContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitListOrLabel([NotNull] VBAParser.ListOrLabelContext context);
+	void ExitTabNumber([NotNull] VBAParser.TabNumberContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.spcClause"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterSeekStmt([NotNull] VBAParser.SeekStmtContext context);
+	void EnterSpcClause([NotNull] VBAParser.SpcClauseContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.spcClause"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitSeekStmt([NotNull] VBAParser.SeekStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.fileNumber"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterFileNumber([NotNull] VBAParser.FileNumberContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitFileNumber([NotNull] VBAParser.FileNumberContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.constStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterConstStmt([NotNull] VBAParser.ConstStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.constStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitConstStmt([NotNull] VBAParser.ConstStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
+	void ExitSpcClause([NotNull] VBAParser.SpcClauseContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>ECS_ProcedureCall</c>
@@ -131,17 +65,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitECS_ProcedureCall([NotNull] VBAParser.ECS_ProcedureCallContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.type"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterType([NotNull] VBAParser.TypeContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.type"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitType([NotNull] VBAParser.TypeContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.rsetStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -151,17 +74,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitRsetStmt([NotNull] VBAParser.RsetStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.inputStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterInputStmt([NotNull] VBAParser.InputStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitInputStmt([NotNull] VBAParser.InputStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>vsAdd</c>
@@ -188,17 +100,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitLsetStmt([NotNull] VBAParser.LsetStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.declareStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterDeclareStmt([NotNull] VBAParser.DeclareStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.implicitCallStmt_InBlock"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -210,30 +111,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitImplicitCallStmt_InBlock([NotNull] VBAParser.ImplicitCallStmt_InBlockContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.resetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterResetStmt([NotNull] VBAParser.ResetStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitResetStmt([NotNull] VBAParser.ResetStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsNew</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsNew([NotNull] VBAParser.VsNewContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsNew</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsNew([NotNull] VBAParser.VsNewContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.remComment"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -243,28 +120,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitRemComment([NotNull] VBAParser.RemCommentContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.block"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterBlock([NotNull] VBAParser.BlockContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.block"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitBlock([NotNull] VBAParser.BlockContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.setStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterSetStmt([NotNull] VBAParser.SetStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.setStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitSetStmt([NotNull] VBAParser.SetStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>vsNegation</c>
@@ -291,17 +146,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitLetterSpec([NotNull] VBAParser.LetterSpecContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.fieldLength"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -324,17 +168,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitECS_MemberCall([NotNull] VBAParser.ECS_MemberCallContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.identifier"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterIdentifier([NotNull] VBAParser.IdentifierContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.identifier"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitIdentifier([NotNull] VBAParser.IdentifierContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.dictionaryCallStmt"/>.
@@ -368,28 +201,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitRedimSubStmt([NotNull] VBAParser.RedimSubStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterAttributeStmt([NotNull] VBAParser.AttributeStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.module"/>.
@@ -438,28 +249,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitVsICS([NotNull] VBAParser.VsICSContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.moduleDeclarations"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -469,28 +258,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitModuleDeclarations([NotNull] VBAParser.ModuleDeclarationsContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.iCS_B_MemberProcedureCall"/>.
@@ -504,15 +271,28 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitICS_B_MemberProcedureCall([NotNull] VBAParser.ICS_B_MemberProcedureCallContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterOutputList([NotNull] VBAParser.OutputListContext context);
+	void EnterInputList([NotNull] VBAParser.InputListContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitOutputList([NotNull] VBAParser.OutputListContext context);
+	void ExitInputList([NotNull] VBAParser.InputListContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsMarkedFileNumber</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsMarkedFileNumber([NotNull] VBAParser.VsMarkedFileNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsMarkedFileNumber</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsMarkedFileNumber([NotNull] VBAParser.VsMarkedFileNumberContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.selectCaseStmt"/>.
@@ -524,19 +304,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitSelectCaseStmt([NotNull] VBAParser.SelectCaseStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsIntDiv</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsIntDiv([NotNull] VBAParser.VsIntDivContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsIntDiv</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsIntDiv([NotNull] VBAParser.VsIntDivContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.moduleBody"/>.
@@ -561,28 +328,15 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitLetterRange([NotNull] VBAParser.LetterRangeContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.access"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterDefDirective([NotNull] VBAParser.DefDirectiveContext context);
+	void EnterAccess([NotNull] VBAParser.AccessContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.access"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitDefDirective([NotNull] VBAParser.DefDirectiveContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>caseCondSelection</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>caseCondSelection</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context);
+	void ExitAccess([NotNull] VBAParser.AccessContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.widthStmt"/>.
@@ -618,6 +372,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitArgCall([NotNull] VBAParser.ArgCallContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.endRecordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterEndRecordNumber([NotNull] VBAParser.EndRecordNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.endRecordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitEndRecordNumber([NotNull] VBAParser.EndRecordNumberContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.annotationName"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -627,17 +392,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitAnnotationName([NotNull] VBAParser.AnnotationNameContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeHint"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterTypeHint([NotNull] VBAParser.TypeHintContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeHint"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitTypeHint([NotNull] VBAParser.TypeHintContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.constSubStmt"/>.
@@ -662,17 +416,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitEndOfStatement([NotNull] VBAParser.EndOfStatementContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.elseBlock"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterElseBlock([NotNull] VBAParser.ElseBlockContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitElseBlock([NotNull] VBAParser.ElseBlockContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by the <c>optionCompareStmt</c>
 	/// labeled alternative in <see cref="VBAParser.moduleOption"/>.
 	/// </summary>
@@ -686,15 +429,15 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitOptionCompareStmt([NotNull] VBAParser.OptionCompareStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.lineWidth"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+	void EnterLineWidth([NotNull] VBAParser.LineWidthContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.lineWidth"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+	void ExitLineWidth([NotNull] VBAParser.LineWidthContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.literal"/>.
@@ -741,19 +484,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitErrorStmt([NotNull] VBAParser.ErrorStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by the <c>vsAddressOf</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsAddressOf([NotNull] VBAParser.VsAddressOfContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsAddressOf</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.arg"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -789,17 +519,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitEventStmt([NotNull] VBAParser.EventStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.firstLetter"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterFirstLetter([NotNull] VBAParser.FirstLetterContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitFirstLetter([NotNull] VBAParser.FirstLetterContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.lockStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -809,17 +528,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitLockStmt([NotNull] VBAParser.LockStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>optionExplicitStmt</c>
@@ -859,28 +567,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitVsNot([NotNull] VBAParser.VsNotContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.endOfLine"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterEndOfLine([NotNull] VBAParser.EndOfLineContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitEndOfLine([NotNull] VBAParser.EndOfLineContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.startRule"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterStartRule([NotNull] VBAParser.StartRuleContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.startRule"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitStartRule([NotNull] VBAParser.StartRuleContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.writeStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -890,30 +576,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitWriteStmt([NotNull] VBAParser.WriteStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsAnd</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsAnd([NotNull] VBAParser.VsAndContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsAnd</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsAnd([NotNull] VBAParser.VsAndContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.endStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterEndStmt([NotNull] VBAParser.EndStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.endStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitEndStmt([NotNull] VBAParser.EndStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.annotationList"/>.
@@ -938,30 +600,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitSingleLetter([NotNull] VBAParser.SingleLetterContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsAmp</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsAmp([NotNull] VBAParser.VsAmpContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsAmp</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsAmp([NotNull] VBAParser.VsAmpContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.ifStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -984,52 +622,15 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitSubroutineName([NotNull] VBAParser.SubroutineNameContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.inputVariable"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterForNextStmt([NotNull] VBAParser.ForNextStmtContext context);
+	void EnterInputVariable([NotNull] VBAParser.InputVariableContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.inputVariable"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitForNextStmt([NotNull] VBAParser.ForNextStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>caseCondTo</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterCaseCondTo([NotNull] VBAParser.CaseCondToContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>caseCondTo</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitCaseCondTo([NotNull] VBAParser.CaseCondToContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsImp</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsImp([NotNull] VBAParser.VsImpContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsImp</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsImp([NotNull] VBAParser.VsImpContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context);
+	void ExitInputVariable([NotNull] VBAParser.InputVariableContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.forEachStmt"/>.
@@ -1043,17 +644,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitForEachStmt([NotNull] VBAParser.ForEachStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.exitStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterExitStmt([NotNull] VBAParser.ExitStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitExitStmt([NotNull] VBAParser.ExitStmtContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.numberLiteral"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1063,17 +653,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitNumberLiteral([NotNull] VBAParser.NumberLiteralContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.argList"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterArgList([NotNull] VBAParser.ArgListContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.argList"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitArgList([NotNull] VBAParser.ArgListContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.singleLineIfStmt"/>.
@@ -1087,30 +666,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitSingleLineIfStmt([NotNull] VBAParser.SingleLineIfStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by the <c>vsStruct</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsStruct([NotNull] VBAParser.VsStructContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsStruct</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsStruct([NotNull] VBAParser.VsStructContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.subscripts"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterSubscripts([NotNull] VBAParser.SubscriptsContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.subscripts"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitSubscripts([NotNull] VBAParser.SubscriptsContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.lastLetter"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1122,6 +677,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitLastLetter([NotNull] VBAParser.LastLetterContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.spcNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterSpcNumber([NotNull] VBAParser.SpcNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.spcNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitSpcNumber([NotNull] VBAParser.SpcNumberContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.letStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1131,17 +697,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitLetStmt([NotNull] VBAParser.LetStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.subStmt"/>.
@@ -1181,17 +736,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitVsRelational([NotNull] VBAParser.VsRelationalContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.lineInputStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1203,15 +747,26 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitLineInputStmt([NotNull] VBAParser.LineInputStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.outputExpression"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterTypeStmt([NotNull] VBAParser.TypeStmtContext context);
+	void EnterOutputExpression([NotNull] VBAParser.OutputExpressionContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.outputExpression"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitTypeStmt([NotNull] VBAParser.TypeStmtContext context);
+	void ExitOutputExpression([NotNull] VBAParser.OutputExpressionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.tabClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterTabClause([NotNull] VBAParser.TabClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.tabClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitTabClause([NotNull] VBAParser.TabClauseContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -1236,26 +791,15 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitICS_S_MemberCall([NotNull] VBAParser.ICS_S_MemberCallContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.outputList_Expression"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.fileNumberList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterOutputList_Expression([NotNull] VBAParser.OutputList_ExpressionContext context);
+	void EnterFileNumberList([NotNull] VBAParser.FileNumberListContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.outputList_Expression"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.fileNumberList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitOutputList_Expression([NotNull] VBAParser.OutputList_ExpressionContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context);
+	void ExitFileNumberList([NotNull] VBAParser.FileNumberListContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>optionPrivateModuleStmt</c>
@@ -1271,17 +815,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitOptionPrivateModuleStmt([NotNull] VBAParser.OptionPrivateModuleStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.putStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterPutStmt([NotNull] VBAParser.PutStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.putStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitPutStmt([NotNull] VBAParser.PutStmtContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.keyword"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1291,28 +824,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitKeyword([NotNull] VBAParser.KeywordContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.annotationArg"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterAnnotationArg([NotNull] VBAParser.AnnotationArgContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>vsAssign</c>
@@ -1328,17 +839,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitVsAssign([NotNull] VBAParser.VsAssignContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.variableStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVariableStmt([NotNull] VBAParser.VariableStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVariableStmt([NotNull] VBAParser.VariableStmtContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.elseIfBlock"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1348,17 +848,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitElseIfBlock([NotNull] VBAParser.ElseIfBlockContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.subscript"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterSubscript([NotNull] VBAParser.SubscriptContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.subscript"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitSubscript([NotNull] VBAParser.SubscriptContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.visibility"/>.
@@ -1396,41 +885,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitVsTypeOf([NotNull] VBAParser.VsTypeOfContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>caseCondValue</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterCaseCondValue([NotNull] VBAParser.CaseCondValueContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>caseCondValue</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.functionStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1440,6 +894,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitFunctionStmt([NotNull] VBAParser.FunctionStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.recordRange"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterRecordRange([NotNull] VBAParser.RecordRangeContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.recordRange"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitRecordRange([NotNull] VBAParser.RecordRangeContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.returnStmt"/>.
@@ -1475,89 +940,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitUniversalLetterRange([NotNull] VBAParser.UniversalLetterRangeContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by the <c>vsMod</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsMod([NotNull] VBAParser.VsModContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsMod</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsMod([NotNull] VBAParser.VsModContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsOr</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsOr([NotNull] VBAParser.VsOrContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsOr</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsOr([NotNull] VBAParser.VsOrContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>caseCondElse</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterCaseCondElse([NotNull] VBAParser.CaseCondElseContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>caseCondElse</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.getStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterGetStmt([NotNull] VBAParser.GetStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.getStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitGetStmt([NotNull] VBAParser.GetStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterSameLineStatement([NotNull] VBAParser.SameLineStatementContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.ifWithEmptyThen"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1567,6 +949,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitIfWithEmptyThen([NotNull] VBAParser.IfWithEmptyThenContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.modeClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterModeClause([NotNull] VBAParser.ModeClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.modeClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitModeClause([NotNull] VBAParser.ModeClauseContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.annotationArgList"/>.
@@ -1602,39 +995,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitOnGoToStmt([NotNull] VBAParser.OnGoToStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.argsCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterArgsCall([NotNull] VBAParser.ArgsCallContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.argsCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitArgsCall([NotNull] VBAParser.ArgsCallContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.upperCaseA"/>.
@@ -1747,15 +1107,15 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitStopStmt([NotNull] VBAParser.StopStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// Enter a parse tree produced by <see cref="VBAParser.variableName"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void EnterIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context);
+	void EnterVariableName([NotNull] VBAParser.VariableNameContext context);
 	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// Exit a parse tree produced by <see cref="VBAParser.variableName"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
-	void ExitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context);
+	void ExitVariableName([NotNull] VBAParser.VariableNameContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.whiteSpace"/>.
@@ -1780,39 +1140,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitSC_Case([NotNull] VBAParser.SC_CaseContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.functionName"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterFunctionName([NotNull] VBAParser.FunctionNameContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.functionName"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitFunctionName([NotNull] VBAParser.FunctionNameContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVariableListStmt([NotNull] VBAParser.VariableListStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.statementLabel"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterStatementLabel([NotNull] VBAParser.StatementLabelContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitStatementLabel([NotNull] VBAParser.StatementLabelContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.upperCaseZ"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1822,39 +1149,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitUpperCaseZ([NotNull] VBAParser.UpperCaseZContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterUnlockStmt([NotNull] VBAParser.UnlockStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>vsXor</c>
@@ -1903,17 +1197,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitMidStmt([NotNull] VBAParser.MidStmtContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by the <c>vsPow</c>
 	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
 	/// </summary>
@@ -1960,6 +1243,1125 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitDoLoopStmt([NotNull] VBAParser.DoLoopStmtContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsLiteral</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsLiteral([NotNull] VBAParser.VsLiteralContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsLiteral</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsLiteral([NotNull] VBAParser.VsLiteralContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.comment"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterComment([NotNull] VBAParser.CommentContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.comment"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitComment([NotNull] VBAParser.CommentContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsMid</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsMid([NotNull] VBAParser.VsMidContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsMid</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsMid([NotNull] VBAParser.VsMidContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterSeekStmt([NotNull] VBAParser.SeekStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitSeekStmt([NotNull] VBAParser.SeekStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterListOrLabel([NotNull] VBAParser.ListOrLabelContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitListOrLabel([NotNull] VBAParser.ListOrLabelContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.fileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterFileNumber([NotNull] VBAParser.FileNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitFileNumber([NotNull] VBAParser.FileNumberContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.constStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterConstStmt([NotNull] VBAParser.ConstStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.constStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitConstStmt([NotNull] VBAParser.ConstStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.type"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterType([NotNull] VBAParser.TypeContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.type"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitType([NotNull] VBAParser.TypeContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.inputStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterInputStmt([NotNull] VBAParser.InputStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitInputStmt([NotNull] VBAParser.InputStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.declareStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterDeclareStmt([NotNull] VBAParser.DeclareStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.resetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterResetStmt([NotNull] VBAParser.ResetStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitResetStmt([NotNull] VBAParser.ResetStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsNew</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsNew([NotNull] VBAParser.VsNewContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsNew</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsNew([NotNull] VBAParser.VsNewContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.lock"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterLock([NotNull] VBAParser.LockContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.lock"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitLock([NotNull] VBAParser.LockContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.block"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterBlock([NotNull] VBAParser.BlockContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.block"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitBlock([NotNull] VBAParser.BlockContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.fileMode"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterFileMode([NotNull] VBAParser.FileModeContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.fileMode"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitFileMode([NotNull] VBAParser.FileModeContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.setStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterSetStmt([NotNull] VBAParser.SetStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.setStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitSetStmt([NotNull] VBAParser.SetStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.identifier"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterIdentifier([NotNull] VBAParser.IdentifierContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.identifier"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitIdentifier([NotNull] VBAParser.IdentifierContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterAttributeStmt([NotNull] VBAParser.AttributeStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterOutputList([NotNull] VBAParser.OutputListContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitOutputList([NotNull] VBAParser.OutputListContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsIntDiv</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsIntDiv([NotNull] VBAParser.VsIntDivContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsIntDiv</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsIntDiv([NotNull] VBAParser.VsIntDivContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterDefDirective([NotNull] VBAParser.DefDirectiveContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitDefDirective([NotNull] VBAParser.DefDirectiveContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>caseCondSelection</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>caseCondSelection</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeHint"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterTypeHint([NotNull] VBAParser.TypeHintContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeHint"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitTypeHint([NotNull] VBAParser.TypeHintContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.fileStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterFileStmt([NotNull] VBAParser.FileStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.fileStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitFileStmt([NotNull] VBAParser.FileStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.elseBlock"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterElseBlock([NotNull] VBAParser.ElseBlockContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitElseBlock([NotNull] VBAParser.ElseBlockContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsAddressOf</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsAddressOf([NotNull] VBAParser.VsAddressOfContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsAddressOf</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.recLength"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterRecLength([NotNull] VBAParser.RecLengthContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.recLength"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitRecLength([NotNull] VBAParser.RecLengthContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.unmarkedFileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterUnmarkedFileNumber([NotNull] VBAParser.UnmarkedFileNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.unmarkedFileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitUnmarkedFileNumber([NotNull] VBAParser.UnmarkedFileNumberContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.firstLetter"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterFirstLetter([NotNull] VBAParser.FirstLetterContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitFirstLetter([NotNull] VBAParser.FirstLetterContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.endOfLine"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterEndOfLine([NotNull] VBAParser.EndOfLineContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitEndOfLine([NotNull] VBAParser.EndOfLineContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.startRule"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterStartRule([NotNull] VBAParser.StartRuleContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.startRule"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitStartRule([NotNull] VBAParser.StartRuleContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsAnd</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsAnd([NotNull] VBAParser.VsAndContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsAnd</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsAnd([NotNull] VBAParser.VsAndContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.endStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterEndStmt([NotNull] VBAParser.EndStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.endStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitEndStmt([NotNull] VBAParser.EndStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsAmp</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsAmp([NotNull] VBAParser.VsAmpContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsAmp</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsAmp([NotNull] VBAParser.VsAmpContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterForNextStmt([NotNull] VBAParser.ForNextStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitForNextStmt([NotNull] VBAParser.ForNextStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>caseCondTo</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterCaseCondTo([NotNull] VBAParser.CaseCondToContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>caseCondTo</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitCaseCondTo([NotNull] VBAParser.CaseCondToContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsImp</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsImp([NotNull] VBAParser.VsImpContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsImp</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsImp([NotNull] VBAParser.VsImpContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.exitStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterExitStmt([NotNull] VBAParser.ExitStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitExitStmt([NotNull] VBAParser.ExitStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.argList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterArgList([NotNull] VBAParser.ArgListContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.argList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitArgList([NotNull] VBAParser.ArgListContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsStruct</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsStruct([NotNull] VBAParser.VsStructContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsStruct</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsStruct([NotNull] VBAParser.VsStructContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.data"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterData([NotNull] VBAParser.DataContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.data"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitData([NotNull] VBAParser.DataContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.subscripts"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterSubscripts([NotNull] VBAParser.SubscriptsContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.subscripts"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitSubscripts([NotNull] VBAParser.SubscriptsContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterTypeStmt([NotNull] VBAParser.TypeStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitTypeStmt([NotNull] VBAParser.TypeStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.putStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPutStmt([NotNull] VBAParser.PutStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.putStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPutStmt([NotNull] VBAParser.PutStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.annotationArg"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterAnnotationArg([NotNull] VBAParser.AnnotationArgContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.recordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterRecordNumber([NotNull] VBAParser.RecordNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.recordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitRecordNumber([NotNull] VBAParser.RecordNumberContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variableStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVariableStmt([NotNull] VBAParser.VariableStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVariableStmt([NotNull] VBAParser.VariableStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.subscript"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterSubscript([NotNull] VBAParser.SubscriptContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.subscript"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitSubscript([NotNull] VBAParser.SubscriptContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.outputClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterOutputClause([NotNull] VBAParser.OutputClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.outputClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitOutputClause([NotNull] VBAParser.OutputClauseContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>caseCondValue</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterCaseCondValue([NotNull] VBAParser.CaseCondValueContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>caseCondValue</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.startRecordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterStartRecordNumber([NotNull] VBAParser.StartRecordNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.startRecordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitStartRecordNumber([NotNull] VBAParser.StartRecordNumberContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsMod</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsMod([NotNull] VBAParser.VsModContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsMod</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsMod([NotNull] VBAParser.VsModContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>vsOr</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVsOr([NotNull] VBAParser.VsOrContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>vsOr</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVsOr([NotNull] VBAParser.VsOrContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.outputItem"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterOutputItem([NotNull] VBAParser.OutputItemContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.outputItem"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitOutputItem([NotNull] VBAParser.OutputItemContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by the <c>caseCondElse</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterCaseCondElse([NotNull] VBAParser.CaseCondElseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by the <c>caseCondElse</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.position"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPosition([NotNull] VBAParser.PositionContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.position"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPosition([NotNull] VBAParser.PositionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.getStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterGetStmt([NotNull] VBAParser.GetStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.getStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitGetStmt([NotNull] VBAParser.GetStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterSameLineStatement([NotNull] VBAParser.SameLineStatementContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.pathName"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPathName([NotNull] VBAParser.PathNameContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.pathName"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPathName([NotNull] VBAParser.PathNameContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.tabNumberClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterTabNumberClause([NotNull] VBAParser.TabNumberClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.tabNumberClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitTabNumberClause([NotNull] VBAParser.TabNumberClauseContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.charPosition"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterCharPosition([NotNull] VBAParser.CharPositionContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.charPosition"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitCharPosition([NotNull] VBAParser.CharPositionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.argsCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterArgsCall([NotNull] VBAParser.ArgsCallContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.argsCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitArgsCall([NotNull] VBAParser.ArgsCallContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterMarkedFileNumber([NotNull] VBAParser.MarkedFileNumberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitMarkedFileNumber([NotNull] VBAParser.MarkedFileNumberContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.accessClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterAccessClause([NotNull] VBAParser.AccessClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.accessClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitAccessClause([NotNull] VBAParser.AccessClauseContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.functionName"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterFunctionName([NotNull] VBAParser.FunctionNameContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.functionName"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitFunctionName([NotNull] VBAParser.FunctionNameContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVariableListStmt([NotNull] VBAParser.VariableListStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.statementLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterStatementLabel([NotNull] VBAParser.StatementLabelContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitStatementLabel([NotNull] VBAParser.StatementLabelContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterUnlockStmt([NotNull] VBAParser.UnlockStmtContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.lenClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterLenClause([NotNull] VBAParser.LenClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.lenClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitLenClause([NotNull] VBAParser.LenClauseContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCall"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -2004,6 +2406,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitWithStmtExpression([NotNull] VBAParser.WithStmtExpressionContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.variable"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterVariable([NotNull] VBAParser.VariableContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.variable"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitVariable([NotNull] VBAParser.VariableContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.eraseStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -2026,30 +2439,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitCommentBody([NotNull] VBAParser.CommentBodyContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsLiteral</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsLiteral([NotNull] VBAParser.VsLiteralContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsLiteral</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsLiteral([NotNull] VBAParser.VsLiteralContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by the <c>vsEqv</c>
 	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
 	/// </summary>
@@ -2063,28 +2452,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitVsEqv([NotNull] VBAParser.VsEqvContext context);
 
 	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.comment"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterComment([NotNull] VBAParser.CommentContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.comment"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitComment([NotNull] VBAParser.CommentContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
-
-	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.unrestrictedIdentifier"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -2094,18 +2461,5 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitUnrestrictedIdentifier([NotNull] VBAParser.UnrestrictedIdentifierContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by the <c>vsMid</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterVsMid([NotNull] VBAParser.VsMidContext context);
-	/// <summary>
-	/// Exit a parse tree produced by the <c>vsMid</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitVsMid([NotNull] VBAParser.VsMidContext context);
 }
 } // namespace Rubberduck.Parsing.Grammar

--- a/Rubberduck.Parsing/Grammar/VBAParserListener.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserListener.cs
@@ -508,6 +508,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitVsMult([NotNull] VBAParser.VsMultContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.scaleSpecialForm"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterScaleSpecialForm([NotNull] VBAParser.ScaleSpecialFormContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.scaleSpecialForm"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitScaleSpecialForm([NotNull] VBAParser.ScaleSpecialFormContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.eventStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -767,6 +778,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitTabClause([NotNull] VBAParser.TabClauseContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.circleSpecialForm"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterCircleSpecialForm([NotNull] VBAParser.CircleSpecialFormContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.circleSpecialForm"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitCircleSpecialForm([NotNull] VBAParser.CircleSpecialFormContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -1669,6 +1691,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.tuple"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterTuple([NotNull] VBAParser.TupleContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.tuple"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitTuple([NotNull] VBAParser.TupleContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>vsAddressOf</c>

--- a/Rubberduck.Parsing/Grammar/VBAParserVisitor.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserVisitor.cs
@@ -333,6 +333,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitVsMult([NotNull] VBAParser.VsMultContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.scaleSpecialForm"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitScaleSpecialForm([NotNull] VBAParser.ScaleSpecialFormContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.eventStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -496,6 +503,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitTabClause([NotNull] VBAParser.TabClauseContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.circleSpecialForm"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitCircleSpecialForm([NotNull] VBAParser.CircleSpecialFormContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -1067,6 +1081,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.tuple"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitTuple([NotNull] VBAParser.TupleContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>vsAddressOf</c>

--- a/Rubberduck.Parsing/Grammar/VBAParserVisitor.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserVisitor.cs
@@ -31,60 +31,18 @@ using IToken = Antlr4.Runtime.IToken;
 [System.CLSCompliant(false)]
 public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitListOrLabel([NotNull] VBAParser.ListOrLabelContext context);
+	Result VisitTabNumber([NotNull] VBAParser.TabNumberContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.spcClause"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitSeekStmt([NotNull] VBAParser.SeekStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitFileNumber([NotNull] VBAParser.FileNumberContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.constStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitConstStmt([NotNull] VBAParser.ConstStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
+	Result VisitSpcClause([NotNull] VBAParser.SpcClauseContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>ECS_ProcedureCall</c>
@@ -95,25 +53,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitECS_ProcedureCall([NotNull] VBAParser.ECS_ProcedureCallContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.type"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitType([NotNull] VBAParser.TypeContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.rsetStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitRsetStmt([NotNull] VBAParser.RsetStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitInputStmt([NotNull] VBAParser.InputStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>vsAdd</c>
@@ -131,13 +75,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitLsetStmt([NotNull] VBAParser.LsetStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InBlock"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -145,40 +82,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitImplicitCallStmt_InBlock([NotNull] VBAParser.ImplicitCallStmt_InBlockContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitResetStmt([NotNull] VBAParser.ResetStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsNew</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsNew([NotNull] VBAParser.VsNewContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.remComment"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitRemComment([NotNull] VBAParser.RemCommentContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.block"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitBlock([NotNull] VBAParser.BlockContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.setStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitSetStmt([NotNull] VBAParser.SetStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>vsNegation</c>
@@ -196,13 +104,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitLetterSpec([NotNull] VBAParser.LetterSpecContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.fieldLength"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -216,13 +117,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitECS_MemberCall([NotNull] VBAParser.ECS_MemberCallContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.identifier"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitIdentifier([NotNull] VBAParser.IdentifierContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.dictionaryCallStmt"/>.
@@ -244,20 +138,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitRedimSubStmt([NotNull] VBAParser.RedimSubStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.module"/>.
@@ -289,39 +169,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitVsICS([NotNull] VBAParser.VsICSContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.moduleDeclarations"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitModuleDeclarations([NotNull] VBAParser.ModuleDeclarationsContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.iCS_B_MemberProcedureCall"/>.
@@ -331,11 +183,19 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitICS_B_MemberProcedureCall([NotNull] VBAParser.ICS_B_MemberProcedureCallContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitOutputList([NotNull] VBAParser.OutputListContext context);
+	Result VisitInputList([NotNull] VBAParser.InputListContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsMarkedFileNumber</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsMarkedFileNumber([NotNull] VBAParser.VsMarkedFileNumberContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.selectCaseStmt"/>.
@@ -343,14 +203,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitSelectCaseStmt([NotNull] VBAParser.SelectCaseStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsIntDiv</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsIntDiv([NotNull] VBAParser.VsIntDivContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.moduleBody"/>.
@@ -367,19 +219,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitLetterRange([NotNull] VBAParser.LetterRangeContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.access"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitDefDirective([NotNull] VBAParser.DefDirectiveContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>caseCondSelection</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context);
+	Result VisitAccess([NotNull] VBAParser.AccessContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.widthStmt"/>.
@@ -403,18 +247,18 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitArgCall([NotNull] VBAParser.ArgCallContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.endRecordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitEndRecordNumber([NotNull] VBAParser.EndRecordNumberContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.annotationName"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitAnnotationName([NotNull] VBAParser.AnnotationNameContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeHint"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitTypeHint([NotNull] VBAParser.TypeHintContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.constSubStmt"/>.
@@ -431,13 +275,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitEndOfStatement([NotNull] VBAParser.EndOfStatementContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitElseBlock([NotNull] VBAParser.ElseBlockContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by the <c>optionCompareStmt</c>
 	/// labeled alternative in <see cref="VBAParser.moduleOption"/>.
 	/// </summary>
@@ -446,11 +283,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitOptionCompareStmt([NotNull] VBAParser.OptionCompareStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.lineWidth"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+	Result VisitLineWidth([NotNull] VBAParser.LineWidthContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.literal"/>.
@@ -481,14 +318,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitErrorStmt([NotNull] VBAParser.ErrorStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by the <c>vsAddressOf</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.arg"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -511,25 +340,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitEventStmt([NotNull] VBAParser.EventStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitFirstLetter([NotNull] VBAParser.FirstLetterContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.lockStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitLockStmt([NotNull] VBAParser.LockStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>optionExplicitStmt</c>
@@ -555,40 +370,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitVsNot([NotNull] VBAParser.VsNotContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitEndOfLine([NotNull] VBAParser.EndOfLineContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.startRule"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitStartRule([NotNull] VBAParser.StartRuleContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.writeStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitWriteStmt([NotNull] VBAParser.WriteStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsAnd</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsAnd([NotNull] VBAParser.VsAndContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.endStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitEndStmt([NotNull] VBAParser.EndStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.annotationList"/>.
@@ -605,21 +391,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitSingleLetter([NotNull] VBAParser.SingleLetterContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsAmp</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsAmp([NotNull] VBAParser.VsAmpContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.ifStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -634,34 +405,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitSubroutineName([NotNull] VBAParser.SubroutineNameContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.inputVariable"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitForNextStmt([NotNull] VBAParser.ForNextStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>caseCondTo</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitCaseCondTo([NotNull] VBAParser.CaseCondToContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsImp</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsImp([NotNull] VBAParser.VsImpContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context);
+	Result VisitInputVariable([NotNull] VBAParser.InputVariableContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.forEachStmt"/>.
@@ -671,25 +419,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitForEachStmt([NotNull] VBAParser.ForEachStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitExitStmt([NotNull] VBAParser.ExitStmtContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.numberLiteral"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitNumberLiteral([NotNull] VBAParser.NumberLiteralContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.argList"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitArgList([NotNull] VBAParser.ArgListContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.singleLineIfStmt"/>.
@@ -699,21 +433,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitSingleLineIfStmt([NotNull] VBAParser.SingleLineIfStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by the <c>vsStruct</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsStruct([NotNull] VBAParser.VsStructContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.subscripts"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitSubscripts([NotNull] VBAParser.SubscriptsContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.lastLetter"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -721,18 +440,18 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitLastLetter([NotNull] VBAParser.LastLetterContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.spcNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitSpcNumber([NotNull] VBAParser.SpcNumberContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.letStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitLetStmt([NotNull] VBAParser.LetStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.subStmt"/>.
@@ -758,13 +477,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitVsRelational([NotNull] VBAParser.VsRelationalContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.lineInputStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -772,11 +484,18 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitLineInputStmt([NotNull] VBAParser.LineInputStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.outputExpression"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitTypeStmt([NotNull] VBAParser.TypeStmtContext context);
+	Result VisitOutputExpression([NotNull] VBAParser.OutputExpressionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.tabClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitTabClause([NotNull] VBAParser.TabClauseContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.statementKeyword"/>.
@@ -793,18 +512,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitICS_S_MemberCall([NotNull] VBAParser.ICS_S_MemberCallContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.outputList_Expression"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.fileNumberList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitOutputList_Expression([NotNull] VBAParser.OutputList_ExpressionContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context);
+	Result VisitFileNumberList([NotNull] VBAParser.FileNumberListContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>optionPrivateModuleStmt</c>
@@ -815,32 +527,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitOptionPrivateModuleStmt([NotNull] VBAParser.OptionPrivateModuleStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.putStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitPutStmt([NotNull] VBAParser.PutStmtContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.keyword"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitKeyword([NotNull] VBAParser.KeywordContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>vsAssign</c>
@@ -851,25 +542,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitVsAssign([NotNull] VBAParser.VsAssignContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVariableStmt([NotNull] VBAParser.VariableStmtContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.elseIfBlock"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitElseIfBlock([NotNull] VBAParser.ElseIfBlockContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.subscript"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitSubscript([NotNull] VBAParser.SubscriptContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.visibility"/>.
@@ -894,33 +571,18 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitVsTypeOf([NotNull] VBAParser.VsTypeOfContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>caseCondValue</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.functionStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitFunctionStmt([NotNull] VBAParser.FunctionStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.recordRange"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitRecordRange([NotNull] VBAParser.RecordRangeContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.returnStmt"/>.
@@ -944,63 +606,18 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitUniversalLetterRange([NotNull] VBAParser.UniversalLetterRangeContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by the <c>vsMod</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsMod([NotNull] VBAParser.VsModContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsOr</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsOr([NotNull] VBAParser.VsOrContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>caseCondElse</c>
-	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.getStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitGetStmt([NotNull] VBAParser.GetStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.ifWithEmptyThen"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitIfWithEmptyThen([NotNull] VBAParser.IfWithEmptyThenContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.modeClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitModeClause([NotNull] VBAParser.ModeClauseContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.annotationArgList"/>.
@@ -1023,27 +640,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitOnGoToStmt([NotNull] VBAParser.OnGoToStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.argsCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitArgsCall([NotNull] VBAParser.ArgsCallContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.upperCaseA"/>.
@@ -1116,11 +712,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitStopStmt([NotNull] VBAParser.StopStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// Visit a parse tree produced by <see cref="VBAParser.variableName"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
-	Result VisitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context);
+	Result VisitVariableName([NotNull] VBAParser.VariableNameContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.whiteSpace"/>.
@@ -1137,53 +733,11 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitSC_Case([NotNull] VBAParser.SC_CaseContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.functionName"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitFunctionName([NotNull] VBAParser.FunctionNameContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitStatementLabel([NotNull] VBAParser.StatementLabelContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.upperCaseZ"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitUpperCaseZ([NotNull] VBAParser.UpperCaseZContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>vsXor</c>
@@ -1215,13 +769,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitMidStmt([NotNull] VBAParser.MidStmtContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by the <c>vsPow</c>
 	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
 	/// </summary>
@@ -1249,6 +796,714 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitDoLoopStmt([NotNull] VBAParser.DoLoopStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsLiteral</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsLiteral([NotNull] VBAParser.VsLiteralContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.comment"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitComment([NotNull] VBAParser.CommentContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsMid</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsMid([NotNull] VBAParser.VsMidContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitSeekStmt([NotNull] VBAParser.SeekStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.listOrLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitListOrLabel([NotNull] VBAParser.ListOrLabelContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.fileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitFileNumber([NotNull] VBAParser.FileNumberContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.constStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitConstStmt([NotNull] VBAParser.ConstStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.argDefaultValue"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitArgDefaultValue([NotNull] VBAParser.ArgDefaultValueContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.propertyLetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPropertyLetStmt([NotNull] VBAParser.PropertyLetStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.moduleAttributes"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.type"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitType([NotNull] VBAParser.TypeContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.inputStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitInputStmt([NotNull] VBAParser.InputStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.declareStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitDeclareStmt([NotNull] VBAParser.DeclareStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.resetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitResetStmt([NotNull] VBAParser.ResetStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsNew</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsNew([NotNull] VBAParser.VsNewContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.lock"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitLock([NotNull] VBAParser.LockContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.block"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitBlock([NotNull] VBAParser.BlockContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.fileMode"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitFileMode([NotNull] VBAParser.FileModeContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.setStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitSetStmt([NotNull] VBAParser.SetStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.onErrorStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.identifier"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitIdentifier([NotNull] VBAParser.IdentifierContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.attributeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitAttributeStmt([NotNull] VBAParser.AttributeStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt_Constant"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitEnumerationStmt_Constant([NotNull] VBAParser.EnumerationStmt_ConstantContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.implicitCallStmt_InStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitImplicitCallStmt_InStmt([NotNull] VBAParser.ImplicitCallStmt_InStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeOfIsExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitTypeOfIsExpression([NotNull] VBAParser.TypeOfIsExpressionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.explicitCallStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitExplicitCallStmt([NotNull] VBAParser.ExplicitCallStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.onGoSubStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitOnGoSubStmt([NotNull] VBAParser.OnGoSubStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.outputList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitOutputList([NotNull] VBAParser.OutputListContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsIntDiv</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsIntDiv([NotNull] VBAParser.VsIntDivContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.defDirective"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitDefDirective([NotNull] VBAParser.DefDirectiveContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>caseCondSelection</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitCaseCondSelection([NotNull] VBAParser.CaseCondSelectionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeHint"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitTypeHint([NotNull] VBAParser.TypeHintContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.fileStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitFileStmt([NotNull] VBAParser.FileStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.elseBlock"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitElseBlock([NotNull] VBAParser.ElseBlockContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.redimStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsAddressOf</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsAddressOf([NotNull] VBAParser.VsAddressOfContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.recLength"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitRecLength([NotNull] VBAParser.RecLengthContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.unmarkedFileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitUnmarkedFileNumber([NotNull] VBAParser.UnmarkedFileNumberContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.firstLetter"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitFirstLetter([NotNull] VBAParser.FirstLetterContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.resumeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.endOfLine"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitEndOfLine([NotNull] VBAParser.EndOfLineContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.startRule"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitStartRule([NotNull] VBAParser.StartRuleContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsAnd</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsAnd([NotNull] VBAParser.VsAndContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.endStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitEndStmt([NotNull] VBAParser.EndStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.singleLineElseClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitSingleLineElseClause([NotNull] VBAParser.SingleLineElseClauseContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsAmp</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsAmp([NotNull] VBAParser.VsAmpContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.forNextStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitForNextStmt([NotNull] VBAParser.ForNextStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>caseCondTo</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitCaseCondTo([NotNull] VBAParser.CaseCondToContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsImp</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsImp([NotNull] VBAParser.VsImpContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_MembersCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitICS_S_MembersCall([NotNull] VBAParser.ICS_S_MembersCallContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitExitStmt([NotNull] VBAParser.ExitStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.argList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitArgList([NotNull] VBAParser.ArgListContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsStruct</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsStruct([NotNull] VBAParser.VsStructContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.data"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitData([NotNull] VBAParser.DataContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.subscripts"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitSubscripts([NotNull] VBAParser.SubscriptsContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.propertySetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPropertySetStmt([NotNull] VBAParser.PropertySetStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.statementLabelDefinition"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitStatementLabelDefinition([NotNull] VBAParser.StatementLabelDefinitionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitTypeStmt([NotNull] VBAParser.TypeStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.ifWithNonEmptyThen"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitIfWithNonEmptyThen([NotNull] VBAParser.IfWithNonEmptyThenContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.putStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPutStmt([NotNull] VBAParser.PutStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_DictionaryCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitICS_S_DictionaryCall([NotNull] VBAParser.ICS_S_DictionaryCallContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.annotationArg"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitAnnotationArg([NotNull] VBAParser.AnnotationArgContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.recordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitRecordNumber([NotNull] VBAParser.RecordNumberContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variableStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVariableStmt([NotNull] VBAParser.VariableStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.subscript"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitSubscript([NotNull] VBAParser.SubscriptContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.outputClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitOutputClause([NotNull] VBAParser.OutputClauseContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.comparisonOperator"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitComparisonOperator([NotNull] VBAParser.ComparisonOperatorContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>caseCondValue</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Selection"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitCaseCondValue([NotNull] VBAParser.CaseCondValueContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.startRecordNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitStartRecordNumber([NotNull] VBAParser.StartRecordNumberContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.whileWendStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitWhileWendStmt([NotNull] VBAParser.WhileWendStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsMod</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsMod([NotNull] VBAParser.VsModContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>vsOr</c>
+	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVsOr([NotNull] VBAParser.VsOrContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.outputItem"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitOutputItem([NotNull] VBAParser.OutputItemContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variableSubStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVariableSubStmt([NotNull] VBAParser.VariableSubStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by the <c>caseCondElse</c>
+	/// labeled alternative in <see cref="VBAParser.sC_Cond"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitCaseCondElse([NotNull] VBAParser.CaseCondElseContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.position"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPosition([NotNull] VBAParser.PositionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.getStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitGetStmt([NotNull] VBAParser.GetStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.raiseEventStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitRaiseEventStmt([NotNull] VBAParser.RaiseEventStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.sameLineStatement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitSameLineStatement([NotNull] VBAParser.SameLineStatementContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.pathName"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPathName([NotNull] VBAParser.PathNameContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.tabNumberClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitTabNumberClause([NotNull] VBAParser.TabNumberClauseContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.charPosition"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitCharPosition([NotNull] VBAParser.CharPositionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.argsCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitArgsCall([NotNull] VBAParser.ArgsCallContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.moduleConfigElement"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitModuleConfigElement([NotNull] VBAParser.ModuleConfigElementContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.propertyGetStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPropertyGetStmt([NotNull] VBAParser.PropertyGetStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitMarkedFileNumber([NotNull] VBAParser.MarkedFileNumberContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.accessClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitAccessClause([NotNull] VBAParser.AccessClauseContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.identifierStatementLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitIdentifierStatementLabel([NotNull] VBAParser.IdentifierStatementLabelContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.functionName"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitFunctionName([NotNull] VBAParser.FunctionNameContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variableListStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVariableListStmt([NotNull] VBAParser.VariableListStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.statementLabel"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitStatementLabel([NotNull] VBAParser.StatementLabelContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCallUnrestricted"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitICS_S_VariableOrProcedureCallUnrestricted([NotNull] VBAParser.ICS_S_VariableOrProcedureCallUnrestrictedContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.iCS_B_ProcedureCall"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitICS_B_ProcedureCall([NotNull] VBAParser.ICS_B_ProcedureCallContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.unlockStmt"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitUnlockStmt([NotNull] VBAParser.UnlockStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.booleanExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitBooleanExpression([NotNull] VBAParser.BooleanExpressionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.lenClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitLenClause([NotNull] VBAParser.LenClauseContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.iCS_S_VariableOrProcedureCall"/>.
@@ -1279,6 +1534,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitWithStmtExpression([NotNull] VBAParser.WithStmtExpressionContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.variable"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitVariable([NotNull] VBAParser.VariableContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.eraseStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1293,21 +1555,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitCommentBody([NotNull] VBAParser.CommentBodyContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.enumerationStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsLiteral</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsLiteral([NotNull] VBAParser.VsLiteralContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by the <c>vsEqv</c>
 	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
 	/// </summary>
@@ -1316,32 +1563,10 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitVsEqv([NotNull] VBAParser.VsEqvContext context);
 
 	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.comment"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitComment([NotNull] VBAParser.CommentContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.moduleBodyElement"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
-
-	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.unrestrictedIdentifier"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitUnrestrictedIdentifier([NotNull] VBAParser.UnrestrictedIdentifierContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by the <c>vsMid</c>
-	/// labeled alternative in <see cref="VBAParser.valueStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitVsMid([NotNull] VBAParser.VsMidContext context);
 }
 } // namespace Rubberduck.Parsing.Grammar

--- a/Rubberduck.Parsing/Symbols/AccessibilityCheck.cs
+++ b/Rubberduck.Parsing/Symbols/AccessibilityCheck.cs
@@ -51,8 +51,7 @@
 
         public static bool IsMemberAccessible(Declaration callingProject, Declaration callingModule, Declaration callingParent, Declaration calleeMember)
         {
-            bool enclosingModule = callingModule.Equals(calleeMember.ParentScopeDeclaration);
-            if (enclosingModule)
+            if (IsEnclosingModule(callingModule, calleeMember))
             {
                 return true;
             }
@@ -80,6 +79,22 @@
                 else
                 {
                     return IsValidAccessibility(calleeMember);
+                }
+            }
+            return false;
+        }
+
+        private static bool IsEnclosingModule(Declaration callingModule, Declaration calleeMember)
+        {
+            if (callingModule.Equals(calleeMember.ParentScopeDeclaration))
+            {
+                return true;
+            }
+            foreach (var supertype in ClassModuleDeclaration.GetSupertypes(callingModule))
+            {
+                if (IsEnclosingModule(supertype, calleeMember))
+                {
+                    return true;
                 }
             }
             return false;

--- a/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
@@ -45,6 +45,15 @@ namespace Rubberduck.Parsing.Symbols
             _subtypes = new HashSet<Declaration>();
         }
 
+        public static IEnumerable<Declaration> GetSupertypes(Declaration type)
+        {
+            if (type.DeclarationType != DeclarationType.ClassModule)
+            {
+                return new List<Declaration>();
+            }
+            return ((ClassModuleDeclaration)type).Supertypes;
+        }
+
         /// <summary>
         /// Gets an attribute value indicating whether a class is exposed to other projects.
         /// If this value is false, any public types and members cannot be accessed from outside the project they're declared in.

--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -31,6 +31,7 @@ namespace Rubberduck.Parsing.Symbols
                 IdentifierName = declaration.IdentifierName.ToLowerInvariant()
             })
             .ToDictionary(grouping => grouping.Key.IdentifierName, grouping => grouping.ToArray());
+            var k = declarations.Where(d => d.IdentifierName == "Input").ToList();
         }
 
         private readonly HashSet<Accessibility> _projectScopePublicModifiers =

--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -31,7 +31,6 @@ namespace Rubberduck.Parsing.Symbols
                 IdentifierName = declaration.IdentifierName.ToLowerInvariant()
             })
             .ToDictionary(grouping => grouping.Key.IdentifierName, grouping => grouping.ToArray());
-            var k = declarations.Where(d => d.IdentifierName == "Input").ToList();
         }
 
         private readonly HashSet<Accessibility> _projectScopePublicModifiers =
@@ -222,7 +221,7 @@ namespace Rubberduck.Parsing.Symbols
         public Declaration FindModuleEnclosingProjectWithoutEnclosingModule(Declaration callingProject, Declaration callingModule, string calleeModuleName, DeclarationType moduleType)
         {
             var nameMatches = MatchName(calleeModuleName);
-            var moduleMatches = nameMatches.Where(m => 
+            var moduleMatches = nameMatches.Where(m =>
                 m.DeclarationType.HasFlag(moduleType)
                 && Declaration.GetProjectParent(m).Equals(callingProject)
                 && !m.Equals(callingModule));
@@ -289,23 +288,22 @@ namespace Rubberduck.Parsing.Symbols
             {
                 return match;
             }
-            // If we don't have a match, try to find the match in one of the implemented interfaces/classes.
-            if (parent.DeclarationType == DeclarationType.ClassModule)
+            foreach (var supertype in ClassModuleDeclaration.GetSupertypes(parent))
             {
-                foreach (var supertype in ((ClassModuleDeclaration)parent).Supertypes)
+                var supertypeMember = FindMemberWithParent(callingProject, callingModule, callingParent, supertype, memberName, memberType);
+                if (supertypeMember != null)
                 {
-                    var supertypeMember = FindMemberWithParent(callingProject, callingModule, callingParent, supertype, memberName, memberType);
-                    if (supertypeMember != null)
-                    {
-                        return supertypeMember;
-                    }
+                    return supertypeMember;
                 }
             }
             return null;
         }
 
-        public Declaration FindMemberEnclosingModule(Declaration callingProject, Declaration callingModule, Declaration callingParent, string memberName, DeclarationType memberType)
+        public Declaration FindMemberEnclosingModule(Declaration callingModule, Declaration callingParent, string memberName, DeclarationType memberType)
         {
+            // We do not explicitly pass the callingProject here because we have to walk up the type hierarchy
+            // and thus the project differs depending on the callingModule.
+            var callingProject = Declaration.GetProjectParent(callingModule);
             var allMatches = MatchName(memberName);
             var memberMatches = allMatches.Where(m =>
                 m.DeclarationType.HasFlag(memberType)
@@ -313,6 +311,26 @@ namespace Rubberduck.Parsing.Symbols
                 && callingModule.Equals(Declaration.GetModuleParent(m)));
             var accessibleMembers = memberMatches.Where(m => AccessibilityCheck.IsMemberAccessible(callingProject, callingModule, callingParent, m));
             var match = accessibleMembers.FirstOrDefault();
+            if (match != null)
+            {
+                return match;
+            }
+            // Classes such as Worksheet have properties such as Range that can be access in a user defined class such as Sheet1,
+            // that's why we have to walk the type hierarchy and find these implementations.
+            foreach (var supertype in ClassModuleDeclaration.GetSupertypes(callingModule))
+            {
+                // Only built-in classes such as Worksheet can be considered "real base classes".
+                // User created interfaces work differently and don't allow accessing accessing implementations.
+                if (!supertype.IsBuiltIn)
+                {
+                    continue;
+                }
+                var supertypeMatch = FindMemberEnclosingModule(supertype, callingParent, memberName, memberType);
+                if (supertypeMatch != null)
+                {
+                    return supertypeMatch;
+                }
+            }
             return match;
         }
 
@@ -363,15 +381,12 @@ namespace Rubberduck.Parsing.Symbols
             {
                 return match;
             }
-            if (memberModule.DeclarationType == DeclarationType.ClassModule)
+            foreach (var supertype in ClassModuleDeclaration.GetSupertypes(memberModule))
             {
-                foreach (var supertype in ((ClassModuleDeclaration)memberModule).Supertypes)
+                var supertypeMember = FindMemberEnclosedProjectInModule(callingProject, callingModule, callingParent, supertype, memberName, memberType);
+                if (supertypeMember != null)
                 {
-                    var supertypeMember = FindMemberEnclosedProjectInModule(callingProject, callingModule, callingParent, supertype, memberName, memberType);
-                    if (supertypeMember != null)
-                    {
-                        return supertypeMember;
-                    }
+                    return supertypeMember;
                 }
             }
             return null;
@@ -411,15 +426,12 @@ namespace Rubberduck.Parsing.Symbols
             {
                 return match;
             }
-            if (memberModule.DeclarationType == DeclarationType.ClassModule)
+            foreach (var supertype in ClassModuleDeclaration.GetSupertypes(memberModule))
             {
-                foreach (var supertype in ((ClassModuleDeclaration)memberModule).Supertypes)
+                var supertypeMember = FindMemberReferencedProjectInModule(callingProject, callingModule, callingParent, supertype, memberName, memberType);
+                if (supertypeMember != null)
                 {
-                    var supertypeMember = FindMemberReferencedProjectInModule(callingProject, callingModule, callingParent, supertype, memberName, memberType);
-                    if (supertypeMember != null)
-                    {
-                        return supertypeMember;
-                    }
+                    return supertypeMember;
                 }
             }
             return null;

--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceListener.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceListener.cs
@@ -298,5 +298,15 @@ namespace Rubberduck.Parsing.Symbols
         {
             _resolver.Resolve(context);
         }
+
+        public override void EnterCircleSpecialForm(VBAParser.CircleSpecialFormContext context)
+        {
+            _resolver.Resolve(context);
+        }
+
+        public override void EnterScaleSpecialForm(VBAParser.ScaleSpecialFormContext context)
+        {
+            _resolver.Resolve(context);
+        }
     }
 }

--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
@@ -619,6 +619,36 @@ namespace Rubberduck.Parsing.Symbols
             ResolveLabel(context.valueStmt(), context.valueStmt().GetText());
         }
 
+        public void Resolve(VBAParser.CircleSpecialFormContext context)
+        {
+            foreach (var expr in context.valueStmt())
+            {
+                ResolveDefault(expr, expr.GetText());
+            }
+            ResolveTuple(context.tuple());
+        }
+
+        public void Resolve(VBAParser.ScaleSpecialFormContext context)
+        {
+            if (context.valueStmt() != null)
+            {
+                ResolveDefault(context.valueStmt(), context.valueStmt().GetText());
+
+            }
+            foreach (var tuple in context.tuple())
+            {
+                ResolveTuple(tuple);
+            }
+        }
+
+        private void ResolveTuple(VBAParser.TupleContext tuple)
+        {
+            foreach (var expr in tuple.valueStmt())
+            {
+                ResolveDefault(expr, expr.GetText());
+            }
+        }
+
         public void Resolve(VBAParser.ImplicitCallStmt_InBlockContext context)
         {
             ParserRuleContext subContext;

--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
@@ -259,7 +259,7 @@ namespace Rubberduck.Parsing.Symbols
             // single-line-if-statements, we do it here for better understanding.
             if (context.ifWithEmptyThen() != null)
             {
-                ResolveDefault(context.ifWithEmptyThen().booleanExpression(), context.ifWithEmptyThen().booleanExpression().GetText());                
+                ResolveDefault(context.ifWithEmptyThen().booleanExpression(), context.ifWithEmptyThen().booleanExpression().GetText());
                 ResolveListOrLabel(context.ifWithEmptyThen().singleLineElseClause().listOrLabel());
             }
             else
@@ -355,106 +355,141 @@ namespace Rubberduck.Parsing.Symbols
 
         public void Resolve(VBAParser.OpenStmtContext context)
         {
-            foreach (var expr in context.valueStmt())
+            ResolveDefault(context.pathName(), context.pathName().GetText());
+            ResolveDefault(context.fileNumber(), context.fileNumber().GetText());
+            if (context.lenClause() != null)
             {
-                ResolveDefault(expr, expr.GetText());
+                ResolveDefault(context.lenClause().recLength(), context.lenClause().recLength().GetText());
             }
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
         }
 
         public void Resolve(VBAParser.CloseStmtContext context)
         {
-            foreach (var expr in context.fileNumber())
+            if (context.fileNumberList() != null)
             {
-                ResolveDefault(expr.valueStmt(), expr.valueStmt().GetText());
+                foreach (var fileNumber in context.fileNumberList().fileNumber())
+                {
+                    ResolveDefault(fileNumber, fileNumber.GetText());
+                }
             }
         }
 
         public void Resolve(VBAParser.SeekStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            ResolveDefault(context.valueStmt(), context.valueStmt().GetText());
+            ResolveDefault(context.fileNumber(), context.fileNumber().GetText());
+            ResolveDefault(context.position(), context.position().GetText());
         }
 
         public void Resolve(VBAParser.LockStmtContext context)
         {
-            foreach (var expr in context.valueStmt())
-            {
-                ResolveDefault(expr, expr.GetText());
-            }
+            ResolveDefault(context.fileNumber(), context.fileNumber().GetText());
+            ResolveRecordRange(context.recordRange());
         }
 
         public void Resolve(VBAParser.UnlockStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            foreach (var expr in context.valueStmt())
+            ResolveDefault(context.fileNumber(), context.fileNumber().GetText());
+            ResolveRecordRange(context.recordRange());
+        }
+
+        private void ResolveRecordRange(VBAParser.RecordRangeContext recordRange)
+        {
+            if (recordRange == null)
             {
-                ResolveDefault(expr, expr.GetText());
+                return;
+            }
+            if (recordRange.startRecordNumber() != null)
+            {
+                ResolveDefault(recordRange.startRecordNumber(), recordRange.startRecordNumber().GetText());
+            }
+            if (recordRange.endRecordNumber() != null)
+            {
+                ResolveDefault(recordRange.endRecordNumber(), recordRange.endRecordNumber().GetText());
             }
         }
 
         public void Resolve(VBAParser.LineInputStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            ResolveDefault(context.valueStmt(), context.valueStmt().GetText());
+            ResolveDefault(context.markedFileNumber(), context.markedFileNumber().GetText());
+            ResolveDefault(context.variableName(), context.variableName().GetText());
         }
 
         public void Resolve(VBAParser.WidthStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            ResolveDefault(context.valueStmt(), context.valueStmt().GetText());
+            ResolveDefault(context.markedFileNumber(), context.markedFileNumber().GetText());
+            ResolveDefault(context.lineWidth(), context.lineWidth().GetText());
         }
 
         public void Resolve(VBAParser.PrintStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            foreach (var expr in context.outputList().outputList_Expression())
-            {
-                if (expr.valueStmt() != null)
-                {
-                    ResolveDefault(expr.valueStmt(), expr.valueStmt().GetText());
-                }
-                ResolveArgsCall(expr.argsCall());
-            }
+            ResolveDefault(context.markedFileNumber(), context.markedFileNumber().GetText());
+            ResolveOutputList(context.outputList());
         }
 
         public void Resolve(VBAParser.WriteStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            foreach (var expr in context.outputList().outputList_Expression())
+            ResolveDefault(context.markedFileNumber(), context.markedFileNumber().GetText());
+            ResolveOutputList(context.outputList());
+        }
+
+        private void ResolveOutputList(VBAParser.OutputListContext outputList)
+        {
+            if (outputList == null)
             {
-                if (expr.valueStmt() != null)
+                return;
+            }
+            foreach (var outputItem in outputList.outputItem())
+            {
+                if (outputItem.outputClause() != null)
                 {
-                    ResolveDefault(expr.valueStmt(), expr.valueStmt().GetText());
+                    if (outputItem.outputClause().spcClause() != null)
+                    {
+                        ResolveDefault(outputItem.outputClause().spcClause().spcNumber(), outputItem.outputClause().spcClause().spcNumber().GetText());
+                    }
+                    if (outputItem.outputClause().tabClause() != null && outputItem.outputClause().tabClause().tabNumberClause() != null)
+                    {
+                        ResolveDefault(outputItem.outputClause().tabClause().tabNumberClause().tabNumber(), outputItem.outputClause().tabClause().tabNumberClause().tabNumber().GetText());
+                    }
+                    if (outputItem.outputClause().outputExpression() != null)
+                    {
+                        ResolveDefault(outputItem.outputClause().outputExpression(), outputItem.outputClause().outputExpression().GetText());
+                    }
                 }
-                ResolveArgsCall(expr.argsCall());
             }
         }
 
         public void Resolve(VBAParser.InputStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            foreach (var expr in context.valueStmt())
+            ResolveDefault(context.markedFileNumber(), context.markedFileNumber().GetText());
+            foreach (var inputVariable in context.inputList().inputVariable())
             {
-                ResolveDefault(expr, expr.GetText());
+                ResolveDefault(inputVariable, inputVariable.GetText());
             }
         }
 
         public void Resolve(VBAParser.PutStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            foreach (var expr in context.valueStmt())
+            ResolveDefault(context.fileNumber(), context.fileNumber().GetText());
+            if (context.recordNumber() != null)
             {
-                ResolveDefault(expr, expr.GetText());
+                ResolveDefault(context.recordNumber(), context.recordNumber().GetText());
+            }
+            if (context.data() != null)
+            {
+                ResolveDefault(context.data(), context.data().GetText());
             }
         }
 
         public void Resolve(VBAParser.GetStmtContext context)
         {
-            ResolveDefault(context.fileNumber().valueStmt(), context.fileNumber().valueStmt().GetText());
-            foreach (var expr in context.valueStmt())
+            ResolveDefault(context.fileNumber(), context.fileNumber().GetText());
+            if (context.recordNumber() != null)
             {
-                ResolveDefault(expr, expr.GetText());
+                ResolveDefault(context.recordNumber(), context.recordNumber().GetText());
+            }
+            if (context.variable() != null)
+            {
+                ResolveDefault(context.variable(), context.variable().GetText());
             }
         }
 

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -220,12 +220,11 @@ namespace Rubberduck.Parsing.VBA
             Debug.Assert(informationModule != null);
             var arrayFunction = new FunctionDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Array"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
             var circleFunction = new FunctionDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Circle"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
-            // INPUT is treated as an inputstmt in the grammar thus does not have a declaration created for it.
-            //var inputFunction = new SubroutineDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Input"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
-            //var numberParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Number"), inputFunction, "Integer", false, false);
-            //var filenumberParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Filenumber"), inputFunction, "Integer", false, false);
-            //inputFunction.AddParameter(numberParam);
-            //inputFunction.AddParameter(filenumberParam);
+            var inputFunction = new SubroutineDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Input"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
+            var numberParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Number"), inputFunction, "Integer", false, false);
+            var filenumberParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Filenumber"), inputFunction, "Integer", false, false);
+            inputFunction.AddParameter(numberParam);
+            inputFunction.AddParameter(filenumberParam);
             var inputBFunction = new SubroutineDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "InputB"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
             var numberBParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Number"), inputBFunction, "Integer", false, false);
             var filenumberBParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Filenumber"), inputBFunction, "Integer", false, false);
@@ -256,6 +255,7 @@ namespace Rubberduck.Parsing.VBA
             {
                 _state.AddDeclaration(arrayFunction);
                 _state.AddDeclaration(circleFunction);
+                _state.AddDeclaration(inputFunction);
                 _state.AddDeclaration(inputBFunction);
                 _state.AddDeclaration(lboundFunction);
                 _state.AddDeclaration(scaleFunction);

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -219,7 +219,6 @@ namespace Rubberduck.Parsing.VBA
             var informationModule = finder.FindStdModule("Information", vba, true);
             Debug.Assert(informationModule != null);
             var arrayFunction = new FunctionDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Array"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
-            var circleFunction = new FunctionDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Circle"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
             var inputFunction = new SubroutineDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Input"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
             var numberParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Number"), inputFunction, "Integer", false, false);
             var filenumberParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Filenumber"), inputFunction, "Integer", false, false);
@@ -235,17 +234,6 @@ namespace Rubberduck.Parsing.VBA
             var dimensionParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Dimension"), lboundFunction, "Integer", true, false);
             lboundFunction.AddParameter(arrayNameParam);
             lboundFunction.AddParameter(dimensionParam);
-            var scaleFunction = new SubroutineDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Scale"), informationModule, informationModule, "Variant", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
-            var flagsParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Flags"), scaleFunction, "Integer", false, false);
-            var x1Param = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "X1"), scaleFunction, "Single", false, false);
-            var y1Param = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Y1"), scaleFunction, "Single", false, false);
-            var x2Param = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "X2"), scaleFunction, "Single", false, false);
-            var y2Param = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Y2"), scaleFunction, "Single", false, false);
-            scaleFunction.AddParameter(flagsParam);
-            scaleFunction.AddParameter(x1Param);
-            scaleFunction.AddParameter(y1Param);
-            scaleFunction.AddParameter(x2Param);
-            scaleFunction.AddParameter(y2Param);
             var uboundFunction = new FunctionDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "UBound"), informationModule, informationModule, "Integer", Accessibility.Public, null, Selection.Home, true, null, new Attributes());
             var arrayParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Array"), uboundFunction, "Variant", false, false, true);
             var rankParam = new ParameterDeclaration(new QualifiedMemberName(informationModule.QualifiedName.QualifiedModuleName, "Rank"), uboundFunction, "Integer", true, false);
@@ -254,11 +242,9 @@ namespace Rubberduck.Parsing.VBA
             lock (_state)
             {
                 _state.AddDeclaration(arrayFunction);
-                _state.AddDeclaration(circleFunction);
                 _state.AddDeclaration(inputFunction);
                 _state.AddDeclaration(inputBFunction);
                 _state.AddDeclaration(lboundFunction);
-                _state.AddDeclaration(scaleFunction);
                 _state.AddDeclaration(uboundFunction);
             }
         }

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -1758,6 +1758,46 @@ End Sub
             Assert.AreEqual(3, declaration.References.Count());
         }
 
+        [TestMethod]
+        public void CircleSpecialForm_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Me.Circle Step(referenced, referenced), referenced, referenced, referenced, referenced, referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(7, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void ScaleSpecialForm_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Scale (referenced, referenced)-(referenced, referenced)
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(4, declaration.References.Count());
+        }
+
         // Ignored because handling forms/hierarchies is an open issue.
         [Ignore]
         [TestMethod]

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -1518,6 +1518,246 @@ End Sub
             Assert.AreEqual(1, usages.Count());
         }
 
+        [TestMethod]
+        public void OpenStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Open referenced For Binary Access Read Lock Read As #referenced Len = referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(3, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void CloseStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Close referenced, referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(2, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void SeekStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Seek #referenced, referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(2, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void LockStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Lock referenced, referenced To referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(3, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void UnlockStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Unlock referenced, referenced To referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(3, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void LineInputStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Line Input #referenced, referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(2, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void WidthStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Width #referenced, referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(2, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void PrintStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Print #referenced,,referenced; SPC(referenced), TAB(referenced)
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(4, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void WriteStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Write #referenced,,referenced; SPC(referenced), TAB(referenced)
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(4, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void InputStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Input #referenced,referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(2, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void PutStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Put referenced,referenced,referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(3, declaration.References.Count());
+        }
+
+        [TestMethod]
+        public void GetStmt_IsReferenceToLocalVariable()
+        {
+            // arrange
+            var code = @"
+Public Sub Test()
+    Dim referenced As Integer
+    Get referenced,referenced,referenced
+End Sub
+";
+            // act
+            var state = Resolve(code);
+
+            // assert
+            var declaration = state.AllUserDeclarations.Single(item =>
+                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+            Assert.AreEqual(3, declaration.References.Count());
+        }
+
         // Ignored because handling forms/hierarchies is an open issue.
         [Ignore]
         [TestMethod]

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -520,6 +520,175 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 7);
         }
 
+        [TestMethod]
+        public void TestOpenStmt()
+        {
+            string code = @"
+Sub Test()
+    Open ""TESTFILE"" For Binary Access Read Lock Read As #1 Len = 2
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//openStmt");
+        }
+
+        [TestMethod]
+        public void TestResetStmt()
+        {
+            string code = @"
+Sub Test()
+    Reset
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//resetStmt");
+        }
+
+        [TestMethod]
+        public void TestCloseStmt()
+        {
+            string code = @"
+Sub Test()
+    Close #1, 2, 3
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//closeStmt");
+        }
+
+        [TestMethod]
+        public void TestSeekStmt()
+        {
+            string code = @"
+Sub Test()
+    Seek #1, 2
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//seekStmt");
+        }
+
+        [TestMethod]
+        public void TestSeekFunction()
+        {
+            // Tests whether SEEK, which is actually a special keyword, can also be used in a "function call context".
+            string code = @"
+Sub Test()
+    anything = Seek(50)
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//implicitCallStmt_InStmt");
+        }
+
+        [TestMethod]
+        public void TestLockStmt()
+        {
+            string code = @"
+Sub Test()
+    Lock #1, 2
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//lockStmt");
+        }
+
+        [TestMethod]
+        public void TestUnlockStmt()
+        {
+            string code = @"
+Sub Test()
+    Unlock #1, 2
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//unlockStmt");
+        }
+
+        [TestMethod]
+        public void TestLineInputStmt()
+        {
+            string code = @"
+Sub Test()
+    Line Input #2, ""ABC""
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//lineInputStmt");
+        }
+
+        [TestMethod]
+        public void TestWidthStmt()
+        {
+            string code = @"
+Sub Test()
+    Width #2, 5
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//widthStmt");
+        }
+
+        [TestMethod]
+        public void TestPrintStmt()
+        {
+            string code = @"
+Sub Test()
+    Print #2, Spc(5) ;
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//printStmt");
+        }
+
+        [TestMethod]
+        public void TestDebugPrintStmt()
+        {
+            // Sanity check so that we don't break Debug.Print because of the Print statement.
+            string code = @"
+Sub Test()
+    Debug.Print ""Anything""
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//implicitCallStmt_InBlock");
+        }
+
+        [TestMethod]
+        public void TestWriteStmt()
+        {
+            string code = @"
+Sub Test()
+    Write #1, ""ABC"", 234
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//writeStmt");
+        }
+
+        [TestMethod]
+        public void TestInputStmt()
+        {
+            string code = @"
+Sub Test()
+    Input #1, ""ABC""
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//inputStmt");
+        }
+
+        [TestMethod]
+        public void TestInputFunction()
+        {
+            string code = @"
+Sub Test()
+    s = Input(LOF(file1), #file1)
+    s = Input$(LOF(file1), #file1)
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//implicitCallStmt_InStmt");
+        }
+
+        [TestMethod]
+        public void TestInputBFunction()
+        {
+            string code = @"
+Sub Test()
+    s = InputB(LOF(file1), #file1)
+    s = InputB$(LOF(file1), #file1)
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//implicitCallStmt_InStmt");
+        }
+
         private Tuple<VBAParser, ParserRuleContext> Parse(string code)
         {
             var stream = new AntlrInputStream(code);

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -689,6 +689,28 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//implicitCallStmt_InStmt");
         }
 
+        [TestMethod]
+        public void TestCircleSpecialForm()
+        {
+            string code = @"
+Sub Test()
+    Me.Circle Step(1, 2), 3, 4, 5, 6, 7
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//circleSpecialForm");
+        }
+
+        [TestMethod]
+        public void TestScaleSpecialForm()
+        {
+            string code = @"
+Sub Test()
+    Scale (1, 2)-(3, 4)
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//scaleSpecialForm");
+        }
+
         private Tuple<VBAParser, ParserRuleContext> Parse(string code)
         {
             var stream = new AntlrInputStream(code);


### PR DESCRIPTION
File statement grammar rules have been cleaned up a bit. Marked file numbers can now be resolved as well (e.g. #filenumber). Input and InputB special forms should be parseable as well now.

Range should now be correctly resolved as _Worksheet.Range (the logic is there but since we can't link up ThisWorkbook/Sheet1/... up with their inherited types it doesn't actually work in practice yet). I'm not sure what the rules are for accessing inherited members tbh so I really hope there won't be false matches this way. All members of all inherited types are now considered part of the enclosing module. "Normal" interfaces are ignored because they don't allow such behavior.

The last change is the addition of the Circle and Scale special forms. They are not treated specially in the grammar. The consequence is though that there won't be a reference created for Circle/Scale anymore, just their arguments. Hope that's OK, otherwise we'd have to manually create a declaration for each of them.