### PR TITLE
Added input validation to HotkeySettings - closes #1281

### DIFF
--- a/RetailCoder.VBE/Common/RubberduckHooks.cs
+++ b/RetailCoder.VBE/Common/RubberduckHooks.cs
@@ -87,7 +87,11 @@ namespace Rubberduck.Common
 
             foreach (var hotkey in settings.Settings.Where(hotkey => hotkey.IsEnabled))
             {
-                AddHook(new Hotkey(_mainWindowHandle, hotkey.ToString(), _mappings[(RubberduckHotkey)Enum.Parse(typeof(RubberduckHotkey), hotkey.Name)]));
+                RubberduckHotkey assigned;
+                if (Enum.TryParse(hotkey.Name, out assigned))
+                {
+                    AddHook(new Hotkey(_mainWindowHandle, hotkey.ToString(), _mappings[assigned]));
+                }
             }
             Attach();
         }

--- a/RetailCoder.VBE/Settings/HotkeySettings.cs
+++ b/RetailCoder.VBE/Settings/HotkeySettings.cs
@@ -1,4 +1,9 @@
-﻿namespace Rubberduck.Settings
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Common.Hotkeys;
+
+namespace Rubberduck.Settings
 {
     public interface IHotkeySettings
     {
@@ -7,23 +12,84 @@
 
     public class HotkeySettings : IHotkeySettings
     {
-        public HotkeySetting[] Settings { get; set; }
+        private static readonly HotkeySetting[] Defaults = 
+        {
+            new HotkeySetting{Name=RubberduckHotkey.ParseAll.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="`" },
+            new HotkeySetting{Name=RubberduckHotkey.IndentProcedure.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="P" },
+            new HotkeySetting{Name=RubberduckHotkey.IndentModule.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="M" },
+            new HotkeySetting{Name=RubberduckHotkey.CodeExplorer.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="R" },
+            new HotkeySetting{Name=RubberduckHotkey.FindSymbol.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="T" },
+            new HotkeySetting{Name=RubberduckHotkey.InspectionResults.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="I" },
+            new HotkeySetting{Name=RubberduckHotkey.TestExplorer.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="T" },
+            new HotkeySetting{Name=RubberduckHotkey.RefactorMoveCloserToUsage.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="C" },
+            new HotkeySetting{Name=RubberduckHotkey.RefactorRename.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="R" },
+            new HotkeySetting{Name=RubberduckHotkey.RefactorExtractMethod.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="M" }            
+        };
+
+        private HashSet<HotkeySetting> _settings;
 
         public HotkeySettings()
         {
-            Settings = new[]
+            Settings = Defaults.ToArray();
+        }
+
+        public HotkeySetting[] Settings
+        {
+            get { return _settings.ToArray(); }
+            set
             {
-                new HotkeySetting{Name=RubberduckHotkey.ParseAll.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="`" },
-                new HotkeySetting{Name=RubberduckHotkey.IndentProcedure.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="P" },
-                new HotkeySetting{Name=RubberduckHotkey.IndentModule.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="M" },
-                new HotkeySetting{Name=RubberduckHotkey.CodeExplorer.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="R" },
-                new HotkeySetting{Name=RubberduckHotkey.FindSymbol.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="T" },
-                new HotkeySetting{Name=RubberduckHotkey.InspectionResults.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="I" },
-                new HotkeySetting{Name=RubberduckHotkey.TestExplorer.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="T" },
-                new HotkeySetting{Name=RubberduckHotkey.RefactorMoveCloserToUsage.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="C" },
-                new HotkeySetting{Name=RubberduckHotkey.RefactorRename.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="R" },
-                new HotkeySetting{Name=RubberduckHotkey.RefactorExtractMethod.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="M" }
-            };
+                if (value == null || value.Length == 0)
+                {
+                    _settings = new HashSet<HotkeySetting>(Defaults);
+                    return;
+                }
+                _settings = new HashSet<HotkeySetting>();
+                var incoming = value.ToList();
+                //Make sure settings are valid to keep trash out of the config file.
+                RubberduckHotkey assigned;
+                incoming.RemoveAll(h => !Enum.TryParse(h.Name, out assigned) || !IsValid(h));
+
+                //Only take the first setting if multiple definitions are found.
+                foreach (var setting in incoming.GroupBy(s => s.Name).Select(hotkey => hotkey.First()))
+                {
+                    //Only allow one hotkey to be enabled with the same key combination.
+                    setting.IsEnabled &= !IsDuplicate(setting);
+                    _settings.Add(setting);
+                }
+
+                //Merge any hotkeys that weren't found in the input.
+                foreach (var setting in Defaults.Where(setting => _settings.FirstOrDefault(s => s.Name.Equals(setting.Name)) == null))
+                {
+                    setting.IsEnabled &= !IsDuplicate(setting);
+                    _settings.Add(setting);
+                }
+            }
+        }
+
+        private bool IsDuplicate(HotkeySetting candidate)
+        {
+            return _settings.FirstOrDefault(
+                s =>
+                    s.Key1 == candidate.Key1 &&
+                    s.Key2 == candidate.Key2 &&
+                    s.HasAltModifier == candidate.HasAltModifier &&
+                    s.HasCtrlModifier == candidate.HasCtrlModifier &&
+                    s.HasShiftModifier == candidate.HasShiftModifier) != null;
+        }
+
+        private static bool IsValid(HotkeySetting candidate)
+        {
+            //This feels a bit sleazy...
+            try
+            {
+                // ReSharper disable once UnusedVariable
+                var test = new Hotkey(new IntPtr(), candidate.ToString(), null);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Refactoring\RemoveParametersTests.cs" />
     <Compile Include="Refactoring\RenameTests.cs" />
     <Compile Include="Refactoring\ReorderParametersTests.cs" />
+    <Compile Include="Settings\HotkeySettingsTests.cs" />
     <Compile Include="Settings\InspectionSettingsTests.cs" />
     <Compile Include="Settings\GeneralSettingsTests.cs" />
     <Compile Include="Settings\IndenterSettingsTests.cs" />

--- a/RubberduckTests/Settings/HotkeySettingsTests.cs
+++ b/RubberduckTests/Settings/HotkeySettingsTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rubberduck.Settings;
+
+namespace RubberduckTests.Settings
+{
+    [TestClass]
+    public class HotkeySettingsTests
+    {
+        [TestMethod]
+        public void DefaultsSetInCtor()
+        {
+            var expected = new[] 
+            {
+                new HotkeySetting{Name=RubberduckHotkey.ParseAll.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="`" },
+                new HotkeySetting{Name=RubberduckHotkey.IndentProcedure.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="P" },
+                new HotkeySetting{Name=RubberduckHotkey.IndentModule.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="M" },
+                new HotkeySetting{Name=RubberduckHotkey.CodeExplorer.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="R" },
+                new HotkeySetting{Name=RubberduckHotkey.FindSymbol.ToString(), IsEnabled=true, HasCtrlModifier = true, Key1="T" },
+                new HotkeySetting{Name=RubberduckHotkey.InspectionResults.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="I" },
+                new HotkeySetting{Name=RubberduckHotkey.TestExplorer.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="T" },
+                new HotkeySetting{Name=RubberduckHotkey.RefactorMoveCloserToUsage.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="C" },
+                new HotkeySetting{Name=RubberduckHotkey.RefactorRename.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="R" },
+                new HotkeySetting{Name=RubberduckHotkey.RefactorExtractMethod.ToString(), IsEnabled=true, HasCtrlModifier = true, HasShiftModifier = true, Key1="M" }            
+            };
+
+            var settings = new HotkeySettings();
+            var actual = settings.Settings;
+
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
+        [TestMethod]
+        public void InvalidSettingNameWontAdd()
+        {
+            var settings = new HotkeySettings();
+            var expected = settings.Settings;
+
+            settings.Settings = new[] {new HotkeySetting {Name = "Foobar", IsEnabled = false, Key1 = "CTRL-C"}};
+
+            var actual = settings.Settings;
+
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
+        [TestMethod]
+        public void InvalidSettingKeyWontAdd()
+        {
+            var settings = new HotkeySettings();
+            var expected = settings.Settings;
+
+            settings.Settings = new[] { new HotkeySetting { Name = "ParseAll", IsEnabled = false, Key1 = "Foobar" } };
+
+            var actual = settings.Settings;
+
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
+        [TestMethod]
+        public void DuplicateKeysAreDeactivated()
+        {
+            var duplicate1 = new HotkeySetting {Name = "ParseAll", IsEnabled = true, Key1 = "X"};
+            var duplicate2 = new HotkeySetting {Name = "FindSymbol", IsEnabled = true, Key1 = "X"};
+
+            // ReSharper disable once UnusedVariable
+            var settings = new HotkeySettings
+            {
+                Settings = new[] {duplicate1, duplicate2}
+            };
+
+            Assert.IsFalse(duplicate1.IsEnabled == duplicate2.IsEnabled);
+        }
+
+        [TestMethod]
+        public void DuplicateNamesAreIgnored()
+        {
+            var expected = new HotkeySetting { Name = "ParseAll", IsEnabled = true, Key1 = "X" };
+            var duplicate = new HotkeySetting { Name = "ParseAll", IsEnabled = true, Key1 = "Y" };
+
+            var settings = new HotkeySettings
+            {
+                Settings = new[] { expected, duplicate }
+            };
+
+            Assert.IsFalse(settings.Settings.Contains(duplicate));
+        }
+    }
+}


### PR DESCRIPTION
1. Only settings that match a member of the RubberduckHotkey Enum can be added to HotkeySettings.Settings. 
2. Only settings that can be successfully used to build a Hotkey can be added to HotkeySettings.Settings.
3. Missing members of the RubberduckHotkey Enum (no settings found in the config file) are added to HotkeySettings.Settings.
4. If more than one Hotkey is configured to use the same key binding - after the first binding is found all additional hotkeys assigned to that binding are disabled.