### PR TITLE
fix built-in enums/udts can't be resolved because of missing parent

### DIFF
--- a/Rubberduck.Parsing/Symbols/AccessibilityCheck.cs
+++ b/Rubberduck.Parsing/Symbols/AccessibilityCheck.cs
@@ -23,12 +23,12 @@
             {
                 return true;
             }
-            bool sameProject = calleeModule != null && callingModule.ParentScopeDeclaration.Equals(calleeModule.ParentScopeDeclaration);
+            bool sameProject = callingModule.ParentScopeDeclaration.Equals(calleeModule.ParentScopeDeclaration);
             if (sameProject)
             {
                 return validAccessibility;
             }
-            if (calleeModule != null && calleeModule.DeclarationType.HasFlag(DeclarationType.ProceduralModule))
+            if (calleeModule.DeclarationType.HasFlag(DeclarationType.ProceduralModule))
             {
                 bool isPrivate = ((ProceduralModuleDeclaration)calleeModule).IsPrivateModule;
                 return validAccessibility && !isPrivate;
@@ -64,13 +64,7 @@
                 return calleeHasSameParent;
             }
             var memberModule = Declaration.GetModuleParent(calleeMember);
-            // TODO: Fix this?
-            // Assume null = built in declaration which is always accessible.
-            if (memberModule == null)
-            {
-                return true;
-            }
-            if (IsModuleAccessible(callingProject, callingModule, memberModule) && calleeMember.ParentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Module))
+            if (IsModuleAccessible(callingProject, callingModule, memberModule))
             {
                 if (calleeMember.DeclarationType.HasFlag(DeclarationType.EnumerationMember) || calleeMember.DeclarationType.HasFlag(DeclarationType.UserDefinedTypeMember))
                 {

--- a/Rubberduck.Parsing/Symbols/Declaration.cs
+++ b/Rubberduck.Parsing/Symbols/Declaration.cs
@@ -438,11 +438,15 @@ namespace Rubberduck.Parsing.Symbols
         /// </remarks>
         public string AsTypeName { get { return _asTypeName; } }
 
-        public virtual string AsTypeNameWithoutArrayDesignator
+        public string AsTypeNameWithoutArrayDesignator
         {
             get
             {
-                return AsTypeName;
+                if (string.IsNullOrWhiteSpace(AsTypeName))
+                {
+                    return AsTypeName;
+                }
+                return AsTypeName.Replace("(", "").Replace(")", "").Trim();
             }
         }
 

--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -63,17 +63,6 @@ namespace Rubberduck.Parsing.Symbols
             return _declarations.Where(d => d.DeclarationType == DeclarationType.Project).ToList();
         }
 
-        public IEnumerable<CommentNode> ModuleComments(QualifiedModuleName module)
-        {
-            CommentNode[] result;
-            if (_comments.TryGetValue(module, out result))
-            {
-                return result;
-            }
-
-            return new List<CommentNode>();
-        }
-
         public Declaration FindParameter(Declaration procedure, string parameterName)
         {
             var matches = MatchName(parameterName);
@@ -88,14 +77,6 @@ namespace Rubberduck.Parsing.Symbols
                 return result;
             }
             return new List<IAnnotation>();
-        }
-
-        public IEnumerable<Declaration> MatchTypeName(string name)
-        {
-            return MatchName(name).Where(declaration =>
-                declaration.DeclarationType.HasFlag(DeclarationType.ClassModule) ||
-                declaration.DeclarationType.HasFlag(DeclarationType.UserDefinedType) ||
-                declaration.DeclarationType.HasFlag(DeclarationType.Enumeration));
         }
 
         public bool IsMatch(string declarationName, string potentialMatchName)
@@ -155,59 +136,6 @@ namespace Rubberduck.Parsing.Symbols
             catch (InvalidOperationException exception)
             {
                 _logger.Error(exception, "Multiple matches found for std.module '{0}'.", name);
-            }
-
-            return result;
-        }
-
-        public Declaration FindUserDefinedType(string name, Declaration parent = null, bool includeBuiltIn = false)
-        {
-            Declaration result = null;
-            try
-            {
-                var matches = MatchName(name);
-                result = matches.SingleOrDefault(declaration => declaration.DeclarationType.HasFlag(DeclarationType.UserDefinedType)
-                    && (parent == null || parent.Equals(declaration.ParentDeclaration))
-                    && (includeBuiltIn || !declaration.IsBuiltIn));
-            }
-            catch (Exception exception)
-            {
-                _logger.Error(exception, "Multiple matches found for user-defined type '{0}'.", name);
-            }
-
-            return result;
-        }
-
-        public Declaration FindEnum(string name, Declaration parent = null, bool includeBuiltIn = false)
-        {
-            Declaration result = null;
-            try
-            {
-                var matches = MatchName(name);
-                result = matches.SingleOrDefault(declaration => declaration.DeclarationType.HasFlag(DeclarationType.Enumeration)
-                    && (parent == null || parent.Equals(declaration.ParentDeclaration))
-                    && (includeBuiltIn || !declaration.IsBuiltIn));
-            }
-            catch (Exception exception)
-            {
-                _logger.Error(exception, "Multiple matches found for enum type '{0}'.", name);
-            }
-
-            return result;
-        }
-
-        public Declaration FindClass(Declaration parent, string name, bool includeBuiltIn = false)
-        {
-            Declaration result = null;
-            try
-            {
-                result = MatchName(name).SingleOrDefault(declaration => declaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
-                    && (parent == null || parent.Equals(declaration.ParentDeclaration))
-                    && (includeBuiltIn || !declaration.IsBuiltIn));
-            }
-            catch (InvalidOperationException exception)
-            {
-                _logger.Error(exception, "Multiple matches found for class '{0}'.", name);
             }
 
             return result;
@@ -353,9 +281,7 @@ namespace Rubberduck.Parsing.Symbols
             var allMatches = MatchName(memberName);
             var memberMatches = allMatches.Where(m =>
                 m.DeclarationType.HasFlag(memberType)
-                // TODO: Fix this?
-                // Assume no module = built-in, not checkable thus we conservatively include it in the matches.
-                && (Declaration.GetModuleParent(m) == null || Declaration.GetModuleParent(m).DeclarationType == DeclarationType.ProceduralModule)
+                && Declaration.GetModuleParent(m).DeclarationType == DeclarationType.ProceduralModule
                 && Declaration.GetProjectParent(m).Equals(callingProject)
                 && !callingModule.Equals(Declaration.GetModuleParent(m)));
             var accessibleMembers = memberMatches.Where(m => AccessibilityCheck.IsMemberAccessible(callingProject, callingModule, callingParent, m));

--- a/Rubberduck.Parsing/Symbols/FunctionDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/FunctionDeclaration.cs
@@ -78,21 +78,5 @@ namespace Rubberduck.Parsing.Symbols
                 return false;
             }
         }
-
-        public override string AsTypeNameWithoutArrayDesignator
-        {
-            get
-            {
-                if (string.IsNullOrWhiteSpace(AsTypeName))
-                {
-                    return AsTypeName;
-                }
-                if (!IsArray)
-                {
-                    return AsTypeName;
-                }
-                return AsTypeName.Substring(0, AsTypeName.IndexOf("("));
-            }
-        }
     }
 }

--- a/Rubberduck.Parsing/Symbols/PropertyGetDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/PropertyGetDeclaration.cs
@@ -78,21 +78,5 @@ namespace Rubberduck.Parsing.Symbols
                 return false;
             }
         }
-
-        public override string AsTypeNameWithoutArrayDesignator
-        {
-            get
-            {
-                if (string.IsNullOrWhiteSpace(AsTypeName))
-                {
-                    return AsTypeName;
-                }
-                if (!IsArray)
-                {
-                    return AsTypeName;
-                }
-                return AsTypeName.Substring(0, AsTypeName.IndexOf("("));
-            }
-        }
     }
 }

--- a/Rubberduck.Parsing/Symbols/TypeAnnotationPass.cs
+++ b/Rubberduck.Parsing/Symbols/TypeAnnotationPass.cs
@@ -64,7 +64,6 @@ namespace Rubberduck.Parsing.Symbols
             var module = Declaration.GetModuleParent(declaration);
             if (module == null)
             {
-                // TODO: Reference Collector does not add module, find workaround?
                 _logger.Warn("Type annotation failed for {0} because module parent is missing.", typeExpression);
                 return;
             }
@@ -76,8 +75,11 @@ namespace Rubberduck.Parsing.Symbols
             }
             else
             {
-                // Commented out due to a massive amount of VT_HRESULT messages.
-                //Debug.WriteLine(string.Format("{0}: Failed to resolve type {1}.", GetType().Name, typeExpression));
+                const string IGNORE_THIS = "DISPATCH";
+                if (typeExpression != IGNORE_THIS)
+                {
+                    _logger.Warn("Failed to resolve type {0}", typeExpression);
+                }
             }
         }
     }


### PR DESCRIPTION
I'll look at the failing test separately, because it seems like quite a few changes might be necessary, hope that's OK.

Edit: This might also be a fix for #1608 because apparently UDT members had array types that couldn't be resolved.