### PR TITLE
preprocess code passed on to attribute parser + allow lexpression as …

### DIFF
--- a/RetailCoder.VBE/API/ParserState.cs
+++ b/RetailCoder.VBE/API/ParserState.cs
@@ -6,6 +6,8 @@ using Microsoft.Vbe.Interop;
 using Rubberduck.Common;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.UI.Command.MenuItems;
+using Rubberduck.Parsing.Preprocessing;
+using System.Globalization;
 
 namespace Rubberduck.API
 {
@@ -44,15 +46,13 @@ namespace Rubberduck.API
         private const string ProgId = "Rubberduck.ParserState";
 
         private readonly RubberduckParserState _state;
-        private readonly AttributeParser _attributeParser;
-
+        private AttributeParser _attributeParser;
         private RubberduckParser _parser;
 
         public ParserState()
         {
             UiDispatcher.Initialize();
             _state = new RubberduckParserState();
-            _attributeParser = new AttributeParser(new ModuleExporter());
             
             _state.StateChanged += _state_StateChanged;
         }
@@ -63,8 +63,9 @@ namespace Rubberduck.API
             {
                 throw new InvalidOperationException("ParserState is already initialized.");
             }
-
-            _parser = new RubberduckParser(vbe, _state, _attributeParser);
+            Func<IVBAPreprocessor> preprocessorFactory = () => new VBAPreprocessor(double.Parse(vbe.Version, CultureInfo.InvariantCulture));
+            _attributeParser = new AttributeParser(new ModuleExporter(), preprocessorFactory);
+            _parser = new RubberduckParser(vbe, _state, _attributeParser, preprocessorFactory);
         }
 
         /// <summary>

--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -33,6 +33,8 @@ using Rubberduck.UI.UnitTesting;
 using Rubberduck.UnitTesting;
 using Rubberduck.VBEditor.VBEHost;
 using NLog;
+using Rubberduck.Parsing.Preprocessing;
+using System.Globalization;
 
 namespace Rubberduck.Root
 {
@@ -94,6 +96,7 @@ namespace Rubberduck.Root
 
             //Bind<TestExplorerModel>().To<StandardModuleTestExplorerModel>().InSingletonScope();
             Rebind<IRubberduckParser>().To<RubberduckParser>().InSingletonScope();
+            Bind<Func<IVBAPreprocessor>>().ToMethod(p => () => new VBAPreprocessor(double.Parse(_vbe.Version, CultureInfo.InvariantCulture)));
 
             _kernel.Rebind<ISearchResultsWindowViewModel>().To<SearchResultsWindowViewModel>().InSingletonScope();
             _kernel.Bind<SearchResultPresenterInstanceManager>().ToSelf().InSingletonScope();

--- a/Rubberduck.Parsing/Grammar/VBAParser.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParser.cs
@@ -831,8 +831,8 @@ public partial class VBAParser : Parser {
 	}
 
 	public partial class AttributeNameContext : ParserRuleContext {
-		public UnrestrictedIdentifierContext unrestrictedIdentifier() {
-			return GetRuleContext<UnrestrictedIdentifierContext>(0);
+		public LExpressionContext lExpression() {
+			return GetRuleContext<LExpressionContext>(0);
 		}
 		public AttributeNameContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
@@ -861,7 +861,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 499; unrestrictedIdentifier();
+			State = 499; lExpression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -876,8 +876,8 @@ public partial class VBAParser : Parser {
 	}
 
 	public partial class AttributeValueContext : ParserRuleContext {
-		public LiteralExpressionContext literalExpression() {
-			return GetRuleContext<LiteralExpressionContext>(0);
+		public ExpressionContext expression() {
+			return GetRuleContext<ExpressionContext>(0);
 		}
 		public AttributeValueContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
@@ -906,7 +906,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 501; literalExpression();
+			State = 501; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -18325,7 +18325,7 @@ public partial class VBAParser : Parser {
 		"\x3\x2\x2\x2\x1ED\x1EE\x3\x2\x2\x2\x1EE\x1EF\x3\x2\x2\x2\x1EF\x1F1\x5"+
 		"\x12\n\x2\x1F0\x1E9\x3\x2\x2\x2\x1F1\x1F4\x3\x2\x2\x2\x1F2\x1F0\x3\x2"+
 		"\x2\x2\x1F2\x1F3\x3\x2\x2\x2\x1F3\xF\x3\x2\x2\x2\x1F4\x1F2\x3\x2\x2\x2"+
-		"\x1F5\x1F6\x5\x126\x94\x2\x1F6\x11\x3\x2\x2\x2\x1F7\x1F8\x5\x150\xA9\x2"+
+		"\x1F5\x1F6\x5\x15A\xAE\x2\x1F6\x11\x3\x2\x2\x2\x1F7\x1F8\x5\x14E\xA8\x2"+
 		"\x1F8\x13\x3\x2\x2\x2\x1F9\x1FA\x5\x18\r\x2\x1FA\x1FB\x5\x17C\xBF\x2\x1FB"+
 		"\x1FD\x3\x2\x2\x2\x1FC\x1F9\x3\x2\x2\x2\x1FD\x200\x3\x2\x2\x2\x1FE\x1FC"+
 		"\x3\x2\x2\x2\x1FE\x1FF\x3\x2\x2\x2\x1FF\x15\x3\x2\x2\x2\x200\x1FE\x3\x2"+

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -47,8 +47,8 @@ moduleConfigElement :
 
 moduleAttributes : (attributeStmt endOfStatement)*;
 attributeStmt : ATTRIBUTE whiteSpace attributeName whiteSpace? EQ whiteSpace? attributeValue (whiteSpace? COMMA whiteSpace? attributeValue)*;
-attributeName : unrestrictedIdentifier;
-attributeValue : literalExpression;
+attributeName : lExpression;
+attributeValue : expression;
 
 moduleDeclarations : (moduleDeclarationsElement endOfStatement)*;
 
@@ -520,7 +520,6 @@ visibility : PRIVATE | PUBLIC | FRIEND | GLOBAL;
 
 // 5.6 Expressions
 expression :
-    // Literal Expression has to come before lExpression, otherwise it'll be classified as simple name expression instead.
     literalExpression                                                                               # literalExpr
     | lExpression                                                                                   # lExpr
     | builtInType                                                                                   # builtInTypeExpr

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -520,6 +520,7 @@ visibility : PRIVATE | PUBLIC | FRIEND | GLOBAL;
 
 // 5.6 Expressions
 expression :
+    // Literal Expression has to come before lExpression, otherwise it'll be classified as simple name expression instead.
     literalExpression                                                                               # literalExpr
     | lExpression                                                                                   # lExpr
     | builtInType                                                                                   # builtInTypeExpr

--- a/Rubberduck.Parsing/Preprocessing/IVBAPreprocessor.cs
+++ b/Rubberduck.Parsing/Preprocessing/IVBAPreprocessor.cs
@@ -1,0 +1,7 @@
+﻿namespace Rubberduck.Parsing.Preprocessing
+{
+    public interface IVBAPreprocessor
+    {
+        string Execute(string moduleName, string unprocessedCode);
+    }
+}

--- a/Rubberduck.Parsing/Preprocessing/VBAPreprocessor.cs
+++ b/Rubberduck.Parsing/Preprocessing/VBAPreprocessor.cs
@@ -2,7 +2,7 @@
 
 namespace Rubberduck.Parsing.Preprocessing
 {
-    public sealed class VBAPreprocessor
+    public sealed class VBAPreprocessor : IVBAPreprocessor
     {
         private readonly double _vbaVersion;
         private readonly VBAPrecompilationParser _parser;

--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Grammar\VBAParserBaseVisitor.cs" />
     <Compile Include="Grammar\VBAParserListener.cs" />
     <Compile Include="Grammar\VBAParserVisitor.cs" />
+    <Compile Include="Preprocessing\IVBAPreprocessor.cs" />
     <Compile Include="Preprocessing\VBAConditionalCompilationParser.cs" />
     <Compile Include="Preprocessing\VBAConditionalCompilationParserBaseListener.cs" />
     <Compile Include="Preprocessing\VBAConditionalCompilationParserBaseVisitor.cs" />

--- a/Rubberduck.Parsing/Symbols/Identifier.cs
+++ b/Rubberduck.Parsing/Symbols/Identifier.cs
@@ -6,6 +6,16 @@ namespace Rubberduck.Parsing.Symbols
 {
     public static class Identifier
     {
+        public static string GetName(VBAParser.FunctionNameContext context)
+        {
+            return GetName(context.identifier());
+        }
+
+        public static string GetName(VBAParser.SubroutineNameContext context)
+        {
+            return GetName(context.identifier());
+        }
+
         public static string GetName(VBAParser.UnrestrictedIdentifierContext context)
         {
             if (context.identifier() != null)

--- a/Rubberduck.Parsing/VBA/AttributeParser.cs
+++ b/Rubberduck.Parsing/VBA/AttributeParser.cs
@@ -1,23 +1,27 @@
-﻿using System;
+﻿using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using Microsoft.Vbe.Interop;
+using NLog;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Preprocessing;
+using Rubberduck.Parsing.Symbols;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Antlr4.Runtime;
-using Antlr4.Runtime.Misc;
-using Antlr4.Runtime.Tree;
-using Microsoft.Vbe.Interop;
-using Rubberduck.Parsing.Grammar;
-using Rubberduck.Parsing.Symbols;
 
 namespace Rubberduck.Parsing.VBA
 {
     public class AttributeParser : IAttributeParser
     {
         private readonly IModuleExporter _exporter;
+        private readonly Func<IVBAPreprocessor> _preprocessorFactory;
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-        public AttributeParser(IModuleExporter exporter)
+        public AttributeParser(IModuleExporter exporter, Func<IVBAPreprocessor> preprocessorFactory)
         {
             _exporter = exporter;
+            _preprocessorFactory = preprocessorFactory;
         }
 
         /// <summary>
@@ -32,26 +36,28 @@ namespace Rubberduck.Parsing.VBA
                 // a document component without any code wouldn't be exported (file would be empty anyway).
                 return new Dictionary<Tuple<string, DeclarationType>, Attributes>();
             }
-
             var code = File.ReadAllText(path);
             File.Delete(path);
-
             var type = component.Type == vbext_ComponentType.vbext_ct_StdModule
                 ? DeclarationType.ProceduralModule
                 : DeclarationType.ClassModule;
+            var preprocessor = _preprocessorFactory();
+            string preprocessed;
+            try
+            {
+                preprocessed = preprocessor.Execute(component.Name, code);
+            }
+            catch (VBAPreprocessorException ex)
+            {
+                _logger.Error(ex, "Preprocessing failed while preparing attribute parsing for module {0}. Trying without preprocessing.", component.Name);
+                preprocessed = code;
+            }
             var listener = new AttributeListener(Tuple.Create(component.Name, type));
-
-            var stream = new AntlrInputStream(code);
-            var lexer = new VBALexer(stream);
-            var tokens = new CommonTokenStream(lexer);
-            var parser = new VBAParser(tokens);
-
             // parse tree isn't usable for declarations because
             // line numbers are offset due to module header and attributes
             // (these don't show up in the VBE, that's why we're parsing an exported file)
-            var tree = parser.startRule();
-            ParseTreeWalker.Default.Walk(listener, tree);
-
+            ITokenStream tokenStream;
+            new VBAModuleParser().Parse(component.Name, preprocessed, new IParseTreeListener[] { listener }, out tokenStream);
             return listener.Attributes;
         }
 
@@ -76,56 +82,21 @@ namespace Rubberduck.Parsing.VBA
 
             public override void ExitModuleAttributes(VBAParser.ModuleAttributesContext context)
             {
-                _attributes.Add(_currentScope, _currentScopeAttributes);
-            }
-
-            private static readonly IReadOnlyDictionary<Type, DeclarationType> ScopingContextTypes =
-                new Dictionary<Type, DeclarationType>
-            {
-                {typeof(VBAParser.SubStmtContext), DeclarationType.Procedure},
-                {typeof(VBAParser.FunctionStmtContext), DeclarationType.Function},
-                {typeof(VBAParser.PropertyGetStmtContext), DeclarationType.PropertyGet},
-                {typeof(VBAParser.PropertyLetStmtContext), DeclarationType.PropertyLet},
-                {typeof(VBAParser.PropertySetStmtContext), DeclarationType.PropertySet}
-            };
-
-            public override void EnterSubroutineName(VBAParser.SubroutineNameContext context)
-            {
-                if (ParserRuleContextHelper.HasParent<VBAParser.SubStmtContext>(context))
+                if (_currentScopeAttributes.Any())
                 {
-                    _currentScope = Tuple.Create(context.GetText(), DeclarationType.Procedure);
-                }
-                else if (ParserRuleContextHelper.HasParent<VBAParser.PropertyGetStmtContext>(context))
-                {
-                    _currentScope = Tuple.Create(context.GetText(), DeclarationType.PropertyGet);
-                }
-            }
-
-            public override void EnterFunctionName(VBAParser.FunctionNameContext context)
-            {
-                if (ParserRuleContextHelper.HasParent<VBAParser.FunctionStmtContext>(context))
-                {
-                    _currentScope = Tuple.Create(context.identifier().GetText(), DeclarationType.Function);
-                }
-                else if (ParserRuleContextHelper.HasParent<VBAParser.PropertyLetStmtContext>(context))
-                {
-                    _currentScope = Tuple.Create(context.identifier().GetText(), DeclarationType.PropertyLet);
-                }
-                else if (ParserRuleContextHelper.HasParent<VBAParser.PropertySetStmtContext>(context))
-                {
-                    _currentScope = Tuple.Create(context.identifier().GetText(), DeclarationType.PropertySet);
+                    _attributes.Add(_currentScope, _currentScopeAttributes);
                 }
             }
 
             public override void EnterSubStmt(VBAParser.SubStmtContext context)
             {
                 _currentScopeAttributes = new Attributes();
-                _currentScope = Tuple.Create(context.subroutineName().GetText(), DeclarationType.Procedure);
+                _currentScope = Tuple.Create(Identifier.GetName(context.subroutineName()), DeclarationType.Procedure);
             }
 
             public override void ExitSubStmt(VBAParser.SubStmtContext context)
             {
-                if (!string.IsNullOrEmpty(_currentScope.Item1) && _currentScopeAttributes.Any())
+                if (_currentScopeAttributes.Any())
                 {
                     _attributes.Add(_currentScope, _currentScopeAttributes);
                 }
@@ -134,12 +105,12 @@ namespace Rubberduck.Parsing.VBA
             public override void EnterFunctionStmt(VBAParser.FunctionStmtContext context)
             {
                 _currentScopeAttributes = new Attributes();
-                _currentScope = Tuple.Create(context.functionName().identifier().GetText(), DeclarationType.Function);
+                _currentScope = Tuple.Create(Identifier.GetName(context.functionName()), DeclarationType.Function);
             }
 
             public override void ExitFunctionStmt(VBAParser.FunctionStmtContext context)
             {
-                if (!string.IsNullOrEmpty(_currentScope.Item1) && _currentScopeAttributes.Any())
+                if (_currentScopeAttributes.Any())
                 {
                     _attributes.Add(_currentScope, _currentScopeAttributes);
                 }
@@ -148,12 +119,12 @@ namespace Rubberduck.Parsing.VBA
             public override void EnterPropertyGetStmt(VBAParser.PropertyGetStmtContext context)
             {
                 _currentScopeAttributes = new Attributes();
-                _currentScope = Tuple.Create(context.functionName().identifier().GetText(), DeclarationType.PropertyGet);
+                _currentScope = Tuple.Create(Identifier.GetName(context.functionName()), DeclarationType.PropertyGet);
             }
 
             public override void ExitPropertyGetStmt(VBAParser.PropertyGetStmtContext context)
             {
-                if (!string.IsNullOrEmpty(_currentScope.Item1) && _currentScopeAttributes.Any())
+                if (_currentScopeAttributes.Any())
                 {
                     _attributes.Add(_currentScope, _currentScopeAttributes);
                 }
@@ -162,12 +133,12 @@ namespace Rubberduck.Parsing.VBA
             public override void EnterPropertyLetStmt(VBAParser.PropertyLetStmtContext context)
             {
                 _currentScopeAttributes = new Attributes();
-                _currentScope = Tuple.Create(context.subroutineName().GetText(), DeclarationType.PropertyLet);
+                _currentScope = Tuple.Create(Identifier.GetName(context.subroutineName()), DeclarationType.PropertyLet);
             }
 
             public override void ExitPropertyLetStmt(VBAParser.PropertyLetStmtContext context)
             {
-                if (!string.IsNullOrEmpty(_currentScope.Item1) && _currentScopeAttributes.Any())
+                if (_currentScopeAttributes.Any())
                 {
                     _attributes.Add(_currentScope, _currentScopeAttributes);
                 }
@@ -176,12 +147,12 @@ namespace Rubberduck.Parsing.VBA
             public override void EnterPropertySetStmt(VBAParser.PropertySetStmtContext context)
             {
                 _currentScopeAttributes = new Attributes();
-                _currentScope = Tuple.Create(context.subroutineName().GetText(), DeclarationType.PropertySet);
+                _currentScope = Tuple.Create(Identifier.GetName(context.subroutineName()), DeclarationType.PropertySet);
             }
 
             public override void ExitPropertySetStmt(VBAParser.PropertySetStmtContext context)
             {
-                if (!string.IsNullOrEmpty(_currentScope.Item1) && _currentScopeAttributes.Any())
+                if (_currentScopeAttributes.Any())
                 {
                     _attributes.Add(_currentScope, _currentScopeAttributes);
                 }
@@ -189,9 +160,34 @@ namespace Rubberduck.Parsing.VBA
 
             public override void ExitAttributeStmt(VBAParser.AttributeStmtContext context)
             {
-                var name = context.attributeName().GetText().Trim();
+                // We assume attributes can either be simple names (VB_Name) or, if they are inside procedures, member access expressions
+                // (e.g. Foo.VB_UserMemId = 0)
+                var expr = context.attributeName().lExpression();
+                string name;
+                if (expr is VBAParser.SimpleNameExprContext)
+                {
+                    name = ((VBAParser.SimpleNameExprContext)expr).identifier().GetText();
+                }
+                else
+                {
+                    // Turns "Foo.VB_ProcData.VB_Invoke_Func" into "VB_ProcData.VB_Invoke_Func",
+                    // because we are not interested in the subroutine name Foo.
+                    name = GetAttributeNameWithoutProcedureName((VBAParser.MemberAccessExprContext)expr);
+                }
                 var values = context.attributeValue().Select(e => e.GetText().Replace("\"", string.Empty)).ToList();
                 _currentScopeAttributes.Add(name, values);
+            }
+
+            private string GetAttributeNameWithoutProcedureName(VBAParser.MemberAccessExprContext expr)
+            {
+                string name = expr.unrestrictedIdentifier().GetText();
+                // The simple name expression represents the procedure's name.
+                // We don't want that one though so we simply ignore it.
+                if (expr.lExpression() is VBAParser.SimpleNameExprContext)
+                {
+                    return name;
+                }
+                return string.Format("{0}.{1}", GetAttributeNameWithoutProcedureName((VBAParser.MemberAccessExprContext)expr.lExpression()), name);
             }
 
             public override void ExitModuleConfigElement(VBAParser.ModuleConfigElementContext context)

--- a/Rubberduck.Parsing/VBA/ComponentParseTask.cs
+++ b/Rubberduck.Parsing/VBA/ComponentParseTask.cs
@@ -25,14 +25,14 @@ namespace Rubberduck.Parsing.VBA
         private readonly QualifiedModuleName _qualifiedName;
         private readonly TokenStreamRewriter _rewriter;
         private readonly IAttributeParser _attributeParser;
-        private readonly VBAPreprocessor _preprocessor;
+        private readonly IVBAPreprocessor _preprocessor;
         private readonly VBAModuleParser _parser;
 
         public event EventHandler<ParseCompletionArgs> ParseCompleted;
         public event EventHandler<ParseFailureArgs> ParseFailure;
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-        public ComponentParseTask(VBComponent vbComponent, VBAPreprocessor preprocessor, IAttributeParser attributeParser, TokenStreamRewriter rewriter = null)
+        public ComponentParseTask(VBComponent vbComponent, IVBAPreprocessor preprocessor, IAttributeParser attributeParser, TokenStreamRewriter rewriter = null)
         {
             _attributeParser = attributeParser;
             _preprocessor = preprocessor;

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -45,14 +45,20 @@ namespace Rubberduck.Parsing.VBA
         private readonly VBE _vbe;
         private readonly RubberduckParserState _state;
         private readonly IAttributeParser _attributeParser;
+        private readonly Func<IVBAPreprocessor> _preprocessorFactory;
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-        public RubberduckParser(VBE vbe, RubberduckParserState state, IAttributeParser attributeParser)
+        public RubberduckParser(
+            VBE vbe, 
+            RubberduckParserState state,
+            IAttributeParser attributeParser,
+            Func<IVBAPreprocessor> preprocessorFactory)
         {
             _resolverTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_central.Token);
             _vbe = vbe;
             _state = state;
             _attributeParser = attributeParser;
+            _preprocessorFactory = preprocessorFactory;
 
             _comReflector = new ReferencedDeclarationsCollector();
 
@@ -428,7 +434,7 @@ namespace Rubberduck.Parsing.VBA
 
         private void ParseAsyncInternal(VBComponent component, CancellationToken token, TokenStreamRewriter rewriter = null)
         {
-            var preprocessor = new VBAPreprocessor(double.Parse(_vbe.Version, CultureInfo.InvariantCulture));
+            var preprocessor = _preprocessorFactory();
             var parser = new ComponentParseTask(component, preprocessor, _attributeParser, rewriter);
             parser.ParseFailure += (sender, e) =>
             {

--- a/Rubberduck.Parsing/VBA/VBAModuleParser.cs
+++ b/Rubberduck.Parsing/VBA/VBAModuleParser.cs
@@ -5,6 +5,7 @@ using NLog;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using System;
+using System.Collections.Generic;
 
 namespace Rubberduck.Parsing.VBA
 {
@@ -19,10 +20,6 @@ namespace Rubberduck.Parsing.VBA
             var tokens = new CommonTokenStream(lexer);
             var parser = new VBAParser(tokens);
             parser.AddErrorListener(new ExceptionErrorListener());
-            foreach (var listener in listeners)
-            {
-                parser.AddParseListener(listener);
-            }
             ParserRuleContext tree = null;
             try
             {
@@ -36,6 +33,10 @@ namespace Rubberduck.Parsing.VBA
                 parser.Reset();
                 parser.Interpreter.PredictionMode = PredictionMode.Ll;
                 tree = parser.startRule();
+            }
+            foreach (var listener in listeners)
+            {
+                ParseTreeWalker.Default.Walk(listener, tree);
             }
             outStream = tokens;
             return tree;

--- a/RubberduckTests/MockParser.cs
+++ b/RubberduckTests/MockParser.cs
@@ -7,6 +7,8 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor;
 using RubberduckTests.Mocks;
+using Rubberduck.Parsing.Preprocessing;
+using System.Globalization;
 
 namespace RubberduckTests
 {
@@ -37,7 +39,7 @@ namespace RubberduckTests
 
         public static RubberduckParser Create(VBE vbe, RubberduckParserState state, IAttributeParser attributeParser)
         {
-            return new RubberduckParser(vbe, state, attributeParser);
+            return new RubberduckParser(vbe, state, attributeParser, () => new VBAPreprocessor(double.Parse(vbe.Version, CultureInfo.InvariantCulture)));
         }
     }
 }


### PR DESCRIPTION
…attribute name

Fixes #1632.

The attribute parser failed with conditional compilation directives so now the code is first preprocessed.

Attributes like "RowColUnhide.VB_ProcData.VB_Invoke_Func" are now handled as well and automatically saved as "VB_ProcData.VB_Invoke_Func" (without the subroutine's name).