### PR TITLE
Parser issues

### DIFF
--- a/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -28,7 +28,7 @@ namespace Rubberduck.Navigation.CodeExplorer
             _folderHelper = folderHelper;
             _state = state;
             _state.StateChanged += ParserState_StateChanged;
-            
+
             _refreshCommand = new DelegateCommand(param => _state.OnParseRequested(this),
                 param => !IsBusy && _state.IsDirty());
 
@@ -188,38 +188,38 @@ namespace Rubberduck.Navigation.CodeExplorer
 
                 if (SelectedItem is CodeExplorerProjectViewModel)
                 {
-                    var node = (CodeExplorerProjectViewModel) SelectedItem;
+                    var node = (CodeExplorerProjectViewModel)SelectedItem;
                     return node.Declaration.IdentifierName + string.Format(" - ({0})", node.Declaration.DeclarationType);
                 }
 
                 if (SelectedItem is CodeExplorerComponentViewModel)
                 {
-                    var node = (CodeExplorerComponentViewModel) SelectedItem;
+                    var node = (CodeExplorerComponentViewModel)SelectedItem;
                     return node.Declaration.IdentifierName + string.Format(" - ({0})", node.Declaration.DeclarationType);
                 }
 
                 if (SelectedItem is CodeExplorerMemberViewModel)
                 {
-                    var node = (CodeExplorerMemberViewModel) SelectedItem;
+                    var node = (CodeExplorerMemberViewModel)SelectedItem;
                     return node.Declaration.IdentifierName + string.Format(" - ({0})", node.Declaration.DeclarationType);
                 }
 
                 return SelectedItem.Name;
             }
         }
-        
+
         public string Description
         {
             get
             {
                 if (SelectedItem is ICodeExplorerDeclarationViewModel)
                 {
-                    return ((ICodeExplorerDeclarationViewModel) SelectedItem).Declaration.DescriptionString;
+                    return ((ICodeExplorerDeclarationViewModel)SelectedItem).Declaration.DescriptionString;
                 }
 
                 if (SelectedItem is CodeExplorerCustomFolderViewModel)
                 {
-                    return ((CodeExplorerCustomFolderViewModel) SelectedItem).FolderAttribute;
+                    return ((CodeExplorerCustomFolderViewModel)SelectedItem).FolderAttribute;
                 }
 
                 return string.Empty;
@@ -237,7 +237,7 @@ namespace Rubberduck.Navigation.CodeExplorer
             set
             {
                 _projects = new ObservableCollection<CodeExplorerItemViewModel>(value.OrderBy(o => o.NameWithSignature));
-                
+
                 ReorderChildNodes(_projects);
                 OnPropertyChanged();
             }
@@ -245,39 +245,36 @@ namespace Rubberduck.Navigation.CodeExplorer
 
         private void ParserState_StateChanged(object sender, EventArgs e)
         {
-            UiDispatcher.InvokeAsync(() =>
+            if (Projects == null)
             {
-                if (Projects == null)
-                {
-                    Projects = new ObservableCollection<CodeExplorerItemViewModel>();
-                }
+                Projects = new ObservableCollection<CodeExplorerItemViewModel>();
+            }
 
-                IsBusy = _state.Status < ParserState.ResolvedDeclarations;
-                if (_state.Status != ParserState.ResolvedDeclarations)
-                {
-                    return;
-                }
+            IsBusy = _state.Status < ParserState.ResolvedDeclarations;
+            if (_state.Status != ParserState.ResolvedDeclarations)
+            {
+                return;
+            }
 
-                var userDeclarations = _state.AllUserDeclarations
-                    .GroupBy(declaration => declaration.Project)
-                    .Where(grouping => grouping.Key != null)
-                    .ToList();
+            var userDeclarations = _state.AllUserDeclarations
+                .GroupBy(declaration => declaration.Project)
+                .Where(grouping => grouping.Key != null)
+                .ToList();
 
-                if (userDeclarations.Any(
+            if (userDeclarations.Any(
                     grouping => grouping.All(declaration => declaration.DeclarationType != DeclarationType.Project)))
-                {
-                    return;
-                }
+            {
+                return;
+            }
 
-                var newProjects = userDeclarations.Select(grouping =>
-                    new CodeExplorerProjectViewModel(_folderHelper,
-                        grouping.SingleOrDefault(declaration => declaration.DeclarationType == DeclarationType.Project),
-                        grouping)).ToList();
+            var newProjects = userDeclarations.Select(grouping =>
+                new CodeExplorerProjectViewModel(_folderHelper,
+                    grouping.SingleOrDefault(declaration => declaration.DeclarationType == DeclarationType.Project),
+                    grouping)).ToList();
 
-                UpdateNodes(Projects, newProjects);
+            UpdateNodes(Projects, newProjects);
 
-                Projects = new ObservableCollection<CodeExplorerItemViewModel>(newProjects);
-            });
+            Projects = new ObservableCollection<CodeExplorerItemViewModel>(newProjects);
         }
 
         private void UpdateNodes(IEnumerable<CodeExplorerItemViewModel> oldList,
@@ -406,7 +403,7 @@ namespace Rubberduck.Navigation.CodeExplorer
 
                 if (node is CodeExplorerComponentViewModel)
                 {
-                    var componentNode = (CodeExplorerComponentViewModel) node;
+                    var componentNode = (CodeExplorerComponentViewModel)node;
                     if (componentNode.GetSelectedDeclaration().QualifiedName.QualifiedModuleName.Component == component)
                     {
                         componentNode.IsErrorState = true;
@@ -475,8 +472,8 @@ namespace Rubberduck.Navigation.CodeExplorer
         // this is a special case--we have to reset SelectedItem to prevent a crash
         private void ExecuteRemoveComand(object param)
         {
-            var node = (CodeExplorerComponentViewModel) SelectedItem;
-            SelectedItem = Projects.First(p => ((CodeExplorerProjectViewModel) p).Declaration.Project == node.Declaration.Project);
+            var node = (CodeExplorerComponentViewModel)SelectedItem;
+            SelectedItem = Projects.First(p => ((CodeExplorerProjectViewModel)p).Declaration.Project == node.Declaration.Project);
 
             _externalRemoveCommand.Execute(param);
         }

--- a/RetailCoder.VBE/UI/Command/MenuItems/RubberduckCommandBar.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/RubberduckCommandBar.cs
@@ -94,7 +94,11 @@ namespace Rubberduck.UI.Command.MenuItems
         private void State_StateChanged(object sender, EventArgs e)
         {
             _logger.Debug("RubberduckCommandBar handles StateChanged...");
-            SetStatusText(RubberduckUI.ResourceManager.GetString("ParserState_" + _state.Status));
+            
+            if (_state.Status != ParserState.ResolvedDeclarations)
+            {
+                SetStatusText(RubberduckUI.ResourceManager.GetString("ParserState_" + _state.Status));
+            }
         }
 
         public event EventHandler Refresh;

--- a/RetailCoder.VBE/UI/UnitTesting/TestExplorerModel.cs
+++ b/RetailCoder.VBE/UI/UnitTesting/TestExplorerModel.cs
@@ -26,18 +26,17 @@ namespace Rubberduck.UI.UnitTesting
 
         private void State_StateChanged(object sender, ParserStateEventArgs e)
         {
-            if (e.State != ParserState.Ready) { return; }
-
-            var tests = UnitTestHelpers.GetAllTests(_vbe, _state).ToList();
-
-            var removedTests = Tests.Where(test =>
-                         !tests.Any(t =>
-                                 t.Declaration.ComponentName == test.Declaration.ComponentName &&
-                                 t.Declaration.IdentifierName == test.Declaration.IdentifierName &&
-                                 t.Declaration.ProjectId == test.Declaration.ProjectId)).ToList();
+            if (e.State != ParserState.ResolvedDeclarations) { return; }
 
             _dispatcher.Invoke(() =>
             {
+                var tests = UnitTestHelpers.GetAllTests(_vbe, _state).ToList();
+
+                var removedTests = Tests.Where(test =>
+                             !tests.Any(t =>
+                                     t.Declaration.ComponentName == test.Declaration.ComponentName &&
+                                     t.Declaration.IdentifierName == test.Declaration.IdentifierName &&
+                                     t.Declaration.ProjectId == test.Declaration.ProjectId)).ToList();
 
                 // remove old tests
                 foreach (var test in removedTests)

--- a/Rubberduck.Parsing/VBA/ParserState.cs
+++ b/Rubberduck.Parsing/VBA/ParserState.cs
@@ -24,6 +24,10 @@ namespace Rubberduck.Parsing.VBA
         /// </summary>
         Resolving,
         /// <summary>
+        /// Resolving identifier references.
+        /// </summary>
+        ResolvedDeclarations,
+        /// <summary>
         /// Parser state is in sync with the actual code in the VBE.
         /// </summary>
         Ready,

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -147,7 +147,7 @@ namespace Rubberduck.Parsing.VBA
                 return;
             }
 
-
+            
             lock (_state)  // note, method is invoked from UI thread... really need the lock here?
             {
                 foreach (var component in toParse)

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -143,7 +143,7 @@ namespace Rubberduck.Parsing.VBA
 
             if (!toParse.Any())
             {
-                State.SetStatusAndFireStateChanged(ParserState.Ready);
+                State.SetStatusAndFireStateChanged(_state.Status);
                 return;
             }
 
@@ -495,6 +495,8 @@ namespace Rubberduck.Parsing.VBA
                 if (token.IsCancellationRequested) return;
                 ResolveDeclarations(qualifiedName.Component, kvp.Value);
             }
+
+            _state.SetStatusAndFireStateChanged(ParserState.ResolvedDeclarations);
 
             // walk all parse trees (modified or not) for identifier references
             var finder = new DeclarationFinder(_state.AllDeclarations, _state.AllComments, _state.AllAnnotations);


### PR DESCRIPTION
Refresh CE and TE after declarations are resolved, rather than waiting for inspections and reference resolving. Prevent reparse without changes from firing Ready when state is Error.