### PR TITLE
allow reserved keywords as udt members (fixes #1766)

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParser.cs
@@ -140,29 +140,33 @@ public partial class VBAParser : Parser {
 		RULE_selectCaseStmt = 128, RULE_selectExpression = 129, RULE_caseClause = 130, 
 		RULE_caseElseClause = 131, RULE_rangeClause = 132, RULE_selectStartValue = 133, 
 		RULE_selectEndValue = 134, RULE_setStmt = 135, RULE_subStmt = 136, RULE_subroutineName = 137, 
-		RULE_typeStmt = 138, RULE_typeStmt_Element = 139, RULE_variableStmt = 140, 
-		RULE_variableListStmt = 141, RULE_variableSubStmt = 142, RULE_whileWendStmt = 143, 
-		RULE_withStmt = 144, RULE_circleSpecialForm = 145, RULE_scaleSpecialForm = 146, 
-		RULE_tuple = 147, RULE_subscripts = 148, RULE_subscript = 149, RULE_unrestrictedIdentifier = 150, 
-		RULE_identifier = 151, RULE_untypedIdentifier = 152, RULE_typedIdentifier = 153, 
-		RULE_identifierValue = 154, RULE_foreignName = 155, RULE_foreignIdentifier = 156, 
-		RULE_asTypeClause = 157, RULE_baseType = 158, RULE_comparisonOperator = 159, 
-		RULE_complexType = 160, RULE_fieldLength = 161, RULE_statementLabelDefinition = 162, 
-		RULE_statementLabel = 163, RULE_identifierStatementLabel = 164, RULE_lineNumberLabel = 165, 
-		RULE_numberLiteral = 166, RULE_type = 167, RULE_typeHint = 168, RULE_visibility = 169, 
-		RULE_expression = 170, RULE_literalExpression = 171, RULE_literalIdentifier = 172, 
-		RULE_booleanLiteralIdentifier = 173, RULE_objectLiteralIdentifier = 174, 
-		RULE_variantLiteralIdentifier = 175, RULE_lExpression = 176, RULE_builtInType = 177, 
-		RULE_argumentList = 178, RULE_positionalOrNamedArgumentList = 179, RULE_positionalArgumentOrMissing = 180, 
-		RULE_positionalArgument = 181, RULE_requiredPositionalArgument = 182, 
-		RULE_namedArgumentList = 183, RULE_namedArgument = 184, RULE_argumentExpression = 185, 
-		RULE_lowerBoundArgumentExpression = 186, RULE_upperBoundArgumentExpression = 187, 
-		RULE_addressOfExpression = 188, RULE_keyword = 189, RULE_markerKeyword = 190, 
-		RULE_statementKeyword = 191, RULE_endOfLine = 192, RULE_endOfStatement = 193, 
-		RULE_commentOrAnnotation = 194, RULE_remComment = 195, RULE_comment = 196, 
-		RULE_commentBody = 197, RULE_annotationList = 198, RULE_annotation = 199, 
-		RULE_annotationName = 200, RULE_annotationArgList = 201, RULE_annotationArg = 202, 
-		RULE_mandatoryLineContinuation = 203, RULE_whiteSpace = 204;
+		RULE_publicTypeDeclaration = 138, RULE_privateTypeDeclaration = 139, RULE_udtDeclaration = 140, 
+		RULE_udtMemberList = 141, RULE_udtMember = 142, RULE_untypedNameMemberDeclaration = 143, 
+		RULE_reservedNameMemberDeclaration = 144, RULE_optionalArrayClause = 145, 
+		RULE_arrayDim = 146, RULE_boundsList = 147, RULE_dimSpec = 148, RULE_lowerBound = 149, 
+		RULE_upperBound = 150, RULE_constantExpression = 151, RULE_variableStmt = 152, 
+		RULE_variableListStmt = 153, RULE_variableSubStmt = 154, RULE_whileWendStmt = 155, 
+		RULE_withStmt = 156, RULE_circleSpecialForm = 157, RULE_scaleSpecialForm = 158, 
+		RULE_tuple = 159, RULE_subscripts = 160, RULE_subscript = 161, RULE_unrestrictedIdentifier = 162, 
+		RULE_identifier = 163, RULE_untypedIdentifier = 164, RULE_typedIdentifier = 165, 
+		RULE_identifierValue = 166, RULE_foreignName = 167, RULE_foreignIdentifier = 168, 
+		RULE_asTypeClause = 169, RULE_baseType = 170, RULE_comparisonOperator = 171, 
+		RULE_complexType = 172, RULE_fieldLength = 173, RULE_statementLabelDefinition = 174, 
+		RULE_statementLabel = 175, RULE_identifierStatementLabel = 176, RULE_lineNumberLabel = 177, 
+		RULE_numberLiteral = 178, RULE_type = 179, RULE_typeHint = 180, RULE_visibility = 181, 
+		RULE_expression = 182, RULE_literalExpression = 183, RULE_literalIdentifier = 184, 
+		RULE_booleanLiteralIdentifier = 185, RULE_objectLiteralIdentifier = 186, 
+		RULE_variantLiteralIdentifier = 187, RULE_lExpression = 188, RULE_builtInType = 189, 
+		RULE_argumentList = 190, RULE_positionalOrNamedArgumentList = 191, RULE_positionalArgumentOrMissing = 192, 
+		RULE_positionalArgument = 193, RULE_requiredPositionalArgument = 194, 
+		RULE_namedArgumentList = 195, RULE_namedArgument = 196, RULE_argumentExpression = 197, 
+		RULE_lowerBoundArgumentExpression = 198, RULE_upperBoundArgumentExpression = 199, 
+		RULE_addressOfExpression = 200, RULE_keyword = 201, RULE_markerKeyword = 202, 
+		RULE_statementKeyword = 203, RULE_endOfLine = 204, RULE_endOfStatement = 205, 
+		RULE_commentOrAnnotation = 206, RULE_remComment = 207, RULE_comment = 208, 
+		RULE_commentBody = 209, RULE_annotationList = 210, RULE_annotation = 211, 
+		RULE_annotationName = 212, RULE_annotationArgList = 213, RULE_annotationArg = 214, 
+		RULE_mandatoryLineContinuation = 215, RULE_whiteSpace = 216;
 	public static readonly string[] ruleNames = {
 		"startRule", "module", "moduleHeader", "moduleConfig", "moduleConfigElement", 
 		"moduleAttributes", "attributeStmt", "attributeName", "attributeValue", 
@@ -191,19 +195,21 @@ public partial class VBAParser : Parser {
 		"redimVariableDeclaration", "integerExpression", "callStmt", "resumeStmt", 
 		"returnStmt", "rsetStmt", "stopStmt", "selectCaseStmt", "selectExpression", 
 		"caseClause", "caseElseClause", "rangeClause", "selectStartValue", "selectEndValue", 
-		"setStmt", "subStmt", "subroutineName", "typeStmt", "typeStmt_Element", 
-		"variableStmt", "variableListStmt", "variableSubStmt", "whileWendStmt", 
-		"withStmt", "circleSpecialForm", "scaleSpecialForm", "tuple", "subscripts", 
-		"subscript", "unrestrictedIdentifier", "identifier", "untypedIdentifier", 
-		"typedIdentifier", "identifierValue", "foreignName", "foreignIdentifier", 
-		"asTypeClause", "baseType", "comparisonOperator", "complexType", "fieldLength", 
-		"statementLabelDefinition", "statementLabel", "identifierStatementLabel", 
-		"lineNumberLabel", "numberLiteral", "type", "typeHint", "visibility", 
-		"expression", "literalExpression", "literalIdentifier", "booleanLiteralIdentifier", 
-		"objectLiteralIdentifier", "variantLiteralIdentifier", "lExpression", 
-		"builtInType", "argumentList", "positionalOrNamedArgumentList", "positionalArgumentOrMissing", 
-		"positionalArgument", "requiredPositionalArgument", "namedArgumentList", 
-		"namedArgument", "argumentExpression", "lowerBoundArgumentExpression", 
+		"setStmt", "subStmt", "subroutineName", "publicTypeDeclaration", "privateTypeDeclaration", 
+		"udtDeclaration", "udtMemberList", "udtMember", "untypedNameMemberDeclaration", 
+		"reservedNameMemberDeclaration", "optionalArrayClause", "arrayDim", "boundsList", 
+		"dimSpec", "lowerBound", "upperBound", "constantExpression", "variableStmt", 
+		"variableListStmt", "variableSubStmt", "whileWendStmt", "withStmt", "circleSpecialForm", 
+		"scaleSpecialForm", "tuple", "subscripts", "subscript", "unrestrictedIdentifier", 
+		"identifier", "untypedIdentifier", "typedIdentifier", "identifierValue", 
+		"foreignName", "foreignIdentifier", "asTypeClause", "baseType", "comparisonOperator", 
+		"complexType", "fieldLength", "statementLabelDefinition", "statementLabel", 
+		"identifierStatementLabel", "lineNumberLabel", "numberLiteral", "type", 
+		"typeHint", "visibility", "expression", "literalExpression", "literalIdentifier", 
+		"booleanLiteralIdentifier", "objectLiteralIdentifier", "variantLiteralIdentifier", 
+		"lExpression", "builtInType", "argumentList", "positionalOrNamedArgumentList", 
+		"positionalArgumentOrMissing", "positionalArgument", "requiredPositionalArgument", 
+		"namedArgumentList", "namedArgument", "argumentExpression", "lowerBoundArgumentExpression", 
 		"upperBoundArgumentExpression", "addressOfExpression", "keyword", "markerKeyword", 
 		"statementKeyword", "endOfLine", "endOfStatement", "commentOrAnnotation", 
 		"remComment", "comment", "commentBody", "annotationList", "annotation", 
@@ -256,8 +262,8 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 410; module();
-			State = 411; Match(Eof);
+			State = 434; module();
+			State = 435; Match(Eof);
 			}
 		}
 		catch (RecognitionException re) {
@@ -324,35 +330,35 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 413; endOfStatement();
-			State = 414; moduleAttributes();
-			State = 416;
+			State = 437; endOfStatement();
+			State = 438; moduleAttributes();
+			State = 440;
 			switch ( Interpreter.AdaptivePredict(_input,0,_ctx) ) {
 			case 1:
 				{
-				State = 415; moduleHeader();
+				State = 439; moduleHeader();
 				}
 				break;
 			}
-			State = 418; moduleAttributes();
-			State = 420;
+			State = 442; moduleAttributes();
+			State = 444;
 			switch ( Interpreter.AdaptivePredict(_input,1,_ctx) ) {
 			case 1:
 				{
-				State = 419; moduleConfig();
+				State = 443; moduleConfig();
 				}
 				break;
 			}
-			State = 422; moduleAttributes();
-			State = 423; moduleDeclarations();
-			State = 424; moduleAttributes();
-			State = 425; moduleBody();
-			State = 426; moduleAttributes();
-			State = 428;
+			State = 446; moduleAttributes();
+			State = 447; moduleDeclarations();
+			State = 448; moduleAttributes();
+			State = 449; moduleBody();
+			State = 450; moduleAttributes();
+			State = 452;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 427; whiteSpace();
+				State = 451; whiteSpace();
 				}
 			}
 
@@ -411,26 +417,26 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 430; Match(VERSION);
-			State = 431; whiteSpace();
-			State = 432; numberLiteral();
-			State = 434;
+			State = 454; Match(VERSION);
+			State = 455; whiteSpace();
+			State = 456; numberLiteral();
+			State = 458;
 			switch ( Interpreter.AdaptivePredict(_input,3,_ctx) ) {
 			case 1:
 				{
-				State = 433; whiteSpace();
+				State = 457; whiteSpace();
 				}
 				break;
 			}
-			State = 437;
+			State = 461;
 			switch ( Interpreter.AdaptivePredict(_input,4,_ctx) ) {
 			case 1:
 				{
-				State = 436; Match(CLASS);
+				State = 460; Match(CLASS);
 				}
 				break;
 			}
-			State = 439; endOfStatement();
+			State = 463; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -497,28 +503,28 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 441; Match(BEGIN);
-			State = 449;
+			State = 465; Match(BEGIN);
+			State = 473;
 			switch ( Interpreter.AdaptivePredict(_input,6,_ctx) ) {
 			case 1:
 				{
-				State = 442; whiteSpace();
-				State = 443; Match(GUIDLITERAL);
-				State = 444; whiteSpace();
-				State = 445; unrestrictedIdentifier();
-				State = 447;
+				State = 466; whiteSpace();
+				State = 467; Match(GUIDLITERAL);
+				State = 468; whiteSpace();
+				State = 469; unrestrictedIdentifier();
+				State = 471;
 				switch ( Interpreter.AdaptivePredict(_input,5,_ctx) ) {
 				case 1:
 					{
-					State = 446; whiteSpace();
+					State = 470; whiteSpace();
 					}
 					break;
 				}
 				}
 				break;
 			}
-			State = 451; endOfStatement();
-			State = 453;
+			State = 475; endOfStatement();
+			State = 477;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -526,19 +532,19 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 452; moduleConfigElement();
+					State = 476; moduleConfigElement();
 					}
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 455;
+				State = 479;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,7,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-			State = 457; Match(END);
-			State = 458; endOfStatement();
+			State = 481; Match(END);
+			State = 482; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -601,45 +607,45 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 460; unrestrictedIdentifier();
-			State = 464;
+			State = 484; unrestrictedIdentifier();
+			State = 488;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==WS || _la==LINE_CONTINUATION) {
 				{
 				{
-				State = 461; whiteSpace();
+				State = 485; whiteSpace();
 				}
 				}
-				State = 466;
+				State = 490;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 467; Match(EQ);
-			State = 471;
+			State = 491; Match(EQ);
+			State = 495;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==WS || _la==LINE_CONTINUATION) {
 				{
 				{
-				State = 468; whiteSpace();
+				State = 492; whiteSpace();
 				}
 				}
-				State = 473;
+				State = 497;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 474; expression(0);
-			State = 477;
+			State = 498; expression(0);
+			State = 501;
 			switch ( Interpreter.AdaptivePredict(_input,10,_ctx) ) {
 			case 1:
 				{
-				State = 475; Match(COLON);
-				State = 476; numberLiteral();
+				State = 499; Match(COLON);
+				State = 500; numberLiteral();
 				}
 				break;
 			}
-			State = 479; endOfStatement();
+			State = 503; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -694,19 +700,19 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 486;
+			State = 510;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,11,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 481; attributeStmt();
-					State = 482; endOfStatement();
+					State = 505; attributeStmt();
+					State = 506; endOfStatement();
 					}
 					} 
 				}
-				State = 488;
+				State = 512;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,11,_ctx);
 			}
@@ -774,56 +780,56 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 489; Match(ATTRIBUTE);
-			State = 490; whiteSpace();
-			State = 491; attributeName();
-			State = 493;
+			State = 513; Match(ATTRIBUTE);
+			State = 514; whiteSpace();
+			State = 515; attributeName();
+			State = 517;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 492; whiteSpace();
+				State = 516; whiteSpace();
 				}
 			}
 
-			State = 495; Match(EQ);
-			State = 497;
+			State = 519; Match(EQ);
+			State = 521;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 496; whiteSpace();
+				State = 520; whiteSpace();
 				}
 			}
 
-			State = 499; attributeValue();
-			State = 510;
+			State = 523; attributeValue();
+			State = 534;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,16,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 501;
+					State = 525;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 500; whiteSpace();
+						State = 524; whiteSpace();
 						}
 					}
 
-					State = 503; Match(COMMA);
-					State = 505;
+					State = 527; Match(COMMA);
+					State = 529;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 504; whiteSpace();
+						State = 528; whiteSpace();
 						}
 					}
 
-					State = 507; attributeValue();
+					State = 531; attributeValue();
 					}
 					} 
 				}
-				State = 512;
+				State = 536;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,16,_ctx);
 			}
@@ -871,7 +877,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 513; lExpression(0);
+			State = 537; lExpression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -916,7 +922,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 515; expression(0);
+			State = 539; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -971,19 +977,19 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 522;
+			State = 546;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,17,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 517; moduleDeclarationsElement();
-					State = 518; endOfStatement();
+					State = 541; moduleDeclarationsElement();
+					State = 542; endOfStatement();
 					}
 					} 
 				}
-				State = 524;
+				State = 548;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,17,_ctx);
 			}
@@ -1099,24 +1105,24 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 20, RULE_moduleOption);
 		int _la;
 		try {
-			State = 535;
+			State = 559;
 			switch (_input.La(1)) {
 			case OPTION_BASE:
 				_localctx = new OptionBaseStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 525; Match(OPTION_BASE);
-				State = 526; whiteSpace();
-				State = 527; numberLiteral();
+				State = 549; Match(OPTION_BASE);
+				State = 550; whiteSpace();
+				State = 551; numberLiteral();
 				}
 				break;
 			case OPTION_COMPARE:
 				_localctx = new OptionCompareStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 529; Match(OPTION_COMPARE);
-				State = 530; whiteSpace();
-				State = 531;
+				State = 553; Match(OPTION_COMPARE);
+				State = 554; whiteSpace();
+				State = 555;
 				_la = _input.La(1);
 				if ( !(_la==BINARY || _la==DATABASE || _la==TEXT) ) {
 				_errHandler.RecoverInline(this);
@@ -1128,14 +1134,14 @@ public partial class VBAParser : Parser {
 				_localctx = new OptionExplicitStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 533; Match(OPTION_EXPLICIT);
+				State = 557; Match(OPTION_EXPLICIT);
 				}
 				break;
 			case OPTION_PRIVATE_MODULE:
 				_localctx = new OptionPrivateModuleStmtContext(_localctx);
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 534; Match(OPTION_PRIVATE_MODULE);
+				State = 558; Match(OPTION_PRIVATE_MODULE);
 				}
 				break;
 			default:
@@ -1160,9 +1166,6 @@ public partial class VBAParser : Parser {
 		public ConstStmtContext constStmt() {
 			return GetRuleContext<ConstStmtContext>(0);
 		}
-		public TypeStmtContext typeStmt() {
-			return GetRuleContext<TypeStmtContext>(0);
-		}
 		public EventStmtContext eventStmt() {
 			return GetRuleContext<EventStmtContext>(0);
 		}
@@ -1186,6 +1189,12 @@ public partial class VBAParser : Parser {
 		}
 		public AttributeStmtContext attributeStmt() {
 			return GetRuleContext<AttributeStmtContext>(0);
+		}
+		public PrivateTypeDeclarationContext privateTypeDeclaration() {
+			return GetRuleContext<PrivateTypeDeclarationContext>(0);
+		}
+		public PublicTypeDeclarationContext publicTypeDeclaration() {
+			return GetRuleContext<PublicTypeDeclarationContext>(0);
 		}
 		public ModuleDeclarationsElementContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
@@ -1215,73 +1224,79 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 538;
+			State = 562;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 537; whiteSpace();
+				State = 561; whiteSpace();
 				}
 			}
 
-			State = 550;
+			State = 575;
 			switch ( Interpreter.AdaptivePredict(_input,20,_ctx) ) {
 			case 1:
 				{
-				State = 540; attributeStmt();
+				State = 564; attributeStmt();
 				}
 				break;
 
 			case 2:
 				{
-				State = 541; declareStmt();
+				State = 565; declareStmt();
 				}
 				break;
 
 			case 3:
 				{
-				State = 542; defDirective();
+				State = 566; defDirective();
 				}
 				break;
 
 			case 4:
 				{
-				State = 543; enumerationStmt();
+				State = 567; enumerationStmt();
 				}
 				break;
 
 			case 5:
 				{
-				State = 544; eventStmt();
+				State = 568; eventStmt();
 				}
 				break;
 
 			case 6:
 				{
-				State = 545; constStmt();
+				State = 569; constStmt();
 				}
 				break;
 
 			case 7:
 				{
-				State = 546; implementsStmt();
+				State = 570; implementsStmt();
 				}
 				break;
 
 			case 8:
 				{
-				State = 547; variableStmt();
+				State = 571; variableStmt();
 				}
 				break;
 
 			case 9:
 				{
-				State = 548; moduleOption();
+				State = 572; moduleOption();
 				}
 				break;
 
 			case 10:
 				{
-				State = 549; typeStmt();
+				State = 573; publicTypeDeclaration();
+				}
+				break;
+
+			case 11:
+				{
+				State = 574; privateTypeDeclaration();
 				}
 				break;
 			}
@@ -1342,27 +1357,27 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 553;
+			State = 578;
 			switch ( Interpreter.AdaptivePredict(_input,21,_ctx) ) {
 			case 1:
 				{
-				State = 552; whiteSpace();
+				State = 577; whiteSpace();
 				}
 				break;
 			}
-			State = 560;
+			State = 585;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,22,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 555; moduleBodyElement();
-					State = 556; endOfStatement();
+					State = 580; moduleBodyElement();
+					State = 581; endOfStatement();
 					}
 					} 
 				}
-				State = 562;
+				State = 587;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,22,_ctx);
 			}
@@ -1420,40 +1435,40 @@ public partial class VBAParser : Parser {
 		ModuleBodyElementContext _localctx = new ModuleBodyElementContext(_ctx, State);
 		EnterRule(_localctx, 26, RULE_moduleBodyElement);
 		try {
-			State = 568;
+			State = 593;
 			switch ( Interpreter.AdaptivePredict(_input,23,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 563; functionStmt();
+				State = 588; functionStmt();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 564; propertyGetStmt();
+				State = 589; propertyGetStmt();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 565; propertySetStmt();
+				State = 590; propertySetStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 566; propertyLetStmt();
+				State = 591; propertyLetStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 567; subStmt();
+				State = 592; subStmt();
 				}
 				break;
 			}
@@ -1510,19 +1525,19 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 575;
+			State = 600;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,24,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 570; blockStmt();
-					State = 571; endOfStatement();
+					State = 595; blockStmt();
+					State = 596; endOfStatement();
 					}
 					} 
 				}
-				State = 577;
+				State = 602;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,24,_ctx);
 			}
@@ -1670,250 +1685,250 @@ public partial class VBAParser : Parser {
 		BlockStmtContext _localctx = new BlockStmtContext(_ctx, State);
 		EnterRule(_localctx, 30, RULE_blockStmt);
 		try {
-			State = 613;
+			State = 638;
 			switch ( Interpreter.AdaptivePredict(_input,25,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 578; statementLabelDefinition();
+				State = 603; statementLabelDefinition();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 579; fileStmt();
+				State = 604; fileStmt();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 580; attributeStmt();
+				State = 605; attributeStmt();
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 581; constStmt();
+				State = 606; constStmt();
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 582; doLoopStmt();
+				State = 607; doLoopStmt();
 				}
 				break;
 
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 583; endStmt();
+				State = 608; endStmt();
 				}
 				break;
 
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 584; eraseStmt();
+				State = 609; eraseStmt();
 				}
 				break;
 
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 585; errorStmt();
+				State = 610; errorStmt();
 				}
 				break;
 
 			case 9:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 586; exitStmt();
+				State = 611; exitStmt();
 				}
 				break;
 
 			case 10:
 				EnterOuterAlt(_localctx, 10);
 				{
-				State = 587; forEachStmt();
+				State = 612; forEachStmt();
 				}
 				break;
 
 			case 11:
 				EnterOuterAlt(_localctx, 11);
 				{
-				State = 588; forNextStmt();
+				State = 613; forNextStmt();
 				}
 				break;
 
 			case 12:
 				EnterOuterAlt(_localctx, 12);
 				{
-				State = 589; goSubStmt();
+				State = 614; goSubStmt();
 				}
 				break;
 
 			case 13:
 				EnterOuterAlt(_localctx, 13);
 				{
-				State = 590; goToStmt();
+				State = 615; goToStmt();
 				}
 				break;
 
 			case 14:
 				EnterOuterAlt(_localctx, 14);
 				{
-				State = 591; ifStmt();
+				State = 616; ifStmt();
 				}
 				break;
 
 			case 15:
 				EnterOuterAlt(_localctx, 15);
 				{
-				State = 592; singleLineIfStmt();
+				State = 617; singleLineIfStmt();
 				}
 				break;
 
 			case 16:
 				EnterOuterAlt(_localctx, 16);
 				{
-				State = 593; implementsStmt();
+				State = 618; implementsStmt();
 				}
 				break;
 
 			case 17:
 				EnterOuterAlt(_localctx, 17);
 				{
-				State = 594; letStmt();
+				State = 619; letStmt();
 				}
 				break;
 
 			case 18:
 				EnterOuterAlt(_localctx, 18);
 				{
-				State = 595; lsetStmt();
+				State = 620; lsetStmt();
 				}
 				break;
 
 			case 19:
 				EnterOuterAlt(_localctx, 19);
 				{
-				State = 596; onErrorStmt();
+				State = 621; onErrorStmt();
 				}
 				break;
 
 			case 20:
 				EnterOuterAlt(_localctx, 20);
 				{
-				State = 597; onGoToStmt();
+				State = 622; onGoToStmt();
 				}
 				break;
 
 			case 21:
 				EnterOuterAlt(_localctx, 21);
 				{
-				State = 598; onGoSubStmt();
+				State = 623; onGoSubStmt();
 				}
 				break;
 
 			case 22:
 				EnterOuterAlt(_localctx, 22);
 				{
-				State = 599; raiseEventStmt();
+				State = 624; raiseEventStmt();
 				}
 				break;
 
 			case 23:
 				EnterOuterAlt(_localctx, 23);
 				{
-				State = 600; redimStmt();
+				State = 625; redimStmt();
 				}
 				break;
 
 			case 24:
 				EnterOuterAlt(_localctx, 24);
 				{
-				State = 601; resumeStmt();
+				State = 626; resumeStmt();
 				}
 				break;
 
 			case 25:
 				EnterOuterAlt(_localctx, 25);
 				{
-				State = 602; returnStmt();
+				State = 627; returnStmt();
 				}
 				break;
 
 			case 26:
 				EnterOuterAlt(_localctx, 26);
 				{
-				State = 603; rsetStmt();
+				State = 628; rsetStmt();
 				}
 				break;
 
 			case 27:
 				EnterOuterAlt(_localctx, 27);
 				{
-				State = 604; selectCaseStmt();
+				State = 629; selectCaseStmt();
 				}
 				break;
 
 			case 28:
 				EnterOuterAlt(_localctx, 28);
 				{
-				State = 605; setStmt();
+				State = 630; setStmt();
 				}
 				break;
 
 			case 29:
 				EnterOuterAlt(_localctx, 29);
 				{
-				State = 606; stopStmt();
+				State = 631; stopStmt();
 				}
 				break;
 
 			case 30:
 				EnterOuterAlt(_localctx, 30);
 				{
-				State = 607; variableStmt();
+				State = 632; variableStmt();
 				}
 				break;
 
 			case 31:
 				EnterOuterAlt(_localctx, 31);
 				{
-				State = 608; whileWendStmt();
+				State = 633; whileWendStmt();
 				}
 				break;
 
 			case 32:
 				EnterOuterAlt(_localctx, 32);
 				{
-				State = 609; withStmt();
+				State = 634; withStmt();
 				}
 				break;
 
 			case 33:
 				EnterOuterAlt(_localctx, 33);
 				{
-				State = 610; circleSpecialForm();
+				State = 635; circleSpecialForm();
 				}
 				break;
 
 			case 34:
 				EnterOuterAlt(_localctx, 34);
 				{
-				State = 611; scaleSpecialForm();
+				State = 636; scaleSpecialForm();
 				}
 				break;
 
 			case 35:
 				EnterOuterAlt(_localctx, 35);
 				{
-				State = 612; callStmt();
+				State = 637; callStmt();
 				}
 				break;
 			}
@@ -1997,90 +2012,90 @@ public partial class VBAParser : Parser {
 		FileStmtContext _localctx = new FileStmtContext(_ctx, State);
 		EnterRule(_localctx, 32, RULE_fileStmt);
 		try {
-			State = 629;
+			State = 654;
 			switch (_input.La(1)) {
 			case OPEN:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 615; openStmt();
+				State = 640; openStmt();
 				}
 				break;
 			case RESET:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 616; resetStmt();
+				State = 641; resetStmt();
 				}
 				break;
 			case CLOSE:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 617; closeStmt();
+				State = 642; closeStmt();
 				}
 				break;
 			case SEEK:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 618; seekStmt();
+				State = 643; seekStmt();
 				}
 				break;
 			case LOCK:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 619; lockStmt();
+				State = 644; lockStmt();
 				}
 				break;
 			case UNLOCK:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 620; unlockStmt();
+				State = 645; unlockStmt();
 				}
 				break;
 			case LINE_INPUT:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 621; lineInputStmt();
+				State = 646; lineInputStmt();
 				}
 				break;
 			case WIDTH:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 622; widthStmt();
+				State = 647; widthStmt();
 				}
 				break;
 			case DEBUG:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 623; debugPrintStmt();
+				State = 648; debugPrintStmt();
 				}
 				break;
 			case PRINT:
 				EnterOuterAlt(_localctx, 10);
 				{
-				State = 624; printStmt();
+				State = 649; printStmt();
 				}
 				break;
 			case WRITE:
 				EnterOuterAlt(_localctx, 11);
 				{
-				State = 625; writeStmt();
+				State = 650; writeStmt();
 				}
 				break;
 			case INPUT:
 				EnterOuterAlt(_localctx, 12);
 				{
-				State = 626; inputStmt();
+				State = 651; inputStmt();
 				}
 				break;
 			case PUT:
 				EnterOuterAlt(_localctx, 13);
 				{
-				State = 627; putStmt();
+				State = 652; putStmt();
 				}
 				break;
 			case GET:
 				EnterOuterAlt(_localctx, 14);
 				{
-				State = 628; getStmt();
+				State = 653; getStmt();
 				}
 				break;
 			default:
@@ -2152,46 +2167,46 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 631; Match(OPEN);
-			State = 632; whiteSpace();
-			State = 633; pathName();
-			State = 637;
+			State = 656; Match(OPEN);
+			State = 657; whiteSpace();
+			State = 658; pathName();
+			State = 662;
 			switch ( Interpreter.AdaptivePredict(_input,27,_ctx) ) {
 			case 1:
 				{
-				State = 634; whiteSpace();
-				State = 635; modeClause();
+				State = 659; whiteSpace();
+				State = 660; modeClause();
 				}
 				break;
 			}
-			State = 642;
+			State = 667;
 			switch ( Interpreter.AdaptivePredict(_input,28,_ctx) ) {
 			case 1:
 				{
-				State = 639; whiteSpace();
-				State = 640; accessClause();
+				State = 664; whiteSpace();
+				State = 665; accessClause();
 				}
 				break;
 			}
-			State = 647;
+			State = 672;
 			switch ( Interpreter.AdaptivePredict(_input,29,_ctx) ) {
 			case 1:
 				{
-				State = 644; whiteSpace();
-				State = 645; @lock();
+				State = 669; whiteSpace();
+				State = 670; @lock();
 				}
 				break;
 			}
-			State = 649; whiteSpace();
-			State = 650; Match(AS);
-			State = 651; whiteSpace();
-			State = 652; fileNumber();
-			State = 656;
+			State = 674; whiteSpace();
+			State = 675; Match(AS);
+			State = 676; whiteSpace();
+			State = 677; fileNumber();
+			State = 681;
 			switch ( Interpreter.AdaptivePredict(_input,30,_ctx) ) {
 			case 1:
 				{
-				State = 653; whiteSpace();
-				State = 654; lenClause();
+				State = 678; whiteSpace();
+				State = 679; lenClause();
 				}
 				break;
 			}
@@ -2239,7 +2254,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 658; expression(0);
+			State = 683; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2288,9 +2303,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 660; Match(FOR);
-			State = 661; whiteSpace();
-			State = 662; fileMode();
+			State = 685; Match(FOR);
+			State = 686; whiteSpace();
+			State = 687; fileMode();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2338,7 +2353,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 664;
+			State = 689;
 			_la = _input.La(1);
 			if ( !(_la==APPEND || _la==BINARY || ((((_la - 121)) & ~0x3f) == 0 && ((1L << (_la - 121)) & ((1L << (INPUT - 121)) | (1L << (OUTPUT - 121)) | (1L << (RANDOM - 121)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2392,9 +2407,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 666; Match(ACCESS);
-			State = 667; whiteSpace();
-			State = 668; access();
+			State = 691; Match(ACCESS);
+			State = 692; whiteSpace();
+			State = 693; access();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2440,7 +2455,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 670;
+			State = 695;
 			_la = _input.La(1);
 			if ( !(((((_la - 167)) & ~0x3f) == 0 && ((1L << (_la - 167)) & ((1L << (READ - 167)) | (1L << (READ_WRITE - 167)) | (1L << (WRITE - 167)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2492,7 +2507,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 672;
+			State = 697;
 			_la = _input.La(1);
 			if ( !(((((_la - 131)) & ~0x3f) == 0 && ((1L << (_la - 131)) & ((1L << (LOCK_READ - 131)) | (1L << (LOCK_WRITE - 131)) | (1L << (LOCK_READ_WRITE - 131)) | (1L << (SHARED - 131)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -2551,25 +2566,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 674; Match(LEN);
-			State = 676;
+			State = 699; Match(LEN);
+			State = 701;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 675; whiteSpace();
+				State = 700; whiteSpace();
 				}
 			}
 
-			State = 678; Match(EQ);
-			State = 680;
+			State = 703; Match(EQ);
+			State = 705;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 679; whiteSpace();
+				State = 704; whiteSpace();
 				}
 			}
 
-			State = 682; recLength();
+			State = 707; recLength();
 			}
 		}
 		catch (RecognitionException re) {
@@ -2614,7 +2629,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 684; expression(0);
+			State = 709; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2660,19 +2675,19 @@ public partial class VBAParser : Parser {
 		FileNumberContext _localctx = new FileNumberContext(_ctx, State);
 		EnterRule(_localctx, 52, RULE_fileNumber);
 		try {
-			State = 688;
+			State = 713;
 			switch ( Interpreter.AdaptivePredict(_input,33,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 686; markedFileNumber();
+				State = 711; markedFileNumber();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 687; unmarkedFileNumber();
+				State = 712; unmarkedFileNumber();
 				}
 				break;
 			}
@@ -2720,8 +2735,8 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 690; Match(HASH);
-			State = 691; expression(0);
+			State = 715; Match(HASH);
+			State = 716; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2766,7 +2781,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 693; expression(0);
+			State = 718; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2815,13 +2830,13 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 695; Match(CLOSE);
-			State = 699;
+			State = 720; Match(CLOSE);
+			State = 724;
 			switch ( Interpreter.AdaptivePredict(_input,34,_ctx) ) {
 			case 1:
 				{
-				State = 696; whiteSpace();
-				State = 697; fileNumberList();
+				State = 721; whiteSpace();
+				State = 722; fileNumberList();
 				}
 				break;
 			}
@@ -2867,7 +2882,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 701; Match(RESET);
+			State = 726; Match(RESET);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2927,36 +2942,36 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 703; fileNumber();
-			State = 714;
+			State = 728; fileNumber();
+			State = 739;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,37,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 705;
+					State = 730;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 704; whiteSpace();
+						State = 729; whiteSpace();
 						}
 					}
 
-					State = 707; Match(COMMA);
-					State = 709;
+					State = 732; Match(COMMA);
+					State = 734;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 708; whiteSpace();
+						State = 733; whiteSpace();
 						}
 					}
 
-					State = 711; fileNumber();
+					State = 736; fileNumber();
 					}
 					} 
 				}
-				State = 716;
+				State = 741;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,37,_ctx);
 			}
@@ -3016,27 +3031,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 717; Match(SEEK);
-			State = 718; whiteSpace();
-			State = 719; fileNumber();
-			State = 721;
+			State = 742; Match(SEEK);
+			State = 743; whiteSpace();
+			State = 744; fileNumber();
+			State = 746;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 720; whiteSpace();
+				State = 745; whiteSpace();
 				}
 			}
 
-			State = 723; Match(COMMA);
-			State = 725;
+			State = 748; Match(COMMA);
+			State = 750;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 724; whiteSpace();
+				State = 749; whiteSpace();
 				}
 			}
 
-			State = 727; position();
+			State = 752; position();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3081,7 +3096,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 729; expression(0);
+			State = 754; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3138,31 +3153,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 731; Match(LOCK);
-			State = 732; whiteSpace();
-			State = 733; fileNumber();
-			State = 742;
+			State = 756; Match(LOCK);
+			State = 757; whiteSpace();
+			State = 758; fileNumber();
+			State = 767;
 			switch ( Interpreter.AdaptivePredict(_input,42,_ctx) ) {
 			case 1:
 				{
-				State = 735;
+				State = 760;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 734; whiteSpace();
+					State = 759; whiteSpace();
 					}
 				}
 
-				State = 737; Match(COMMA);
-				State = 739;
+				State = 762; Match(COMMA);
+				State = 764;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 738; whiteSpace();
+					State = 763; whiteSpace();
 					}
 				}
 
-				State = 741; recordRange();
+				State = 766; recordRange();
 				}
 				break;
 			}
@@ -3218,30 +3233,30 @@ public partial class VBAParser : Parser {
 		RecordRangeContext _localctx = new RecordRangeContext(_ctx, State);
 		EnterRule(_localctx, 70, RULE_recordRange);
 		try {
-			State = 754;
+			State = 779;
 			switch ( Interpreter.AdaptivePredict(_input,44,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 744; startRecordNumber();
+				State = 769; startRecordNumber();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 748;
+				State = 773;
 				switch ( Interpreter.AdaptivePredict(_input,43,_ctx) ) {
 				case 1:
 					{
-					State = 745; startRecordNumber();
-					State = 746; whiteSpace();
+					State = 770; startRecordNumber();
+					State = 771; whiteSpace();
 					}
 					break;
 				}
-				State = 750; Match(TO);
-				State = 751; whiteSpace();
-				State = 752; endRecordNumber();
+				State = 775; Match(TO);
+				State = 776; whiteSpace();
+				State = 777; endRecordNumber();
 				}
 				break;
 			}
@@ -3288,7 +3303,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 756; expression(0);
+			State = 781; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3333,7 +3348,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 758; expression(0);
+			State = 783; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3390,31 +3405,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 760; Match(UNLOCK);
-			State = 761; whiteSpace();
-			State = 762; fileNumber();
-			State = 771;
+			State = 785; Match(UNLOCK);
+			State = 786; whiteSpace();
+			State = 787; fileNumber();
+			State = 796;
 			switch ( Interpreter.AdaptivePredict(_input,47,_ctx) ) {
 			case 1:
 				{
-				State = 764;
+				State = 789;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 763; whiteSpace();
+					State = 788; whiteSpace();
 					}
 				}
 
-				State = 766; Match(COMMA);
-				State = 768;
+				State = 791; Match(COMMA);
+				State = 793;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 767; whiteSpace();
+					State = 792; whiteSpace();
 					}
 				}
 
-				State = 770; recordRange();
+				State = 795; recordRange();
 				}
 				break;
 			}
@@ -3474,27 +3489,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 773; Match(LINE_INPUT);
-			State = 774; whiteSpace();
-			State = 775; markedFileNumber();
-			State = 777;
+			State = 798; Match(LINE_INPUT);
+			State = 799; whiteSpace();
+			State = 800; markedFileNumber();
+			State = 802;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 776; whiteSpace();
+				State = 801; whiteSpace();
 				}
 			}
 
-			State = 779; Match(COMMA);
-			State = 781;
+			State = 804; Match(COMMA);
+			State = 806;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 780; whiteSpace();
+				State = 805; whiteSpace();
 				}
 			}
 
-			State = 783; variableName();
+			State = 808; variableName();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3539,7 +3554,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 785; expression(0);
+			State = 810; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3596,27 +3611,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 787; Match(WIDTH);
-			State = 788; whiteSpace();
-			State = 789; markedFileNumber();
-			State = 791;
+			State = 812; Match(WIDTH);
+			State = 813; whiteSpace();
+			State = 814; markedFileNumber();
+			State = 816;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 790; whiteSpace();
+				State = 815; whiteSpace();
 				}
 			}
 
-			State = 793; Match(COMMA);
-			State = 795;
+			State = 818; Match(COMMA);
+			State = 820;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 794; whiteSpace();
+				State = 819; whiteSpace();
 				}
 			}
 
-			State = 797; lineWidth();
+			State = 822; lineWidth();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3661,7 +3676,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 799; expression(0);
+			State = 824; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3712,13 +3727,13 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 801; debugPrint();
-			State = 805;
+			State = 826; debugPrint();
+			State = 830;
 			switch ( Interpreter.AdaptivePredict(_input,52,_ctx) ) {
 			case 1:
 				{
-				State = 802; whiteSpace();
-				State = 803; outputList();
+				State = 827; whiteSpace();
+				State = 828; outputList();
 				}
 				break;
 			}
@@ -3777,25 +3792,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 807; debugModule();
-			State = 809;
+			State = 832; debugModule();
+			State = 834;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 808; whiteSpace();
+				State = 833; whiteSpace();
 				}
 			}
 
-			State = 811; Match(DOT);
-			State = 813;
+			State = 836; Match(DOT);
+			State = 838;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 812; whiteSpace();
+				State = 837; whiteSpace();
 				}
 			}
 
-			State = 815; debugPrintSub();
+			State = 840; debugPrintSub();
 			}
 		}
 		catch (RecognitionException re) {
@@ -3838,7 +3853,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 817; Match(DEBUG);
+			State = 842; Match(DEBUG);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3881,7 +3896,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 819; Match(PRINT);
+			State = 844; Match(PRINT);
 			}
 		}
 		catch (RecognitionException re) {
@@ -3938,31 +3953,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 821; Match(PRINT);
-			State = 822; whiteSpace();
-			State = 823; markedFileNumber();
-			State = 825;
+			State = 846; Match(PRINT);
+			State = 847; whiteSpace();
+			State = 848; markedFileNumber();
+			State = 850;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 824; whiteSpace();
+				State = 849; whiteSpace();
 				}
 			}
 
-			State = 827; Match(COMMA);
-			State = 832;
+			State = 852; Match(COMMA);
+			State = 857;
 			switch ( Interpreter.AdaptivePredict(_input,57,_ctx) ) {
 			case 1:
 				{
-				State = 829;
+				State = 854;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 828; whiteSpace();
+					State = 853; whiteSpace();
 					}
 				}
 
-				State = 831; outputList();
+				State = 856; outputList();
 				}
 				break;
 			}
@@ -4021,27 +4036,27 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 834; outputItem();
-			State = 841;
+			State = 859; outputItem();
+			State = 866;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,59,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 836;
+					State = 861;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 835; whiteSpace();
+						State = 860; whiteSpace();
 						}
 					}
 
-					State = 838; outputItem();
+					State = 863; outputItem();
 					}
 					} 
 				}
-				State = 843;
+				State = 868;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,59,_ctx);
 			}
@@ -4094,35 +4109,35 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 98, RULE_outputItem);
 		int _la;
 		try {
-			State = 852;
+			State = 877;
 			switch ( Interpreter.AdaptivePredict(_input,61,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 844; outputClause();
+				State = 869; outputClause();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 845; charPosition();
+				State = 870; charPosition();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 846; outputClause();
-				State = 848;
+				State = 871; outputClause();
+				State = 873;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 847; whiteSpace();
+					State = 872; whiteSpace();
 					}
 				}
 
-				State = 850; charPosition();
+				State = 875; charPosition();
 				}
 				break;
 			}
@@ -4173,26 +4188,26 @@ public partial class VBAParser : Parser {
 		OutputClauseContext _localctx = new OutputClauseContext(_ctx, State);
 		EnterRule(_localctx, 100, RULE_outputClause);
 		try {
-			State = 857;
+			State = 882;
 			switch ( Interpreter.AdaptivePredict(_input,62,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 854; spcClause();
+				State = 879; spcClause();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 855; tabClause();
+				State = 880; tabClause();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 856; outputExpression();
+				State = 881; outputExpression();
 				}
 				break;
 			}
@@ -4239,7 +4254,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 859;
+			State = 884;
 			_la = _input.La(1);
 			if ( !(_la==COMMA || _la==SEMICOLON) ) {
 			_errHandler.RecoverInline(this);
@@ -4289,7 +4304,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 861; expression(0);
+			State = 886; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4344,34 +4359,34 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 863; Match(SPC);
-			State = 865;
+			State = 888; Match(SPC);
+			State = 890;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 864; whiteSpace();
+				State = 889; whiteSpace();
 				}
 			}
 
-			State = 867; Match(LPAREN);
-			State = 869;
+			State = 892; Match(LPAREN);
+			State = 894;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 868; whiteSpace();
+				State = 893; whiteSpace();
 				}
 			}
 
-			State = 871; spcNumber();
-			State = 873;
+			State = 896; spcNumber();
+			State = 898;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 872; whiteSpace();
+				State = 897; whiteSpace();
 				}
 			}
 
-			State = 875; Match(RPAREN);
+			State = 900; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4416,7 +4431,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 877; expression(0);
+			State = 902; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4466,20 +4481,20 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 879; Match(TAB);
-			State = 884;
+			State = 904; Match(TAB);
+			State = 909;
 			switch ( Interpreter.AdaptivePredict(_input,67,_ctx) ) {
 			case 1:
 				{
-				State = 881;
+				State = 906;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 880; whiteSpace();
+					State = 905; whiteSpace();
 					}
 				}
 
-				State = 883; tabNumberClause();
+				State = 908; tabNumberClause();
 				}
 				break;
 			}
@@ -4536,25 +4551,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 886; Match(LPAREN);
-			State = 888;
+			State = 911; Match(LPAREN);
+			State = 913;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 887; whiteSpace();
+				State = 912; whiteSpace();
 				}
 			}
 
-			State = 890; tabNumber();
-			State = 892;
+			State = 915; tabNumber();
+			State = 917;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 891; whiteSpace();
+				State = 916; whiteSpace();
 				}
 			}
 
-			State = 894; Match(RPAREN);
+			State = 919; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4599,7 +4614,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 896; expression(0);
+			State = 921; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4656,31 +4671,31 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 898; Match(WRITE);
-			State = 899; whiteSpace();
-			State = 900; markedFileNumber();
-			State = 902;
+			State = 923; Match(WRITE);
+			State = 924; whiteSpace();
+			State = 925; markedFileNumber();
+			State = 927;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 901; whiteSpace();
+				State = 926; whiteSpace();
 				}
 			}
 
-			State = 904; Match(COMMA);
-			State = 909;
+			State = 929; Match(COMMA);
+			State = 934;
 			switch ( Interpreter.AdaptivePredict(_input,72,_ctx) ) {
 			case 1:
 				{
-				State = 906;
+				State = 931;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 905; whiteSpace();
+					State = 930; whiteSpace();
 					}
 				}
 
-				State = 908; outputList();
+				State = 933; outputList();
 				}
 				break;
 			}
@@ -4740,27 +4755,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 911; Match(INPUT);
-			State = 912; whiteSpace();
-			State = 913; markedFileNumber();
-			State = 915;
+			State = 936; Match(INPUT);
+			State = 937; whiteSpace();
+			State = 938; markedFileNumber();
+			State = 940;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 914; whiteSpace();
+				State = 939; whiteSpace();
 				}
 			}
 
-			State = 917; Match(COMMA);
-			State = 919;
+			State = 942; Match(COMMA);
+			State = 944;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 918; whiteSpace();
+				State = 943; whiteSpace();
 				}
 			}
 
-			State = 921; inputList();
+			State = 946; inputList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -4820,36 +4835,36 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 923; inputVariable();
-			State = 934;
+			State = 948; inputVariable();
+			State = 959;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,77,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 925;
+					State = 950;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 924; whiteSpace();
+						State = 949; whiteSpace();
 						}
 					}
 
-					State = 927; Match(COMMA);
-					State = 929;
+					State = 952; Match(COMMA);
+					State = 954;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 928; whiteSpace();
+						State = 953; whiteSpace();
 						}
 					}
 
-					State = 931; inputVariable();
+					State = 956; inputVariable();
 					}
 					} 
 				}
-				State = 936;
+				State = 961;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,77,_ctx);
 			}
@@ -4897,7 +4912,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 937; expression(0);
+			State = 962; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -4960,52 +4975,52 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 939; Match(PUT);
-			State = 940; whiteSpace();
-			State = 941; fileNumber();
-			State = 943;
+			State = 964; Match(PUT);
+			State = 965; whiteSpace();
+			State = 966; fileNumber();
+			State = 968;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 942; whiteSpace();
+				State = 967; whiteSpace();
 				}
 			}
 
-			State = 945; Match(COMMA);
-			State = 947;
+			State = 970; Match(COMMA);
+			State = 972;
 			switch ( Interpreter.AdaptivePredict(_input,79,_ctx) ) {
 			case 1:
 				{
-				State = 946; whiteSpace();
+				State = 971; whiteSpace();
 				}
 				break;
 			}
-			State = 950;
+			State = 975;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 949; recordNumber();
+				State = 974; recordNumber();
 				}
 			}
 
-			State = 953;
+			State = 978;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 952; whiteSpace();
+				State = 977; whiteSpace();
 				}
 			}
 
-			State = 955; Match(COMMA);
-			State = 957;
+			State = 980; Match(COMMA);
+			State = 982;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 956; whiteSpace();
+				State = 981; whiteSpace();
 				}
 			}
 
-			State = 959; data();
+			State = 984; data();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5050,7 +5065,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 961; expression(0);
+			State = 986; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5095,7 +5110,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 963; expression(0);
+			State = 988; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5158,52 +5173,52 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 965; Match(GET);
-			State = 966; whiteSpace();
-			State = 967; fileNumber();
-			State = 969;
+			State = 990; Match(GET);
+			State = 991; whiteSpace();
+			State = 992; fileNumber();
+			State = 994;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 968; whiteSpace();
+				State = 993; whiteSpace();
 				}
 			}
 
-			State = 971; Match(COMMA);
-			State = 973;
+			State = 996; Match(COMMA);
+			State = 998;
 			switch ( Interpreter.AdaptivePredict(_input,84,_ctx) ) {
 			case 1:
 				{
-				State = 972; whiteSpace();
+				State = 997; whiteSpace();
 				}
 				break;
 			}
-			State = 976;
+			State = 1001;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 975; recordNumber();
+				State = 1000; recordNumber();
 				}
 			}
 
-			State = 979;
+			State = 1004;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 978; whiteSpace();
+				State = 1003; whiteSpace();
 				}
 			}
 
-			State = 981; Match(COMMA);
-			State = 983;
+			State = 1006; Match(COMMA);
+			State = 1008;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 982; whiteSpace();
+				State = 1007; whiteSpace();
 				}
 			}
 
-			State = 985; variable();
+			State = 1010; variable();
 			}
 		}
 		catch (RecognitionException re) {
@@ -5248,7 +5263,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 987; expression(0);
+			State = 1012; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5312,47 +5327,47 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 992;
+			State = 1017;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 989; visibility();
-				State = 990; whiteSpace();
+				State = 1014; visibility();
+				State = 1015; whiteSpace();
 				}
 			}
 
-			State = 994; Match(CONST);
-			State = 995; whiteSpace();
-			State = 996; constSubStmt();
-			State = 1007;
+			State = 1019; Match(CONST);
+			State = 1020; whiteSpace();
+			State = 1021; constSubStmt();
+			State = 1032;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,91,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 998;
+					State = 1023;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 997; whiteSpace();
+						State = 1022; whiteSpace();
 						}
 					}
 
-					State = 1000; Match(COMMA);
-					State = 1002;
+					State = 1025; Match(COMMA);
+					State = 1027;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1001; whiteSpace();
+						State = 1026; whiteSpace();
 						}
 					}
 
-					State = 1004; constSubStmt();
+					State = 1029; constSubStmt();
 					}
 					} 
 				}
-				State = 1009;
+				State = 1034;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,91,_ctx);
 			}
@@ -5414,34 +5429,34 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1010; identifier();
-			State = 1014;
+			State = 1035; identifier();
+			State = 1039;
 			switch ( Interpreter.AdaptivePredict(_input,92,_ctx) ) {
 			case 1:
 				{
-				State = 1011; whiteSpace();
-				State = 1012; asTypeClause();
+				State = 1036; whiteSpace();
+				State = 1037; asTypeClause();
 				}
 				break;
 			}
-			State = 1017;
+			State = 1042;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1016; whiteSpace();
+				State = 1041; whiteSpace();
 				}
 			}
 
-			State = 1019; Match(EQ);
-			State = 1021;
+			State = 1044; Match(EQ);
+			State = 1046;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1020; whiteSpace();
+				State = 1045; whiteSpace();
 				}
 			}
 
-			State = 1023; expression(0);
+			State = 1048; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5512,71 +5527,71 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1028;
+			State = 1053;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1025; visibility();
-				State = 1026; whiteSpace();
+				State = 1050; visibility();
+				State = 1051; whiteSpace();
 				}
 			}
 
-			State = 1030; Match(DECLARE);
-			State = 1031; whiteSpace();
-			State = 1034;
+			State = 1055; Match(DECLARE);
+			State = 1056; whiteSpace();
+			State = 1059;
 			_la = _input.La(1);
 			if (_la==PTRSAFE) {
 				{
-				State = 1032; Match(PTRSAFE);
-				State = 1033; whiteSpace();
+				State = 1057; Match(PTRSAFE);
+				State = 1058; whiteSpace();
 				}
 			}
 
-			State = 1036;
+			State = 1061;
 			_la = _input.La(1);
 			if ( !(_la==FUNCTION || _la==SUB) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 1037; whiteSpace();
-			State = 1038; identifier();
-			State = 1039; whiteSpace();
-			State = 1040; Match(LIB);
-			State = 1041; whiteSpace();
-			State = 1042; Match(STRINGLITERAL);
-			State = 1048;
+			State = 1062; whiteSpace();
+			State = 1063; identifier();
+			State = 1064; whiteSpace();
+			State = 1065; Match(LIB);
+			State = 1066; whiteSpace();
+			State = 1067; Match(STRINGLITERAL);
+			State = 1073;
 			switch ( Interpreter.AdaptivePredict(_input,97,_ctx) ) {
 			case 1:
 				{
-				State = 1043; whiteSpace();
-				State = 1044; Match(ALIAS);
-				State = 1045; whiteSpace();
-				State = 1046; Match(STRINGLITERAL);
+				State = 1068; whiteSpace();
+				State = 1069; Match(ALIAS);
+				State = 1070; whiteSpace();
+				State = 1071; Match(STRINGLITERAL);
 				}
 				break;
 			}
-			State = 1054;
+			State = 1079;
 			switch ( Interpreter.AdaptivePredict(_input,99,_ctx) ) {
 			case 1:
 				{
-				State = 1051;
+				State = 1076;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1050; whiteSpace();
+					State = 1075; whiteSpace();
 					}
 				}
 
-				State = 1053; argList();
+				State = 1078; argList();
 				}
 				break;
 			}
-			State = 1059;
+			State = 1084;
 			switch ( Interpreter.AdaptivePredict(_input,100,_ctx) ) {
 			case 1:
 				{
-				State = 1056; whiteSpace();
-				State = 1057; asTypeClause();
+				State = 1081; whiteSpace();
+				State = 1082; asTypeClause();
 				}
 				break;
 			}
@@ -5641,64 +5656,64 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1061; Match(LPAREN);
-			State = 1079;
+			State = 1086; Match(LPAREN);
+			State = 1104;
 			switch ( Interpreter.AdaptivePredict(_input,105,_ctx) ) {
 			case 1:
 				{
-				State = 1063;
+				State = 1088;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1062; whiteSpace();
+					State = 1087; whiteSpace();
 					}
 				}
 
-				State = 1065; arg();
-				State = 1076;
+				State = 1090; arg();
+				State = 1101;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,104,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1067;
+						State = 1092;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1066; whiteSpace();
+							State = 1091; whiteSpace();
 							}
 						}
 
-						State = 1069; Match(COMMA);
-						State = 1071;
+						State = 1094; Match(COMMA);
+						State = 1096;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1070; whiteSpace();
+							State = 1095; whiteSpace();
 							}
 						}
 
-						State = 1073; arg();
+						State = 1098; arg();
 						}
 						} 
 					}
-					State = 1078;
+					State = 1103;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,104,_ctx);
 				}
 				}
 				break;
 			}
-			State = 1082;
+			State = 1107;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1081; whiteSpace();
+				State = 1106; whiteSpace();
 				}
 			}
 
-			State = 1084; Match(RPAREN);
+			State = 1109; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5762,93 +5777,93 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1088;
+			State = 1113;
 			switch ( Interpreter.AdaptivePredict(_input,107,_ctx) ) {
 			case 1:
 				{
-				State = 1086; Match(OPTIONAL);
-				State = 1087; whiteSpace();
+				State = 1111; Match(OPTIONAL);
+				State = 1112; whiteSpace();
 				}
 				break;
 			}
-			State = 1092;
+			State = 1117;
 			switch ( Interpreter.AdaptivePredict(_input,108,_ctx) ) {
 			case 1:
 				{
-				State = 1090;
+				State = 1115;
 				_la = _input.La(1);
 				if ( !(_la==BYVAL || _la==BYREF) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 1091; whiteSpace();
+				State = 1116; whiteSpace();
 				}
 				break;
 			}
-			State = 1096;
+			State = 1121;
 			switch ( Interpreter.AdaptivePredict(_input,109,_ctx) ) {
 			case 1:
 				{
-				State = 1094; Match(PARAMARRAY);
-				State = 1095; whiteSpace();
+				State = 1119; Match(PARAMARRAY);
+				State = 1120; whiteSpace();
 				}
 				break;
 			}
-			State = 1098; unrestrictedIdentifier();
-			State = 1107;
+			State = 1123; unrestrictedIdentifier();
+			State = 1132;
 			switch ( Interpreter.AdaptivePredict(_input,112,_ctx) ) {
 			case 1:
 				{
-				State = 1100;
+				State = 1125;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1099; whiteSpace();
+					State = 1124; whiteSpace();
 					}
 				}
 
-				State = 1102; Match(LPAREN);
-				State = 1104;
+				State = 1127; Match(LPAREN);
+				State = 1129;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1103; whiteSpace();
+					State = 1128; whiteSpace();
 					}
 				}
 
-				State = 1106; Match(RPAREN);
+				State = 1131; Match(RPAREN);
 				}
 				break;
 			}
-			State = 1113;
+			State = 1138;
 			switch ( Interpreter.AdaptivePredict(_input,114,_ctx) ) {
 			case 1:
 				{
-				State = 1110;
+				State = 1135;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1109; whiteSpace();
+					State = 1134; whiteSpace();
 					}
 				}
 
-				State = 1112; asTypeClause();
+				State = 1137; asTypeClause();
 				}
 				break;
 			}
-			State = 1119;
+			State = 1144;
 			switch ( Interpreter.AdaptivePredict(_input,116,_ctx) ) {
 			case 1:
 				{
-				State = 1116;
+				State = 1141;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1115; whiteSpace();
+					State = 1140; whiteSpace();
 					}
 				}
 
-				State = 1118; argDefaultValue();
+				State = 1143; argDefaultValue();
 				}
 				break;
 			}
@@ -5901,16 +5916,16 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1121; Match(EQ);
-			State = 1123;
+			State = 1146; Match(EQ);
+			State = 1148;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1122; whiteSpace();
+				State = 1147; whiteSpace();
 				}
 			}
 
-			State = 1125; expression(0);
+			State = 1150; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -5973,38 +5988,38 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1127; defType();
-			State = 1128; whiteSpace();
-			State = 1129; letterSpec();
-			State = 1140;
+			State = 1152; defType();
+			State = 1153; whiteSpace();
+			State = 1154; letterSpec();
+			State = 1165;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,120,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1131;
+					State = 1156;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1130; whiteSpace();
+						State = 1155; whiteSpace();
 						}
 					}
 
-					State = 1133; Match(COMMA);
-					State = 1135;
+					State = 1158; Match(COMMA);
+					State = 1160;
 					switch ( Interpreter.AdaptivePredict(_input,119,_ctx) ) {
 					case 1:
 						{
-						State = 1134; whiteSpace();
+						State = 1159; whiteSpace();
 						}
 						break;
 					}
-					State = 1137; letterSpec();
+					State = 1162; letterSpec();
 					}
 					} 
 				}
-				State = 1142;
+				State = 1167;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,120,_ctx);
 			}
@@ -6063,7 +6078,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1143;
+			State = 1168;
 			_la = _input.La(1);
 			if ( !(((((_la - 70)) & ~0x3f) == 0 && ((1L << (_la - 70)) & ((1L << (DEFBOOL - 70)) | (1L << (DEFBYTE - 70)) | (1L << (DEFDATE - 70)) | (1L << (DEFDBL - 70)) | (1L << (DEFCUR - 70)) | (1L << (DEFINT - 70)) | (1L << (DEFLNG - 70)) | (1L << (DEFLNGLNG - 70)) | (1L << (DEFLNGPTR - 70)) | (1L << (DEFOBJ - 70)) | (1L << (DEFSNG - 70)) | (1L << (DEFSTR - 70)) | (1L << (DEFVAR - 70)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -6117,26 +6132,26 @@ public partial class VBAParser : Parser {
 		LetterSpecContext _localctx = new LetterSpecContext(_ctx, State);
 		EnterRule(_localctx, 150, RULE_letterSpec);
 		try {
-			State = 1148;
+			State = 1173;
 			switch ( Interpreter.AdaptivePredict(_input,121,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1145; singleLetter();
+				State = 1170; singleLetter();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1146; universalLetterRange();
+				State = 1171; universalLetterRange();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1147; letterRange();
+				State = 1172; letterRange();
 				}
 				break;
 			}
@@ -6183,7 +6198,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1150; unrestrictedIdentifier();
+			State = 1175; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6239,25 +6254,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1152; upperCaseA();
-			State = 1154;
+			State = 1177; upperCaseA();
+			State = 1179;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1153; whiteSpace();
+				State = 1178; whiteSpace();
 				}
 			}
 
-			State = 1156; Match(MINUS);
-			State = 1158;
+			State = 1181; Match(MINUS);
+			State = 1183;
 			switch ( Interpreter.AdaptivePredict(_input,123,_ctx) ) {
 			case 1:
 				{
-				State = 1157; whiteSpace();
+				State = 1182; whiteSpace();
 				}
 				break;
 			}
-			State = 1160; upperCaseZ();
+			State = 1185; upperCaseZ();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6302,9 +6317,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1162;
+			State = 1187;
 			if (!(_input.Lt(1).Text.Equals("A"))) throw new FailedPredicateException(this, "_input.Lt(1).Text.Equals(\"A\")");
-			State = 1163; unrestrictedIdentifier();
+			State = 1188; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6349,9 +6364,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1165;
+			State = 1190;
 			if (!(_input.Lt(1).Text.Equals("Z"))) throw new FailedPredicateException(this, "_input.Lt(1).Text.Equals(\"Z\")");
-			State = 1166; unrestrictedIdentifier();
+			State = 1191; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6407,25 +6422,25 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1168; firstLetter();
-			State = 1170;
+			State = 1193; firstLetter();
+			State = 1195;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1169; whiteSpace();
+				State = 1194; whiteSpace();
 				}
 			}
 
-			State = 1172; Match(MINUS);
-			State = 1174;
+			State = 1197; Match(MINUS);
+			State = 1199;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1173; whiteSpace();
+				State = 1198; whiteSpace();
 				}
 			}
 
-			State = 1176; lastLetter();
+			State = 1201; lastLetter();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6470,7 +6485,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1178; unrestrictedIdentifier();
+			State = 1203; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6515,7 +6530,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1180; unrestrictedIdentifier();
+			State = 1205; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6575,53 +6590,53 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 166, RULE_doLoopStmt);
 		int _la;
 		try {
-			State = 1205;
+			State = 1230;
 			switch ( Interpreter.AdaptivePredict(_input,126,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1182; Match(DO);
-				State = 1183; endOfStatement();
-				State = 1184; block();
-				State = 1185; Match(LOOP);
+				State = 1207; Match(DO);
+				State = 1208; endOfStatement();
+				State = 1209; block();
+				State = 1210; Match(LOOP);
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1187; Match(DO);
-				State = 1188; whiteSpace();
-				State = 1189;
+				State = 1212; Match(DO);
+				State = 1213; whiteSpace();
+				State = 1214;
 				_la = _input.La(1);
 				if ( !(_la==UNTIL || _la==WHILE) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 1190; whiteSpace();
-				State = 1191; expression(0);
-				State = 1192; endOfStatement();
-				State = 1193; block();
-				State = 1194; Match(LOOP);
+				State = 1215; whiteSpace();
+				State = 1216; expression(0);
+				State = 1217; endOfStatement();
+				State = 1218; block();
+				State = 1219; Match(LOOP);
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1196; Match(DO);
-				State = 1197; endOfStatement();
-				State = 1198; block();
-				State = 1199; Match(LOOP);
-				State = 1200; whiteSpace();
-				State = 1201;
+				State = 1221; Match(DO);
+				State = 1222; endOfStatement();
+				State = 1223; block();
+				State = 1224; Match(LOOP);
+				State = 1225; whiteSpace();
+				State = 1226;
 				_la = _input.La(1);
 				if ( !(_la==UNTIL || _la==WHILE) ) {
 				_errHandler.RecoverInline(this);
 				}
 				Consume();
-				State = 1202; whiteSpace();
-				State = 1203; expression(0);
+				State = 1227; whiteSpace();
+				State = 1228; expression(0);
 				}
 				break;
 			}
@@ -6689,33 +6704,33 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1210;
+			State = 1235;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1207; visibility();
-				State = 1208; whiteSpace();
+				State = 1232; visibility();
+				State = 1233; whiteSpace();
 				}
 			}
 
-			State = 1212; Match(ENUM);
-			State = 1213; whiteSpace();
-			State = 1214; identifier();
-			State = 1215; endOfStatement();
-			State = 1219;
+			State = 1237; Match(ENUM);
+			State = 1238; whiteSpace();
+			State = 1239; identifier();
+			State = 1240; endOfStatement();
+			State = 1244;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
 				{
-				State = 1216; enumerationStmt_Constant();
+				State = 1241; enumerationStmt_Constant();
 				}
 				}
-				State = 1221;
+				State = 1246;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1222; Match(END_ENUM);
+			State = 1247; Match(END_ENUM);
 			}
 		}
 		catch (RecognitionException re) {
@@ -6774,33 +6789,33 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1224; identifier();
-			State = 1233;
+			State = 1249; identifier();
+			State = 1258;
 			switch ( Interpreter.AdaptivePredict(_input,131,_ctx) ) {
 			case 1:
 				{
-				State = 1226;
+				State = 1251;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1225; whiteSpace();
+					State = 1250; whiteSpace();
 					}
 				}
 
-				State = 1228; Match(EQ);
-				State = 1230;
+				State = 1253; Match(EQ);
+				State = 1255;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1229; whiteSpace();
+					State = 1254; whiteSpace();
 					}
 				}
 
-				State = 1232; expression(0);
+				State = 1257; expression(0);
 				}
 				break;
 			}
-			State = 1235; endOfStatement();
+			State = 1260; endOfStatement();
 			}
 		}
 		catch (RecognitionException re) {
@@ -6843,7 +6858,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1237; Match(END);
+			State = 1262; Match(END);
 			}
 		}
 		catch (RecognitionException re) {
@@ -6904,38 +6919,38 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1239; Match(ERASE);
-			State = 1240; whiteSpace();
-			State = 1241; expression(0);
-			State = 1252;
+			State = 1264; Match(ERASE);
+			State = 1265; whiteSpace();
+			State = 1266; expression(0);
+			State = 1277;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,134,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1243;
+					State = 1268;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1242; whiteSpace();
+						State = 1267; whiteSpace();
 						}
 					}
 
-					State = 1245; Match(COMMA);
-					State = 1247;
+					State = 1270; Match(COMMA);
+					State = 1272;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1246; whiteSpace();
+						State = 1271; whiteSpace();
 						}
 					}
 
-					State = 1249; expression(0);
+					State = 1274; expression(0);
 					}
 					} 
 				}
-				State = 1254;
+				State = 1279;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,134,_ctx);
 			}
@@ -6987,9 +7002,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1255; Match(ERROR);
-			State = 1256; whiteSpace();
-			State = 1257; expression(0);
+			State = 1280; Match(ERROR);
+			State = 1281; whiteSpace();
+			State = 1282; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7048,27 +7063,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1262;
+			State = 1287;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1259; visibility();
-				State = 1260; whiteSpace();
+				State = 1284; visibility();
+				State = 1285; whiteSpace();
 				}
 			}
 
-			State = 1264; Match(EVENT);
-			State = 1265; whiteSpace();
-			State = 1266; identifier();
-			State = 1268;
+			State = 1289; Match(EVENT);
+			State = 1290; whiteSpace();
+			State = 1291; identifier();
+			State = 1293;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1267; whiteSpace();
+				State = 1292; whiteSpace();
 				}
 			}
 
-			State = 1270; argList();
+			State = 1295; argList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -7116,7 +7131,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1272;
+			State = 1297;
 			_la = _input.La(1);
 			if ( !(((((_la - 104)) & ~0x3f) == 0 && ((1L << (_la - 104)) & ((1L << (EXIT_DO - 104)) | (1L << (EXIT_FOR - 104)) | (1L << (EXIT_FUNCTION - 104)) | (1L << (EXIT_PROPERTY - 104)) | (1L << (EXIT_SUB - 104)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -7185,24 +7200,24 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1274; Match(FOR);
-			State = 1275; whiteSpace();
-			State = 1276; Match(EACH);
-			State = 1277; whiteSpace();
-			State = 1278; expression(0);
-			State = 1279; whiteSpace();
-			State = 1280; Match(IN);
-			State = 1281; whiteSpace();
-			State = 1282; expression(0);
-			State = 1283; endOfStatement();
-			State = 1284; block();
-			State = 1285; Match(NEXT);
-			State = 1289;
+			State = 1299; Match(FOR);
+			State = 1300; whiteSpace();
+			State = 1301; Match(EACH);
+			State = 1302; whiteSpace();
+			State = 1303; expression(0);
+			State = 1304; whiteSpace();
+			State = 1305; Match(IN);
+			State = 1306; whiteSpace();
+			State = 1307; expression(0);
+			State = 1308; endOfStatement();
+			State = 1309; block();
+			State = 1310; Match(NEXT);
+			State = 1314;
 			switch ( Interpreter.AdaptivePredict(_input,137,_ctx) ) {
 			case 1:
 				{
-				State = 1286; whiteSpace();
-				State = 1287; expression(0);
+				State = 1311; whiteSpace();
+				State = 1312; expression(0);
 				}
 				break;
 			}
@@ -7269,33 +7284,33 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1291; Match(FOR);
-			State = 1292; whiteSpace();
-			State = 1293; expression(0);
-			State = 1294; whiteSpace();
-			State = 1295; Match(TO);
-			State = 1296; whiteSpace();
-			State = 1297; expression(0);
-			State = 1303;
+			State = 1316; Match(FOR);
+			State = 1317; whiteSpace();
+			State = 1318; expression(0);
+			State = 1319; whiteSpace();
+			State = 1320; Match(TO);
+			State = 1321; whiteSpace();
+			State = 1322; expression(0);
+			State = 1328;
 			switch ( Interpreter.AdaptivePredict(_input,138,_ctx) ) {
 			case 1:
 				{
-				State = 1298; whiteSpace();
-				State = 1299; Match(STEP);
-				State = 1300; whiteSpace();
-				State = 1301; expression(0);
+				State = 1323; whiteSpace();
+				State = 1324; Match(STEP);
+				State = 1325; whiteSpace();
+				State = 1326; expression(0);
 				}
 				break;
 			}
-			State = 1305; endOfStatement();
-			State = 1306; block();
-			State = 1307; Match(NEXT);
-			State = 1311;
+			State = 1330; endOfStatement();
+			State = 1331; block();
+			State = 1332; Match(NEXT);
+			State = 1336;
 			switch ( Interpreter.AdaptivePredict(_input,139,_ctx) ) {
 			case 1:
 				{
-				State = 1308; whiteSpace();
-				State = 1309; expression(0);
+				State = 1333; whiteSpace();
+				State = 1334; expression(0);
 				}
 				break;
 			}
@@ -7368,69 +7383,69 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1316;
+			State = 1341;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1313; visibility();
-				State = 1314; whiteSpace();
+				State = 1338; visibility();
+				State = 1339; whiteSpace();
 				}
 			}
 
-			State = 1320;
+			State = 1345;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1318; Match(STATIC);
-				State = 1319; whiteSpace();
+				State = 1343; Match(STATIC);
+				State = 1344; whiteSpace();
 				}
 			}
 
-			State = 1322; Match(FUNCTION);
-			State = 1324;
+			State = 1347; Match(FUNCTION);
+			State = 1349;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1323; whiteSpace();
+				State = 1348; whiteSpace();
 				}
 			}
 
-			State = 1326; functionName();
-			State = 1331;
+			State = 1351; functionName();
+			State = 1356;
 			switch ( Interpreter.AdaptivePredict(_input,144,_ctx) ) {
 			case 1:
 				{
-				State = 1328;
+				State = 1353;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1327; whiteSpace();
+					State = 1352; whiteSpace();
 					}
 				}
 
-				State = 1330; argList();
+				State = 1355; argList();
 				}
 				break;
 			}
-			State = 1337;
+			State = 1362;
 			switch ( Interpreter.AdaptivePredict(_input,146,_ctx) ) {
 			case 1:
 				{
-				State = 1334;
+				State = 1359;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1333; whiteSpace();
+					State = 1358; whiteSpace();
 					}
 				}
 
-				State = 1336; asTypeClause();
+				State = 1361; asTypeClause();
 				}
 				break;
 			}
-			State = 1339; endOfStatement();
-			State = 1340; block();
-			State = 1341; Match(END_FUNCTION);
+			State = 1364; endOfStatement();
+			State = 1365; block();
+			State = 1366; Match(END_FUNCTION);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7475,7 +7490,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1343; identifier();
+			State = 1368; identifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -7524,9 +7539,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1345; Match(GOSUB);
-			State = 1346; whiteSpace();
-			State = 1347; expression(0);
+			State = 1370; Match(GOSUB);
+			State = 1371; whiteSpace();
+			State = 1372; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7575,9 +7590,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1349; Match(GOTO);
-			State = 1350; whiteSpace();
-			State = 1351; expression(0);
+			State = 1374; Match(GOTO);
+			State = 1375; whiteSpace();
+			State = 1376; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7647,35 +7662,35 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1353; Match(IF);
-			State = 1354; whiteSpace();
-			State = 1355; booleanExpression();
-			State = 1356; whiteSpace();
-			State = 1357; Match(THEN);
-			State = 1358; endOfStatement();
-			State = 1359; block();
-			State = 1363;
+			State = 1378; Match(IF);
+			State = 1379; whiteSpace();
+			State = 1380; booleanExpression();
+			State = 1381; whiteSpace();
+			State = 1382; Match(THEN);
+			State = 1383; endOfStatement();
+			State = 1384; block();
+			State = 1388;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==ELSEIF) {
 				{
 				{
-				State = 1360; elseIfBlock();
+				State = 1385; elseIfBlock();
 				}
 				}
-				State = 1365;
+				State = 1390;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 1367;
+			State = 1392;
 			_la = _input.La(1);
 			if (_la==ELSE) {
 				{
-				State = 1366; elseBlock();
+				State = 1391; elseBlock();
 				}
 			}
 
-			State = 1369; Match(END_IF);
+			State = 1394; Match(END_IF);
 			}
 		}
 		catch (RecognitionException re) {
@@ -7733,38 +7748,38 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 196, RULE_elseIfBlock);
 		int _la;
 		try {
-			State = 1389;
+			State = 1414;
 			switch ( Interpreter.AdaptivePredict(_input,150,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1371; Match(ELSEIF);
-				State = 1372; whiteSpace();
-				State = 1373; booleanExpression();
-				State = 1374; whiteSpace();
-				State = 1375; Match(THEN);
-				State = 1376; endOfStatement();
-				State = 1377; block();
+				State = 1396; Match(ELSEIF);
+				State = 1397; whiteSpace();
+				State = 1398; booleanExpression();
+				State = 1399; whiteSpace();
+				State = 1400; Match(THEN);
+				State = 1401; endOfStatement();
+				State = 1402; block();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1379; Match(ELSEIF);
-				State = 1380; whiteSpace();
-				State = 1381; booleanExpression();
-				State = 1382; whiteSpace();
-				State = 1383; Match(THEN);
-				State = 1385;
+				State = 1404; Match(ELSEIF);
+				State = 1405; whiteSpace();
+				State = 1406; booleanExpression();
+				State = 1407; whiteSpace();
+				State = 1408; Match(THEN);
+				State = 1410;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1384; whiteSpace();
+					State = 1409; whiteSpace();
 					}
 				}
 
-				State = 1387; block();
+				State = 1412; block();
 				}
 				break;
 			}
@@ -7815,9 +7830,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1391; Match(ELSE);
-			State = 1392; endOfStatement();
-			State = 1393; block();
+			State = 1416; Match(ELSE);
+			State = 1417; endOfStatement();
+			State = 1418; block();
 			}
 		}
 		catch (RecognitionException re) {
@@ -7863,19 +7878,19 @@ public partial class VBAParser : Parser {
 		SingleLineIfStmtContext _localctx = new SingleLineIfStmtContext(_ctx, State);
 		EnterRule(_localctx, 200, RULE_singleLineIfStmt);
 		try {
-			State = 1397;
+			State = 1422;
 			switch ( Interpreter.AdaptivePredict(_input,151,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1395; ifWithNonEmptyThen();
+				State = 1420; ifWithNonEmptyThen();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1396; ifWithEmptyThen();
+				State = 1421; ifWithEmptyThen();
 				}
 				break;
 			}
@@ -7937,40 +7952,40 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1399; Match(IF);
-			State = 1401;
+			State = 1424; Match(IF);
+			State = 1426;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1400; whiteSpace();
+				State = 1425; whiteSpace();
 				}
 			}
 
-			State = 1403; booleanExpression();
-			State = 1405;
+			State = 1428; booleanExpression();
+			State = 1430;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1404; whiteSpace();
+				State = 1429; whiteSpace();
 				}
 			}
 
-			State = 1407; Match(THEN);
-			State = 1409;
+			State = 1432; Match(THEN);
+			State = 1434;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1408; whiteSpace();
+				State = 1433; whiteSpace();
 				}
 			}
 
-			State = 1411; listOrLabel();
-			State = 1415;
+			State = 1436; listOrLabel();
+			State = 1440;
 			switch ( Interpreter.AdaptivePredict(_input,155,_ctx) ) {
 			case 1:
 				{
-				State = 1412; whiteSpace();
-				State = 1413; singleLineElseClause();
+				State = 1437; whiteSpace();
+				State = 1438; singleLineElseClause();
 				}
 				break;
 			}
@@ -8033,35 +8048,35 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1417; Match(IF);
-			State = 1419;
+			State = 1442; Match(IF);
+			State = 1444;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1418; whiteSpace();
+				State = 1443; whiteSpace();
 				}
 			}
 
-			State = 1421; booleanExpression();
-			State = 1423;
+			State = 1446; booleanExpression();
+			State = 1448;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1422; whiteSpace();
+				State = 1447; whiteSpace();
 				}
 			}
 
-			State = 1425; Match(THEN);
-			State = 1426; endOfStatement();
-			State = 1428;
+			State = 1450; Match(THEN);
+			State = 1451; endOfStatement();
+			State = 1453;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1427; whiteSpace();
+				State = 1452; whiteSpace();
 				}
 			}
 
-			State = 1430; singleLineElseClause();
+			State = 1455; singleLineElseClause();
 			}
 		}
 		catch (RecognitionException re) {
@@ -8110,20 +8125,20 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1432; Match(ELSE);
-			State = 1434;
+			State = 1457; Match(ELSE);
+			State = 1459;
 			switch ( Interpreter.AdaptivePredict(_input,159,_ctx) ) {
 			case 1:
 				{
-				State = 1433; whiteSpace();
+				State = 1458; whiteSpace();
 				}
 				break;
 			}
-			State = 1437;
+			State = 1462;
 			switch ( Interpreter.AdaptivePredict(_input,160,_ctx) ) {
 			case 1:
 				{
-				State = 1436; listOrLabel();
+				State = 1461; listOrLabel();
 				}
 				break;
 			}
@@ -8187,48 +8202,48 @@ public partial class VBAParser : Parser {
 		int _la;
 		try {
 			int _alt;
-			State = 1477;
+			State = 1502;
 			switch ( Interpreter.AdaptivePredict(_input,171,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1439; lineNumberLabel();
-				State = 1452;
+				State = 1464; lineNumberLabel();
+				State = 1477;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,164,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1441;
+						State = 1466;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1440; whiteSpace();
+							State = 1465; whiteSpace();
 							}
 						}
 
-						State = 1443; Match(COLON);
-						State = 1445;
+						State = 1468; Match(COLON);
+						State = 1470;
 						switch ( Interpreter.AdaptivePredict(_input,162,_ctx) ) {
 						case 1:
 							{
-							State = 1444; whiteSpace();
+							State = 1469; whiteSpace();
 							}
 							break;
 						}
-						State = 1448;
+						State = 1473;
 						switch ( Interpreter.AdaptivePredict(_input,163,_ctx) ) {
 						case 1:
 							{
-							State = 1447; sameLineStatement();
+							State = 1472; sameLineStatement();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 1454;
+					State = 1479;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,164,_ctx);
 				}
@@ -8238,59 +8253,59 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1459;
+				State = 1484;
 				_la = _input.La(1);
 				if (_la==COLON) {
 					{
-					State = 1455; Match(COLON);
-					State = 1457;
+					State = 1480; Match(COLON);
+					State = 1482;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1456; whiteSpace();
+						State = 1481; whiteSpace();
 						}
 					}
 
 					}
 				}
 
-				State = 1461; sameLineStatement();
-				State = 1474;
+				State = 1486; sameLineStatement();
+				State = 1499;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,170,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1463;
+						State = 1488;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 1462; whiteSpace();
+							State = 1487; whiteSpace();
 							}
 						}
 
-						State = 1465; Match(COLON);
-						State = 1467;
+						State = 1490; Match(COLON);
+						State = 1492;
 						switch ( Interpreter.AdaptivePredict(_input,168,_ctx) ) {
 						case 1:
 							{
-							State = 1466; whiteSpace();
+							State = 1491; whiteSpace();
 							}
 							break;
 						}
-						State = 1470;
+						State = 1495;
 						switch ( Interpreter.AdaptivePredict(_input,169,_ctx) ) {
 						case 1:
 							{
-							State = 1469; sameLineStatement();
+							State = 1494; sameLineStatement();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 1476;
+					State = 1501;
 					_errHandler.Sync(this);
 					_alt = Interpreter.AdaptivePredict(_input,170,_ctx);
 				}
@@ -8340,7 +8355,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1479; blockStmt();
+			State = 1504; blockStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -8385,7 +8400,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1481; expression(0);
+			State = 1506; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8434,9 +8449,9 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1483; Match(IMPLEMENTS);
-			State = 1484; whiteSpace();
-			State = 1485; expression(0);
+			State = 1508; Match(IMPLEMENTS);
+			State = 1509; whiteSpace();
+			State = 1510; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8493,34 +8508,34 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1489;
+			State = 1514;
 			_la = _input.La(1);
 			if (_la==LET) {
 				{
-				State = 1487; Match(LET);
-				State = 1488; whiteSpace();
+				State = 1512; Match(LET);
+				State = 1513; whiteSpace();
 				}
 			}
 
-			State = 1491; lExpression(0);
-			State = 1493;
+			State = 1516; lExpression(0);
+			State = 1518;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1492; whiteSpace();
+				State = 1517; whiteSpace();
 				}
 			}
 
-			State = 1495; Match(EQ);
-			State = 1497;
+			State = 1520; Match(EQ);
+			State = 1522;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1496; whiteSpace();
+				State = 1521; whiteSpace();
 				}
 			}
 
-			State = 1499; expression(0);
+			State = 1524; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8577,27 +8592,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1501; Match(LSET);
-			State = 1502; whiteSpace();
-			State = 1503; expression(0);
-			State = 1505;
+			State = 1526; Match(LSET);
+			State = 1527; whiteSpace();
+			State = 1528; expression(0);
+			State = 1530;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1504; whiteSpace();
+				State = 1529; whiteSpace();
 				}
 			}
 
-			State = 1507; Match(EQ);
-			State = 1509;
+			State = 1532; Match(EQ);
+			State = 1534;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1508; whiteSpace();
+				State = 1533; whiteSpace();
 				}
 			}
 
-			State = 1511; expression(0);
+			State = 1536; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -8654,27 +8669,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1513;
+			State = 1538;
 			_la = _input.La(1);
 			if ( !(_la==ON_ERROR || _la==ON_LOCAL_ERROR) ) {
 			_errHandler.RecoverInline(this);
 			}
 			Consume();
-			State = 1514; whiteSpace();
-			State = 1523;
+			State = 1539; whiteSpace();
+			State = 1548;
 			switch (_input.La(1)) {
 			case GOTO:
 				{
-				State = 1515; Match(GOTO);
-				State = 1516; whiteSpace();
-				State = 1517; expression(0);
+				State = 1540; Match(GOTO);
+				State = 1541; whiteSpace();
+				State = 1542; expression(0);
 				}
 				break;
 			case RESUME:
 				{
-				State = 1519; Match(RESUME);
-				State = 1520; whiteSpace();
-				State = 1521; Match(NEXT);
+				State = 1544; Match(RESUME);
+				State = 1545; whiteSpace();
+				State = 1546; Match(NEXT);
 				}
 				break;
 			default:
@@ -8741,42 +8756,42 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1525; Match(ON);
-			State = 1526; whiteSpace();
-			State = 1527; expression(0);
-			State = 1528; whiteSpace();
-			State = 1529; Match(GOTO);
-			State = 1530; whiteSpace();
-			State = 1531; expression(0);
-			State = 1542;
+			State = 1550; Match(ON);
+			State = 1551; whiteSpace();
+			State = 1552; expression(0);
+			State = 1553; whiteSpace();
+			State = 1554; Match(GOTO);
+			State = 1555; whiteSpace();
+			State = 1556; expression(0);
+			State = 1567;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,180,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1533;
+					State = 1558;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1532; whiteSpace();
+						State = 1557; whiteSpace();
 						}
 					}
 
-					State = 1535; Match(COMMA);
-					State = 1537;
+					State = 1560; Match(COMMA);
+					State = 1562;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1536; whiteSpace();
+						State = 1561; whiteSpace();
 						}
 					}
 
-					State = 1539; expression(0);
+					State = 1564; expression(0);
 					}
 					} 
 				}
-				State = 1544;
+				State = 1569;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,180,_ctx);
 			}
@@ -8841,42 +8856,42 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1545; Match(ON);
-			State = 1546; whiteSpace();
-			State = 1547; expression(0);
-			State = 1548; whiteSpace();
-			State = 1549; Match(GOSUB);
-			State = 1550; whiteSpace();
-			State = 1551; expression(0);
-			State = 1562;
+			State = 1570; Match(ON);
+			State = 1571; whiteSpace();
+			State = 1572; expression(0);
+			State = 1573; whiteSpace();
+			State = 1574; Match(GOSUB);
+			State = 1575; whiteSpace();
+			State = 1576; expression(0);
+			State = 1587;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,183,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1553;
+					State = 1578;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1552; whiteSpace();
+						State = 1577; whiteSpace();
 						}
 					}
 
-					State = 1555; Match(COMMA);
-					State = 1557;
+					State = 1580; Match(COMMA);
+					State = 1582;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1556; whiteSpace();
+						State = 1581; whiteSpace();
 						}
 					}
 
-					State = 1559; expression(0);
+					State = 1584; expression(0);
 					}
 					} 
 				}
-				State = 1564;
+				State = 1589;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,183,_ctx);
 			}
@@ -8949,55 +8964,55 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1568;
+			State = 1593;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1565; visibility();
-				State = 1566; whiteSpace();
+				State = 1590; visibility();
+				State = 1591; whiteSpace();
 				}
 			}
 
-			State = 1572;
+			State = 1597;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1570; Match(STATIC);
-				State = 1571; whiteSpace();
+				State = 1595; Match(STATIC);
+				State = 1596; whiteSpace();
 				}
 			}
 
-			State = 1574; Match(PROPERTY_GET);
-			State = 1575; whiteSpace();
-			State = 1576; functionName();
-			State = 1581;
+			State = 1599; Match(PROPERTY_GET);
+			State = 1600; whiteSpace();
+			State = 1601; functionName();
+			State = 1606;
 			switch ( Interpreter.AdaptivePredict(_input,187,_ctx) ) {
 			case 1:
 				{
-				State = 1578;
+				State = 1603;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1577; whiteSpace();
+					State = 1602; whiteSpace();
 					}
 				}
 
-				State = 1580; argList();
+				State = 1605; argList();
 				}
 				break;
 			}
-			State = 1586;
+			State = 1611;
 			switch ( Interpreter.AdaptivePredict(_input,188,_ctx) ) {
 			case 1:
 				{
-				State = 1583; whiteSpace();
-				State = 1584; asTypeClause();
+				State = 1608; whiteSpace();
+				State = 1609; asTypeClause();
 				}
 				break;
 			}
-			State = 1588; endOfStatement();
-			State = 1589; block();
-			State = 1590; Match(END_PROPERTY);
+			State = 1613; endOfStatement();
+			State = 1614; block();
+			State = 1615; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9064,46 +9079,46 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1595;
+			State = 1620;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1592; visibility();
-				State = 1593; whiteSpace();
+				State = 1617; visibility();
+				State = 1618; whiteSpace();
 				}
 			}
 
-			State = 1599;
+			State = 1624;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1597; Match(STATIC);
-				State = 1598; whiteSpace();
+				State = 1622; Match(STATIC);
+				State = 1623; whiteSpace();
 				}
 			}
 
-			State = 1601; Match(PROPERTY_SET);
-			State = 1602; whiteSpace();
-			State = 1603; subroutineName();
-			State = 1608;
+			State = 1626; Match(PROPERTY_SET);
+			State = 1627; whiteSpace();
+			State = 1628; subroutineName();
+			State = 1633;
 			switch ( Interpreter.AdaptivePredict(_input,192,_ctx) ) {
 			case 1:
 				{
-				State = 1605;
+				State = 1630;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1604; whiteSpace();
+					State = 1629; whiteSpace();
 					}
 				}
 
-				State = 1607; argList();
+				State = 1632; argList();
 				}
 				break;
 			}
-			State = 1610; endOfStatement();
-			State = 1611; block();
-			State = 1612; Match(END_PROPERTY);
+			State = 1635; endOfStatement();
+			State = 1636; block();
+			State = 1637; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9170,46 +9185,46 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1617;
+			State = 1642;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1614; visibility();
-				State = 1615; whiteSpace();
+				State = 1639; visibility();
+				State = 1640; whiteSpace();
 				}
 			}
 
-			State = 1621;
+			State = 1646;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1619; Match(STATIC);
-				State = 1620; whiteSpace();
+				State = 1644; Match(STATIC);
+				State = 1645; whiteSpace();
 				}
 			}
 
-			State = 1623; Match(PROPERTY_LET);
-			State = 1624; whiteSpace();
-			State = 1625; subroutineName();
-			State = 1630;
+			State = 1648; Match(PROPERTY_LET);
+			State = 1649; whiteSpace();
+			State = 1650; subroutineName();
+			State = 1655;
 			switch ( Interpreter.AdaptivePredict(_input,196,_ctx) ) {
 			case 1:
 				{
-				State = 1627;
+				State = 1652;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1626; whiteSpace();
+					State = 1651; whiteSpace();
 					}
 				}
 
-				State = 1629; argList();
+				State = 1654; argList();
 				}
 				break;
 			}
-			State = 1632; endOfStatement();
-			State = 1633; block();
-			State = 1634; Match(END_PROPERTY);
+			State = 1657; endOfStatement();
+			State = 1658; block();
+			State = 1659; Match(END_PROPERTY);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9267,47 +9282,47 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1636; Match(RAISEEVENT);
-			State = 1637; whiteSpace();
-			State = 1638; identifier();
-			State = 1653;
+			State = 1661; Match(RAISEEVENT);
+			State = 1662; whiteSpace();
+			State = 1663; identifier();
+			State = 1678;
 			switch ( Interpreter.AdaptivePredict(_input,201,_ctx) ) {
 			case 1:
 				{
-				State = 1640;
+				State = 1665;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1639; whiteSpace();
+					State = 1664; whiteSpace();
 					}
 				}
 
-				State = 1642; Match(LPAREN);
-				State = 1644;
+				State = 1667; Match(LPAREN);
+				State = 1669;
 				switch ( Interpreter.AdaptivePredict(_input,198,_ctx) ) {
 				case 1:
 					{
-					State = 1643; whiteSpace();
+					State = 1668; whiteSpace();
 					}
 					break;
 				}
-				State = 1647;
+				State = 1672;
 				_la = _input.La(1);
 				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 					{
-					State = 1646; eventArgumentList();
+					State = 1671; eventArgumentList();
 					}
 				}
 
-				State = 1650;
+				State = 1675;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1649; whiteSpace();
+					State = 1674; whiteSpace();
 					}
 				}
 
-				State = 1652; Match(RPAREN);
+				State = 1677; Match(RPAREN);
 				}
 				break;
 			}
@@ -9370,36 +9385,36 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1655; eventArgument();
-			State = 1666;
+			State = 1680; eventArgument();
+			State = 1691;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,204,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1657;
+					State = 1682;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1656; whiteSpace();
+						State = 1681; whiteSpace();
 						}
 					}
 
-					State = 1659; Match(COMMA);
-					State = 1661;
+					State = 1684; Match(COMMA);
+					State = 1686;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1660; whiteSpace();
+						State = 1685; whiteSpace();
 						}
 					}
 
-					State = 1663; eventArgument();
+					State = 1688; eventArgument();
 					}
 					} 
 				}
-				State = 1668;
+				State = 1693;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,204,_ctx);
 			}
@@ -9447,7 +9462,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1669; expression(0);
+			State = 1694; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9500,18 +9515,18 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1671; Match(REDIM);
-			State = 1672; whiteSpace();
-			State = 1675;
+			State = 1696; Match(REDIM);
+			State = 1697; whiteSpace();
+			State = 1700;
 			switch ( Interpreter.AdaptivePredict(_input,205,_ctx) ) {
 			case 1:
 				{
-				State = 1673; Match(PRESERVE);
-				State = 1674; whiteSpace();
+				State = 1698; Match(PRESERVE);
+				State = 1699; whiteSpace();
 				}
 				break;
 			}
-			State = 1677; redimDeclarationList();
+			State = 1702; redimDeclarationList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -9571,36 +9586,36 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1679; redimVariableDeclaration();
-			State = 1690;
+			State = 1704; redimVariableDeclaration();
+			State = 1715;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,208,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1681;
+					State = 1706;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1680; whiteSpace();
+						State = 1705; whiteSpace();
 						}
 					}
 
-					State = 1683; Match(COMMA);
-					State = 1685;
+					State = 1708; Match(COMMA);
+					State = 1710;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1684; whiteSpace();
+						State = 1709; whiteSpace();
 						}
 					}
 
-					State = 1687; redimVariableDeclaration();
+					State = 1712; redimVariableDeclaration();
 					}
 					} 
 				}
-				State = 1692;
+				State = 1717;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,208,_ctx);
 			}
@@ -9654,13 +9669,13 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1693; expression(0);
-			State = 1697;
+			State = 1718; expression(0);
+			State = 1722;
 			switch ( Interpreter.AdaptivePredict(_input,209,_ctx) ) {
 			case 1:
 				{
-				State = 1694; whiteSpace();
-				State = 1695; asTypeClause();
+				State = 1719; whiteSpace();
+				State = 1720; asTypeClause();
 				}
 				break;
 			}
@@ -9708,7 +9723,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1699; expression(0);
+			State = 1724; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -9758,14 +9773,14 @@ public partial class VBAParser : Parser {
 		CallStmtContext _localctx = new CallStmtContext(_ctx, State);
 		EnterRule(_localctx, 246, RULE_callStmt);
 		try {
-			State = 1711;
+			State = 1736;
 			switch (_input.La(1)) {
 			case CALL:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1701; Match(CALL);
-				State = 1702; whiteSpace();
-				State = 1703; expression(0);
+				State = 1726; Match(CALL);
+				State = 1727; whiteSpace();
+				State = 1728; expression(0);
 				}
 				break;
 			case ABS:
@@ -9898,13 +9913,13 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1705; expression(0);
-				State = 1709;
+				State = 1730; expression(0);
+				State = 1734;
 				switch ( Interpreter.AdaptivePredict(_input,210,_ctx) ) {
 				case 1:
 					{
-					State = 1706; whiteSpace();
-					State = 1707; argumentList();
+					State = 1731; whiteSpace();
+					State = 1732; argumentList();
 					}
 					break;
 				}
@@ -9961,17 +9976,17 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1713; Match(RESUME);
-			State = 1719;
+			State = 1738; Match(RESUME);
+			State = 1744;
 			switch ( Interpreter.AdaptivePredict(_input,213,_ctx) ) {
 			case 1:
 				{
-				State = 1714; whiteSpace();
-				State = 1717;
+				State = 1739; whiteSpace();
+				State = 1742;
 				switch (_input.La(1)) {
 				case NEXT:
 					{
-					State = 1715; Match(NEXT);
+					State = 1740; Match(NEXT);
 					}
 					break;
 				case ABS:
@@ -10103,7 +10118,7 @@ public partial class VBAParser : Parser {
 				case LOAD:
 				case RESUME_NEXT:
 					{
-					State = 1716; expression(0);
+					State = 1741; expression(0);
 					}
 					break;
 				default:
@@ -10154,7 +10169,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1721; Match(RETURN);
+			State = 1746; Match(RETURN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10211,27 +10226,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1723; Match(RSET);
-			State = 1724; whiteSpace();
-			State = 1725; expression(0);
-			State = 1727;
+			State = 1748; Match(RSET);
+			State = 1749; whiteSpace();
+			State = 1750; expression(0);
+			State = 1752;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1726; whiteSpace();
+				State = 1751; whiteSpace();
 				}
 			}
 
-			State = 1729; Match(EQ);
-			State = 1731;
+			State = 1754; Match(EQ);
+			State = 1756;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1730; whiteSpace();
+				State = 1755; whiteSpace();
 				}
 			}
 
-			State = 1733; expression(0);
+			State = 1758; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10274,7 +10289,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1735; Match(STOP);
+			State = 1760; Match(STOP);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10342,50 +10357,50 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1737; Match(SELECT);
-			State = 1739;
+			State = 1762; Match(SELECT);
+			State = 1764;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1738; whiteSpace();
+				State = 1763; whiteSpace();
 				}
 			}
 
-			State = 1741; Match(CASE);
-			State = 1743;
+			State = 1766; Match(CASE);
+			State = 1768;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1742; whiteSpace();
+				State = 1767; whiteSpace();
 				}
 			}
 
-			State = 1745; selectExpression();
-			State = 1746; endOfStatement();
-			State = 1750;
+			State = 1770; selectExpression();
+			State = 1771; endOfStatement();
+			State = 1775;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,218,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1747; caseClause();
+					State = 1772; caseClause();
 					}
 					} 
 				}
-				State = 1752;
+				State = 1777;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,218,_ctx);
 			}
-			State = 1754;
+			State = 1779;
 			_la = _input.La(1);
 			if (_la==CASE) {
 				{
-				State = 1753; caseElseClause();
+				State = 1778; caseElseClause();
 				}
 			}
 
-			State = 1756; Match(END_SELECT);
+			State = 1781; Match(END_SELECT);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10430,7 +10445,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1758; expression(0);
+			State = 1783; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10497,43 +10512,43 @@ public partial class VBAParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1760; Match(CASE);
-			State = 1761; whiteSpace();
-			State = 1762; rangeClause();
-			State = 1773;
+			State = 1785; Match(CASE);
+			State = 1786; whiteSpace();
+			State = 1787; rangeClause();
+			State = 1798;
 			_errHandler.Sync(this);
 			_alt = Interpreter.AdaptivePredict(_input,222,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1764;
+					State = 1789;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1763; whiteSpace();
+						State = 1788; whiteSpace();
 						}
 					}
 
-					State = 1766; Match(COMMA);
-					State = 1768;
+					State = 1791; Match(COMMA);
+					State = 1793;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1767; whiteSpace();
+						State = 1792; whiteSpace();
 						}
 					}
 
-					State = 1770; rangeClause();
+					State = 1795; rangeClause();
 					}
 					} 
 				}
-				State = 1775;
+				State = 1800;
 				_errHandler.Sync(this);
 				_alt = Interpreter.AdaptivePredict(_input,222,_ctx);
 			}
-			State = 1776; endOfStatement();
-			State = 1777; block();
+			State = 1801; endOfStatement();
+			State = 1802; block();
 			}
 		}
 		catch (RecognitionException re) {
@@ -10587,18 +10602,18 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1779; Match(CASE);
-			State = 1781;
+			State = 1804; Match(CASE);
+			State = 1806;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1780; whiteSpace();
+				State = 1805; whiteSpace();
 				}
 			}
 
-			State = 1783; Match(ELSE);
-			State = 1784; endOfStatement();
-			State = 1785; block();
+			State = 1808; Match(ELSE);
+			State = 1809; endOfStatement();
+			State = 1810; block();
 			}
 		}
 		catch (RecognitionException re) {
@@ -10659,55 +10674,55 @@ public partial class VBAParser : Parser {
 		EnterRule(_localctx, 264, RULE_rangeClause);
 		int _la;
 		try {
-			State = 1806;
+			State = 1831;
 			switch ( Interpreter.AdaptivePredict(_input,227,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1787; expression(0);
+				State = 1812; expression(0);
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1788; selectStartValue();
-				State = 1789; whiteSpace();
-				State = 1790; Match(TO);
-				State = 1791; whiteSpace();
-				State = 1792; selectEndValue();
+				State = 1813; selectStartValue();
+				State = 1814; whiteSpace();
+				State = 1815; Match(TO);
+				State = 1816; whiteSpace();
+				State = 1817; selectEndValue();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1798;
+				State = 1823;
 				switch ( Interpreter.AdaptivePredict(_input,225,_ctx) ) {
 				case 1:
 					{
-					State = 1794; Match(IS);
-					State = 1796;
+					State = 1819; Match(IS);
+					State = 1821;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1795; whiteSpace();
+						State = 1820; whiteSpace();
 						}
 					}
 
 					}
 					break;
 				}
-				State = 1800; comparisonOperator();
-				State = 1802;
+				State = 1825; comparisonOperator();
+				State = 1827;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1801; whiteSpace();
+					State = 1826; whiteSpace();
 					}
 				}
 
-				State = 1804; expression(0);
+				State = 1829; expression(0);
 				}
 				break;
 			}
@@ -10754,7 +10769,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1808; expression(0);
+			State = 1833; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10799,7 +10814,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1810; expression(0);
+			State = 1835; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10856,27 +10871,27 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1812; Match(SET);
-			State = 1813; whiteSpace();
-			State = 1814; lExpression(0);
-			State = 1816;
+			State = 1837; Match(SET);
+			State = 1838; whiteSpace();
+			State = 1839; lExpression(0);
+			State = 1841;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1815; whiteSpace();
+				State = 1840; whiteSpace();
 				}
 			}
 
-			State = 1818; Match(EQ);
-			State = 1820;
+			State = 1843; Match(EQ);
+			State = 1845;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1819; whiteSpace();
+				State = 1844; whiteSpace();
 				}
 			}
 
-			State = 1822; expression(0);
+			State = 1847; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -10943,53 +10958,53 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1827;
+			State = 1852;
 			_la = _input.La(1);
 			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
 				{
-				State = 1824; visibility();
-				State = 1825; whiteSpace();
+				State = 1849; visibility();
+				State = 1850; whiteSpace();
 				}
 			}
 
-			State = 1831;
+			State = 1856;
 			_la = _input.La(1);
 			if (_la==STATIC) {
 				{
-				State = 1829; Match(STATIC);
-				State = 1830; whiteSpace();
+				State = 1854; Match(STATIC);
+				State = 1855; whiteSpace();
 				}
 			}
 
-			State = 1833; Match(SUB);
-			State = 1835;
+			State = 1858; Match(SUB);
+			State = 1860;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1834; whiteSpace();
+				State = 1859; whiteSpace();
 				}
 			}
 
-			State = 1837; subroutineName();
-			State = 1842;
+			State = 1862; subroutineName();
+			State = 1867;
 			switch ( Interpreter.AdaptivePredict(_input,234,_ctx) ) {
 			case 1:
 				{
-				State = 1839;
+				State = 1864;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1838; whiteSpace();
+					State = 1863; whiteSpace();
 					}
 				}
 
-				State = 1841; argList();
+				State = 1866; argList();
 				}
 				break;
 			}
-			State = 1844; endOfStatement();
-			State = 1845; block();
-			State = 1846; Match(END_SUB);
+			State = 1869; endOfStatement();
+			State = 1870; block();
+			State = 1871; Match(END_SUB);
 			}
 		}
 		catch (RecognitionException re) {
@@ -11034,7 +11049,7 @@ public partial class VBAParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1848; identifier();
+			State = 1873; identifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -11048,85 +11063,58 @@ public partial class VBAParser : Parser {
 		return _localctx;
 	}
 
-	public partial class TypeStmtContext : ParserRuleContext {
-		public WhiteSpaceContext whiteSpace(int i) {
-			return GetRuleContext<WhiteSpaceContext>(i);
+	public partial class PublicTypeDeclarationContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
 		}
-		public IReadOnlyList<TypeStmt_ElementContext> typeStmt_Element() {
-			return GetRuleContexts<TypeStmt_ElementContext>();
+		public ITerminalNode PUBLIC() { return GetToken(VBAParser.PUBLIC, 0); }
+		public ITerminalNode GLOBAL() { return GetToken(VBAParser.GLOBAL, 0); }
+		public UdtDeclarationContext udtDeclaration() {
+			return GetRuleContext<UdtDeclarationContext>(0);
 		}
-		public ITerminalNode TYPE() { return GetToken(VBAParser.TYPE, 0); }
-		public TypeStmt_ElementContext typeStmt_Element(int i) {
-			return GetRuleContext<TypeStmt_ElementContext>(i);
-		}
-		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
-			return GetRuleContexts<WhiteSpaceContext>();
-		}
-		public IdentifierContext identifier() {
-			return GetRuleContext<IdentifierContext>(0);
-		}
-		public VisibilityContext visibility() {
-			return GetRuleContext<VisibilityContext>(0);
-		}
-		public EndOfStatementContext endOfStatement() {
-			return GetRuleContext<EndOfStatementContext>(0);
-		}
-		public ITerminalNode END_TYPE() { return GetToken(VBAParser.END_TYPE, 0); }
-		public TypeStmtContext(ParserRuleContext parent, int invokingState)
+		public PublicTypeDeclarationContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
 		{
 		}
-		public override int RuleIndex { get { return RULE_typeStmt; } }
+		public override int RuleIndex { get { return RULE_publicTypeDeclaration; } }
 		public override void EnterRule(IParseTreeListener listener) {
 			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterTypeStmt(this);
+			if (typedListener != null) typedListener.EnterPublicTypeDeclaration(this);
 		}
 		public override void ExitRule(IParseTreeListener listener) {
 			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitTypeStmt(this);
+			if (typedListener != null) typedListener.ExitPublicTypeDeclaration(this);
 		}
 		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
 			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitTypeStmt(this);
+			if (typedVisitor != null) return typedVisitor.VisitPublicTypeDeclaration(this);
 			else return visitor.VisitChildren(this);
 		}
 	}
 
 	[RuleVersion(0)]
-	public TypeStmtContext typeStmt() {
-		TypeStmtContext _localctx = new TypeStmtContext(_ctx, State);
-		EnterRule(_localctx, 276, RULE_typeStmt);
+	public PublicTypeDeclarationContext publicTypeDeclaration() {
+		PublicTypeDeclarationContext _localctx = new PublicTypeDeclarationContext(_ctx, State);
+		EnterRule(_localctx, 276, RULE_publicTypeDeclaration);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1853;
+			State = 1877;
 			_la = _input.La(1);
-			if (((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) {
+			if (_la==GLOBAL || _la==PUBLIC) {
 				{
-				State = 1850; visibility();
-				State = 1851; whiteSpace();
+				State = 1875;
+				_la = _input.La(1);
+				if ( !(_la==GLOBAL || _la==PUBLIC) ) {
+				_errHandler.RecoverInline(this);
+				}
+				Consume();
+				State = 1876; whiteSpace();
 				}
 			}
 
-			State = 1855; Match(TYPE);
-			State = 1856; whiteSpace();
-			State = 1857; identifier();
-			State = 1858; endOfStatement();
-			State = 1862;
-			_errHandler.Sync(this);
-			_la = _input.La(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
-				{
-				{
-				State = 1859; typeStmt_Element();
-				}
-				}
-				State = 1864;
-				_errHandler.Sync(this);
-				_la = _input.La(1);
-			}
-			State = 1865; Match(END_TYPE);
+			State = 1879; udtDeclaration();
 			}
 		}
 		catch (RecognitionException re) {
@@ -11140,7 +11128,429 @@ public partial class VBAParser : Parser {
 		return _localctx;
 	}
 
-	public partial class TypeStmt_ElementContext : ParserRuleContext {
+	public partial class PrivateTypeDeclarationContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public ITerminalNode PRIVATE() { return GetToken(VBAParser.PRIVATE, 0); }
+		public UdtDeclarationContext udtDeclaration() {
+			return GetRuleContext<UdtDeclarationContext>(0);
+		}
+		public PrivateTypeDeclarationContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_privateTypeDeclaration; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterPrivateTypeDeclaration(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitPrivateTypeDeclaration(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitPrivateTypeDeclaration(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public PrivateTypeDeclarationContext privateTypeDeclaration() {
+		PrivateTypeDeclarationContext _localctx = new PrivateTypeDeclarationContext(_ctx, State);
+		EnterRule(_localctx, 278, RULE_privateTypeDeclaration);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1881; Match(PRIVATE);
+			State = 1882; whiteSpace();
+			State = 1883; udtDeclaration();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class UdtDeclarationContext : ParserRuleContext {
+		public EndOfStatementContext endOfStatement(int i) {
+			return GetRuleContext<EndOfStatementContext>(i);
+		}
+		public UntypedIdentifierContext untypedIdentifier() {
+			return GetRuleContext<UntypedIdentifierContext>(0);
+		}
+		public ITerminalNode TYPE() { return GetToken(VBAParser.TYPE, 0); }
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public UdtMemberListContext udtMemberList() {
+			return GetRuleContext<UdtMemberListContext>(0);
+		}
+		public IReadOnlyList<EndOfStatementContext> endOfStatement() {
+			return GetRuleContexts<EndOfStatementContext>();
+		}
+		public ITerminalNode END_TYPE() { return GetToken(VBAParser.END_TYPE, 0); }
+		public UdtDeclarationContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_udtDeclaration; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterUdtDeclaration(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitUdtDeclaration(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitUdtDeclaration(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public UdtDeclarationContext udtDeclaration() {
+		UdtDeclarationContext _localctx = new UdtDeclarationContext(_ctx, State);
+		EnterRule(_localctx, 280, RULE_udtDeclaration);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1885; Match(TYPE);
+			State = 1886; whiteSpace();
+			State = 1887; untypedIdentifier();
+			State = 1888; endOfStatement();
+			State = 1889; udtMemberList();
+			State = 1890; endOfStatement();
+			State = 1891; Match(END_TYPE);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class UdtMemberListContext : ParserRuleContext {
+		public EndOfStatementContext endOfStatement(int i) {
+			return GetRuleContext<EndOfStatementContext>(i);
+		}
+		public UdtMemberContext udtMember(int i) {
+			return GetRuleContext<UdtMemberContext>(i);
+		}
+		public IReadOnlyList<UdtMemberContext> udtMember() {
+			return GetRuleContexts<UdtMemberContext>();
+		}
+		public IReadOnlyList<EndOfStatementContext> endOfStatement() {
+			return GetRuleContexts<EndOfStatementContext>();
+		}
+		public UdtMemberListContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_udtMemberList; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterUdtMemberList(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitUdtMemberList(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitUdtMemberList(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public UdtMemberListContext udtMemberList() {
+		UdtMemberListContext _localctx = new UdtMemberListContext(_ctx, State);
+		EnterRule(_localctx, 282, RULE_udtMemberList);
+		try {
+			int _alt;
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1893; udtMember();
+			State = 1899;
+			_errHandler.Sync(this);
+			_alt = Interpreter.AdaptivePredict(_input,236,_ctx);
+			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
+				if ( _alt==1 ) {
+					{
+					{
+					State = 1894; endOfStatement();
+					State = 1895; udtMember();
+					}
+					} 
+				}
+				State = 1901;
+				_errHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(_input,236,_ctx);
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class UdtMemberContext : ParserRuleContext {
+		public UntypedNameMemberDeclarationContext untypedNameMemberDeclaration() {
+			return GetRuleContext<UntypedNameMemberDeclarationContext>(0);
+		}
+		public ReservedNameMemberDeclarationContext reservedNameMemberDeclaration() {
+			return GetRuleContext<ReservedNameMemberDeclarationContext>(0);
+		}
+		public UdtMemberContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_udtMember; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterUdtMember(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitUdtMember(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitUdtMember(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public UdtMemberContext udtMember() {
+		UdtMemberContext _localctx = new UdtMemberContext(_ctx, State);
+		EnterRule(_localctx, 284, RULE_udtMember);
+		try {
+			State = 1904;
+			switch ( Interpreter.AdaptivePredict(_input,237,_ctx) ) {
+			case 1:
+				EnterOuterAlt(_localctx, 1);
+				{
+				State = 1902; reservedNameMemberDeclaration();
+				}
+				break;
+
+			case 2:
+				EnterOuterAlt(_localctx, 2);
+				{
+				State = 1903; untypedNameMemberDeclaration();
+				}
+				break;
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class UntypedNameMemberDeclarationContext : ParserRuleContext {
+		public UntypedIdentifierContext untypedIdentifier() {
+			return GetRuleContext<UntypedIdentifierContext>(0);
+		}
+		public OptionalArrayClauseContext optionalArrayClause() {
+			return GetRuleContext<OptionalArrayClauseContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public UntypedNameMemberDeclarationContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_untypedNameMemberDeclaration; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterUntypedNameMemberDeclaration(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitUntypedNameMemberDeclaration(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitUntypedNameMemberDeclaration(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public UntypedNameMemberDeclarationContext untypedNameMemberDeclaration() {
+		UntypedNameMemberDeclarationContext _localctx = new UntypedNameMemberDeclarationContext(_ctx, State);
+		EnterRule(_localctx, 286, RULE_untypedNameMemberDeclaration);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1906; untypedIdentifier();
+			State = 1908;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 1907; whiteSpace();
+				}
+			}
+
+			State = 1910; optionalArrayClause();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class ReservedNameMemberDeclarationContext : ParserRuleContext {
+		public UnrestrictedIdentifierContext unrestrictedIdentifier() {
+			return GetRuleContext<UnrestrictedIdentifierContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public AsTypeClauseContext asTypeClause() {
+			return GetRuleContext<AsTypeClauseContext>(0);
+		}
+		public ReservedNameMemberDeclarationContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_reservedNameMemberDeclaration; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterReservedNameMemberDeclaration(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitReservedNameMemberDeclaration(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitReservedNameMemberDeclaration(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public ReservedNameMemberDeclarationContext reservedNameMemberDeclaration() {
+		ReservedNameMemberDeclarationContext _localctx = new ReservedNameMemberDeclarationContext(_ctx, State);
+		EnterRule(_localctx, 288, RULE_reservedNameMemberDeclaration);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1912; unrestrictedIdentifier();
+			State = 1913; whiteSpace();
+			State = 1914; asTypeClause();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class OptionalArrayClauseContext : ParserRuleContext {
+		public AsTypeClauseContext asTypeClause() {
+			return GetRuleContext<AsTypeClauseContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public ArrayDimContext arrayDim() {
+			return GetRuleContext<ArrayDimContext>(0);
+		}
+		public OptionalArrayClauseContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_optionalArrayClause; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterOptionalArrayClause(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitOptionalArrayClause(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitOptionalArrayClause(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public OptionalArrayClauseContext optionalArrayClause() {
+		OptionalArrayClauseContext _localctx = new OptionalArrayClauseContext(_ctx, State);
+		EnterRule(_localctx, 290, RULE_optionalArrayClause);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1919;
+			_la = _input.La(1);
+			if (_la==LPAREN) {
+				{
+				State = 1916; arrayDim();
+				State = 1917; whiteSpace();
+				}
+			}
+
+			State = 1921; asTypeClause();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class ArrayDimContext : ParserRuleContext {
 		public WhiteSpaceContext whiteSpace(int i) {
 			return GetRuleContext<WhiteSpaceContext>(i);
 		}
@@ -11148,99 +11558,373 @@ public partial class VBAParser : Parser {
 		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
 			return GetRuleContexts<WhiteSpaceContext>();
 		}
-		public AsTypeClauseContext asTypeClause() {
-			return GetRuleContext<AsTypeClauseContext>(0);
-		}
 		public ITerminalNode RPAREN() { return GetToken(VBAParser.RPAREN, 0); }
-		public IdentifierContext identifier() {
-			return GetRuleContext<IdentifierContext>(0);
+		public BoundsListContext boundsList() {
+			return GetRuleContext<BoundsListContext>(0);
 		}
-		public SubscriptsContext subscripts() {
-			return GetRuleContext<SubscriptsContext>(0);
-		}
-		public EndOfStatementContext endOfStatement() {
-			return GetRuleContext<EndOfStatementContext>(0);
-		}
-		public TypeStmt_ElementContext(ParserRuleContext parent, int invokingState)
+		public ArrayDimContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
 		{
 		}
-		public override int RuleIndex { get { return RULE_typeStmt_Element; } }
+		public override int RuleIndex { get { return RULE_arrayDim; } }
 		public override void EnterRule(IParseTreeListener listener) {
 			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.EnterTypeStmt_Element(this);
+			if (typedListener != null) typedListener.EnterArrayDim(this);
 		}
 		public override void ExitRule(IParseTreeListener listener) {
 			IVBAParserListener typedListener = listener as IVBAParserListener;
-			if (typedListener != null) typedListener.ExitTypeStmt_Element(this);
+			if (typedListener != null) typedListener.ExitArrayDim(this);
 		}
 		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
 			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
-			if (typedVisitor != null) return typedVisitor.VisitTypeStmt_Element(this);
+			if (typedVisitor != null) return typedVisitor.VisitArrayDim(this);
 			else return visitor.VisitChildren(this);
 		}
 	}
 
 	[RuleVersion(0)]
-	public TypeStmt_ElementContext typeStmt_Element() {
-		TypeStmt_ElementContext _localctx = new TypeStmt_ElementContext(_ctx, State);
-		EnterRule(_localctx, 278, RULE_typeStmt_Element);
+	public ArrayDimContext arrayDim() {
+		ArrayDimContext _localctx = new ArrayDimContext(_ctx, State);
+		EnterRule(_localctx, 292, RULE_arrayDim);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1867; identifier();
-			State = 1882;
-			switch ( Interpreter.AdaptivePredict(_input,241,_ctx) ) {
+			State = 1923; Match(LPAREN);
+			State = 1925;
+			switch ( Interpreter.AdaptivePredict(_input,240,_ctx) ) {
 			case 1:
 				{
-				State = 1869;
-				_la = _input.La(1);
-				if (_la==WS || _la==LINE_CONTINUATION) {
-					{
-					State = 1868; whiteSpace();
-					}
+				State = 1924; whiteSpace();
 				}
+				break;
+			}
+			State = 1928;
+			_la = _input.La(1);
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
+				{
+				State = 1927; boundsList();
+				}
+			}
 
-				State = 1871; Match(LPAREN);
-				State = 1876;
-				switch ( Interpreter.AdaptivePredict(_input,239,_ctx) ) {
-				case 1:
+			State = 1931;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
+				{
+				State = 1930; whiteSpace();
+				}
+			}
+
+			State = 1933; Match(RPAREN);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class BoundsListContext : ParserRuleContext {
+		public DimSpecContext dimSpec(int i) {
+			return GetRuleContext<DimSpecContext>(i);
+		}
+		public WhiteSpaceContext whiteSpace(int i) {
+			return GetRuleContext<WhiteSpaceContext>(i);
+		}
+		public IReadOnlyList<DimSpecContext> dimSpec() {
+			return GetRuleContexts<DimSpecContext>();
+		}
+		public IReadOnlyList<ITerminalNode> COMMA() { return GetTokens(VBAParser.COMMA); }
+		public IReadOnlyList<WhiteSpaceContext> whiteSpace() {
+			return GetRuleContexts<WhiteSpaceContext>();
+		}
+		public ITerminalNode COMMA(int i) {
+			return GetToken(VBAParser.COMMA, i);
+		}
+		public BoundsListContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_boundsList; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterBoundsList(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitBoundsList(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitBoundsList(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public BoundsListContext boundsList() {
+		BoundsListContext _localctx = new BoundsListContext(_ctx, State);
+		EnterRule(_localctx, 294, RULE_boundsList);
+		int _la;
+		try {
+			int _alt;
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1935; dimSpec();
+			State = 1946;
+			_errHandler.Sync(this);
+			_alt = Interpreter.AdaptivePredict(_input,245,_ctx);
+			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
+				if ( _alt==1 ) {
 					{
-					State = 1873;
+					{
+					State = 1937;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1872; whiteSpace();
+						State = 1936; whiteSpace();
 						}
 					}
 
-					State = 1875; subscripts();
+					State = 1939; Match(COMMA);
+					State = 1941;
+					_la = _input.La(1);
+					if (_la==WS || _la==LINE_CONTINUATION) {
+						{
+						State = 1940; whiteSpace();
+						}
 					}
-					break;
+
+					State = 1943; dimSpec();
+					}
+					} 
 				}
-				State = 1879;
+				State = 1948;
+				_errHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(_input,245,_ctx);
+			}
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class DimSpecContext : ParserRuleContext {
+		public LowerBoundContext lowerBound() {
+			return GetRuleContext<LowerBoundContext>(0);
+		}
+		public UpperBoundContext upperBound() {
+			return GetRuleContext<UpperBoundContext>(0);
+		}
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public DimSpecContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_dimSpec; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterDimSpec(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitDimSpec(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitDimSpec(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public DimSpecContext dimSpec() {
+		DimSpecContext _localctx = new DimSpecContext(_ctx, State);
+		EnterRule(_localctx, 296, RULE_dimSpec);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1953;
+			switch ( Interpreter.AdaptivePredict(_input,247,_ctx) ) {
+			case 1:
+				{
+				State = 1949; lowerBound();
+				State = 1951;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1878; whiteSpace();
+					State = 1950; whiteSpace();
 					}
 				}
 
-				State = 1881; Match(RPAREN);
 				}
 				break;
 			}
-			State = 1887;
-			switch ( Interpreter.AdaptivePredict(_input,242,_ctx) ) {
-			case 1:
+			State = 1955; upperBound();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class LowerBoundContext : ParserRuleContext {
+		public WhiteSpaceContext whiteSpace() {
+			return GetRuleContext<WhiteSpaceContext>(0);
+		}
+		public ITerminalNode TO() { return GetToken(VBAParser.TO, 0); }
+		public ConstantExpressionContext constantExpression() {
+			return GetRuleContext<ConstantExpressionContext>(0);
+		}
+		public LowerBoundContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_lowerBound; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterLowerBound(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitLowerBound(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitLowerBound(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public LowerBoundContext lowerBound() {
+		LowerBoundContext _localctx = new LowerBoundContext(_ctx, State);
+		EnterRule(_localctx, 298, RULE_lowerBound);
+		int _la;
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1957; constantExpression();
+			State = 1959;
+			_la = _input.La(1);
+			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 1884; whiteSpace();
-				State = 1885; asTypeClause();
+				State = 1958; whiteSpace();
 				}
-				break;
 			}
-			State = 1889; endOfStatement();
+
+			State = 1961; Match(TO);
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class UpperBoundContext : ParserRuleContext {
+		public ConstantExpressionContext constantExpression() {
+			return GetRuleContext<ConstantExpressionContext>(0);
+		}
+		public UpperBoundContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_upperBound; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterUpperBound(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitUpperBound(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitUpperBound(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public UpperBoundContext upperBound() {
+		UpperBoundContext _localctx = new UpperBoundContext(_ctx, State);
+		EnterRule(_localctx, 300, RULE_upperBound);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1963; constantExpression();
+			}
+		}
+		catch (RecognitionException re) {
+			_localctx.exception = re;
+			_errHandler.ReportError(this, re);
+			_errHandler.Recover(this, re);
+		}
+		finally {
+			ExitRule();
+		}
+		return _localctx;
+	}
+
+	public partial class ConstantExpressionContext : ParserRuleContext {
+		public ExpressionContext expression() {
+			return GetRuleContext<ExpressionContext>(0);
+		}
+		public ConstantExpressionContext(ParserRuleContext parent, int invokingState)
+			: base(parent, invokingState)
+		{
+		}
+		public override int RuleIndex { get { return RULE_constantExpression; } }
+		public override void EnterRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.EnterConstantExpression(this);
+		}
+		public override void ExitRule(IParseTreeListener listener) {
+			IVBAParserListener typedListener = listener as IVBAParserListener;
+			if (typedListener != null) typedListener.ExitConstantExpression(this);
+		}
+		public override TResult Accept<TResult>(IParseTreeVisitor<TResult> visitor) {
+			IVBAParserVisitor<TResult> typedVisitor = visitor as IVBAParserVisitor<TResult>;
+			if (typedVisitor != null) return typedVisitor.VisitConstantExpression(this);
+			else return visitor.VisitChildren(this);
+		}
+	}
+
+	[RuleVersion(0)]
+	public ConstantExpressionContext constantExpression() {
+		ConstantExpressionContext _localctx = new ConstantExpressionContext(_ctx, State);
+		EnterRule(_localctx, 302, RULE_constantExpression);
+		try {
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 1965; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -11293,20 +11977,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VariableStmtContext variableStmt() {
 		VariableStmtContext _localctx = new VariableStmtContext(_ctx, State);
-		EnterRule(_localctx, 280, RULE_variableStmt);
+		EnterRule(_localctx, 304, RULE_variableStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1894;
+			State = 1970;
 			switch (_input.La(1)) {
 			case DIM:
 				{
-				State = 1891; Match(DIM);
+				State = 1967; Match(DIM);
 				}
 				break;
 			case STATIC:
 				{
-				State = 1892; Match(STATIC);
+				State = 1968; Match(STATIC);
 				}
 				break;
 			case FRIEND:
@@ -11314,23 +11998,23 @@ public partial class VBAParser : Parser {
 			case PRIVATE:
 			case PUBLIC:
 				{
-				State = 1893; visibility();
+				State = 1969; visibility();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 1896; whiteSpace();
-			State = 1899;
-			switch ( Interpreter.AdaptivePredict(_input,244,_ctx) ) {
+			State = 1972; whiteSpace();
+			State = 1975;
+			switch ( Interpreter.AdaptivePredict(_input,250,_ctx) ) {
 			case 1:
 				{
-				State = 1897; Match(WITHEVENTS);
-				State = 1898; whiteSpace();
+				State = 1973; Match(WITHEVENTS);
+				State = 1974; whiteSpace();
 				}
 				break;
 			}
-			State = 1901; variableListStmt();
+			State = 1977; variableListStmt();
 			}
 		}
 		catch (RecognitionException re) {
@@ -11384,44 +12068,44 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VariableListStmtContext variableListStmt() {
 		VariableListStmtContext _localctx = new VariableListStmtContext(_ctx, State);
-		EnterRule(_localctx, 282, RULE_variableListStmt);
+		EnterRule(_localctx, 306, RULE_variableListStmt);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1903; variableSubStmt();
-			State = 1914;
+			State = 1979; variableSubStmt();
+			State = 1990;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,247,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,253,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1905;
+					State = 1981;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1904; whiteSpace();
+						State = 1980; whiteSpace();
 						}
 					}
 
-					State = 1907; Match(COMMA);
-					State = 1909;
+					State = 1983; Match(COMMA);
+					State = 1985;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1908; whiteSpace();
+						State = 1984; whiteSpace();
 						}
 					}
 
-					State = 1911; variableSubStmt();
+					State = 1987; variableSubStmt();
 					}
 					} 
 				}
-				State = 1916;
+				State = 1992;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,247,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,253,_ctx);
 			}
 			}
 		}
@@ -11477,67 +12161,67 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VariableSubStmtContext variableSubStmt() {
 		VariableSubStmtContext _localctx = new VariableSubStmtContext(_ctx, State);
-		EnterRule(_localctx, 284, RULE_variableSubStmt);
+		EnterRule(_localctx, 308, RULE_variableSubStmt);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1917; identifier();
-			State = 1935;
-			switch ( Interpreter.AdaptivePredict(_input,253,_ctx) ) {
+			State = 1993; identifier();
+			State = 2011;
+			switch ( Interpreter.AdaptivePredict(_input,259,_ctx) ) {
 			case 1:
 				{
-				State = 1919;
+				State = 1995;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1918; whiteSpace();
+					State = 1994; whiteSpace();
 					}
 				}
 
-				State = 1921; Match(LPAREN);
-				State = 1923;
+				State = 1997; Match(LPAREN);
+				State = 1999;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1922; whiteSpace();
+					State = 1998; whiteSpace();
 					}
 				}
 
-				State = 1929;
+				State = 2005;
 				_la = _input.La(1);
 				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 					{
-					State = 1925; subscripts();
-					State = 1927;
+					State = 2001; subscripts();
+					State = 2003;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1926; whiteSpace();
+						State = 2002; whiteSpace();
 						}
 					}
 
 					}
 				}
 
-				State = 1931; Match(RPAREN);
-				State = 1933;
-				switch ( Interpreter.AdaptivePredict(_input,252,_ctx) ) {
+				State = 2007; Match(RPAREN);
+				State = 2009;
+				switch ( Interpreter.AdaptivePredict(_input,258,_ctx) ) {
 				case 1:
 					{
-					State = 1932; whiteSpace();
+					State = 2008; whiteSpace();
 					}
 					break;
 				}
 				}
 				break;
 			}
-			State = 1940;
-			switch ( Interpreter.AdaptivePredict(_input,254,_ctx) ) {
+			State = 2016;
+			switch ( Interpreter.AdaptivePredict(_input,260,_ctx) ) {
 			case 1:
 				{
-				State = 1937; whiteSpace();
-				State = 1938; asTypeClause();
+				State = 2013; whiteSpace();
+				State = 2014; asTypeClause();
 				}
 				break;
 			}
@@ -11592,16 +12276,16 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WhileWendStmtContext whileWendStmt() {
 		WhileWendStmtContext _localctx = new WhileWendStmtContext(_ctx, State);
-		EnterRule(_localctx, 286, RULE_whileWendStmt);
+		EnterRule(_localctx, 310, RULE_whileWendStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1942; Match(WHILE);
-			State = 1943; whiteSpace();
-			State = 1944; expression(0);
-			State = 1945; endOfStatement();
-			State = 1946; block();
-			State = 1947; Match(WEND);
+			State = 2018; Match(WHILE);
+			State = 2019; whiteSpace();
+			State = 2020; expression(0);
+			State = 2021; endOfStatement();
+			State = 2022; block();
+			State = 2023; Match(WEND);
 			}
 		}
 		catch (RecognitionException re) {
@@ -11653,16 +12337,16 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WithStmtContext withStmt() {
 		WithStmtContext _localctx = new WithStmtContext(_ctx, State);
-		EnterRule(_localctx, 288, RULE_withStmt);
+		EnterRule(_localctx, 312, RULE_withStmt);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1949; Match(WITH);
-			State = 1950; whiteSpace();
-			State = 1951; expression(0);
-			State = 1952; endOfStatement();
-			State = 1953; block();
-			State = 1954; Match(END_WITH);
+			State = 2025; Match(WITH);
+			State = 2026; whiteSpace();
+			State = 2027; expression(0);
+			State = 2028; endOfStatement();
+			State = 2029; block();
+			State = 2030; Match(END_WITH);
 			}
 		}
 		catch (RecognitionException re) {
@@ -11722,57 +12406,57 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CircleSpecialFormContext circleSpecialForm() {
 		CircleSpecialFormContext _localctx = new CircleSpecialFormContext(_ctx, State);
-		EnterRule(_localctx, 290, RULE_circleSpecialForm);
+		EnterRule(_localctx, 314, RULE_circleSpecialForm);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1964;
+			State = 2040;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1956; expression(0);
-				State = 1958;
+				State = 2032; expression(0);
+				State = 2034;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1957; whiteSpace();
+					State = 2033; whiteSpace();
 					}
 				}
 
-				State = 1960; Match(DOT);
-				State = 1962;
+				State = 2036; Match(DOT);
+				State = 2038;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1961; whiteSpace();
+					State = 2037; whiteSpace();
 					}
 				}
 
 				}
 			}
 
-			State = 1966; Match(CIRCLE);
-			State = 1967; whiteSpace();
-			State = 1972;
+			State = 2042; Match(CIRCLE);
+			State = 2043; whiteSpace();
+			State = 2048;
 			_la = _input.La(1);
 			if (_la==STEP) {
 				{
-				State = 1968; Match(STEP);
-				State = 1970;
+				State = 2044; Match(STEP);
+				State = 2046;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1969; whiteSpace();
+					State = 2045; whiteSpace();
 					}
 				}
 
 				}
 			}
 
-			State = 1974; tuple();
-			State = 1983;
+			State = 2050; tuple();
+			State = 2059;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -11780,33 +12464,33 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 1976;
+					State = 2052;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1975; whiteSpace();
+						State = 2051; whiteSpace();
 						}
 					}
 
-					State = 1978; Match(COMMA);
-					State = 1980;
+					State = 2054; Match(COMMA);
+					State = 2056;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 1979; whiteSpace();
+						State = 2055; whiteSpace();
 						}
 					}
 
-					State = 1982; expression(0);
+					State = 2058; expression(0);
 					}
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 1985;
+				State = 2061;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,262,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,268,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
 			}
 		}
@@ -11863,57 +12547,57 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ScaleSpecialFormContext scaleSpecialForm() {
 		ScaleSpecialFormContext _localctx = new ScaleSpecialFormContext(_ctx, State);
-		EnterRule(_localctx, 292, RULE_scaleSpecialForm);
+		EnterRule(_localctx, 316, RULE_scaleSpecialForm);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1995;
+			State = 2071;
 			_la = _input.La(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (EMPTY - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LPAREN - 192)) | (1L << (MINUS - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
-				State = 1987; expression(0);
-				State = 1989;
+				State = 2063; expression(0);
+				State = 2065;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1988; whiteSpace();
+					State = 2064; whiteSpace();
 					}
 				}
 
-				State = 1991; Match(DOT);
-				State = 1993;
+				State = 2067; Match(DOT);
+				State = 2069;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 1992; whiteSpace();
+					State = 2068; whiteSpace();
 					}
 				}
 
 				}
 			}
 
-			State = 1997; Match(SCALE);
-			State = 1998; whiteSpace();
-			State = 1999; tuple();
-			State = 2001;
+			State = 2073; Match(SCALE);
+			State = 2074; whiteSpace();
+			State = 2075; tuple();
+			State = 2077;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2000; whiteSpace();
+				State = 2076; whiteSpace();
 				}
 			}
 
-			State = 2003; Match(MINUS);
-			State = 2005;
+			State = 2079; Match(MINUS);
+			State = 2081;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2004; whiteSpace();
+				State = 2080; whiteSpace();
 				}
 			}
 
-			State = 2007; tuple();
+			State = 2083; tuple();
 			}
 		}
 		catch (RecognitionException re) {
@@ -11966,48 +12650,48 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TupleContext tuple() {
 		TupleContext _localctx = new TupleContext(_ctx, State);
-		EnterRule(_localctx, 294, RULE_tuple);
+		EnterRule(_localctx, 318, RULE_tuple);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2009; Match(LPAREN);
-			State = 2011;
+			State = 2085; Match(LPAREN);
+			State = 2087;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2010; whiteSpace();
+				State = 2086; whiteSpace();
 				}
 			}
 
-			State = 2013; expression(0);
-			State = 2015;
+			State = 2089; expression(0);
+			State = 2091;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2014; whiteSpace();
+				State = 2090; whiteSpace();
 				}
 			}
 
-			State = 2017; Match(COMMA);
-			State = 2019;
+			State = 2093; Match(COMMA);
+			State = 2095;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2018; whiteSpace();
+				State = 2094; whiteSpace();
 				}
 			}
 
-			State = 2021; expression(0);
-			State = 2023;
+			State = 2097; expression(0);
+			State = 2099;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2022; whiteSpace();
+				State = 2098; whiteSpace();
 				}
 			}
 
-			State = 2025; Match(RPAREN);
+			State = 2101; Match(RPAREN);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12061,44 +12745,44 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubscriptsContext subscripts() {
 		SubscriptsContext _localctx = new SubscriptsContext(_ctx, State);
-		EnterRule(_localctx, 296, RULE_subscripts);
+		EnterRule(_localctx, 320, RULE_subscripts);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2027; subscript();
-			State = 2038;
+			State = 2103; subscript();
+			State = 2114;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,274,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,280,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2029;
+					State = 2105;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2028; whiteSpace();
+						State = 2104; whiteSpace();
 						}
 					}
 
-					State = 2031; Match(COMMA);
-					State = 2033;
+					State = 2107; Match(COMMA);
+					State = 2109;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2032; whiteSpace();
+						State = 2108; whiteSpace();
 						}
 					}
 
-					State = 2035; subscript();
+					State = 2111; subscript();
 					}
 					} 
 				}
-				State = 2040;
+				State = 2116;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,274,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,280,_ctx);
 			}
 			}
 		}
@@ -12150,22 +12834,22 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public SubscriptContext subscript() {
 		SubscriptContext _localctx = new SubscriptContext(_ctx, State);
-		EnterRule(_localctx, 298, RULE_subscript);
+		EnterRule(_localctx, 322, RULE_subscript);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2046;
-			switch ( Interpreter.AdaptivePredict(_input,275,_ctx) ) {
+			State = 2122;
+			switch ( Interpreter.AdaptivePredict(_input,281,_ctx) ) {
 			case 1:
 				{
-				State = 2041; expression(0);
-				State = 2042; whiteSpace();
-				State = 2043; Match(TO);
-				State = 2044; whiteSpace();
+				State = 2117; expression(0);
+				State = 2118; whiteSpace();
+				State = 2119; Match(TO);
+				State = 2120; whiteSpace();
 				}
 				break;
 			}
-			State = 2048; expression(0);
+			State = 2124; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12212,9 +12896,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UnrestrictedIdentifierContext unrestrictedIdentifier() {
 		UnrestrictedIdentifierContext _localctx = new UnrestrictedIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 300, RULE_unrestrictedIdentifier);
+		EnterRule(_localctx, 324, RULE_unrestrictedIdentifier);
 		try {
-			State = 2053;
+			State = 2129;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -12334,7 +13018,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2050; identifier();
+				State = 2126; identifier();
 				}
 				break;
 			case EXIT:
@@ -12401,13 +13085,13 @@ public partial class VBAParser : Parser {
 			case WITH:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2051; statementKeyword();
+				State = 2127; statementKeyword();
 				}
 				break;
 			case AS:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2052; markerKeyword();
+				State = 2128; markerKeyword();
 				}
 				break;
 			default:
@@ -12455,21 +13139,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IdentifierContext identifier() {
 		IdentifierContext _localctx = new IdentifierContext(_ctx, State);
-		EnterRule(_localctx, 302, RULE_identifier);
+		EnterRule(_localctx, 326, RULE_identifier);
 		try {
-			State = 2057;
-			switch ( Interpreter.AdaptivePredict(_input,277,_ctx) ) {
+			State = 2133;
+			switch ( Interpreter.AdaptivePredict(_input,283,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2055; untypedIdentifier();
+				State = 2131; untypedIdentifier();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2056; typedIdentifier();
+				State = 2132; typedIdentifier();
 				}
 				break;
 			}
@@ -12512,11 +13196,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UntypedIdentifierContext untypedIdentifier() {
 		UntypedIdentifierContext _localctx = new UntypedIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 304, RULE_untypedIdentifier);
+		EnterRule(_localctx, 328, RULE_untypedIdentifier);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2059; identifierValue();
+			State = 2135; identifierValue();
 			}
 		}
 		catch (RecognitionException re) {
@@ -12560,12 +13244,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypedIdentifierContext typedIdentifier() {
 		TypedIdentifierContext _localctx = new TypedIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 306, RULE_typedIdentifier);
+		EnterRule(_localctx, 330, RULE_typedIdentifier);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2061; identifierValue();
-			State = 2062; typeHint();
+			State = 2137; identifierValue();
+			State = 2138; typeHint();
 			}
 		}
 		catch (RecognitionException re) {
@@ -12610,14 +13294,14 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IdentifierValueContext identifierValue() {
 		IdentifierValueContext _localctx = new IdentifierValueContext(_ctx, State);
-		EnterRule(_localctx, 308, RULE_identifierValue);
+		EnterRule(_localctx, 332, RULE_identifierValue);
 		try {
-			State = 2067;
+			State = 2143;
 			switch (_input.La(1)) {
 			case IDENTIFIER:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2064; Match(IDENTIFIER);
+				State = 2140; Match(IDENTIFIER);
 				}
 				break;
 			case ABS:
@@ -12736,13 +13420,13 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2065; keyword();
+				State = 2141; keyword();
 				}
 				break;
 			case L_SQUARE_BRACKET:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2066; foreignName();
+				State = 2142; foreignName();
 				}
 				break;
 			default:
@@ -12792,26 +13476,26 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ForeignNameContext foreignName() {
 		ForeignNameContext _localctx = new ForeignNameContext(_ctx, State);
-		EnterRule(_localctx, 310, RULE_foreignName);
+		EnterRule(_localctx, 334, RULE_foreignName);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2069; Match(L_SQUARE_BRACKET);
-			State = 2073;
+			State = 2145; Match(L_SQUARE_BRACKET);
+			State = 2149;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CIRCLE) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << EXIT) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << OPTION) | (1L << PSET) | (1L << SCALE) | (1L << SGN) | (1L << UBOUND) | (1L << COMMA) | (1L << COLON) | (1L << SEMICOLON) | (1L << EXCLAMATIONPOINT) | (1L << DOT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << AS) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE) | (1L << CALL) | (1L << CASE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (CONST - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DECLARE - 64)) | (1L << (DEFBOOL - 64)) | (1L << (DEFBYTE - 64)) | (1L << (DEFDATE - 64)) | (1L << (DEFDBL - 64)) | (1L << (DEFCUR - 64)) | (1L << (DEFINT - 64)) | (1L << (DEFLNG - 64)) | (1L << (DEFLNGLNG - 64)) | (1L << (DEFLNGPTR - 64)) | (1L << (DEFOBJ - 64)) | (1L << (DEFSNG - 64)) | (1L << (DEFSTR - 64)) | (1L << (DEFVAR - 64)) | (1L << (DIM - 64)) | (1L << (DO - 64)) | (1L << (DOUBLE - 64)) | (1L << (EACH - 64)) | (1L << (ELSE - 64)) | (1L << (ELSEIF - 64)) | (1L << (EMPTY - 64)) | (1L << (END_ENUM - 64)) | (1L << (END_FUNCTION - 64)) | (1L << (END_IF - 64)) | (1L << (END_PROPERTY - 64)) | (1L << (END_SELECT - 64)) | (1L << (END_SUB - 64)) | (1L << (END_TYPE - 64)) | (1L << (END_WITH - 64)) | (1L << (END - 64)) | (1L << (ENUM - 64)) | (1L << (EQV - 64)) | (1L << (ERASE - 64)) | (1L << (ERROR - 64)) | (1L << (EVENT - 64)) | (1L << (EXIT_DO - 64)) | (1L << (EXIT_FOR - 64)) | (1L << (EXIT_FUNCTION - 64)) | (1L << (EXIT_PROPERTY - 64)) | (1L << (EXIT_SUB - 64)) | (1L << (FALSE - 64)) | (1L << (FRIEND - 64)) | (1L << (FOR - 64)) | (1L << (FUNCTION - 64)) | (1L << (GET - 64)) | (1L << (GLOBAL - 64)) | (1L << (GOSUB - 64)) | (1L << (GOTO - 64)) | (1L << (IF - 64)) | (1L << (IMP - 64)) | (1L << (IMPLEMENTS - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)) | (1L << (LOOP - 64)) | (1L << (LET - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (LSET - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEXT - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON - 128)) | (1L << (ON_ERROR - 128)) | (1L << (ON_LOCAL_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OPTION_BASE - 128)) | (1L << (OPTION_EXPLICIT - 128)) | (1L << (OPTION_COMPARE - 128)) | (1L << (OPTION_PRIVATE_MODULE - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PRIVATE - 128)) | (1L << (PROPERTY_GET - 128)) | (1L << (PROPERTY_LET - 128)) | (1L << (PROPERTY_SET - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUBLIC - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (RAISEEVENT - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REDIM - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (RESUME - 128)) | (1L << (RETURN - 128)) | (1L << (RSET - 128)) | (1L << (SEEK - 128)) | (1L << (SELECT - 128)) | (1L << (SET - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STATIC - 128)) | (1L << (STEP - 128)) | (1L << (STOP - 128)) | (1L << (STRING - 128)) | (1L << (SUB - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)) | (1L << (TYPE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WEND - 192)) | (1L << (WHILE - 192)) | (1L << (WIDTH - 192)) | (1L << (WITH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (ASSIGN - 192)) | (1L << (DIV - 192)) | (1L << (INTDIV - 192)) | (1L << (EQ - 192)) | (1L << (GEQ - 192)) | (1L << (GT - 192)) | (1L << (LEQ - 192)) | (1L << (LPAREN - 192)) | (1L << (LT - 192)) | (1L << (MINUS - 192)) | (1L << (MULT - 192)) | (1L << (NEQ - 192)) | (1L << (PLUS - 192)) | (1L << (POW - 192)) | (1L << (RPAREN - 192)) | (1L << (L_SQUARE_BRACKET - 192)) | (1L << (STRINGLITERAL - 192)) | (1L << (OCTLITERAL - 192)) | (1L << (HEXLITERAL - 192)) | (1L << (FLOATLITERAL - 192)) | (1L << (INTEGERLITERAL - 192)) | (1L << (DATELITERAL - 192)) | (1L << (NEWLINE - 192)) | (1L << (SINGLEQUOTE - 192)) | (1L << (UNDERSCORE - 192)) | (1L << (WS - 192)) | (1L << (GUIDLITERAL - 192)) | (1L << (IDENTIFIER - 192)) | (1L << (LINE_CONTINUATION - 192)) | (1L << (ERRORCHAR - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) {
 				{
 				{
-				State = 2070; foreignIdentifier();
+				State = 2146; foreignIdentifier();
 				}
 				}
-				State = 2075;
+				State = 2151;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
-			State = 2076; Match(R_SQUARE_BRACKET);
+			State = 2152; Match(R_SQUARE_BRACKET);
 			}
 		}
 		catch (RecognitionException re) {
@@ -12854,10 +13538,10 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ForeignIdentifierContext foreignIdentifier() {
 		ForeignIdentifierContext _localctx = new ForeignIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 312, RULE_foreignIdentifier);
+		EnterRule(_localctx, 336, RULE_foreignIdentifier);
 		int _la;
 		try {
-			State = 2080;
+			State = 2156;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -13095,7 +13779,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2078;
+				State = 2154;
 				_la = _input.La(1);
 				if ( _la <= 0 || (_la==L_SQUARE_BRACKET || _la==R_SQUARE_BRACKET) ) {
 				_errHandler.RecoverInline(this);
@@ -13106,7 +13790,7 @@ public partial class VBAParser : Parser {
 			case L_SQUARE_BRACKET:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2079; foreignName();
+				State = 2155; foreignName();
 				}
 				break;
 			default:
@@ -13162,43 +13846,43 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AsTypeClauseContext asTypeClause() {
 		AsTypeClauseContext _localctx = new AsTypeClauseContext(_ctx, State);
-		EnterRule(_localctx, 314, RULE_asTypeClause);
+		EnterRule(_localctx, 338, RULE_asTypeClause);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2082; Match(AS);
-			State = 2084;
+			State = 2158; Match(AS);
+			State = 2160;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2083; whiteSpace();
+				State = 2159; whiteSpace();
 				}
 			}
 
-			State = 2088;
-			switch ( Interpreter.AdaptivePredict(_input,282,_ctx) ) {
+			State = 2164;
+			switch ( Interpreter.AdaptivePredict(_input,288,_ctx) ) {
 			case 1:
 				{
-				State = 2086; Match(NEW);
-				State = 2087; whiteSpace();
+				State = 2162; Match(NEW);
+				State = 2163; whiteSpace();
 				}
 				break;
 			}
-			State = 2090; type();
-			State = 2095;
-			switch ( Interpreter.AdaptivePredict(_input,284,_ctx) ) {
+			State = 2166; type();
+			State = 2171;
+			switch ( Interpreter.AdaptivePredict(_input,290,_ctx) ) {
 			case 1:
 				{
-				State = 2092;
+				State = 2168;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2091; whiteSpace();
+					State = 2167; whiteSpace();
 					}
 				}
 
-				State = 2094; fieldLength();
+				State = 2170; fieldLength();
 				}
 				break;
 			}
@@ -13252,12 +13936,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public BaseTypeContext baseType() {
 		BaseTypeContext _localctx = new BaseTypeContext(_ctx, State);
-		EnterRule(_localctx, 316, RULE_baseType);
+		EnterRule(_localctx, 340, RULE_baseType);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2097;
+			State = 2173;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANY) | (1L << CURRENCY) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << BOOLEAN) | (1L << BYTE))) != 0) || ((((_la - 68)) & ~0x3f) == 0 && ((1L << (_la - 68)) & ((1L << (DATE - 68)) | (1L << (DOUBLE - 68)) | (1L << (INTEGER - 68)) | (1L << (LONG - 68)))) != 0) || ((((_la - 179)) & ~0x3f) == 0 && ((1L << (_la - 179)) & ((1L << (SINGLE - 179)) | (1L << (STRING - 179)) | (1L << (VARIANT - 179)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -13308,12 +13992,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ComparisonOperatorContext comparisonOperator() {
 		ComparisonOperatorContext _localctx = new ComparisonOperatorContext(_ctx, State);
-		EnterRule(_localctx, 318, RULE_comparisonOperator);
+		EnterRule(_localctx, 342, RULE_comparisonOperator);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2099;
+			State = 2175;
 			_la = _input.La(1);
 			if ( !(_la==IS || _la==LIKE || ((((_la - 207)) & ~0x3f) == 0 && ((1L << (_la - 207)) & ((1L << (EQ - 207)) | (1L << (GEQ - 207)) | (1L << (GT - 207)) | (1L << (LEQ - 207)) | (1L << (LT - 207)) | (1L << (NEQ - 207)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -13359,11 +14043,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ComplexTypeContext complexType() {
 		ComplexTypeContext _localctx = new ComplexTypeContext(_ctx, State);
-		EnterRule(_localctx, 320, RULE_complexType);
+		EnterRule(_localctx, 344, RULE_complexType);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2101; expression(0);
+			State = 2177; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -13408,21 +14092,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public FieldLengthContext fieldLength() {
 		FieldLengthContext _localctx = new FieldLengthContext(_ctx, State);
-		EnterRule(_localctx, 322, RULE_fieldLength);
+		EnterRule(_localctx, 346, RULE_fieldLength);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2103; Match(MULT);
-			State = 2105;
+			State = 2179; Match(MULT);
+			State = 2181;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2104; whiteSpace();
+				State = 2180; whiteSpace();
 				}
 			}
 
-			State = 2107; expression(0);
+			State = 2183; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -13467,21 +14151,21 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementLabelDefinitionContext statementLabelDefinition() {
 		StatementLabelDefinitionContext _localctx = new StatementLabelDefinitionContext(_ctx, State);
-		EnterRule(_localctx, 324, RULE_statementLabelDefinition);
+		EnterRule(_localctx, 348, RULE_statementLabelDefinition);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2109; statementLabel();
-			State = 2111;
+			State = 2185; statementLabel();
+			State = 2187;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2110; whiteSpace();
+				State = 2186; whiteSpace();
 				}
 			}
 
-			State = 2113; Match(COLON);
+			State = 2189; Match(COLON);
 			}
 		}
 		catch (RecognitionException re) {
@@ -13525,9 +14209,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementLabelContext statementLabel() {
 		StatementLabelContext _localctx = new StatementLabelContext(_ctx, State);
-		EnterRule(_localctx, 326, RULE_statementLabel);
+		EnterRule(_localctx, 350, RULE_statementLabel);
 		try {
-			State = 2117;
+			State = 2193;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -13710,7 +14394,7 @@ public partial class VBAParser : Parser {
 			case RESUME_NEXT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2115; identifierStatementLabel();
+				State = 2191; identifierStatementLabel();
 				}
 				break;
 			case OCTLITERAL:
@@ -13719,7 +14403,7 @@ public partial class VBAParser : Parser {
 			case INTEGERLITERAL:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2116; lineNumberLabel();
+				State = 2192; lineNumberLabel();
 				}
 				break;
 			default:
@@ -13764,11 +14448,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public IdentifierStatementLabelContext identifierStatementLabel() {
 		IdentifierStatementLabelContext _localctx = new IdentifierStatementLabelContext(_ctx, State);
-		EnterRule(_localctx, 328, RULE_identifierStatementLabel);
+		EnterRule(_localctx, 352, RULE_identifierStatementLabel);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2119; unrestrictedIdentifier();
+			State = 2195; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -13809,11 +14493,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LineNumberLabelContext lineNumberLabel() {
 		LineNumberLabelContext _localctx = new LineNumberLabelContext(_ctx, State);
-		EnterRule(_localctx, 330, RULE_lineNumberLabel);
+		EnterRule(_localctx, 354, RULE_lineNumberLabel);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2121; numberLiteral();
+			State = 2197; numberLiteral();
 			}
 		}
 		catch (RecognitionException re) {
@@ -13855,12 +14539,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public NumberLiteralContext numberLiteral() {
 		NumberLiteralContext _localctx = new NumberLiteralContext(_ctx, State);
-		EnterRule(_localctx, 332, RULE_numberLiteral);
+		EnterRule(_localctx, 356, RULE_numberLiteral);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2123;
+			State = 2199;
 			_la = _input.La(1);
 			if ( !(((((_la - 222)) & ~0x3f) == 0 && ((1L << (_la - 222)) & ((1L << (OCTLITERAL - 222)) | (1L << (HEXLITERAL - 222)) | (1L << (FLOATLITERAL - 222)) | (1L << (INTEGERLITERAL - 222)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -13917,47 +14601,47 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeContext type() {
 		TypeContext _localctx = new TypeContext(_ctx, State);
-		EnterRule(_localctx, 334, RULE_type);
+		EnterRule(_localctx, 358, RULE_type);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2127;
-			switch ( Interpreter.AdaptivePredict(_input,288,_ctx) ) {
+			State = 2203;
+			switch ( Interpreter.AdaptivePredict(_input,294,_ctx) ) {
 			case 1:
 				{
-				State = 2125; baseType();
+				State = 2201; baseType();
 				}
 				break;
 
 			case 2:
 				{
-				State = 2126; complexType();
+				State = 2202; complexType();
 				}
 				break;
 			}
-			State = 2137;
-			switch ( Interpreter.AdaptivePredict(_input,291,_ctx) ) {
+			State = 2213;
+			switch ( Interpreter.AdaptivePredict(_input,297,_ctx) ) {
 			case 1:
 				{
-				State = 2130;
+				State = 2206;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2129; whiteSpace();
+					State = 2205; whiteSpace();
 					}
 				}
 
-				State = 2132; Match(LPAREN);
-				State = 2134;
+				State = 2208; Match(LPAREN);
+				State = 2210;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2133; whiteSpace();
+					State = 2209; whiteSpace();
 					}
 				}
 
-				State = 2136; Match(RPAREN);
+				State = 2212; Match(RPAREN);
 				}
 				break;
 			}
@@ -14005,12 +14689,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public TypeHintContext typeHint() {
 		TypeHintContext _localctx = new TypeHintContext(_ctx, State);
-		EnterRule(_localctx, 336, RULE_typeHint);
+		EnterRule(_localctx, 360, RULE_typeHint);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2139;
+			State = 2215;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EXCLAMATIONPOINT) | (1L << HASH) | (1L << AT) | (1L << PERCENT) | (1L << DOLLAR) | (1L << AMPERSAND))) != 0) || _la==POW) ) {
 			_errHandler.RecoverInline(this);
@@ -14057,12 +14741,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VisibilityContext visibility() {
 		VisibilityContext _localctx = new VisibilityContext(_ctx, State);
-		EnterRule(_localctx, 338, RULE_visibility);
+		EnterRule(_localctx, 362, RULE_visibility);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2141;
+			State = 2217;
 			_la = _input.La(1);
 			if ( !(((((_la - 110)) & ~0x3f) == 0 && ((1L << (_la - 110)) & ((1L << (FRIEND - 110)) | (1L << (GLOBAL - 110)) | (1L << (PRIVATE - 110)) | (1L << (PUBLIC - 110)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -14657,24 +15341,24 @@ public partial class VBAParser : Parser {
 		int _parentState = State;
 		ExpressionContext _localctx = new ExpressionContext(_ctx, _parentState);
 		ExpressionContext _prevctx = _localctx;
-		int _startState = 340;
-		EnterRecursionRule(_localctx, 340, RULE_expression, _p);
+		int _startState = 364;
+		EnterRecursionRule(_localctx, 364, RULE_expression, _p);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2177;
-			switch ( Interpreter.AdaptivePredict(_input,296,_ctx) ) {
+			State = 2253;
+			switch ( Interpreter.AdaptivePredict(_input,302,_ctx) ) {
 			case 1:
 				{
 				_localctx = new TypeofexprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
 
-				State = 2144; Match(TYPEOF);
-				State = 2145; whiteSpace();
-				State = 2146; expression(17);
+				State = 2220; Match(TYPEOF);
+				State = 2221; whiteSpace();
+				State = 2222; expression(17);
 				}
 				break;
 
@@ -14683,9 +15367,9 @@ public partial class VBAParser : Parser {
 				_localctx = new NewExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2148; Match(NEW);
-				State = 2149; whiteSpace();
-				State = 2150; expression(16);
+				State = 2224; Match(NEW);
+				State = 2225; whiteSpace();
+				State = 2226; expression(16);
 				}
 				break;
 
@@ -14694,16 +15378,16 @@ public partial class VBAParser : Parser {
 				_localctx = new UnaryMinusOpContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2152; Match(MINUS);
-				State = 2154;
+				State = 2228; Match(MINUS);
+				State = 2230;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2153; whiteSpace();
+					State = 2229; whiteSpace();
 					}
 				}
 
-				State = 2156; expression(14);
+				State = 2232; expression(14);
 				}
 				break;
 
@@ -14712,16 +15396,16 @@ public partial class VBAParser : Parser {
 				_localctx = new LogicalNotOpContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2157; Match(NOT);
-				State = 2159;
+				State = 2233; Match(NOT);
+				State = 2235;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2158; whiteSpace();
+					State = 2234; whiteSpace();
 					}
 				}
 
-				State = 2161; expression(7);
+				State = 2237; expression(7);
 				}
 				break;
 
@@ -14730,8 +15414,8 @@ public partial class VBAParser : Parser {
 				_localctx = new MarkedFileNumberExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2162; Match(HASH);
-				State = 2163; expression(1);
+				State = 2238; Match(HASH);
+				State = 2239; expression(1);
 				}
 				break;
 
@@ -14740,7 +15424,7 @@ public partial class VBAParser : Parser {
 				_localctx = new LiteralExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2164; literalExpression();
+				State = 2240; literalExpression();
 				}
 				break;
 
@@ -14749,7 +15433,7 @@ public partial class VBAParser : Parser {
 				_localctx = new LExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2165; lExpression(0);
+				State = 2241; lExpression(0);
 				}
 				break;
 
@@ -14758,7 +15442,7 @@ public partial class VBAParser : Parser {
 				_localctx = new BuiltInTypeExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2166; builtInType();
+				State = 2242; builtInType();
 				}
 				break;
 
@@ -14767,285 +15451,45 @@ public partial class VBAParser : Parser {
 				_localctx = new ParenthesizedExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2167; Match(LPAREN);
-				State = 2169;
+				State = 2243; Match(LPAREN);
+				State = 2245;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2168; whiteSpace();
+					State = 2244; whiteSpace();
 					}
 				}
 
-				State = 2171; expression(0);
-				State = 2173;
+				State = 2247; expression(0);
+				State = 2249;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2172; whiteSpace();
+					State = 2248; whiteSpace();
 					}
 				}
 
-				State = 2175; Match(RPAREN);
+				State = 2251; Match(RPAREN);
 				}
 				break;
 			}
 			_ctx.stop = _input.Lt(-1);
-			State = 2289;
+			State = 2365;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,322,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,328,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					if ( _parseListeners!=null ) TriggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					State = 2287;
-					switch ( Interpreter.AdaptivePredict(_input,321,_ctx) ) {
+					State = 2363;
+					switch ( Interpreter.AdaptivePredict(_input,327,_ctx) ) {
 					case 1:
 						{
 						_localctx = new PowOpContext(new ExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2179;
+						State = 2255;
 						if (!(Precpred(_ctx, 15))) throw new FailedPredicateException(this, "Precpred(_ctx, 15)");
-						State = 2181;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2180; whiteSpace();
-							}
-						}
-
-						State = 2183; Match(POW);
-						State = 2185;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2184; whiteSpace();
-							}
-						}
-
-						State = 2187; expression(16);
-						}
-						break;
-
-					case 2:
-						{
-						_localctx = new MultOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2188;
-						if (!(Precpred(_ctx, 13))) throw new FailedPredicateException(this, "Precpred(_ctx, 13)");
-						State = 2190;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2189; whiteSpace();
-							}
-						}
-
-						State = 2192;
-						_la = _input.La(1);
-						if ( !(_la==DIV || _la==MULT) ) {
-						_errHandler.RecoverInline(this);
-						}
-						Consume();
-						State = 2194;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2193; whiteSpace();
-							}
-						}
-
-						State = 2196; expression(14);
-						}
-						break;
-
-					case 3:
-						{
-						_localctx = new IntDivOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2197;
-						if (!(Precpred(_ctx, 12))) throw new FailedPredicateException(this, "Precpred(_ctx, 12)");
-						State = 2199;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2198; whiteSpace();
-							}
-						}
-
-						State = 2201; Match(INTDIV);
-						State = 2203;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2202; whiteSpace();
-							}
-						}
-
-						State = 2205; expression(13);
-						}
-						break;
-
-					case 4:
-						{
-						_localctx = new ModOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2206;
-						if (!(Precpred(_ctx, 11))) throw new FailedPredicateException(this, "Precpred(_ctx, 11)");
-						State = 2208;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2207; whiteSpace();
-							}
-						}
-
-						State = 2210; Match(MOD);
-						State = 2212;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2211; whiteSpace();
-							}
-						}
-
-						State = 2214; expression(12);
-						}
-						break;
-
-					case 5:
-						{
-						_localctx = new AddOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2215;
-						if (!(Precpred(_ctx, 10))) throw new FailedPredicateException(this, "Precpred(_ctx, 10)");
-						State = 2217;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2216; whiteSpace();
-							}
-						}
-
-						State = 2219;
-						_la = _input.La(1);
-						if ( !(_la==MINUS || _la==PLUS) ) {
-						_errHandler.RecoverInline(this);
-						}
-						Consume();
-						State = 2221;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2220; whiteSpace();
-							}
-						}
-
-						State = 2223; expression(11);
-						}
-						break;
-
-					case 6:
-						{
-						_localctx = new ConcatOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2224;
-						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
-						State = 2226;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2225; whiteSpace();
-							}
-						}
-
-						State = 2228; Match(AMPERSAND);
-						State = 2230;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2229; whiteSpace();
-							}
-						}
-
-						State = 2232; expression(10);
-						}
-						break;
-
-					case 7:
-						{
-						_localctx = new RelationalOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2233;
-						if (!(Precpred(_ctx, 8))) throw new FailedPredicateException(this, "Precpred(_ctx, 8)");
-						State = 2235;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2234; whiteSpace();
-							}
-						}
-
-						State = 2237;
-						_la = _input.La(1);
-						if ( !(_la==IS || _la==LIKE || ((((_la - 207)) & ~0x3f) == 0 && ((1L << (_la - 207)) & ((1L << (EQ - 207)) | (1L << (GEQ - 207)) | (1L << (GT - 207)) | (1L << (LEQ - 207)) | (1L << (LT - 207)) | (1L << (NEQ - 207)))) != 0)) ) {
-						_errHandler.RecoverInline(this);
-						}
-						Consume();
-						State = 2239;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2238; whiteSpace();
-							}
-						}
-
-						State = 2241; expression(9);
-						}
-						break;
-
-					case 8:
-						{
-						_localctx = new LogicalAndOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2242;
-						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
-						State = 2244;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2243; whiteSpace();
-							}
-						}
-
-						State = 2246; Match(AND);
-						State = 2248;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2247; whiteSpace();
-							}
-						}
-
-						State = 2250; expression(7);
-						}
-						break;
-
-					case 9:
-						{
-						_localctx = new LogicalOrOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2251;
-						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
-						State = 2253;
-						_la = _input.La(1);
-						if (_la==WS || _la==LINE_CONTINUATION) {
-							{
-							State = 2252; whiteSpace();
-							}
-						}
-
-						State = 2255; Match(OR);
 						State = 2257;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
@@ -15054,25 +15498,25 @@ public partial class VBAParser : Parser {
 							}
 						}
 
-						State = 2259; expression(6);
-						}
-						break;
-
-					case 10:
-						{
-						_localctx = new LogicalXorOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2260;
-						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
-						State = 2262;
+						State = 2259; Match(POW);
+						State = 2261;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2261; whiteSpace();
+							State = 2260; whiteSpace();
 							}
 						}
 
-						State = 2264; Match(XOR);
+						State = 2263; expression(16);
+						}
+						break;
+
+					case 2:
+						{
+						_localctx = new MultOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2264;
+						if (!(Precpred(_ctx, 13))) throw new FailedPredicateException(this, "Precpred(_ctx, 13)");
 						State = 2266;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
@@ -15081,25 +15525,30 @@ public partial class VBAParser : Parser {
 							}
 						}
 
-						State = 2268; expression(5);
+						State = 2268;
+						_la = _input.La(1);
+						if ( !(_la==DIV || _la==MULT) ) {
+						_errHandler.RecoverInline(this);
 						}
-						break;
-
-					case 11:
-						{
-						_localctx = new LogicalEqvOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2269;
-						if (!(Precpred(_ctx, 3))) throw new FailedPredicateException(this, "Precpred(_ctx, 3)");
-						State = 2271;
+						Consume();
+						State = 2270;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2270; whiteSpace();
+							State = 2269; whiteSpace();
 							}
 						}
 
-						State = 2273; Match(EQV);
+						State = 2272; expression(14);
+						}
+						break;
+
+					case 3:
+						{
+						_localctx = new IntDivOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2273;
+						if (!(Precpred(_ctx, 12))) throw new FailedPredicateException(this, "Precpred(_ctx, 12)");
 						State = 2275;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
@@ -15108,25 +15557,25 @@ public partial class VBAParser : Parser {
 							}
 						}
 
-						State = 2277; expression(4);
-						}
-						break;
-
-					case 12:
-						{
-						_localctx = new LogicalImpOpContext(new ExpressionContext(_parentctx, _parentState));
-						PushNewRecursionContext(_localctx, _startState, RULE_expression);
-						State = 2278;
-						if (!(Precpred(_ctx, 2))) throw new FailedPredicateException(this, "Precpred(_ctx, 2)");
-						State = 2280;
+						State = 2277; Match(INTDIV);
+						State = 2279;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2279; whiteSpace();
+							State = 2278; whiteSpace();
 							}
 						}
 
-						State = 2282; Match(IMP);
+						State = 2281; expression(13);
+						}
+						break;
+
+					case 4:
+						{
+						_localctx = new ModOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2282;
+						if (!(Precpred(_ctx, 11))) throw new FailedPredicateException(this, "Precpred(_ctx, 11)");
 						State = 2284;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
@@ -15135,15 +15584,250 @@ public partial class VBAParser : Parser {
 							}
 						}
 
-						State = 2286; expression(3);
+						State = 2286; Match(MOD);
+						State = 2288;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2287; whiteSpace();
+							}
+						}
+
+						State = 2290; expression(12);
+						}
+						break;
+
+					case 5:
+						{
+						_localctx = new AddOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2291;
+						if (!(Precpred(_ctx, 10))) throw new FailedPredicateException(this, "Precpred(_ctx, 10)");
+						State = 2293;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2292; whiteSpace();
+							}
+						}
+
+						State = 2295;
+						_la = _input.La(1);
+						if ( !(_la==MINUS || _la==PLUS) ) {
+						_errHandler.RecoverInline(this);
+						}
+						Consume();
+						State = 2297;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2296; whiteSpace();
+							}
+						}
+
+						State = 2299; expression(11);
+						}
+						break;
+
+					case 6:
+						{
+						_localctx = new ConcatOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2300;
+						if (!(Precpred(_ctx, 9))) throw new FailedPredicateException(this, "Precpred(_ctx, 9)");
+						State = 2302;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2301; whiteSpace();
+							}
+						}
+
+						State = 2304; Match(AMPERSAND);
+						State = 2306;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2305; whiteSpace();
+							}
+						}
+
+						State = 2308; expression(10);
+						}
+						break;
+
+					case 7:
+						{
+						_localctx = new RelationalOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2309;
+						if (!(Precpred(_ctx, 8))) throw new FailedPredicateException(this, "Precpred(_ctx, 8)");
+						State = 2311;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2310; whiteSpace();
+							}
+						}
+
+						State = 2313;
+						_la = _input.La(1);
+						if ( !(_la==IS || _la==LIKE || ((((_la - 207)) & ~0x3f) == 0 && ((1L << (_la - 207)) & ((1L << (EQ - 207)) | (1L << (GEQ - 207)) | (1L << (GT - 207)) | (1L << (LEQ - 207)) | (1L << (LT - 207)) | (1L << (NEQ - 207)))) != 0)) ) {
+						_errHandler.RecoverInline(this);
+						}
+						Consume();
+						State = 2315;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2314; whiteSpace();
+							}
+						}
+
+						State = 2317; expression(9);
+						}
+						break;
+
+					case 8:
+						{
+						_localctx = new LogicalAndOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2318;
+						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
+						State = 2320;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2319; whiteSpace();
+							}
+						}
+
+						State = 2322; Match(AND);
+						State = 2324;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2323; whiteSpace();
+							}
+						}
+
+						State = 2326; expression(7);
+						}
+						break;
+
+					case 9:
+						{
+						_localctx = new LogicalOrOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2327;
+						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
+						State = 2329;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2328; whiteSpace();
+							}
+						}
+
+						State = 2331; Match(OR);
+						State = 2333;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2332; whiteSpace();
+							}
+						}
+
+						State = 2335; expression(6);
+						}
+						break;
+
+					case 10:
+						{
+						_localctx = new LogicalXorOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2336;
+						if (!(Precpred(_ctx, 4))) throw new FailedPredicateException(this, "Precpred(_ctx, 4)");
+						State = 2338;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2337; whiteSpace();
+							}
+						}
+
+						State = 2340; Match(XOR);
+						State = 2342;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2341; whiteSpace();
+							}
+						}
+
+						State = 2344; expression(5);
+						}
+						break;
+
+					case 11:
+						{
+						_localctx = new LogicalEqvOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2345;
+						if (!(Precpred(_ctx, 3))) throw new FailedPredicateException(this, "Precpred(_ctx, 3)");
+						State = 2347;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2346; whiteSpace();
+							}
+						}
+
+						State = 2349; Match(EQV);
+						State = 2351;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2350; whiteSpace();
+							}
+						}
+
+						State = 2353; expression(4);
+						}
+						break;
+
+					case 12:
+						{
+						_localctx = new LogicalImpOpContext(new ExpressionContext(_parentctx, _parentState));
+						PushNewRecursionContext(_localctx, _startState, RULE_expression);
+						State = 2354;
+						if (!(Precpred(_ctx, 2))) throw new FailedPredicateException(this, "Precpred(_ctx, 2)");
+						State = 2356;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2355; whiteSpace();
+							}
+						}
+
+						State = 2358; Match(IMP);
+						State = 2360;
+						_la = _input.La(1);
+						if (_la==WS || _la==LINE_CONTINUATION) {
+							{
+							State = 2359; whiteSpace();
+							}
+						}
+
+						State = 2362; expression(3);
 						}
 						break;
 					}
 					} 
 				}
-				State = 2291;
+				State = 2367;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,322,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,328,_ctx);
 			}
 			}
 		}
@@ -15193,9 +15877,9 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LiteralExpressionContext literalExpression() {
 		LiteralExpressionContext _localctx = new LiteralExpressionContext(_ctx, State);
-		EnterRule(_localctx, 342, RULE_literalExpression);
+		EnterRule(_localctx, 366, RULE_literalExpression);
 		try {
-			State = 2299;
+			State = 2375;
 			switch (_input.La(1)) {
 			case OCTLITERAL:
 			case HEXLITERAL:
@@ -15203,19 +15887,19 @@ public partial class VBAParser : Parser {
 			case INTEGERLITERAL:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2292; numberLiteral();
+				State = 2368; numberLiteral();
 				}
 				break;
 			case DATELITERAL:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2293; Match(DATELITERAL);
+				State = 2369; Match(DATELITERAL);
 				}
 				break;
 			case STRINGLITERAL:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2294; Match(STRINGLITERAL);
+				State = 2370; Match(STRINGLITERAL);
 				}
 				break;
 			case EMPTY:
@@ -15225,12 +15909,12 @@ public partial class VBAParser : Parser {
 			case TRUE:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2295; literalIdentifier();
-				State = 2297;
-				switch ( Interpreter.AdaptivePredict(_input,323,_ctx) ) {
+				State = 2371; literalIdentifier();
+				State = 2373;
+				switch ( Interpreter.AdaptivePredict(_input,329,_ctx) ) {
 				case 1:
 					{
-					State = 2296; typeHint();
+					State = 2372; typeHint();
 					}
 					break;
 				}
@@ -15284,28 +15968,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LiteralIdentifierContext literalIdentifier() {
 		LiteralIdentifierContext _localctx = new LiteralIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 344, RULE_literalIdentifier);
+		EnterRule(_localctx, 368, RULE_literalIdentifier);
 		try {
-			State = 2304;
+			State = 2380;
 			switch (_input.La(1)) {
 			case FALSE:
 			case TRUE:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2301; booleanLiteralIdentifier();
+				State = 2377; booleanLiteralIdentifier();
 				}
 				break;
 			case NOTHING:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2302; objectLiteralIdentifier();
+				State = 2378; objectLiteralIdentifier();
 				}
 				break;
 			case EMPTY:
 			case NULL:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2303; variantLiteralIdentifier();
+				State = 2379; variantLiteralIdentifier();
 				}
 				break;
 			default:
@@ -15349,12 +16033,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public BooleanLiteralIdentifierContext booleanLiteralIdentifier() {
 		BooleanLiteralIdentifierContext _localctx = new BooleanLiteralIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 346, RULE_booleanLiteralIdentifier);
+		EnterRule(_localctx, 370, RULE_booleanLiteralIdentifier);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2306;
+			State = 2382;
 			_la = _input.La(1);
 			if ( !(_la==FALSE || _la==TRUE) ) {
 			_errHandler.RecoverInline(this);
@@ -15398,11 +16082,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ObjectLiteralIdentifierContext objectLiteralIdentifier() {
 		ObjectLiteralIdentifierContext _localctx = new ObjectLiteralIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 348, RULE_objectLiteralIdentifier);
+		EnterRule(_localctx, 372, RULE_objectLiteralIdentifier);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2308; Match(NOTHING);
+			State = 2384; Match(NOTHING);
 			}
 		}
 		catch (RecognitionException re) {
@@ -15442,12 +16126,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public VariantLiteralIdentifierContext variantLiteralIdentifier() {
 		VariantLiteralIdentifierContext _localctx = new VariantLiteralIdentifierContext(_ctx, State);
-		EnterRule(_localctx, 350, RULE_variantLiteralIdentifier);
+		EnterRule(_localctx, 374, RULE_variantLiteralIdentifier);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2310;
+			State = 2386;
 			_la = _input.La(1);
 			if ( !(_la==EMPTY || _la==NULL) ) {
 			_errHandler.RecoverInline(this);
@@ -15659,22 +16343,22 @@ public partial class VBAParser : Parser {
 		int _parentState = State;
 		LExpressionContext _localctx = new LExpressionContext(_ctx, _parentState);
 		LExpressionContext _prevctx = _localctx;
-		int _startState = 352;
-		EnterRecursionRule(_localctx, 352, RULE_lExpression, _p);
+		int _startState = 376;
+		EnterRecursionRule(_localctx, 376, RULE_lExpression, _p);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2325;
-			switch ( Interpreter.AdaptivePredict(_input,328,_ctx) ) {
+			State = 2401;
+			switch ( Interpreter.AdaptivePredict(_input,334,_ctx) ) {
 			case 1:
 				{
 				_localctx = new InstanceExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
 
-				State = 2313; Match(ME);
+				State = 2389; Match(ME);
 				}
 				break;
 
@@ -15683,7 +16367,7 @@ public partial class VBAParser : Parser {
 				_localctx = new SimpleNameExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2314; identifier();
+				State = 2390; identifier();
 				}
 				break;
 
@@ -15692,16 +16376,16 @@ public partial class VBAParser : Parser {
 				_localctx = new WithMemberAccessExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2315; Match(DOT);
-				State = 2317;
+				State = 2391; Match(DOT);
+				State = 2393;
 				_la = _input.La(1);
 				if (_la==LINE_CONTINUATION) {
 					{
-					State = 2316; mandatoryLineContinuation();
+					State = 2392; mandatoryLineContinuation();
 					}
 				}
 
-				State = 2319; unrestrictedIdentifier();
+				State = 2395; unrestrictedIdentifier();
 				}
 				break;
 
@@ -15710,70 +16394,70 @@ public partial class VBAParser : Parser {
 				_localctx = new WithDictionaryAccessExprContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				State = 2320; Match(EXCLAMATIONPOINT);
-				State = 2322;
+				State = 2396; Match(EXCLAMATIONPOINT);
+				State = 2398;
 				_la = _input.La(1);
 				if (_la==LINE_CONTINUATION) {
 					{
-					State = 2321; mandatoryLineContinuation();
+					State = 2397; mandatoryLineContinuation();
 					}
 				}
 
-				State = 2324; unrestrictedIdentifier();
+				State = 2400; unrestrictedIdentifier();
 				}
 				break;
 			}
 			_ctx.stop = _input.Lt(-1);
-			State = 2362;
+			State = 2438;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,338,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,344,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					if ( _parseListeners!=null ) TriggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					State = 2360;
-					switch ( Interpreter.AdaptivePredict(_input,337,_ctx) ) {
+					State = 2436;
+					switch ( Interpreter.AdaptivePredict(_input,343,_ctx) ) {
 					case 1:
 						{
 						_localctx = new IndexExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 2327;
+						State = 2403;
 						if (!(Precpred(_ctx, 7))) throw new FailedPredicateException(this, "Precpred(_ctx, 7)");
-						State = 2329;
+						State = 2405;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2328; whiteSpace();
+							State = 2404; whiteSpace();
 							}
 						}
 
-						State = 2331; Match(LPAREN);
-						State = 2333;
-						switch ( Interpreter.AdaptivePredict(_input,330,_ctx) ) {
+						State = 2407; Match(LPAREN);
+						State = 2409;
+						switch ( Interpreter.AdaptivePredict(_input,336,_ctx) ) {
 						case 1:
 							{
-							State = 2332; whiteSpace();
+							State = 2408; whiteSpace();
 							}
 							break;
 						}
-						State = 2336;
-						switch ( Interpreter.AdaptivePredict(_input,331,_ctx) ) {
+						State = 2412;
+						switch ( Interpreter.AdaptivePredict(_input,337,_ctx) ) {
 						case 1:
 							{
-							State = 2335; argumentList();
+							State = 2411; argumentList();
 							}
 							break;
 						}
-						State = 2339;
+						State = 2415;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2338; whiteSpace();
+							State = 2414; whiteSpace();
 							}
 						}
 
-						State = 2341; Match(RPAREN);
+						State = 2417; Match(RPAREN);
 						}
 						break;
 
@@ -15781,26 +16465,26 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new MemberAccessExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 2342;
+						State = 2418;
 						if (!(Precpred(_ctx, 6))) throw new FailedPredicateException(this, "Precpred(_ctx, 6)");
-						State = 2344;
+						State = 2420;
 						_la = _input.La(1);
 						if (_la==LINE_CONTINUATION) {
 							{
-							State = 2343; mandatoryLineContinuation();
+							State = 2419; mandatoryLineContinuation();
 							}
 						}
 
-						State = 2346; Match(DOT);
-						State = 2348;
+						State = 2422; Match(DOT);
+						State = 2424;
 						_la = _input.La(1);
 						if (_la==LINE_CONTINUATION) {
 							{
-							State = 2347; mandatoryLineContinuation();
+							State = 2423; mandatoryLineContinuation();
 							}
 						}
 
-						State = 2350; unrestrictedIdentifier();
+						State = 2426; unrestrictedIdentifier();
 						}
 						break;
 
@@ -15808,34 +16492,34 @@ public partial class VBAParser : Parser {
 						{
 						_localctx = new DictionaryAccessExprContext(new LExpressionContext(_parentctx, _parentState));
 						PushNewRecursionContext(_localctx, _startState, RULE_lExpression);
-						State = 2351;
+						State = 2427;
 						if (!(Precpred(_ctx, 5))) throw new FailedPredicateException(this, "Precpred(_ctx, 5)");
-						State = 2353;
+						State = 2429;
 						_la = _input.La(1);
 						if (_la==LINE_CONTINUATION) {
 							{
-							State = 2352; mandatoryLineContinuation();
+							State = 2428; mandatoryLineContinuation();
 							}
 						}
 
-						State = 2355; Match(EXCLAMATIONPOINT);
-						State = 2357;
+						State = 2431; Match(EXCLAMATIONPOINT);
+						State = 2433;
 						_la = _input.La(1);
 						if (_la==LINE_CONTINUATION) {
 							{
-							State = 2356; mandatoryLineContinuation();
+							State = 2432; mandatoryLineContinuation();
 							}
 						}
 
-						State = 2359; unrestrictedIdentifier();
+						State = 2435; unrestrictedIdentifier();
 						}
 						break;
 					}
 					} 
 				}
-				State = 2364;
+				State = 2440;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,338,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,344,_ctx);
 			}
 			}
 		}
@@ -15886,72 +16570,72 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public BuiltInTypeContext builtInType() {
 		BuiltInTypeContext _localctx = new BuiltInTypeContext(_ctx, State);
-		EnterRule(_localctx, 354, RULE_builtInType);
+		EnterRule(_localctx, 378, RULE_builtInType);
 		int _la;
 		try {
-			State = 2386;
-			switch ( Interpreter.AdaptivePredict(_input,343,_ctx) ) {
+			State = 2462;
+			switch ( Interpreter.AdaptivePredict(_input,349,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2365; baseType();
+				State = 2441; baseType();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2366; Match(L_SQUARE_BRACKET);
-				State = 2368;
+				State = 2442; Match(L_SQUARE_BRACKET);
+				State = 2444;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2367; whiteSpace();
+					State = 2443; whiteSpace();
 					}
 				}
 
-				State = 2370; baseType();
-				State = 2372;
+				State = 2446; baseType();
+				State = 2448;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2371; whiteSpace();
+					State = 2447; whiteSpace();
 					}
 				}
 
-				State = 2374; Match(R_SQUARE_BRACKET);
+				State = 2450; Match(R_SQUARE_BRACKET);
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2376; Match(OBJECT);
+				State = 2452; Match(OBJECT);
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2377; Match(L_SQUARE_BRACKET);
-				State = 2379;
+				State = 2453; Match(L_SQUARE_BRACKET);
+				State = 2455;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2378; whiteSpace();
+					State = 2454; whiteSpace();
 					}
 				}
 
-				State = 2381; Match(OBJECT);
-				State = 2383;
+				State = 2457; Match(OBJECT);
+				State = 2459;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2382; whiteSpace();
+					State = 2458; whiteSpace();
 					}
 				}
 
-				State = 2385; Match(R_SQUARE_BRACKET);
+				State = 2461; Match(R_SQUARE_BRACKET);
 				}
 				break;
 			}
@@ -15994,11 +16678,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgumentListContext argumentList() {
 		ArgumentListContext _localctx = new ArgumentListContext(_ctx, State);
-		EnterRule(_localctx, 356, RULE_argumentList);
+		EnterRule(_localctx, 380, RULE_argumentList);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2388; positionalOrNamedArgumentList();
+			State = 2464; positionalOrNamedArgumentList();
 			}
 		}
 		catch (RecognitionException re) {
@@ -16054,68 +16738,68 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public PositionalOrNamedArgumentListContext positionalOrNamedArgumentList() {
 		PositionalOrNamedArgumentListContext _localctx = new PositionalOrNamedArgumentListContext(_ctx, State);
-		EnterRule(_localctx, 358, RULE_positionalOrNamedArgumentList);
+		EnterRule(_localctx, 382, RULE_positionalOrNamedArgumentList);
 		try {
 			int _alt;
-			State = 2410;
-			switch ( Interpreter.AdaptivePredict(_input,348,_ctx) ) {
+			State = 2486;
+			switch ( Interpreter.AdaptivePredict(_input,354,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2396;
+				State = 2472;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,345,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,351,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2390; positionalArgumentOrMissing();
-						State = 2392;
-						switch ( Interpreter.AdaptivePredict(_input,344,_ctx) ) {
+						State = 2466; positionalArgumentOrMissing();
+						State = 2468;
+						switch ( Interpreter.AdaptivePredict(_input,350,_ctx) ) {
 						case 1:
 							{
-							State = 2391; whiteSpace();
+							State = 2467; whiteSpace();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 2398;
+					State = 2474;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,345,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,351,_ctx);
 				}
-				State = 2399; requiredPositionalArgument();
+				State = 2475; requiredPositionalArgument();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2406;
+				State = 2482;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,347,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,353,_ctx);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 2400; positionalArgumentOrMissing();
-						State = 2402;
-						switch ( Interpreter.AdaptivePredict(_input,346,_ctx) ) {
+						State = 2476; positionalArgumentOrMissing();
+						State = 2478;
+						switch ( Interpreter.AdaptivePredict(_input,352,_ctx) ) {
 						case 1:
 							{
-							State = 2401; whiteSpace();
+							State = 2477; whiteSpace();
 							}
 							break;
 						}
 						}
 						} 
 					}
-					State = 2408;
+					State = 2484;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,347,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,353,_ctx);
 				}
-				State = 2409; namedArgumentList();
+				State = 2485; namedArgumentList();
 				}
 				break;
 			}
@@ -16190,10 +16874,10 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public PositionalArgumentOrMissingContext positionalArgumentOrMissing() {
 		PositionalArgumentOrMissingContext _localctx = new PositionalArgumentOrMissingContext(_ctx, State);
-		EnterRule(_localctx, 360, RULE_positionalArgumentOrMissing);
+		EnterRule(_localctx, 384, RULE_positionalArgumentOrMissing);
 		int _la;
 		try {
-			State = 2422;
+			State = 2498;
 			switch (_input.La(1)) {
 			case ABS:
 			case ANY:
@@ -16326,16 +17010,16 @@ public partial class VBAParser : Parser {
 				_localctx = new SpecifiedPositionalArgumentContext(_localctx);
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2412; positionalArgument();
-				State = 2414;
+				State = 2488; positionalArgument();
+				State = 2490;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2413; whiteSpace();
+					State = 2489; whiteSpace();
 					}
 				}
 
-				State = 2416; Match(COMMA);
+				State = 2492; Match(COMMA);
 				}
 				break;
 			case COMMA:
@@ -16344,15 +17028,15 @@ public partial class VBAParser : Parser {
 				_localctx = new MissingPositionalArgumentContext(_localctx);
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2419;
+				State = 2495;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2418; whiteSpace();
+					State = 2494; whiteSpace();
 					}
 				}
 
-				State = 2421; Match(COMMA);
+				State = 2497; Match(COMMA);
 				}
 				break;
 			default:
@@ -16397,11 +17081,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public PositionalArgumentContext positionalArgument() {
 		PositionalArgumentContext _localctx = new PositionalArgumentContext(_ctx, State);
-		EnterRule(_localctx, 362, RULE_positionalArgument);
+		EnterRule(_localctx, 386, RULE_positionalArgument);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2424; argumentExpression();
+			State = 2500; argumentExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -16442,11 +17126,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RequiredPositionalArgumentContext requiredPositionalArgument() {
 		RequiredPositionalArgumentContext _localctx = new RequiredPositionalArgumentContext(_ctx, State);
-		EnterRule(_localctx, 364, RULE_requiredPositionalArgument);
+		EnterRule(_localctx, 388, RULE_requiredPositionalArgument);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2426; argumentExpression();
+			State = 2502; argumentExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -16500,44 +17184,44 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public NamedArgumentListContext namedArgumentList() {
 		NamedArgumentListContext _localctx = new NamedArgumentListContext(_ctx, State);
-		EnterRule(_localctx, 366, RULE_namedArgumentList);
+		EnterRule(_localctx, 390, RULE_namedArgumentList);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2428; namedArgument();
-			State = 2439;
+			State = 2504; namedArgument();
+			State = 2515;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,354,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,360,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 2430;
+					State = 2506;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2429; whiteSpace();
+						State = 2505; whiteSpace();
 						}
 					}
 
-					State = 2432; Match(COMMA);
-					State = 2434;
+					State = 2508; Match(COMMA);
+					State = 2510;
 					_la = _input.La(1);
 					if (_la==WS || _la==LINE_CONTINUATION) {
 						{
-						State = 2433; whiteSpace();
+						State = 2509; whiteSpace();
 						}
 					}
 
-					State = 2436; namedArgument();
+					State = 2512; namedArgument();
 					}
 					} 
 				}
-				State = 2441;
+				State = 2517;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,354,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,360,_ctx);
 			}
 			}
 		}
@@ -16589,30 +17273,30 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public NamedArgumentContext namedArgument() {
 		NamedArgumentContext _localctx = new NamedArgumentContext(_ctx, State);
-		EnterRule(_localctx, 368, RULE_namedArgument);
+		EnterRule(_localctx, 392, RULE_namedArgument);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2442; unrestrictedIdentifier();
-			State = 2444;
+			State = 2518; unrestrictedIdentifier();
+			State = 2520;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2443; whiteSpace();
+				State = 2519; whiteSpace();
 				}
 			}
 
-			State = 2446; Match(ASSIGN);
-			State = 2448;
+			State = 2522; Match(ASSIGN);
+			State = 2524;
 			_la = _input.La(1);
 			if (_la==WS || _la==LINE_CONTINUATION) {
 				{
-				State = 2447; whiteSpace();
+				State = 2523; whiteSpace();
 				}
 			}
 
-			State = 2450; argumentExpression();
+			State = 2526; argumentExpression();
 			}
 		}
 		catch (RecognitionException re) {
@@ -16670,41 +17354,41 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public ArgumentExpressionContext argumentExpression() {
 		ArgumentExpressionContext _localctx = new ArgumentExpressionContext(_ctx, State);
-		EnterRule(_localctx, 370, RULE_argumentExpression);
+		EnterRule(_localctx, 394, RULE_argumentExpression);
 		try {
-			State = 2464;
-			switch ( Interpreter.AdaptivePredict(_input,358,_ctx) ) {
+			State = 2540;
+			switch ( Interpreter.AdaptivePredict(_input,364,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2454;
-				switch ( Interpreter.AdaptivePredict(_input,357,_ctx) ) {
+				State = 2530;
+				switch ( Interpreter.AdaptivePredict(_input,363,_ctx) ) {
 				case 1:
 					{
-					State = 2452; Match(BYVAL);
-					State = 2453; whiteSpace();
+					State = 2528; Match(BYVAL);
+					State = 2529; whiteSpace();
 					}
 					break;
 				}
-				State = 2456; expression(0);
+				State = 2532; expression(0);
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2457; addressOfExpression();
+				State = 2533; addressOfExpression();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2458; lowerBoundArgumentExpression();
-				State = 2459; whiteSpace();
-				State = 2460; Match(TO);
-				State = 2461; whiteSpace();
-				State = 2462; upperBoundArgumentExpression();
+				State = 2534; lowerBoundArgumentExpression();
+				State = 2535; whiteSpace();
+				State = 2536; Match(TO);
+				State = 2537; whiteSpace();
+				State = 2538; upperBoundArgumentExpression();
 				}
 				break;
 			}
@@ -16747,11 +17431,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public LowerBoundArgumentExpressionContext lowerBoundArgumentExpression() {
 		LowerBoundArgumentExpressionContext _localctx = new LowerBoundArgumentExpressionContext(_ctx, State);
-		EnterRule(_localctx, 372, RULE_lowerBoundArgumentExpression);
+		EnterRule(_localctx, 396, RULE_lowerBoundArgumentExpression);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2466; expression(0);
+			State = 2542; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -16792,11 +17476,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public UpperBoundArgumentExpressionContext upperBoundArgumentExpression() {
 		UpperBoundArgumentExpressionContext _localctx = new UpperBoundArgumentExpressionContext(_ctx, State);
-		EnterRule(_localctx, 374, RULE_upperBoundArgumentExpression);
+		EnterRule(_localctx, 398, RULE_upperBoundArgumentExpression);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2468; expression(0);
+			State = 2544; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -16841,13 +17525,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AddressOfExpressionContext addressOfExpression() {
 		AddressOfExpressionContext _localctx = new AddressOfExpressionContext(_ctx, State);
-		EnterRule(_localctx, 376, RULE_addressOfExpression);
+		EnterRule(_localctx, 400, RULE_addressOfExpression);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2470; Match(ADDRESSOF);
-			State = 2471; whiteSpace();
-			State = 2472; expression(0);
+			State = 2546; Match(ADDRESSOF);
+			State = 2547; whiteSpace();
+			State = 2548; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -17005,12 +17689,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public KeywordContext keyword() {
 		KeywordContext _localctx = new KeywordContext(_ctx, State);
-		EnterRule(_localctx, 378, RULE_keyword);
+		EnterRule(_localctx, 402, RULE_keyword);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2474;
+			State = 2550;
 			_la = _input.La(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ABS) | (1L << ANY) | (1L << ARRAY) | (1L << CBOOL) | (1L << CBYTE) | (1L << CCUR) | (1L << CDATE) | (1L << CDBL) | (1L << CDEC) | (1L << CINT) | (1L << CLNG) | (1L << CLNGLNG) | (1L << CLNGPTR) | (1L << CSNG) | (1L << CSTR) | (1L << CURRENCY) | (1L << CVAR) | (1L << CVERR) | (1L << DEBUG) | (1L << DOEVENTS) | (1L << FIX) | (1L << INPUTB) | (1L << INT) | (1L << LBOUND) | (1L << LEN) | (1L << LENB) | (1L << LONGLONG) | (1L << LONGPTR) | (1L << MIDB) | (1L << MIDBTYPESUFFIX) | (1L << MIDTYPESUFFIX) | (1L << PSET) | (1L << SGN) | (1L << UBOUND) | (1L << ACCESS) | (1L << ADDRESSOF) | (1L << ALIAS) | (1L << AND) | (1L << ATTRIBUTE) | (1L << APPEND) | (1L << BEGIN) | (1L << BINARY) | (1L << BOOLEAN) | (1L << BYVAL) | (1L << BYREF) | (1L << BYTE))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (CLASS - 64)) | (1L << (CLOSE - 64)) | (1L << (DATABASE - 64)) | (1L << (DATE - 64)) | (1L << (DOUBLE - 64)) | (1L << (END - 64)) | (1L << (EQV - 64)) | (1L << (ERROR - 64)) | (1L << (FALSE - 64)) | (1L << (GET - 64)) | (1L << (IMP - 64)) | (1L << (IN - 64)) | (1L << (INPUT - 64)) | (1L << (IS - 64)) | (1L << (INTEGER - 64)) | (1L << (LOCK - 64)) | (1L << (LONG - 64)))) != 0) || ((((_la - 128)) & ~0x3f) == 0 && ((1L << (_la - 128)) & ((1L << (LIB - 128)) | (1L << (LIKE - 128)) | (1L << (LINE_INPUT - 128)) | (1L << (LOCK_READ - 128)) | (1L << (LOCK_WRITE - 128)) | (1L << (LOCK_READ_WRITE - 128)) | (1L << (ME - 128)) | (1L << (MID - 128)) | (1L << (MOD - 128)) | (1L << (NEW - 128)) | (1L << (NOT - 128)) | (1L << (NOTHING - 128)) | (1L << (NULL - 128)) | (1L << (OBJECT - 128)) | (1L << (ON_ERROR - 128)) | (1L << (OPEN - 128)) | (1L << (OPTIONAL - 128)) | (1L << (OR - 128)) | (1L << (OUTPUT - 128)) | (1L << (PARAMARRAY - 128)) | (1L << (PRESERVE - 128)) | (1L << (PRINT - 128)) | (1L << (PTRSAFE - 128)) | (1L << (PUT - 128)) | (1L << (RANDOM - 128)) | (1L << (READ - 128)) | (1L << (READ_WRITE - 128)) | (1L << (REM - 128)) | (1L << (RESET - 128)) | (1L << (SEEK - 128)) | (1L << (SHARED - 128)) | (1L << (SINGLE - 128)) | (1L << (SPC - 128)) | (1L << (STEP - 128)) | (1L << (STRING - 128)) | (1L << (TAB - 128)) | (1L << (TEXT - 128)) | (1L << (THEN - 128)) | (1L << (TO - 128)) | (1L << (TRUE - 128)))) != 0) || ((((_la - 192)) & ~0x3f) == 0 && ((1L << (_la - 192)) & ((1L << (TYPEOF - 192)) | (1L << (UNLOCK - 192)) | (1L << (UNTIL - 192)) | (1L << (VARIANT - 192)) | (1L << (VERSION - 192)) | (1L << (WIDTH - 192)) | (1L << (WITHEVENTS - 192)) | (1L << (WRITE - 192)) | (1L << (XOR - 192)) | (1L << (LOAD - 192)) | (1L << (RESUME_NEXT - 192)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -17054,11 +17738,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public MarkerKeywordContext markerKeyword() {
 		MarkerKeywordContext _localctx = new MarkerKeywordContext(_ctx, State);
-		EnterRule(_localctx, 380, RULE_markerKeyword);
+		EnterRule(_localctx, 404, RULE_markerKeyword);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2476; Match(AS);
+			State = 2552; Match(AS);
 			}
 		}
 		catch (RecognitionException re) {
@@ -17158,12 +17842,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public StatementKeywordContext statementKeyword() {
 		StatementKeywordContext _localctx = new StatementKeywordContext(_ctx, State);
-		EnterRule(_localctx, 382, RULE_statementKeyword);
+		EnterRule(_localctx, 406, RULE_statementKeyword);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2478;
+			State = 2554;
 			_la = _input.La(1);
 			if ( !(((((_la - 22)) & ~0x3f) == 0 && ((1L << (_la - 22)) & ((1L << (EXIT - 22)) | (1L << (OPTION - 22)) | (1L << (CALL - 22)) | (1L << (CASE - 22)) | (1L << (CONST - 22)) | (1L << (DECLARE - 22)) | (1L << (DEFBOOL - 22)) | (1L << (DEFBYTE - 22)) | (1L << (DEFDATE - 22)) | (1L << (DEFDBL - 22)) | (1L << (DEFCUR - 22)) | (1L << (DEFINT - 22)) | (1L << (DEFLNG - 22)) | (1L << (DEFLNGLNG - 22)) | (1L << (DEFLNGPTR - 22)) | (1L << (DEFOBJ - 22)) | (1L << (DEFSNG - 22)) | (1L << (DEFSTR - 22)) | (1L << (DEFVAR - 22)) | (1L << (DIM - 22)) | (1L << (DO - 22)))) != 0) || ((((_la - 87)) & ~0x3f) == 0 && ((1L << (_la - 87)) & ((1L << (ELSE - 87)) | (1L << (ELSEIF - 87)) | (1L << (END_SELECT - 87)) | (1L << (END_WITH - 87)) | (1L << (ENUM - 87)) | (1L << (ERASE - 87)) | (1L << (EVENT - 87)) | (1L << (EXIT_DO - 87)) | (1L << (EXIT_FOR - 87)) | (1L << (EXIT_FUNCTION - 87)) | (1L << (EXIT_PROPERTY - 87)) | (1L << (EXIT_SUB - 87)) | (1L << (FRIEND - 87)) | (1L << (FOR - 87)) | (1L << (FUNCTION - 87)) | (1L << (GLOBAL - 87)) | (1L << (GOSUB - 87)) | (1L << (GOTO - 87)) | (1L << (IF - 87)) | (1L << (IMPLEMENTS - 87)) | (1L << (LOOP - 87)) | (1L << (LET - 87)) | (1L << (LSET - 87)) | (1L << (NEXT - 87)) | (1L << (ON - 87)))) != 0) || ((((_la - 158)) & ~0x3f) == 0 && ((1L << (_la - 158)) & ((1L << (PRIVATE - 158)) | (1L << (PUBLIC - 158)) | (1L << (RAISEEVENT - 158)) | (1L << (REDIM - 158)) | (1L << (RESUME - 158)) | (1L << (RETURN - 158)) | (1L << (RSET - 158)) | (1L << (SELECT - 158)) | (1L << (SET - 158)) | (1L << (STATIC - 158)) | (1L << (STOP - 158)) | (1L << (SUB - 158)) | (1L << (TYPE - 158)) | (1L << (WEND - 158)) | (1L << (WHILE - 158)) | (1L << (WITH - 158)))) != 0)) ) {
 			_errHandler.RecoverInline(this);
@@ -17216,28 +17900,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EndOfLineContext endOfLine() {
 		EndOfLineContext _localctx = new EndOfLineContext(_ctx, State);
-		EnterRule(_localctx, 384, RULE_endOfLine);
+		EnterRule(_localctx, 408, RULE_endOfLine);
 		int _la;
 		try {
-			State = 2491;
-			switch ( Interpreter.AdaptivePredict(_input,362,_ctx) ) {
+			State = 2567;
+			switch ( Interpreter.AdaptivePredict(_input,368,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2481;
+				State = 2557;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2480; whiteSpace();
+					State = 2556; whiteSpace();
 					}
 				}
 
-				State = 2483; Match(NEWLINE);
-				State = 2485;
-				switch ( Interpreter.AdaptivePredict(_input,360,_ctx) ) {
+				State = 2559; Match(NEWLINE);
+				State = 2561;
+				switch ( Interpreter.AdaptivePredict(_input,366,_ctx) ) {
 				case 1:
 					{
-					State = 2484; whiteSpace();
+					State = 2560; whiteSpace();
 					}
 					break;
 				}
@@ -17247,15 +17931,15 @@ public partial class VBAParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2488;
+				State = 2564;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2487; whiteSpace();
+					State = 2563; whiteSpace();
 					}
 				}
 
-				State = 2490; commentOrAnnotation();
+				State = 2566; commentOrAnnotation();
 				}
 				break;
 			}
@@ -17311,43 +17995,43 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public EndOfStatementContext endOfStatement() {
 		EndOfStatementContext _localctx = new EndOfStatementContext(_ctx, State);
-		EnterRule(_localctx, 386, RULE_endOfStatement);
+		EnterRule(_localctx, 410, RULE_endOfStatement);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2503;
+			State = 2579;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,366,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,372,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
-					State = 2501;
-					switch ( Interpreter.AdaptivePredict(_input,365,_ctx) ) {
+					State = 2577;
+					switch ( Interpreter.AdaptivePredict(_input,371,_ctx) ) {
 					case 1:
 						{
-						State = 2493; endOfLine();
+						State = 2569; endOfLine();
 						}
 						break;
 
 					case 2:
 						{
 						{
-						State = 2495;
+						State = 2571;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2494; whiteSpace();
+							State = 2570; whiteSpace();
 							}
 						}
 
-						State = 2497; Match(COLON);
-						State = 2499;
-						switch ( Interpreter.AdaptivePredict(_input,364,_ctx) ) {
+						State = 2573; Match(COLON);
+						State = 2575;
+						switch ( Interpreter.AdaptivePredict(_input,370,_ctx) ) {
 						case 1:
 							{
-							State = 2498; whiteSpace();
+							State = 2574; whiteSpace();
 							}
 							break;
 						}
@@ -17357,9 +18041,9 @@ public partial class VBAParser : Parser {
 					}
 					} 
 				}
-				State = 2505;
+				State = 2581;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,366,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,372,_ctx);
 			}
 			}
 		}
@@ -17407,28 +18091,28 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentOrAnnotationContext commentOrAnnotation() {
 		CommentOrAnnotationContext _localctx = new CommentOrAnnotationContext(_ctx, State);
-		EnterRule(_localctx, 388, RULE_commentOrAnnotation);
+		EnterRule(_localctx, 412, RULE_commentOrAnnotation);
 		try {
-			State = 2509;
-			switch ( Interpreter.AdaptivePredict(_input,367,_ctx) ) {
+			State = 2585;
+			switch ( Interpreter.AdaptivePredict(_input,373,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2506; annotationList();
+				State = 2582; annotationList();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2507; comment();
+				State = 2583; comment();
 				}
 				break;
 
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2508; remComment();
+				State = 2584; remComment();
 				}
 				break;
 			}
@@ -17475,20 +18159,20 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public RemCommentContext remComment() {
 		RemCommentContext _localctx = new RemCommentContext(_ctx, State);
-		EnterRule(_localctx, 390, RULE_remComment);
+		EnterRule(_localctx, 414, RULE_remComment);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2511; Match(REM);
-			State = 2513;
-			switch ( Interpreter.AdaptivePredict(_input,368,_ctx) ) {
+			State = 2587; Match(REM);
+			State = 2589;
+			switch ( Interpreter.AdaptivePredict(_input,374,_ctx) ) {
 			case 1:
 				{
-				State = 2512; whiteSpace();
+				State = 2588; whiteSpace();
 				}
 				break;
 			}
-			State = 2515; commentBody();
+			State = 2591; commentBody();
 			}
 		}
 		catch (RecognitionException re) {
@@ -17530,12 +18214,12 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentContext comment() {
 		CommentContext _localctx = new CommentContext(_ctx, State);
-		EnterRule(_localctx, 392, RULE_comment);
+		EnterRule(_localctx, 416, RULE_comment);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2517; Match(SINGLEQUOTE);
-			State = 2518; commentBody();
+			State = 2593; Match(SINGLEQUOTE);
+			State = 2594; commentBody();
 			}
 		}
 		catch (RecognitionException re) {
@@ -17581,29 +18265,29 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public CommentBodyContext commentBody() {
 		CommentBodyContext _localctx = new CommentBodyContext(_ctx, State);
-		EnterRule(_localctx, 394, RULE_commentBody);
+		EnterRule(_localctx, 418, RULE_commentBody);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2524;
+			State = 2600;
 			_errHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(_input,370,_ctx);
+			_alt = Interpreter.AdaptivePredict(_input,376,_ctx);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber ) {
 				if ( _alt==1 ) {
 					{
-					State = 2522;
-					switch ( Interpreter.AdaptivePredict(_input,369,_ctx) ) {
+					State = 2598;
+					switch ( Interpreter.AdaptivePredict(_input,375,_ctx) ) {
 					case 1:
 						{
-						State = 2520; Match(LINE_CONTINUATION);
+						State = 2596; Match(LINE_CONTINUATION);
 						}
 						break;
 
 					case 2:
 						{
-						State = 2521;
+						State = 2597;
 						_la = _input.La(1);
 						if ( _la <= 0 || (_la==NEWLINE) ) {
 						_errHandler.RecoverInline(this);
@@ -17614,9 +18298,9 @@ public partial class VBAParser : Parser {
 					}
 					} 
 				}
-				State = 2526;
+				State = 2602;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,370,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,376,_ctx);
 			}
 			}
 		}
@@ -17672,31 +18356,31 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationListContext annotationList() {
 		AnnotationListContext _localctx = new AnnotationListContext(_ctx, State);
-		EnterRule(_localctx, 396, RULE_annotationList);
+		EnterRule(_localctx, 420, RULE_annotationList);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2527; Match(SINGLEQUOTE);
-			State = 2533;
+			State = 2603; Match(SINGLEQUOTE);
+			State = 2609;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			do {
 				{
 				{
-				State = 2528; Match(AT);
-				State = 2529; annotation();
-				State = 2531;
-				switch ( Interpreter.AdaptivePredict(_input,371,_ctx) ) {
+				State = 2604; Match(AT);
+				State = 2605; annotation();
+				State = 2607;
+				switch ( Interpreter.AdaptivePredict(_input,377,_ctx) ) {
 				case 1:
 					{
-					State = 2530; whiteSpace();
+					State = 2606; whiteSpace();
 					}
 					break;
 				}
 				}
 				}
-				State = 2535;
+				State = 2611;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			} while ( _la==AT );
@@ -17743,16 +18427,16 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationContext annotation() {
 		AnnotationContext _localctx = new AnnotationContext(_ctx, State);
-		EnterRule(_localctx, 398, RULE_annotation);
+		EnterRule(_localctx, 422, RULE_annotation);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2537; annotationName();
-			State = 2539;
-			switch ( Interpreter.AdaptivePredict(_input,373,_ctx) ) {
+			State = 2613; annotationName();
+			State = 2615;
+			switch ( Interpreter.AdaptivePredict(_input,379,_ctx) ) {
 			case 1:
 				{
-				State = 2538; annotationArgList();
+				State = 2614; annotationArgList();
 				}
 				break;
 			}
@@ -17796,11 +18480,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationNameContext annotationName() {
 		AnnotationNameContext _localctx = new AnnotationNameContext(_ctx, State);
-		EnterRule(_localctx, 400, RULE_annotationName);
+		EnterRule(_localctx, 424, RULE_annotationName);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2541; unrestrictedIdentifier();
+			State = 2617; unrestrictedIdentifier();
 			}
 		}
 		catch (RecognitionException re) {
@@ -17856,26 +18540,26 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationArgListContext annotationArgList() {
 		AnnotationArgListContext _localctx = new AnnotationArgListContext(_ctx, State);
-		EnterRule(_localctx, 402, RULE_annotationArgList);
+		EnterRule(_localctx, 426, RULE_annotationArgList);
 		int _la;
 		try {
 			int _alt;
-			State = 2603;
-			switch ( Interpreter.AdaptivePredict(_input,387,_ctx) ) {
+			State = 2679;
+			switch ( Interpreter.AdaptivePredict(_input,393,_ctx) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 2543; whiteSpace();
-				State = 2544; annotationArg();
+				State = 2619; whiteSpace();
+				State = 2620; annotationArg();
 				}
 				break;
 
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 2546; whiteSpace();
-				State = 2547; annotationArg();
-				State = 2556;
+				State = 2622; whiteSpace();
+				State = 2623; annotationArg();
+				State = 2632;
 				_errHandler.Sync(this);
 				_alt = 1;
 				do {
@@ -17883,33 +18567,33 @@ public partial class VBAParser : Parser {
 					case 1:
 						{
 						{
-						State = 2549;
+						State = 2625;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2548; whiteSpace();
+							State = 2624; whiteSpace();
 							}
 						}
 
-						State = 2551; Match(COMMA);
-						State = 2553;
+						State = 2627; Match(COMMA);
+						State = 2629;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2552; whiteSpace();
+							State = 2628; whiteSpace();
 							}
 						}
 
-						State = 2555; annotationArg();
+						State = 2631; annotationArg();
 						}
 						}
 						break;
 					default:
 						throw new NoViableAltException(this);
 					}
-					State = 2558;
+					State = 2634;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,376,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,382,_ctx);
 				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
 				}
 				break;
@@ -17917,74 +18601,74 @@ public partial class VBAParser : Parser {
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 2561;
+				State = 2637;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2560; whiteSpace();
+					State = 2636; whiteSpace();
 					}
 				}
 
-				State = 2563; Match(LPAREN);
-				State = 2565;
+				State = 2639; Match(LPAREN);
+				State = 2641;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2564; whiteSpace();
+					State = 2640; whiteSpace();
 					}
 				}
 
-				State = 2567; Match(RPAREN);
+				State = 2643; Match(RPAREN);
 				}
 				break;
 
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 2569;
+				State = 2645;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2568; whiteSpace();
+					State = 2644; whiteSpace();
 					}
 				}
 
-				State = 2571; Match(LPAREN);
-				State = 2573;
+				State = 2647; Match(LPAREN);
+				State = 2649;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2572; whiteSpace();
+					State = 2648; whiteSpace();
 					}
 				}
 
-				State = 2575; annotationArg();
-				State = 2577;
+				State = 2651; annotationArg();
+				State = 2653;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2576; whiteSpace();
+					State = 2652; whiteSpace();
 					}
 				}
 
-				State = 2579; Match(RPAREN);
+				State = 2655; Match(RPAREN);
 				}
 				break;
 
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 2582;
+				State = 2658;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2581; whiteSpace();
+					State = 2657; whiteSpace();
 					}
 				}
 
-				State = 2584; Match(LPAREN);
-				State = 2585; annotationArg();
-				State = 2594;
+				State = 2660; Match(LPAREN);
+				State = 2661; annotationArg();
+				State = 2670;
 				_errHandler.Sync(this);
 				_alt = 1;
 				do {
@@ -17992,43 +18676,43 @@ public partial class VBAParser : Parser {
 					case 1:
 						{
 						{
-						State = 2587;
+						State = 2663;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2586; whiteSpace();
+							State = 2662; whiteSpace();
 							}
 						}
 
-						State = 2589; Match(COMMA);
-						State = 2591;
+						State = 2665; Match(COMMA);
+						State = 2667;
 						_la = _input.La(1);
 						if (_la==WS || _la==LINE_CONTINUATION) {
 							{
-							State = 2590; whiteSpace();
+							State = 2666; whiteSpace();
 							}
 						}
 
-						State = 2593; annotationArg();
+						State = 2669; annotationArg();
 						}
 						}
 						break;
 					default:
 						throw new NoViableAltException(this);
 					}
-					State = 2596;
+					State = 2672;
 					_errHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(_input,385,_ctx);
+					_alt = Interpreter.AdaptivePredict(_input,391,_ctx);
 				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
-				State = 2599;
+				State = 2675;
 				_la = _input.La(1);
 				if (_la==WS || _la==LINE_CONTINUATION) {
 					{
-					State = 2598; whiteSpace();
+					State = 2674; whiteSpace();
 					}
 				}
 
-				State = 2601; Match(RPAREN);
+				State = 2677; Match(RPAREN);
 				}
 				break;
 			}
@@ -18071,11 +18755,11 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public AnnotationArgContext annotationArg() {
 		AnnotationArgContext _localctx = new AnnotationArgContext(_ctx, State);
-		EnterRule(_localctx, 404, RULE_annotationArg);
+		EnterRule(_localctx, 428, RULE_annotationArg);
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2605; expression(0);
+			State = 2681; expression(0);
 			}
 		}
 		catch (RecognitionException re) {
@@ -18118,22 +18802,22 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public MandatoryLineContinuationContext mandatoryLineContinuation() {
 		MandatoryLineContinuationContext _localctx = new MandatoryLineContinuationContext(_ctx, State);
-		EnterRule(_localctx, 406, RULE_mandatoryLineContinuation);
+		EnterRule(_localctx, 430, RULE_mandatoryLineContinuation);
 		int _la;
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2607; Match(LINE_CONTINUATION);
-			State = 2611;
+			State = 2683; Match(LINE_CONTINUATION);
+			State = 2687;
 			_errHandler.Sync(this);
 			_la = _input.La(1);
 			while (_la==WS) {
 				{
 				{
-				State = 2608; Match(WS);
+				State = 2684; Match(WS);
 				}
 				}
-				State = 2613;
+				State = 2689;
 				_errHandler.Sync(this);
 				_la = _input.La(1);
 			}
@@ -18182,13 +18866,13 @@ public partial class VBAParser : Parser {
 	[RuleVersion(0)]
 	public WhiteSpaceContext whiteSpace() {
 		WhiteSpaceContext _localctx = new WhiteSpaceContext(_ctx, State);
-		EnterRule(_localctx, 408, RULE_whiteSpace);
+		EnterRule(_localctx, 432, RULE_whiteSpace);
 		int _la;
 		try {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 2615;
+			State = 2691;
 			_errHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -18196,7 +18880,7 @@ public partial class VBAParser : Parser {
 				case 1:
 					{
 					{
-					State = 2614;
+					State = 2690;
 					_la = _input.La(1);
 					if ( !(_la==WS || _la==LINE_CONTINUATION) ) {
 					_errHandler.RecoverInline(this);
@@ -18208,9 +18892,9 @@ public partial class VBAParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 2617;
+				State = 2693;
 				_errHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(_input,389,_ctx);
+				_alt = Interpreter.AdaptivePredict(_input,395,_ctx);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.InvalidAltNumber );
 			}
 		}
@@ -18231,9 +18915,9 @@ public partial class VBAParser : Parser {
 
 		case 79: return upperCaseZ_sempred((UpperCaseZContext)_localctx, predIndex);
 
-		case 170: return expression_sempred((ExpressionContext)_localctx, predIndex);
+		case 182: return expression_sempred((ExpressionContext)_localctx, predIndex);
 
-		case 176: return lExpression_sempred((LExpressionContext)_localctx, predIndex);
+		case 188: return lExpression_sempred((LExpressionContext)_localctx, predIndex);
 		}
 		return true;
 	}
@@ -18289,7 +18973,7 @@ public partial class VBAParser : Parser {
 	}
 
 	public static readonly string _serializedATN =
-		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xEE\xA3E\x4\x2"+
+		"\x3\xAF6F\x8320\x479D\xB75C\x4880\x1605\x191C\xAB37\x3\xEE\xA8A\x4\x2"+
 		"\t\x2\x4\x3\t\x3\x4\x4\t\x4\x4\x5\t\x5\x4\x6\t\x6\x4\a\t\a\x4\b\t\b\x4"+
 		"\t\t\t\x4\n\t\n\x4\v\t\v\x4\f\t\f\x4\r\t\r\x4\xE\t\xE\x4\xF\t\xF\x4\x10"+
 		"\t\x10\x4\x11\t\x11\x4\x12\t\x12\x4\x13\t\x13\x4\x14\t\x14\x4\x15\t\x15"+
@@ -18320,1197 +19004,1231 @@ public partial class VBAParser : Parser {
 		"\t\xB9\x4\xBA\t\xBA\x4\xBB\t\xBB\x4\xBC\t\xBC\x4\xBD\t\xBD\x4\xBE\t\xBE"+
 		"\x4\xBF\t\xBF\x4\xC0\t\xC0\x4\xC1\t\xC1\x4\xC2\t\xC2\x4\xC3\t\xC3\x4\xC4"+
 		"\t\xC4\x4\xC5\t\xC5\x4\xC6\t\xC6\x4\xC7\t\xC7\x4\xC8\t\xC8\x4\xC9\t\xC9"+
-		"\x4\xCA\t\xCA\x4\xCB\t\xCB\x4\xCC\t\xCC\x4\xCD\t\xCD\x4\xCE\t\xCE\x3\x2"+
-		"\x3\x2\x3\x2\x3\x3\x3\x3\x3\x3\x5\x3\x1A3\n\x3\x3\x3\x3\x3\x5\x3\x1A7"+
-		"\n\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x5\x3\x1AF\n\x3\x3\x4\x3\x4"+
-		"\x3\x4\x3\x4\x5\x4\x1B5\n\x4\x3\x4\x5\x4\x1B8\n\x4\x3\x4\x3\x4\x3\x5\x3"+
-		"\x5\x3\x5\x3\x5\x3\x5\x3\x5\x5\x5\x1C2\n\x5\x5\x5\x1C4\n\x5\x3\x5\x3\x5"+
-		"\x6\x5\x1C8\n\x5\r\x5\xE\x5\x1C9\x3\x5\x3\x5\x3\x5\x3\x6\x3\x6\a\x6\x1D1"+
-		"\n\x6\f\x6\xE\x6\x1D4\v\x6\x3\x6\x3\x6\a\x6\x1D8\n\x6\f\x6\xE\x6\x1DB"+
-		"\v\x6\x3\x6\x3\x6\x3\x6\x5\x6\x1E0\n\x6\x3\x6\x3\x6\x3\a\x3\a\x3\a\a\a"+
-		"\x1E7\n\a\f\a\xE\a\x1EA\v\a\x3\b\x3\b\x3\b\x3\b\x5\b\x1F0\n\b\x3\b\x3"+
-		"\b\x5\b\x1F4\n\b\x3\b\x3\b\x5\b\x1F8\n\b\x3\b\x3\b\x5\b\x1FC\n\b\x3\b"+
-		"\a\b\x1FF\n\b\f\b\xE\b\x202\v\b\x3\t\x3\t\x3\n\x3\n\x3\v\x3\v\x3\v\a\v"+
-		"\x20B\n\v\f\v\xE\v\x20E\v\v\x3\f\x3\f\x3\f\x3\f\x3\f\x3\f\x3\f\x3\f\x3"+
-		"\f\x3\f\x5\f\x21A\n\f\x3\r\x5\r\x21D\n\r\x3\r\x3\r\x3\r\x3\r\x3\r\x3\r"+
-		"\x3\r\x3\r\x3\r\x3\r\x5\r\x229\n\r\x3\xE\x5\xE\x22C\n\xE\x3\xE\x3\xE\x3"+
-		"\xE\a\xE\x231\n\xE\f\xE\xE\xE\x234\v\xE\x3\xF\x3\xF\x3\xF\x3\xF\x3\xF"+
-		"\x5\xF\x23B\n\xF\x3\x10\x3\x10\x3\x10\a\x10\x240\n\x10\f\x10\xE\x10\x243"+
-		"\v\x10\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11"+
-		"\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x5\x11\x268\n\x11\x3\x12\x3"+
-		"\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3"+
-		"\x12\x3\x12\x3\x12\x5\x12\x278\n\x12\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13"+
-		"\x3\x13\x5\x13\x280\n\x13\x3\x13\x3\x13\x3\x13\x5\x13\x285\n\x13\x3\x13"+
-		"\x3\x13\x3\x13\x5\x13\x28A\n\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3\x13\x3"+
-		"\x13\x3\x13\x5\x13\x293\n\x13\x3\x14\x3\x14\x3\x15\x3\x15\x3\x15\x3\x15"+
-		"\x3\x16\x3\x16\x3\x17\x3\x17\x3\x17\x3\x17\x3\x18\x3\x18\x3\x19\x3\x19"+
-		"\x3\x1A\x3\x1A\x5\x1A\x2A7\n\x1A\x3\x1A\x3\x1A\x5\x1A\x2AB\n\x1A\x3\x1A"+
-		"\x3\x1A\x3\x1B\x3\x1B\x3\x1C\x3\x1C\x5\x1C\x2B3\n\x1C\x3\x1D\x3\x1D\x3"+
-		"\x1D\x3\x1E\x3\x1E\x3\x1F\x3\x1F\x3\x1F\x3\x1F\x5\x1F\x2BE\n\x1F\x3 \x3"+
-		" \x3!\x3!\x5!\x2C4\n!\x3!\x3!\x5!\x2C8\n!\x3!\a!\x2CB\n!\f!\xE!\x2CE\v"+
-		"!\x3\"\x3\"\x3\"\x3\"\x5\"\x2D4\n\"\x3\"\x3\"\x5\"\x2D8\n\"\x3\"\x3\""+
-		"\x3#\x3#\x3$\x3$\x3$\x3$\x5$\x2E2\n$\x3$\x3$\x5$\x2E6\n$\x3$\x5$\x2E9"+
-		"\n$\x3%\x3%\x3%\x3%\x5%\x2EF\n%\x3%\x3%\x3%\x3%\x5%\x2F5\n%\x3&\x3&\x3"+
-		"\'\x3\'\x3(\x3(\x3(\x3(\x5(\x2FF\n(\x3(\x3(\x5(\x303\n(\x3(\x5(\x306\n"+
-		"(\x3)\x3)\x3)\x3)\x5)\x30C\n)\x3)\x3)\x5)\x310\n)\x3)\x3)\x3*\x3*\x3+"+
-		"\x3+\x3+\x3+\x5+\x31A\n+\x3+\x3+\x5+\x31E\n+\x3+\x3+\x3,\x3,\x3-\x3-\x3"+
-		"-\x3-\x5-\x328\n-\x3.\x3.\x5.\x32C\n.\x3.\x3.\x5.\x330\n.\x3.\x3.\x3/"+
-		"\x3/\x3\x30\x3\x30\x3\x31\x3\x31\x3\x31\x3\x31\x5\x31\x33C\n\x31\x3\x31"+
-		"\x3\x31\x5\x31\x340\n\x31\x3\x31\x5\x31\x343\n\x31\x3\x32\x3\x32\x5\x32"+
-		"\x347\n\x32\x3\x32\a\x32\x34A\n\x32\f\x32\xE\x32\x34D\v\x32\x3\x33\x3"+
-		"\x33\x3\x33\x3\x33\x5\x33\x353\n\x33\x3\x33\x3\x33\x5\x33\x357\n\x33\x3"+
-		"\x34\x3\x34\x3\x34\x5\x34\x35C\n\x34\x3\x35\x3\x35\x3\x36\x3\x36\x3\x37"+
-		"\x3\x37\x5\x37\x364\n\x37\x3\x37\x3\x37\x5\x37\x368\n\x37\x3\x37\x3\x37"+
-		"\x5\x37\x36C\n\x37\x3\x37\x3\x37\x3\x38\x3\x38\x3\x39\x3\x39\x5\x39\x374"+
-		"\n\x39\x3\x39\x5\x39\x377\n\x39\x3:\x3:\x5:\x37B\n:\x3:\x3:\x5:\x37F\n"+
-		":\x3:\x3:\x3;\x3;\x3<\x3<\x3<\x3<\x5<\x389\n<\x3<\x3<\x5<\x38D\n<\x3<"+
-		"\x5<\x390\n<\x3=\x3=\x3=\x3=\x5=\x396\n=\x3=\x3=\x5=\x39A\n=\x3=\x3=\x3"+
-		">\x3>\x5>\x3A0\n>\x3>\x3>\x5>\x3A4\n>\x3>\a>\x3A7\n>\f>\xE>\x3AA\v>\x3"+
-		"?\x3?\x3@\x3@\x3@\x3@\x5@\x3B2\n@\x3@\x3@\x5@\x3B6\n@\x3@\x5@\x3B9\n@"+
-		"\x3@\x5@\x3BC\n@\x3@\x3@\x5@\x3C0\n@\x3@\x3@\x3\x41\x3\x41\x3\x42\x3\x42"+
-		"\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3CC\n\x43\x3\x43\x3\x43\x5\x43\x3D0"+
-		"\n\x43\x3\x43\x5\x43\x3D3\n\x43\x3\x43\x5\x43\x3D6\n\x43\x3\x43\x3\x43"+
-		"\x5\x43\x3DA\n\x43\x3\x43\x3\x43\x3\x44\x3\x44\x3\x45\x3\x45\x3\x45\x5"+
-		"\x45\x3E3\n\x45\x3\x45\x3\x45\x3\x45\x3\x45\x5\x45\x3E9\n\x45\x3\x45\x3"+
-		"\x45\x5\x45\x3ED\n\x45\x3\x45\a\x45\x3F0\n\x45\f\x45\xE\x45\x3F3\v\x45"+
-		"\x3\x46\x3\x46\x3\x46\x3\x46\x5\x46\x3F9\n\x46\x3\x46\x5\x46\x3FC\n\x46"+
-		"\x3\x46\x3\x46\x5\x46\x400\n\x46\x3\x46\x3\x46\x3G\x3G\x3G\x5G\x407\n"+
-		"G\x3G\x3G\x3G\x3G\x5G\x40D\nG\x3G\x3G\x3G\x3G\x3G\x3G\x3G\x3G\x3G\x3G"+
-		"\x3G\x3G\x5G\x41B\nG\x3G\x5G\x41E\nG\x3G\x5G\x421\nG\x3G\x3G\x3G\x5G\x426"+
-		"\nG\x3H\x3H\x5H\x42A\nH\x3H\x3H\x5H\x42E\nH\x3H\x3H\x5H\x432\nH\x3H\a"+
-		"H\x435\nH\fH\xEH\x438\vH\x5H\x43A\nH\x3H\x5H\x43D\nH\x3H\x3H\x3I\x3I\x5"+
-		"I\x443\nI\x3I\x3I\x5I\x447\nI\x3I\x3I\x5I\x44B\nI\x3I\x3I\x5I\x44F\nI"+
-		"\x3I\x3I\x5I\x453\nI\x3I\x5I\x456\nI\x3I\x5I\x459\nI\x3I\x5I\x45C\nI\x3"+
-		"I\x5I\x45F\nI\x3I\x5I\x462\nI\x3J\x3J\x5J\x466\nJ\x3J\x3J\x3K\x3K\x3K"+
-		"\x3K\x5K\x46E\nK\x3K\x3K\x5K\x472\nK\x3K\aK\x475\nK\fK\xEK\x478\vK\x3"+
-		"L\x3L\x3M\x3M\x3M\x5M\x47F\nM\x3N\x3N\x3O\x3O\x5O\x485\nO\x3O\x3O\x5O"+
-		"\x489\nO\x3O\x3O\x3P\x3P\x3P\x3Q\x3Q\x3Q\x3R\x3R\x5R\x495\nR\x3R\x3R\x5"+
-		"R\x499\nR\x3R\x3R\x3S\x3S\x3T\x3T\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U"+
-		"\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x5U\x4B8\nU\x3"+
-		"V\x3V\x3V\x5V\x4BD\nV\x3V\x3V\x3V\x3V\x3V\aV\x4C4\nV\fV\xEV\x4C7\vV\x3"+
-		"V\x3V\x3W\x3W\x5W\x4CD\nW\x3W\x3W\x5W\x4D1\nW\x3W\x5W\x4D4\nW\x3W\x3W"+
-		"\x3X\x3X\x3Y\x3Y\x3Y\x3Y\x5Y\x4DE\nY\x3Y\x3Y\x5Y\x4E2\nY\x3Y\aY\x4E5\n"+
-		"Y\fY\xEY\x4E8\vY\x3Z\x3Z\x3Z\x3Z\x3[\x3[\x3[\x5[\x4F1\n[\x3[\x3[\x3[\x3"+
-		"[\x5[\x4F7\n[\x3[\x3[\x3\\\x3\\\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x3"+
-		"]\x3]\x3]\x3]\x3]\x3]\x5]\x50C\n]\x3^\x3^\x3^\x3^\x3^\x3^\x3^\x3^\x3^"+
-		"\x3^\x3^\x3^\x5^\x51A\n^\x3^\x3^\x3^\x3^\x3^\x3^\x5^\x522\n^\x3_\x3_\x3"+
-		"_\x5_\x527\n_\x3_\x3_\x5_\x52B\n_\x3_\x3_\x5_\x52F\n_\x3_\x3_\x5_\x533"+
-		"\n_\x3_\x5_\x536\n_\x3_\x5_\x539\n_\x3_\x5_\x53C\n_\x3_\x3_\x3_\x3_\x3"+
-		"`\x3`\x3\x61\x3\x61\x3\x61\x3\x61\x3\x62\x3\x62\x3\x62\x3\x62\x3\x63\x3"+
-		"\x63\x3\x63\x3\x63\x3\x63\x3\x63\x3\x63\x3\x63\a\x63\x554\n\x63\f\x63"+
-		"\xE\x63\x557\v\x63\x3\x63\x5\x63\x55A\n\x63\x3\x63\x3\x63\x3\x64\x3\x64"+
-		"\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64"+
-		"\x3\x64\x3\x64\x5\x64\x56C\n\x64\x3\x64\x3\x64\x5\x64\x570\n\x64\x3\x65"+
-		"\x3\x65\x3\x65\x3\x65\x3\x66\x3\x66\x5\x66\x578\n\x66\x3g\x3g\x5g\x57C"+
-		"\ng\x3g\x3g\x5g\x580\ng\x3g\x3g\x5g\x584\ng\x3g\x3g\x3g\x3g\x5g\x58A\n"+
-		"g\x3h\x3h\x5h\x58E\nh\x3h\x3h\x5h\x592\nh\x3h\x3h\x3h\x5h\x597\nh\x3h"+
-		"\x3h\x3i\x3i\x5i\x59D\ni\x3i\x5i\x5A0\ni\x3j\x3j\x5j\x5A4\nj\x3j\x3j\x5"+
-		"j\x5A8\nj\x3j\x5j\x5AB\nj\aj\x5AD\nj\fj\xEj\x5B0\vj\x3j\x3j\x5j\x5B4\n"+
-		"j\x5j\x5B6\nj\x3j\x3j\x5j\x5BA\nj\x3j\x3j\x5j\x5BE\nj\x3j\x5j\x5C1\nj"+
-		"\aj\x5C3\nj\fj\xEj\x5C6\vj\x5j\x5C8\nj\x3k\x3k\x3l\x3l\x3m\x3m\x3m\x3"+
-		"m\x3n\x3n\x5n\x5D4\nn\x3n\x3n\x5n\x5D8\nn\x3n\x3n\x5n\x5DC\nn\x3n\x3n"+
-		"\x3o\x3o\x3o\x3o\x5o\x5E4\no\x3o\x3o\x5o\x5E8\no\x3o\x3o\x3p\x3p\x3p\x3"+
-		"p\x3p\x3p\x3p\x3p\x3p\x3p\x5p\x5F6\np\x3q\x3q\x3q\x3q\x3q\x3q\x3q\x3q"+
-		"\x5q\x600\nq\x3q\x3q\x5q\x604\nq\x3q\aq\x607\nq\fq\xEq\x60A\vq\x3r\x3"+
-		"r\x3r\x3r\x3r\x3r\x3r\x3r\x5r\x614\nr\x3r\x3r\x5r\x618\nr\x3r\ar\x61B"+
-		"\nr\fr\xEr\x61E\vr\x3s\x3s\x3s\x5s\x623\ns\x3s\x3s\x5s\x627\ns\x3s\x3"+
-		"s\x3s\x3s\x5s\x62D\ns\x3s\x5s\x630\ns\x3s\x3s\x3s\x5s\x635\ns\x3s\x3s"+
-		"\x3s\x3s\x3t\x3t\x3t\x5t\x63E\nt\x3t\x3t\x5t\x642\nt\x3t\x3t\x3t\x3t\x5"+
-		"t\x648\nt\x3t\x5t\x64B\nt\x3t\x3t\x3t\x3t\x3u\x3u\x3u\x5u\x654\nu\x3u"+
-		"\x3u\x5u\x658\nu\x3u\x3u\x3u\x3u\x5u\x65E\nu\x3u\x5u\x661\nu\x3u\x3u\x3"+
-		"u\x3u\x3v\x3v\x3v\x3v\x5v\x66B\nv\x3v\x3v\x5v\x66F\nv\x3v\x5v\x672\nv"+
-		"\x3v\x5v\x675\nv\x3v\x5v\x678\nv\x3w\x3w\x5w\x67C\nw\x3w\x3w\x5w\x680"+
-		"\nw\x3w\aw\x683\nw\fw\xEw\x686\vw\x3x\x3x\x3y\x3y\x3y\x3y\x5y\x68E\ny"+
-		"\x3y\x3y\x3z\x3z\x5z\x694\nz\x3z\x3z\x5z\x698\nz\x3z\az\x69B\nz\fz\xE"+
-		"z\x69E\vz\x3{\x3{\x3{\x3{\x5{\x6A4\n{\x3|\x3|\x3}\x3}\x3}\x3}\x3}\x3}"+
-		"\x3}\x3}\x5}\x6B0\n}\x5}\x6B2\n}\x3~\x3~\x3~\x3~\x5~\x6B8\n~\x5~\x6BA"+
-		"\n~\x3\x7F\x3\x7F\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x6C2\n\x80\x3\x80"+
-		"\x3\x80\x5\x80\x6C6\n\x80\x3\x80\x3\x80\x3\x81\x3\x81\x3\x82\x3\x82\x5"+
-		"\x82\x6CE\n\x82\x3\x82\x3\x82\x5\x82\x6D2\n\x82\x3\x82\x3\x82\x3\x82\a"+
-		"\x82\x6D7\n\x82\f\x82\xE\x82\x6DA\v\x82\x3\x82\x5\x82\x6DD\n\x82\x3\x82"+
-		"\x3\x82\x3\x83\x3\x83\x3\x84\x3\x84\x3\x84\x3\x84\x5\x84\x6E7\n\x84\x3"+
-		"\x84\x3\x84\x5\x84\x6EB\n\x84\x3\x84\a\x84\x6EE\n\x84\f\x84\xE\x84\x6F1"+
-		"\v\x84\x3\x84\x3\x84\x3\x84\x3\x85\x3\x85\x5\x85\x6F8\n\x85\x3\x85\x3"+
-		"\x85\x3\x85\x3\x85\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x3"+
-		"\x86\x3\x86\x5\x86\x707\n\x86\x5\x86\x709\n\x86\x3\x86\x3\x86\x5\x86\x70D"+
-		"\n\x86\x3\x86\x3\x86\x5\x86\x711\n\x86\x3\x87\x3\x87\x3\x88\x3\x88\x3"+
-		"\x89\x3\x89\x3\x89\x3\x89\x5\x89\x71B\n\x89\x3\x89\x3\x89\x5\x89\x71F"+
-		"\n\x89\x3\x89\x3\x89\x3\x8A\x3\x8A\x3\x8A\x5\x8A\x726\n\x8A\x3\x8A\x3"+
-		"\x8A\x5\x8A\x72A\n\x8A\x3\x8A\x3\x8A\x5\x8A\x72E\n\x8A\x3\x8A\x3\x8A\x5"+
-		"\x8A\x732\n\x8A\x3\x8A\x5\x8A\x735\n\x8A\x3\x8A\x3\x8A\x3\x8A\x3\x8A\x3"+
-		"\x8B\x3\x8B\x3\x8C\x3\x8C\x3\x8C\x5\x8C\x740\n\x8C\x3\x8C\x3\x8C\x3\x8C"+
-		"\x3\x8C\x3\x8C\a\x8C\x747\n\x8C\f\x8C\xE\x8C\x74A\v\x8C\x3\x8C\x3\x8C"+
-		"\x3\x8D\x3\x8D\x5\x8D\x750\n\x8D\x3\x8D\x3\x8D\x5\x8D\x754\n\x8D\x3\x8D"+
-		"\x5\x8D\x757\n\x8D\x3\x8D\x5\x8D\x75A\n\x8D\x3\x8D\x5\x8D\x75D\n\x8D\x3"+
-		"\x8D\x3\x8D\x3\x8D\x5\x8D\x762\n\x8D\x3\x8D\x3\x8D\x3\x8E\x3\x8E\x3\x8E"+
-		"\x5\x8E\x769\n\x8E\x3\x8E\x3\x8E\x3\x8E\x5\x8E\x76E\n\x8E\x3\x8E\x3\x8E"+
-		"\x3\x8F\x3\x8F\x5\x8F\x774\n\x8F\x3\x8F\x3\x8F\x5\x8F\x778\n\x8F\x3\x8F"+
-		"\a\x8F\x77B\n\x8F\f\x8F\xE\x8F\x77E\v\x8F\x3\x90\x3\x90\x5\x90\x782\n"+
-		"\x90\x3\x90\x3\x90\x5\x90\x786\n\x90\x3\x90\x3\x90\x5\x90\x78A\n\x90\x5"+
-		"\x90\x78C\n\x90\x3\x90\x3\x90\x5\x90\x790\n\x90\x5\x90\x792\n\x90\x3\x90"+
-		"\x3\x90\x3\x90\x5\x90\x797\n\x90\x3\x91\x3\x91\x3\x91\x3\x91\x3\x91\x3"+
-		"\x91\x3\x91\x3\x92\x3\x92\x3\x92\x3\x92\x3\x92\x3\x92\x3\x92\x3\x93\x3"+
-		"\x93\x5\x93\x7A9\n\x93\x3\x93\x3\x93\x5\x93\x7AD\n\x93\x5\x93\x7AF\n\x93"+
-		"\x3\x93\x3\x93\x3\x93\x3\x93\x5\x93\x7B5\n\x93\x5\x93\x7B7\n\x93\x3\x93"+
-		"\x3\x93\x5\x93\x7BB\n\x93\x3\x93\x3\x93\x5\x93\x7BF\n\x93\x3\x93\x6\x93"+
-		"\x7C2\n\x93\r\x93\xE\x93\x7C3\x3\x94\x3\x94\x5\x94\x7C8\n\x94\x3\x94\x3"+
-		"\x94\x5\x94\x7CC\n\x94\x5\x94\x7CE\n\x94\x3\x94\x3\x94\x3\x94\x3\x94\x5"+
-		"\x94\x7D4\n\x94\x3\x94\x3\x94\x5\x94\x7D8\n\x94\x3\x94\x3\x94\x3\x95\x3"+
-		"\x95\x5\x95\x7DE\n\x95\x3\x95\x3\x95\x5\x95\x7E2\n\x95\x3\x95\x3\x95\x5"+
-		"\x95\x7E6\n\x95\x3\x95\x3\x95\x5\x95\x7EA\n\x95\x3\x95\x3\x95\x3\x96\x3"+
-		"\x96\x5\x96\x7F0\n\x96\x3\x96\x3\x96\x5\x96\x7F4\n\x96\x3\x96\a\x96\x7F7"+
-		"\n\x96\f\x96\xE\x96\x7FA\v\x96\x3\x97\x3\x97\x3\x97\x3\x97\x3\x97\x5\x97"+
-		"\x801\n\x97\x3\x97\x3\x97\x3\x98\x3\x98\x3\x98\x5\x98\x808\n\x98\x3\x99"+
-		"\x3\x99\x5\x99\x80C\n\x99\x3\x9A\x3\x9A\x3\x9B\x3\x9B\x3\x9B\x3\x9C\x3"+
-		"\x9C\x3\x9C\x5\x9C\x816\n\x9C\x3\x9D\x3\x9D\a\x9D\x81A\n\x9D\f\x9D\xE"+
-		"\x9D\x81D\v\x9D\x3\x9D\x3\x9D\x3\x9E\x3\x9E\x5\x9E\x823\n\x9E\x3\x9F\x3"+
-		"\x9F\x5\x9F\x827\n\x9F\x3\x9F\x3\x9F\x5\x9F\x82B\n\x9F\x3\x9F\x3\x9F\x5"+
-		"\x9F\x82F\n\x9F\x3\x9F\x5\x9F\x832\n\x9F\x3\xA0\x3\xA0\x3\xA1\x3\xA1\x3"+
-		"\xA2\x3\xA2\x3\xA3\x3\xA3\x5\xA3\x83C\n\xA3\x3\xA3\x3\xA3\x3\xA4\x3\xA4"+
-		"\x5\xA4\x842\n\xA4\x3\xA4\x3\xA4\x3\xA5\x3\xA5\x5\xA5\x848\n\xA5\x3\xA6"+
-		"\x3\xA6\x3\xA7\x3\xA7\x3\xA8\x3\xA8\x3\xA9\x3\xA9\x5\xA9\x852\n\xA9\x3"+
-		"\xA9\x5\xA9\x855\n\xA9\x3\xA9\x3\xA9\x5\xA9\x859\n\xA9\x3\xA9\x5\xA9\x85C"+
-		"\n\xA9\x3\xAA\x3\xAA\x3\xAB\x3\xAB\x3\xAC\x3\xAC\x3\xAC\x3\xAC\x3\xAC"+
-		"\x3\xAC\x3\xAC\x3\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x86D\n\xAC\x3\xAC\x3"+
-		"\xAC\x3\xAC\x5\xAC\x872\n\xAC\x3\xAC\x3\xAC\x3\xAC\x3\xAC\x3\xAC\x3\xAC"+
-		"\x3\xAC\x3\xAC\x5\xAC\x87C\n\xAC\x3\xAC\x3\xAC\x5\xAC\x880\n\xAC\x3\xAC"+
-		"\x3\xAC\x5\xAC\x884\n\xAC\x3\xAC\x3\xAC\x5\xAC\x888\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x88C\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x891\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x895\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x89A\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x89E\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8A3\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8A7\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8AC\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8B0\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8B5\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8B9\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8BE\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8C2\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8C7\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8CB\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8D0\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8D4\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8D9\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8DD\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8E2\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8E6\n\xAC\x3\xAC\x3\xAC\x3\xAC\x5\xAC\x8EB\n\xAC\x3\xAC\x3\xAC"+
-		"\x5\xAC\x8EF\n\xAC\x3\xAC\a\xAC\x8F2\n\xAC\f\xAC\xE\xAC\x8F5\v\xAC\x3"+
-		"\xAD\x3\xAD\x3\xAD\x3\xAD\x3\xAD\x5\xAD\x8FC\n\xAD\x5\xAD\x8FE\n\xAD\x3"+
-		"\xAE\x3\xAE\x3\xAE\x5\xAE\x903\n\xAE\x3\xAF\x3\xAF\x3\xB0\x3\xB0\x3\xB1"+
-		"\x3\xB1\x3\xB2\x3\xB2\x3\xB2\x3\xB2\x3\xB2\x5\xB2\x910\n\xB2\x3\xB2\x3"+
-		"\xB2\x3\xB2\x5\xB2\x915\n\xB2\x3\xB2\x5\xB2\x918\n\xB2\x3\xB2\x3\xB2\x5"+
-		"\xB2\x91C\n\xB2\x3\xB2\x3\xB2\x5\xB2\x920\n\xB2\x3\xB2\x5\xB2\x923\n\xB2"+
-		"\x3\xB2\x5\xB2\x926\n\xB2\x3\xB2\x3\xB2\x3\xB2\x5\xB2\x92B\n\xB2\x3\xB2"+
-		"\x3\xB2\x5\xB2\x92F\n\xB2\x3\xB2\x3\xB2\x3\xB2\x5\xB2\x934\n\xB2\x3\xB2"+
-		"\x3\xB2\x5\xB2\x938\n\xB2\x3\xB2\a\xB2\x93B\n\xB2\f\xB2\xE\xB2\x93E\v"+
-		"\xB2\x3\xB3\x3\xB3\x3\xB3\x5\xB3\x943\n\xB3\x3\xB3\x3\xB3\x5\xB3\x947"+
-		"\n\xB3\x3\xB3\x3\xB3\x3\xB3\x3\xB3\x3\xB3\x5\xB3\x94E\n\xB3\x3\xB3\x3"+
-		"\xB3\x5\xB3\x952\n\xB3\x3\xB3\x5\xB3\x955\n\xB3\x3\xB4\x3\xB4\x3\xB5\x3"+
-		"\xB5\x5\xB5\x95B\n\xB5\a\xB5\x95D\n\xB5\f\xB5\xE\xB5\x960\v\xB5\x3\xB5"+
-		"\x3\xB5\x3\xB5\x5\xB5\x965\n\xB5\a\xB5\x967\n\xB5\f\xB5\xE\xB5\x96A\v"+
-		"\xB5\x3\xB5\x5\xB5\x96D\n\xB5\x3\xB6\x3\xB6\x5\xB6\x971\n\xB6\x3\xB6\x3"+
-		"\xB6\x3\xB6\x5\xB6\x976\n\xB6\x3\xB6\x5\xB6\x979\n\xB6\x3\xB7\x3\xB7\x3"+
-		"\xB8\x3\xB8\x3\xB9\x3\xB9\x5\xB9\x981\n\xB9\x3\xB9\x3\xB9\x5\xB9\x985"+
-		"\n\xB9\x3\xB9\a\xB9\x988\n\xB9\f\xB9\xE\xB9\x98B\v\xB9\x3\xBA\x3\xBA\x5"+
-		"\xBA\x98F\n\xBA\x3\xBA\x3\xBA\x5\xBA\x993\n\xBA\x3\xBA\x3\xBA\x3\xBB\x3"+
-		"\xBB\x5\xBB\x999\n\xBB\x3\xBB\x3\xBB\x3\xBB\x3\xBB\x3\xBB\x3\xBB\x3\xBB"+
-		"\x3\xBB\x5\xBB\x9A3\n\xBB\x3\xBC\x3\xBC\x3\xBD\x3\xBD\x3\xBE\x3\xBE\x3"+
-		"\xBE\x3\xBE\x3\xBF\x3\xBF\x3\xC0\x3\xC0\x3\xC1\x3\xC1\x3\xC2\x5\xC2\x9B4"+
-		"\n\xC2\x3\xC2\x3\xC2\x5\xC2\x9B8\n\xC2\x3\xC2\x5\xC2\x9BB\n\xC2\x3\xC2"+
-		"\x5\xC2\x9BE\n\xC2\x3\xC3\x3\xC3\x5\xC3\x9C2\n\xC3\x3\xC3\x3\xC3\x5\xC3"+
-		"\x9C6\n\xC3\a\xC3\x9C8\n\xC3\f\xC3\xE\xC3\x9CB\v\xC3\x3\xC4\x3\xC4\x3"+
-		"\xC4\x5\xC4\x9D0\n\xC4\x3\xC5\x3\xC5\x5\xC5\x9D4\n\xC5\x3\xC5\x3\xC5\x3"+
-		"\xC6\x3\xC6\x3\xC6\x3\xC7\x3\xC7\a\xC7\x9DD\n\xC7\f\xC7\xE\xC7\x9E0\v"+
-		"\xC7\x3\xC8\x3\xC8\x3\xC8\x3\xC8\x5\xC8\x9E6\n\xC8\x6\xC8\x9E8\n\xC8\r"+
-		"\xC8\xE\xC8\x9E9\x3\xC9\x3\xC9\x5\xC9\x9EE\n\xC9\x3\xCA\x3\xCA\x3\xCB"+
-		"\x3\xCB\x3\xCB\x3\xCB\x3\xCB\x3\xCB\x5\xCB\x9F8\n\xCB\x3\xCB\x3\xCB\x5"+
-		"\xCB\x9FC\n\xCB\x3\xCB\x6\xCB\x9FF\n\xCB\r\xCB\xE\xCB\xA00\x3\xCB\x5\xCB"+
-		"\xA04\n\xCB\x3\xCB\x3\xCB\x5\xCB\xA08\n\xCB\x3\xCB\x3\xCB\x5\xCB\xA0C"+
-		"\n\xCB\x3\xCB\x3\xCB\x5\xCB\xA10\n\xCB\x3\xCB\x3\xCB\x5\xCB\xA14\n\xCB"+
-		"\x3\xCB\x3\xCB\x3\xCB\x5\xCB\xA19\n\xCB\x3\xCB\x3\xCB\x3\xCB\x5\xCB\xA1E"+
-		"\n\xCB\x3\xCB\x3\xCB\x5\xCB\xA22\n\xCB\x3\xCB\x6\xCB\xA25\n\xCB\r\xCB"+
-		"\xE\xCB\xA26\x3\xCB\x5\xCB\xA2A\n\xCB\x3\xCB\x3\xCB\x5\xCB\xA2E\n\xCB"+
-		"\x3\xCC\x3\xCC\x3\xCD\x3\xCD\a\xCD\xA34\n\xCD\f\xCD\xE\xCD\xA37\v\xCD"+
-		"\x3\xCE\x6\xCE\xA3A\n\xCE\r\xCE\xE\xCE\xA3B\x3\xCE\x2\x2\x4\x156\x162"+
-		"\xCF\x2\x2\x4\x2\x6\x2\b\x2\n\x2\f\x2\xE\x2\x10\x2\x12\x2\x14\x2\x16\x2"+
-		"\x18\x2\x1A\x2\x1C\x2\x1E\x2 \x2\"\x2$\x2&\x2(\x2*\x2,\x2.\x2\x30\x2\x32"+
-		"\x2\x34\x2\x36\x2\x38\x2:\x2<\x2>\x2@\x2\x42\x2\x44\x2\x46\x2H\x2J\x2"+
-		"L\x2N\x2P\x2R\x2T\x2V\x2X\x2Z\x2\\\x2^\x2`\x2\x62\x2\x64\x2\x66\x2h\x2"+
-		"j\x2l\x2n\x2p\x2r\x2t\x2v\x2x\x2z\x2|\x2~\x2\x80\x2\x82\x2\x84\x2\x86"+
-		"\x2\x88\x2\x8A\x2\x8C\x2\x8E\x2\x90\x2\x92\x2\x94\x2\x96\x2\x98\x2\x9A"+
-		"\x2\x9C\x2\x9E\x2\xA0\x2\xA2\x2\xA4\x2\xA6\x2\xA8\x2\xAA\x2\xAC\x2\xAE"+
-		"\x2\xB0\x2\xB2\x2\xB4\x2\xB6\x2\xB8\x2\xBA\x2\xBC\x2\xBE\x2\xC0\x2\xC2"+
-		"\x2\xC4\x2\xC6\x2\xC8\x2\xCA\x2\xCC\x2\xCE\x2\xD0\x2\xD2\x2\xD4\x2\xD6"+
-		"\x2\xD8\x2\xDA\x2\xDC\x2\xDE\x2\xE0\x2\xE2\x2\xE4\x2\xE6\x2\xE8\x2\xEA"+
-		"\x2\xEC\x2\xEE\x2\xF0\x2\xF2\x2\xF4\x2\xF6\x2\xF8\x2\xFA\x2\xFC\x2\xFE"+
-		"\x2\x100\x2\x102\x2\x104\x2\x106\x2\x108\x2\x10A\x2\x10C\x2\x10E\x2\x110"+
-		"\x2\x112\x2\x114\x2\x116\x2\x118\x2\x11A\x2\x11C\x2\x11E\x2\x120\x2\x122"+
-		"\x2\x124\x2\x126\x2\x128\x2\x12A\x2\x12C\x2\x12E\x2\x130\x2\x132\x2\x134"+
-		"\x2\x136\x2\x138\x2\x13A\x2\x13C\x2\x13E\x2\x140\x2\x142\x2\x144\x2\x146"+
-		"\x2\x148\x2\x14A\x2\x14C\x2\x14E\x2\x150\x2\x152\x2\x154\x2\x156\x2\x158"+
-		"\x2\x15A\x2\x15C\x2\x15E\x2\x160\x2\x162\x2\x164\x2\x166\x2\x168\x2\x16A"+
-		"\x2\x16C\x2\x16E\x2\x170\x2\x172\x2\x174\x2\x176\x2\x178\x2\x17A\x2\x17C"+
-		"\x2\x17E\x2\x180\x2\x182\x2\x184\x2\x186\x2\x188\x2\x18A\x2\x18C\x2\x18E"+
-		"\x2\x190\x2\x192\x2\x194\x2\x196\x2\x198\x2\x19A\x2\x2\x1B\x5\x2;;\x45"+
+		"\x4\xCA\t\xCA\x4\xCB\t\xCB\x4\xCC\t\xCC\x4\xCD\t\xCD\x4\xCE\t\xCE\x4\xCF"+
+		"\t\xCF\x4\xD0\t\xD0\x4\xD1\t\xD1\x4\xD2\t\xD2\x4\xD3\t\xD3\x4\xD4\t\xD4"+
+		"\x4\xD5\t\xD5\x4\xD6\t\xD6\x4\xD7\t\xD7\x4\xD8\t\xD8\x4\xD9\t\xD9\x4\xDA"+
+		"\t\xDA\x3\x2\x3\x2\x3\x2\x3\x3\x3\x3\x3\x3\x5\x3\x1BB\n\x3\x3\x3\x3\x3"+
+		"\x5\x3\x1BF\n\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x3\x5\x3\x1C7\n\x3\x3"+
+		"\x4\x3\x4\x3\x4\x3\x4\x5\x4\x1CD\n\x4\x3\x4\x5\x4\x1D0\n\x4\x3\x4\x3\x4"+
+		"\x3\x5\x3\x5\x3\x5\x3\x5\x3\x5\x3\x5\x5\x5\x1DA\n\x5\x5\x5\x1DC\n\x5\x3"+
+		"\x5\x3\x5\x6\x5\x1E0\n\x5\r\x5\xE\x5\x1E1\x3\x5\x3\x5\x3\x5\x3\x6\x3\x6"+
+		"\a\x6\x1E9\n\x6\f\x6\xE\x6\x1EC\v\x6\x3\x6\x3\x6\a\x6\x1F0\n\x6\f\x6\xE"+
+		"\x6\x1F3\v\x6\x3\x6\x3\x6\x3\x6\x5\x6\x1F8\n\x6\x3\x6\x3\x6\x3\a\x3\a"+
+		"\x3\a\a\a\x1FF\n\a\f\a\xE\a\x202\v\a\x3\b\x3\b\x3\b\x3\b\x5\b\x208\n\b"+
+		"\x3\b\x3\b\x5\b\x20C\n\b\x3\b\x3\b\x5\b\x210\n\b\x3\b\x3\b\x5\b\x214\n"+
+		"\b\x3\b\a\b\x217\n\b\f\b\xE\b\x21A\v\b\x3\t\x3\t\x3\n\x3\n\x3\v\x3\v\x3"+
+		"\v\a\v\x223\n\v\f\v\xE\v\x226\v\v\x3\f\x3\f\x3\f\x3\f\x3\f\x3\f\x3\f\x3"+
+		"\f\x3\f\x3\f\x5\f\x232\n\f\x3\r\x5\r\x235\n\r\x3\r\x3\r\x3\r\x3\r\x3\r"+
+		"\x3\r\x3\r\x3\r\x3\r\x3\r\x3\r\x5\r\x242\n\r\x3\xE\x5\xE\x245\n\xE\x3"+
+		"\xE\x3\xE\x3\xE\a\xE\x24A\n\xE\f\xE\xE\xE\x24D\v\xE\x3\xF\x3\xF\x3\xF"+
+		"\x3\xF\x3\xF\x5\xF\x254\n\xF\x3\x10\x3\x10\x3\x10\a\x10\x259\n\x10\f\x10"+
+		"\xE\x10\x25C\v\x10\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3"+
+		"\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3"+
+		"\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3"+
+		"\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x3\x11\x5\x11\x281\n\x11"+
+		"\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12\x3\x12"+
+		"\x3\x12\x3\x12\x3\x12\x3\x12\x5\x12\x291\n\x12\x3\x13\x3\x13\x3\x13\x3"+
+		"\x13\x3\x13\x3\x13\x5\x13\x299\n\x13\x3\x13\x3\x13\x3\x13\x5\x13\x29E"+
+		"\n\x13\x3\x13\x3\x13\x3\x13\x5\x13\x2A3\n\x13\x3\x13\x3\x13\x3\x13\x3"+
+		"\x13\x3\x13\x3\x13\x3\x13\x5\x13\x2AC\n\x13\x3\x14\x3\x14\x3\x15\x3\x15"+
+		"\x3\x15\x3\x15\x3\x16\x3\x16\x3\x17\x3\x17\x3\x17\x3\x17\x3\x18\x3\x18"+
+		"\x3\x19\x3\x19\x3\x1A\x3\x1A\x5\x1A\x2C0\n\x1A\x3\x1A\x3\x1A\x5\x1A\x2C4"+
+		"\n\x1A\x3\x1A\x3\x1A\x3\x1B\x3\x1B\x3\x1C\x3\x1C\x5\x1C\x2CC\n\x1C\x3"+
+		"\x1D\x3\x1D\x3\x1D\x3\x1E\x3\x1E\x3\x1F\x3\x1F\x3\x1F\x3\x1F\x5\x1F\x2D7"+
+		"\n\x1F\x3 \x3 \x3!\x3!\x5!\x2DD\n!\x3!\x3!\x5!\x2E1\n!\x3!\a!\x2E4\n!"+
+		"\f!\xE!\x2E7\v!\x3\"\x3\"\x3\"\x3\"\x5\"\x2ED\n\"\x3\"\x3\"\x5\"\x2F1"+
+		"\n\"\x3\"\x3\"\x3#\x3#\x3$\x3$\x3$\x3$\x5$\x2FB\n$\x3$\x3$\x5$\x2FF\n"+
+		"$\x3$\x5$\x302\n$\x3%\x3%\x3%\x3%\x5%\x308\n%\x3%\x3%\x3%\x3%\x5%\x30E"+
+		"\n%\x3&\x3&\x3\'\x3\'\x3(\x3(\x3(\x3(\x5(\x318\n(\x3(\x3(\x5(\x31C\n("+
+		"\x3(\x5(\x31F\n(\x3)\x3)\x3)\x3)\x5)\x325\n)\x3)\x3)\x5)\x329\n)\x3)\x3"+
+		")\x3*\x3*\x3+\x3+\x3+\x3+\x5+\x333\n+\x3+\x3+\x5+\x337\n+\x3+\x3+\x3,"+
+		"\x3,\x3-\x3-\x3-\x3-\x5-\x341\n-\x3.\x3.\x5.\x345\n.\x3.\x3.\x5.\x349"+
+		"\n.\x3.\x3.\x3/\x3/\x3\x30\x3\x30\x3\x31\x3\x31\x3\x31\x3\x31\x5\x31\x355"+
+		"\n\x31\x3\x31\x3\x31\x5\x31\x359\n\x31\x3\x31\x5\x31\x35C\n\x31\x3\x32"+
+		"\x3\x32\x5\x32\x360\n\x32\x3\x32\a\x32\x363\n\x32\f\x32\xE\x32\x366\v"+
+		"\x32\x3\x33\x3\x33\x3\x33\x3\x33\x5\x33\x36C\n\x33\x3\x33\x3\x33\x5\x33"+
+		"\x370\n\x33\x3\x34\x3\x34\x3\x34\x5\x34\x375\n\x34\x3\x35\x3\x35\x3\x36"+
+		"\x3\x36\x3\x37\x3\x37\x5\x37\x37D\n\x37\x3\x37\x3\x37\x5\x37\x381\n\x37"+
+		"\x3\x37\x3\x37\x5\x37\x385\n\x37\x3\x37\x3\x37\x3\x38\x3\x38\x3\x39\x3"+
+		"\x39\x5\x39\x38D\n\x39\x3\x39\x5\x39\x390\n\x39\x3:\x3:\x5:\x394\n:\x3"+
+		":\x3:\x5:\x398\n:\x3:\x3:\x3;\x3;\x3<\x3<\x3<\x3<\x5<\x3A2\n<\x3<\x3<"+
+		"\x5<\x3A6\n<\x3<\x5<\x3A9\n<\x3=\x3=\x3=\x3=\x5=\x3AF\n=\x3=\x3=\x5=\x3B3"+
+		"\n=\x3=\x3=\x3>\x3>\x5>\x3B9\n>\x3>\x3>\x5>\x3BD\n>\x3>\a>\x3C0\n>\f>"+
+		"\xE>\x3C3\v>\x3?\x3?\x3@\x3@\x3@\x3@\x5@\x3CB\n@\x3@\x3@\x5@\x3CF\n@\x3"+
+		"@\x5@\x3D2\n@\x3@\x5@\x3D5\n@\x3@\x3@\x5@\x3D9\n@\x3@\x3@\x3\x41\x3\x41"+
+		"\x3\x42\x3\x42\x3\x43\x3\x43\x3\x43\x3\x43\x5\x43\x3E5\n\x43\x3\x43\x3"+
+		"\x43\x5\x43\x3E9\n\x43\x3\x43\x5\x43\x3EC\n\x43\x3\x43\x5\x43\x3EF\n\x43"+
+		"\x3\x43\x3\x43\x5\x43\x3F3\n\x43\x3\x43\x3\x43\x3\x44\x3\x44\x3\x45\x3"+
+		"\x45\x3\x45\x5\x45\x3FC\n\x45\x3\x45\x3\x45\x3\x45\x3\x45\x5\x45\x402"+
+		"\n\x45\x3\x45\x3\x45\x5\x45\x406\n\x45\x3\x45\a\x45\x409\n\x45\f\x45\xE"+
+		"\x45\x40C\v\x45\x3\x46\x3\x46\x3\x46\x3\x46\x5\x46\x412\n\x46\x3\x46\x5"+
+		"\x46\x415\n\x46\x3\x46\x3\x46\x5\x46\x419\n\x46\x3\x46\x3\x46\x3G\x3G"+
+		"\x3G\x5G\x420\nG\x3G\x3G\x3G\x3G\x5G\x426\nG\x3G\x3G\x3G\x3G\x3G\x3G\x3"+
+		"G\x3G\x3G\x3G\x3G\x3G\x5G\x434\nG\x3G\x5G\x437\nG\x3G\x5G\x43A\nG\x3G"+
+		"\x3G\x3G\x5G\x43F\nG\x3H\x3H\x5H\x443\nH\x3H\x3H\x5H\x447\nH\x3H\x3H\x5"+
+		"H\x44B\nH\x3H\aH\x44E\nH\fH\xEH\x451\vH\x5H\x453\nH\x3H\x5H\x456\nH\x3"+
+		"H\x3H\x3I\x3I\x5I\x45C\nI\x3I\x3I\x5I\x460\nI\x3I\x3I\x5I\x464\nI\x3I"+
+		"\x3I\x5I\x468\nI\x3I\x3I\x5I\x46C\nI\x3I\x5I\x46F\nI\x3I\x5I\x472\nI\x3"+
+		"I\x5I\x475\nI\x3I\x5I\x478\nI\x3I\x5I\x47B\nI\x3J\x3J\x5J\x47F\nJ\x3J"+
+		"\x3J\x3K\x3K\x3K\x3K\x5K\x487\nK\x3K\x3K\x5K\x48B\nK\x3K\aK\x48E\nK\f"+
+		"K\xEK\x491\vK\x3L\x3L\x3M\x3M\x3M\x5M\x498\nM\x3N\x3N\x3O\x3O\x5O\x49E"+
+		"\nO\x3O\x3O\x5O\x4A2\nO\x3O\x3O\x3P\x3P\x3P\x3Q\x3Q\x3Q\x3R\x3R\x5R\x4AE"+
+		"\nR\x3R\x3R\x5R\x4B2\nR\x3R\x3R\x3S\x3S\x3T\x3T\x3U\x3U\x3U\x3U\x3U\x3"+
+		"U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U\x3U"+
+		"\x5U\x4D1\nU\x3V\x3V\x3V\x5V\x4D6\nV\x3V\x3V\x3V\x3V\x3V\aV\x4DD\nV\f"+
+		"V\xEV\x4E0\vV\x3V\x3V\x3W\x3W\x5W\x4E6\nW\x3W\x3W\x5W\x4EA\nW\x3W\x5W"+
+		"\x4ED\nW\x3W\x3W\x3X\x3X\x3Y\x3Y\x3Y\x3Y\x5Y\x4F7\nY\x3Y\x3Y\x5Y\x4FB"+
+		"\nY\x3Y\aY\x4FE\nY\fY\xEY\x501\vY\x3Z\x3Z\x3Z\x3Z\x3[\x3[\x3[\x5[\x50A"+
+		"\n[\x3[\x3[\x3[\x3[\x5[\x510\n[\x3[\x3[\x3\\\x3\\\x3]\x3]\x3]\x3]\x3]"+
+		"\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x3]\x5]\x525\n]\x3^\x3^\x3^\x3^\x3"+
+		"^\x3^\x3^\x3^\x3^\x3^\x3^\x3^\x5^\x533\n^\x3^\x3^\x3^\x3^\x3^\x3^\x5^"+
+		"\x53B\n^\x3_\x3_\x3_\x5_\x540\n_\x3_\x3_\x5_\x544\n_\x3_\x3_\x5_\x548"+
+		"\n_\x3_\x3_\x5_\x54C\n_\x3_\x5_\x54F\n_\x3_\x5_\x552\n_\x3_\x5_\x555\n"+
+		"_\x3_\x3_\x3_\x3_\x3`\x3`\x3\x61\x3\x61\x3\x61\x3\x61\x3\x62\x3\x62\x3"+
+		"\x62\x3\x62\x3\x63\x3\x63\x3\x63\x3\x63\x3\x63\x3\x63\x3\x63\x3\x63\a"+
+		"\x63\x56D\n\x63\f\x63\xE\x63\x570\v\x63\x3\x63\x5\x63\x573\n\x63\x3\x63"+
+		"\x3\x63\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64"+
+		"\x3\x64\x3\x64\x3\x64\x3\x64\x3\x64\x5\x64\x585\n\x64\x3\x64\x3\x64\x5"+
+		"\x64\x589\n\x64\x3\x65\x3\x65\x3\x65\x3\x65\x3\x66\x3\x66\x5\x66\x591"+
+		"\n\x66\x3g\x3g\x5g\x595\ng\x3g\x3g\x5g\x599\ng\x3g\x3g\x5g\x59D\ng\x3"+
+		"g\x3g\x3g\x3g\x5g\x5A3\ng\x3h\x3h\x5h\x5A7\nh\x3h\x3h\x5h\x5AB\nh\x3h"+
+		"\x3h\x3h\x5h\x5B0\nh\x3h\x3h\x3i\x3i\x5i\x5B6\ni\x3i\x5i\x5B9\ni\x3j\x3"+
+		"j\x5j\x5BD\nj\x3j\x3j\x5j\x5C1\nj\x3j\x5j\x5C4\nj\aj\x5C6\nj\fj\xEj\x5C9"+
+		"\vj\x3j\x3j\x5j\x5CD\nj\x5j\x5CF\nj\x3j\x3j\x5j\x5D3\nj\x3j\x3j\x5j\x5D7"+
+		"\nj\x3j\x5j\x5DA\nj\aj\x5DC\nj\fj\xEj\x5DF\vj\x5j\x5E1\nj\x3k\x3k\x3l"+
+		"\x3l\x3m\x3m\x3m\x3m\x3n\x3n\x5n\x5ED\nn\x3n\x3n\x5n\x5F1\nn\x3n\x3n\x5"+
+		"n\x5F5\nn\x3n\x3n\x3o\x3o\x3o\x3o\x5o\x5FD\no\x3o\x3o\x5o\x601\no\x3o"+
+		"\x3o\x3p\x3p\x3p\x3p\x3p\x3p\x3p\x3p\x3p\x3p\x5p\x60F\np\x3q\x3q\x3q\x3"+
+		"q\x3q\x3q\x3q\x3q\x5q\x619\nq\x3q\x3q\x5q\x61D\nq\x3q\aq\x620\nq\fq\xE"+
+		"q\x623\vq\x3r\x3r\x3r\x3r\x3r\x3r\x3r\x3r\x5r\x62D\nr\x3r\x3r\x5r\x631"+
+		"\nr\x3r\ar\x634\nr\fr\xEr\x637\vr\x3s\x3s\x3s\x5s\x63C\ns\x3s\x3s\x5s"+
+		"\x640\ns\x3s\x3s\x3s\x3s\x5s\x646\ns\x3s\x5s\x649\ns\x3s\x3s\x3s\x5s\x64E"+
+		"\ns\x3s\x3s\x3s\x3s\x3t\x3t\x3t\x5t\x657\nt\x3t\x3t\x5t\x65B\nt\x3t\x3"+
+		"t\x3t\x3t\x5t\x661\nt\x3t\x5t\x664\nt\x3t\x3t\x3t\x3t\x3u\x3u\x3u\x5u"+
+		"\x66D\nu\x3u\x3u\x5u\x671\nu\x3u\x3u\x3u\x3u\x5u\x677\nu\x3u\x5u\x67A"+
+		"\nu\x3u\x3u\x3u\x3u\x3v\x3v\x3v\x3v\x5v\x684\nv\x3v\x3v\x5v\x688\nv\x3"+
+		"v\x5v\x68B\nv\x3v\x5v\x68E\nv\x3v\x5v\x691\nv\x3w\x3w\x5w\x695\nw\x3w"+
+		"\x3w\x5w\x699\nw\x3w\aw\x69C\nw\fw\xEw\x69F\vw\x3x\x3x\x3y\x3y\x3y\x3"+
+		"y\x5y\x6A7\ny\x3y\x3y\x3z\x3z\x5z\x6AD\nz\x3z\x3z\x5z\x6B1\nz\x3z\az\x6B4"+
+		"\nz\fz\xEz\x6B7\vz\x3{\x3{\x3{\x3{\x5{\x6BD\n{\x3|\x3|\x3}\x3}\x3}\x3"+
+		"}\x3}\x3}\x3}\x3}\x5}\x6C9\n}\x5}\x6CB\n}\x3~\x3~\x3~\x3~\x5~\x6D1\n~"+
+		"\x5~\x6D3\n~\x3\x7F\x3\x7F\x3\x80\x3\x80\x3\x80\x3\x80\x5\x80\x6DB\n\x80"+
+		"\x3\x80\x3\x80\x5\x80\x6DF\n\x80\x3\x80\x3\x80\x3\x81\x3\x81\x3\x82\x3"+
+		"\x82\x5\x82\x6E7\n\x82\x3\x82\x3\x82\x5\x82\x6EB\n\x82\x3\x82\x3\x82\x3"+
+		"\x82\a\x82\x6F0\n\x82\f\x82\xE\x82\x6F3\v\x82\x3\x82\x5\x82\x6F6\n\x82"+
+		"\x3\x82\x3\x82\x3\x83\x3\x83\x3\x84\x3\x84\x3\x84\x3\x84\x5\x84\x700\n"+
+		"\x84\x3\x84\x3\x84\x5\x84\x704\n\x84\x3\x84\a\x84\x707\n\x84\f\x84\xE"+
+		"\x84\x70A\v\x84\x3\x84\x3\x84\x3\x84\x3\x85\x3\x85\x5\x85\x711\n\x85\x3"+
+		"\x85\x3\x85\x3\x85\x3\x85\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x3\x86\x3"+
+		"\x86\x3\x86\x3\x86\x5\x86\x720\n\x86\x5\x86\x722\n\x86\x3\x86\x3\x86\x5"+
+		"\x86\x726\n\x86\x3\x86\x3\x86\x5\x86\x72A\n\x86\x3\x87\x3\x87\x3\x88\x3"+
+		"\x88\x3\x89\x3\x89\x3\x89\x3\x89\x5\x89\x734\n\x89\x3\x89\x3\x89\x5\x89"+
+		"\x738\n\x89\x3\x89\x3\x89\x3\x8A\x3\x8A\x3\x8A\x5\x8A\x73F\n\x8A\x3\x8A"+
+		"\x3\x8A\x5\x8A\x743\n\x8A\x3\x8A\x3\x8A\x5\x8A\x747\n\x8A\x3\x8A\x3\x8A"+
+		"\x5\x8A\x74B\n\x8A\x3\x8A\x5\x8A\x74E\n\x8A\x3\x8A\x3\x8A\x3\x8A\x3\x8A"+
+		"\x3\x8B\x3\x8B\x3\x8C\x3\x8C\x5\x8C\x758\n\x8C\x3\x8C\x3\x8C\x3\x8D\x3"+
+		"\x8D\x3\x8D\x3\x8D\x3\x8E\x3\x8E\x3\x8E\x3\x8E\x3\x8E\x3\x8E\x3\x8E\x3"+
+		"\x8E\x3\x8F\x3\x8F\x3\x8F\x3\x8F\a\x8F\x76C\n\x8F\f\x8F\xE\x8F\x76F\v"+
+		"\x8F\x3\x90\x3\x90\x5\x90\x773\n\x90\x3\x91\x3\x91\x5\x91\x777\n\x91\x3"+
+		"\x91\x3\x91\x3\x92\x3\x92\x3\x92\x3\x92\x3\x93\x3\x93\x3\x93\x5\x93\x782"+
+		"\n\x93\x3\x93\x3\x93\x3\x94\x3\x94\x5\x94\x788\n\x94\x3\x94\x5\x94\x78B"+
+		"\n\x94\x3\x94\x5\x94\x78E\n\x94\x3\x94\x3\x94\x3\x95\x3\x95\x5\x95\x794"+
+		"\n\x95\x3\x95\x3\x95\x5\x95\x798\n\x95\x3\x95\a\x95\x79B\n\x95\f\x95\xE"+
+		"\x95\x79E\v\x95\x3\x96\x3\x96\x5\x96\x7A2\n\x96\x5\x96\x7A4\n\x96\x3\x96"+
+		"\x3\x96\x3\x97\x3\x97\x5\x97\x7AA\n\x97\x3\x97\x3\x97\x3\x98\x3\x98\x3"+
+		"\x99\x3\x99\x3\x9A\x3\x9A\x3\x9A\x5\x9A\x7B5\n\x9A\x3\x9A\x3\x9A\x3\x9A"+
+		"\x5\x9A\x7BA\n\x9A\x3\x9A\x3\x9A\x3\x9B\x3\x9B\x5\x9B\x7C0\n\x9B\x3\x9B"+
+		"\x3\x9B\x5\x9B\x7C4\n\x9B\x3\x9B\a\x9B\x7C7\n\x9B\f\x9B\xE\x9B\x7CA\v"+
+		"\x9B\x3\x9C\x3\x9C\x5\x9C\x7CE\n\x9C\x3\x9C\x3\x9C\x5\x9C\x7D2\n\x9C\x3"+
+		"\x9C\x3\x9C\x5\x9C\x7D6\n\x9C\x5\x9C\x7D8\n\x9C\x3\x9C\x3\x9C\x5\x9C\x7DC"+
+		"\n\x9C\x5\x9C\x7DE\n\x9C\x3\x9C\x3\x9C\x3\x9C\x5\x9C\x7E3\n\x9C\x3\x9D"+
+		"\x3\x9D\x3\x9D\x3\x9D\x3\x9D\x3\x9D\x3\x9D\x3\x9E\x3\x9E\x3\x9E\x3\x9E"+
+		"\x3\x9E\x3\x9E\x3\x9E\x3\x9F\x3\x9F\x5\x9F\x7F5\n\x9F\x3\x9F\x3\x9F\x5"+
+		"\x9F\x7F9\n\x9F\x5\x9F\x7FB\n\x9F\x3\x9F\x3\x9F\x3\x9F\x3\x9F\x5\x9F\x801"+
+		"\n\x9F\x5\x9F\x803\n\x9F\x3\x9F\x3\x9F\x5\x9F\x807\n\x9F\x3\x9F\x3\x9F"+
+		"\x5\x9F\x80B\n\x9F\x3\x9F\x6\x9F\x80E\n\x9F\r\x9F\xE\x9F\x80F\x3\xA0\x3"+
+		"\xA0\x5\xA0\x814\n\xA0\x3\xA0\x3\xA0\x5\xA0\x818\n\xA0\x5\xA0\x81A\n\xA0"+
+		"\x3\xA0\x3\xA0\x3\xA0\x3\xA0\x5\xA0\x820\n\xA0\x3\xA0\x3\xA0\x5\xA0\x824"+
+		"\n\xA0\x3\xA0\x3\xA0\x3\xA1\x3\xA1\x5\xA1\x82A\n\xA1\x3\xA1\x3\xA1\x5"+
+		"\xA1\x82E\n\xA1\x3\xA1\x3\xA1\x5\xA1\x832\n\xA1\x3\xA1\x3\xA1\x5\xA1\x836"+
+		"\n\xA1\x3\xA1\x3\xA1\x3\xA2\x3\xA2\x5\xA2\x83C\n\xA2\x3\xA2\x3\xA2\x5"+
+		"\xA2\x840\n\xA2\x3\xA2\a\xA2\x843\n\xA2\f\xA2\xE\xA2\x846\v\xA2\x3\xA3"+
+		"\x3\xA3\x3\xA3\x3\xA3\x3\xA3\x5\xA3\x84D\n\xA3\x3\xA3\x3\xA3\x3\xA4\x3"+
+		"\xA4\x3\xA4\x5\xA4\x854\n\xA4\x3\xA5\x3\xA5\x5\xA5\x858\n\xA5\x3\xA6\x3"+
+		"\xA6\x3\xA7\x3\xA7\x3\xA7\x3\xA8\x3\xA8\x3\xA8\x5\xA8\x862\n\xA8\x3\xA9"+
+		"\x3\xA9\a\xA9\x866\n\xA9\f\xA9\xE\xA9\x869\v\xA9\x3\xA9\x3\xA9\x3\xAA"+
+		"\x3\xAA\x5\xAA\x86F\n\xAA\x3\xAB\x3\xAB\x5\xAB\x873\n\xAB\x3\xAB\x3\xAB"+
+		"\x5\xAB\x877\n\xAB\x3\xAB\x3\xAB\x5\xAB\x87B\n\xAB\x3\xAB\x5\xAB\x87E"+
+		"\n\xAB\x3\xAC\x3\xAC\x3\xAD\x3\xAD\x3\xAE\x3\xAE\x3\xAF\x3\xAF\x5\xAF"+
+		"\x888\n\xAF\x3\xAF\x3\xAF\x3\xB0\x3\xB0\x5\xB0\x88E\n\xB0\x3\xB0\x3\xB0"+
+		"\x3\xB1\x3\xB1\x5\xB1\x894\n\xB1\x3\xB2\x3\xB2\x3\xB3\x3\xB3\x3\xB4\x3"+
+		"\xB4\x3\xB5\x3\xB5\x5\xB5\x89E\n\xB5\x3\xB5\x5\xB5\x8A1\n\xB5\x3\xB5\x3"+
+		"\xB5\x5\xB5\x8A5\n\xB5\x3\xB5\x5\xB5\x8A8\n\xB5\x3\xB6\x3\xB6\x3\xB7\x3"+
+		"\xB7\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3"+
+		"\xB8\x3\xB8\x5\xB8\x8B9\n\xB8\x3\xB8\x3\xB8\x3\xB8\x5\xB8\x8BE\n\xB8\x3"+
+		"\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x3\xB8\x5\xB8\x8C8\n\xB8"+
+		"\x3\xB8\x3\xB8\x5\xB8\x8CC\n\xB8\x3\xB8\x3\xB8\x5\xB8\x8D0\n\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x8D4\n\xB8\x3\xB8\x3\xB8\x5\xB8\x8D8\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x8DD\n\xB8\x3\xB8\x3\xB8\x5\xB8\x8E1\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x8E6\n\xB8\x3\xB8\x3\xB8\x5\xB8\x8EA\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x8EF\n\xB8\x3\xB8\x3\xB8\x5\xB8\x8F3\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x8F8\n\xB8\x3\xB8\x3\xB8\x5\xB8\x8FC\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x901\n\xB8\x3\xB8\x3\xB8\x5\xB8\x905\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x90A\n\xB8\x3\xB8\x3\xB8\x5\xB8\x90E\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x913\n\xB8\x3\xB8\x3\xB8\x5\xB8\x917\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x91C\n\xB8\x3\xB8\x3\xB8\x5\xB8\x920\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x925\n\xB8\x3\xB8\x3\xB8\x5\xB8\x929\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x92E\n\xB8\x3\xB8\x3\xB8\x5\xB8\x932\n\xB8\x3\xB8\x3\xB8"+
+		"\x3\xB8\x5\xB8\x937\n\xB8\x3\xB8\x3\xB8\x5\xB8\x93B\n\xB8\x3\xB8\a\xB8"+
+		"\x93E\n\xB8\f\xB8\xE\xB8\x941\v\xB8\x3\xB9\x3\xB9\x3\xB9\x3\xB9\x3\xB9"+
+		"\x5\xB9\x948\n\xB9\x5\xB9\x94A\n\xB9\x3\xBA\x3\xBA\x3\xBA\x5\xBA\x94F"+
+		"\n\xBA\x3\xBB\x3\xBB\x3\xBC\x3\xBC\x3\xBD\x3\xBD\x3\xBE\x3\xBE\x3\xBE"+
+		"\x3\xBE\x3\xBE\x5\xBE\x95C\n\xBE\x3\xBE\x3\xBE\x3\xBE\x5\xBE\x961\n\xBE"+
+		"\x3\xBE\x5\xBE\x964\n\xBE\x3\xBE\x3\xBE\x5\xBE\x968\n\xBE\x3\xBE\x3\xBE"+
+		"\x5\xBE\x96C\n\xBE\x3\xBE\x5\xBE\x96F\n\xBE\x3\xBE\x5\xBE\x972\n\xBE\x3"+
+		"\xBE\x3\xBE\x3\xBE\x5\xBE\x977\n\xBE\x3\xBE\x3\xBE\x5\xBE\x97B\n\xBE\x3"+
+		"\xBE\x3\xBE\x3\xBE\x5\xBE\x980\n\xBE\x3\xBE\x3\xBE\x5\xBE\x984\n\xBE\x3"+
+		"\xBE\a\xBE\x987\n\xBE\f\xBE\xE\xBE\x98A\v\xBE\x3\xBF\x3\xBF\x3\xBF\x5"+
+		"\xBF\x98F\n\xBF\x3\xBF\x3\xBF\x5\xBF\x993\n\xBF\x3\xBF\x3\xBF\x3\xBF\x3"+
+		"\xBF\x3\xBF\x5\xBF\x99A\n\xBF\x3\xBF\x3\xBF\x5\xBF\x99E\n\xBF\x3\xBF\x5"+
+		"\xBF\x9A1\n\xBF\x3\xC0\x3\xC0\x3\xC1\x3\xC1\x5\xC1\x9A7\n\xC1\a\xC1\x9A9"+
+		"\n\xC1\f\xC1\xE\xC1\x9AC\v\xC1\x3\xC1\x3\xC1\x3\xC1\x5\xC1\x9B1\n\xC1"+
+		"\a\xC1\x9B3\n\xC1\f\xC1\xE\xC1\x9B6\v\xC1\x3\xC1\x5\xC1\x9B9\n\xC1\x3"+
+		"\xC2\x3\xC2\x5\xC2\x9BD\n\xC2\x3\xC2\x3\xC2\x3\xC2\x5\xC2\x9C2\n\xC2\x3"+
+		"\xC2\x5\xC2\x9C5\n\xC2\x3\xC3\x3\xC3\x3\xC4\x3\xC4\x3\xC5\x3\xC5\x5\xC5"+
+		"\x9CD\n\xC5\x3\xC5\x3\xC5\x5\xC5\x9D1\n\xC5\x3\xC5\a\xC5\x9D4\n\xC5\f"+
+		"\xC5\xE\xC5\x9D7\v\xC5\x3\xC6\x3\xC6\x5\xC6\x9DB\n\xC6\x3\xC6\x3\xC6\x5"+
+		"\xC6\x9DF\n\xC6\x3\xC6\x3\xC6\x3\xC7\x3\xC7\x5\xC7\x9E5\n\xC7\x3\xC7\x3"+
+		"\xC7\x3\xC7\x3\xC7\x3\xC7\x3\xC7\x3\xC7\x3\xC7\x5\xC7\x9EF\n\xC7\x3\xC8"+
+		"\x3\xC8\x3\xC9\x3\xC9\x3\xCA\x3\xCA\x3\xCA\x3\xCA\x3\xCB\x3\xCB\x3\xCC"+
+		"\x3\xCC\x3\xCD\x3\xCD\x3\xCE\x5\xCE\xA00\n\xCE\x3\xCE\x3\xCE\x5\xCE\xA04"+
+		"\n\xCE\x3\xCE\x5\xCE\xA07\n\xCE\x3\xCE\x5\xCE\xA0A\n\xCE\x3\xCF\x3\xCF"+
+		"\x5\xCF\xA0E\n\xCF\x3\xCF\x3\xCF\x5\xCF\xA12\n\xCF\a\xCF\xA14\n\xCF\f"+
+		"\xCF\xE\xCF\xA17\v\xCF\x3\xD0\x3\xD0\x3\xD0\x5\xD0\xA1C\n\xD0\x3\xD1\x3"+
+		"\xD1\x5\xD1\xA20\n\xD1\x3\xD1\x3\xD1\x3\xD2\x3\xD2\x3\xD2\x3\xD3\x3\xD3"+
+		"\a\xD3\xA29\n\xD3\f\xD3\xE\xD3\xA2C\v\xD3\x3\xD4\x3\xD4\x3\xD4\x3\xD4"+
+		"\x5\xD4\xA32\n\xD4\x6\xD4\xA34\n\xD4\r\xD4\xE\xD4\xA35\x3\xD5\x3\xD5\x5"+
+		"\xD5\xA3A\n\xD5\x3\xD6\x3\xD6\x3\xD7\x3\xD7\x3\xD7\x3\xD7\x3\xD7\x3\xD7"+
+		"\x5\xD7\xA44\n\xD7\x3\xD7\x3\xD7\x5\xD7\xA48\n\xD7\x3\xD7\x6\xD7\xA4B"+
+		"\n\xD7\r\xD7\xE\xD7\xA4C\x3\xD7\x5\xD7\xA50\n\xD7\x3\xD7\x3\xD7\x5\xD7"+
+		"\xA54\n\xD7\x3\xD7\x3\xD7\x5\xD7\xA58\n\xD7\x3\xD7\x3\xD7\x5\xD7\xA5C"+
+		"\n\xD7\x3\xD7\x3\xD7\x5\xD7\xA60\n\xD7\x3\xD7\x3\xD7\x3\xD7\x5\xD7\xA65"+
+		"\n\xD7\x3\xD7\x3\xD7\x3\xD7\x5\xD7\xA6A\n\xD7\x3\xD7\x3\xD7\x5\xD7\xA6E"+
+		"\n\xD7\x3\xD7\x6\xD7\xA71\n\xD7\r\xD7\xE\xD7\xA72\x3\xD7\x5\xD7\xA76\n"+
+		"\xD7\x3\xD7\x3\xD7\x5\xD7\xA7A\n\xD7\x3\xD8\x3\xD8\x3\xD9\x3\xD9\a\xD9"+
+		"\xA80\n\xD9\f\xD9\xE\xD9\xA83\v\xD9\x3\xDA\x6\xDA\xA86\n\xDA\r\xDA\xE"+
+		"\xDA\xA87\x3\xDA\x2\x2\x4\x16E\x17A\xDB\x2\x2\x4\x2\x6\x2\b\x2\n\x2\f"+
+		"\x2\xE\x2\x10\x2\x12\x2\x14\x2\x16\x2\x18\x2\x1A\x2\x1C\x2\x1E\x2 \x2"+
+		"\"\x2$\x2&\x2(\x2*\x2,\x2.\x2\x30\x2\x32\x2\x34\x2\x36\x2\x38\x2:\x2<"+
+		"\x2>\x2@\x2\x42\x2\x44\x2\x46\x2H\x2J\x2L\x2N\x2P\x2R\x2T\x2V\x2X\x2Z"+
+		"\x2\\\x2^\x2`\x2\x62\x2\x64\x2\x66\x2h\x2j\x2l\x2n\x2p\x2r\x2t\x2v\x2"+
+		"x\x2z\x2|\x2~\x2\x80\x2\x82\x2\x84\x2\x86\x2\x88\x2\x8A\x2\x8C\x2\x8E"+
+		"\x2\x90\x2\x92\x2\x94\x2\x96\x2\x98\x2\x9A\x2\x9C\x2\x9E\x2\xA0\x2\xA2"+
+		"\x2\xA4\x2\xA6\x2\xA8\x2\xAA\x2\xAC\x2\xAE\x2\xB0\x2\xB2\x2\xB4\x2\xB6"+
+		"\x2\xB8\x2\xBA\x2\xBC\x2\xBE\x2\xC0\x2\xC2\x2\xC4\x2\xC6\x2\xC8\x2\xCA"+
+		"\x2\xCC\x2\xCE\x2\xD0\x2\xD2\x2\xD4\x2\xD6\x2\xD8\x2\xDA\x2\xDC\x2\xDE"+
+		"\x2\xE0\x2\xE2\x2\xE4\x2\xE6\x2\xE8\x2\xEA\x2\xEC\x2\xEE\x2\xF0\x2\xF2"+
+		"\x2\xF4\x2\xF6\x2\xF8\x2\xFA\x2\xFC\x2\xFE\x2\x100\x2\x102\x2\x104\x2"+
+		"\x106\x2\x108\x2\x10A\x2\x10C\x2\x10E\x2\x110\x2\x112\x2\x114\x2\x116"+
+		"\x2\x118\x2\x11A\x2\x11C\x2\x11E\x2\x120\x2\x122\x2\x124\x2\x126\x2\x128"+
+		"\x2\x12A\x2\x12C\x2\x12E\x2\x130\x2\x132\x2\x134\x2\x136\x2\x138\x2\x13A"+
+		"\x2\x13C\x2\x13E\x2\x140\x2\x142\x2\x144\x2\x146\x2\x148\x2\x14A\x2\x14C"+
+		"\x2\x14E\x2\x150\x2\x152\x2\x154\x2\x156\x2\x158\x2\x15A\x2\x15C\x2\x15E"+
+		"\x2\x160\x2\x162\x2\x164\x2\x166\x2\x168\x2\x16A\x2\x16C\x2\x16E\x2\x170"+
+		"\x2\x172\x2\x174\x2\x176\x2\x178\x2\x17A\x2\x17C\x2\x17E\x2\x180\x2\x182"+
+		"\x2\x184\x2\x186\x2\x188\x2\x18A\x2\x18C\x2\x18E\x2\x190\x2\x192\x2\x194"+
+		"\x2\x196\x2\x198\x2\x19A\x2\x19C\x2\x19E\x2\x1A0\x2\x1A2\x2\x1A4\x2\x1A6"+
+		"\x2\x1A8\x2\x1AA\x2\x1AC\x2\x1AE\x2\x1B0\x2\x1B2\x2\x2\x1C\x5\x2;;\x45"+
 		"\x45\xBD\xBD\a\x2\x38\x38;;{{\x9C\x9C\xA7\xA7\x4\x2\xA9\xAA\xCC\xCC\x4"+
 		"\x2\x85\x87\xB4\xB4\x4\x2))++\x4\x2rr\xBB\xBB\x3\x2=>\x3\x2HT\x4\x2\xC4"+
-		"\xC4\xC8\xC8\x3\x2jn\x3\x2\x93\x94\x3\x2\xDD\xDE\xE\x2\x4\x4\x13\x13\x1F"+
-		" <<??\x46\x46WW}}\x7F\x7F\xB5\xB5\xBA\xBA\xC5\xC5\a\x2||\x83\x83\xD1\xD4"+
-		"\xD6\xD6\xD9\xD9\x3\x2\xE0\xE3\x5\x2,,.\x32\xDB\xDB\x6\x2pptt\xA0\xA0"+
-		"\xA5\xA5\x4\x2\xCF\xCF\xD8\xD8\x4\x2\xD7\xD7\xDA\xDA\x4\x2oo\xC0\xC0\x4"+
-		"\x2[[\x90\x90&\x2\x3\f\xE\x17\x19#%%\'(\x33\x38:?\x42\x43\x45\x46WW\x64"+
-		"\x64\x66\x66hhoossxxz\x7F\x82\x87\x89\x8B\x8D\x91\x93\x93\x95\x96\x9B"+
-		"\x9F\xA4\xA4\xA6\xA7\xA9\xAA\xAC\xAD\xB1\xB1\xB4\xB6\xB8\xB8\xBA\xBA\xBC"+
-		"\xC0\xC2\xC6\xC9\xC9\xCB\xCD\xED\xEE \x2\x18\x18$$@\x41\x44\x44GVYZ``"+
-		"\x63\x63\x65\x65gginprtwyy\x80\x81\x88\x88\x8C\x8C\x92\x92\xA0\xA0\xA5"+
-		"\xA5\xA8\xA8\xAB\xAB\xAE\xB0\xB2\xB3\xB7\xB7\xB9\xB9\xBB\xBB\xC1\xC1\xC7"+
-		"\xC8\xCA\xCA\x3\x2\xE5\xE5\x4\x2\xE8\xE8\xEB\xEB\xB56\x2\x19C\x3\x2\x2"+
-		"\x2\x4\x19F\x3\x2\x2\x2\x6\x1B0\x3\x2\x2\x2\b\x1BB\x3\x2\x2\x2\n\x1CE"+
-		"\x3\x2\x2\x2\f\x1E8\x3\x2\x2\x2\xE\x1EB\x3\x2\x2\x2\x10\x203\x3\x2\x2"+
-		"\x2\x12\x205\x3\x2\x2\x2\x14\x20C\x3\x2\x2\x2\x16\x219\x3\x2\x2\x2\x18"+
-		"\x21C\x3\x2\x2\x2\x1A\x22B\x3\x2\x2\x2\x1C\x23A\x3\x2\x2\x2\x1E\x241\x3"+
-		"\x2\x2\x2 \x267\x3\x2\x2\x2\"\x277\x3\x2\x2\x2$\x279\x3\x2\x2\x2&\x294"+
-		"\x3\x2\x2\x2(\x296\x3\x2\x2\x2*\x29A\x3\x2\x2\x2,\x29C\x3\x2\x2\x2.\x2A0"+
-		"\x3\x2\x2\x2\x30\x2A2\x3\x2\x2\x2\x32\x2A4\x3\x2\x2\x2\x34\x2AE\x3\x2"+
-		"\x2\x2\x36\x2B2\x3\x2\x2\x2\x38\x2B4\x3\x2\x2\x2:\x2B7\x3\x2\x2\x2<\x2B9"+
-		"\x3\x2\x2\x2>\x2BF\x3\x2\x2\x2@\x2C1\x3\x2\x2\x2\x42\x2CF\x3\x2\x2\x2"+
-		"\x44\x2DB\x3\x2\x2\x2\x46\x2DD\x3\x2\x2\x2H\x2F4\x3\x2\x2\x2J\x2F6\x3"+
-		"\x2\x2\x2L\x2F8\x3\x2\x2\x2N\x2FA\x3\x2\x2\x2P\x307\x3\x2\x2\x2R\x313"+
-		"\x3\x2\x2\x2T\x315\x3\x2\x2\x2V\x321\x3\x2\x2\x2X\x323\x3\x2\x2\x2Z\x329"+
-		"\x3\x2\x2\x2\\\x333\x3\x2\x2\x2^\x335\x3\x2\x2\x2`\x337\x3\x2\x2\x2\x62"+
-		"\x344\x3\x2\x2\x2\x64\x356\x3\x2\x2\x2\x66\x35B\x3\x2\x2\x2h\x35D\x3\x2"+
-		"\x2\x2j\x35F\x3\x2\x2\x2l\x361\x3\x2\x2\x2n\x36F\x3\x2\x2\x2p\x371\x3"+
-		"\x2\x2\x2r\x378\x3\x2\x2\x2t\x382\x3\x2\x2\x2v\x384\x3\x2\x2\x2x\x391"+
-		"\x3\x2\x2\x2z\x39D\x3\x2\x2\x2|\x3AB\x3\x2\x2\x2~\x3AD\x3\x2\x2\x2\x80"+
-		"\x3C3\x3\x2\x2\x2\x82\x3C5\x3\x2\x2\x2\x84\x3C7\x3\x2\x2\x2\x86\x3DD\x3"+
-		"\x2\x2\x2\x88\x3E2\x3\x2\x2\x2\x8A\x3F4\x3\x2\x2\x2\x8C\x406\x3\x2\x2"+
-		"\x2\x8E\x427\x3\x2\x2\x2\x90\x442\x3\x2\x2\x2\x92\x463\x3\x2\x2\x2\x94"+
-		"\x469\x3\x2\x2\x2\x96\x479\x3\x2\x2\x2\x98\x47E\x3\x2\x2\x2\x9A\x480\x3"+
-		"\x2\x2\x2\x9C\x482\x3\x2\x2\x2\x9E\x48C\x3\x2\x2\x2\xA0\x48F\x3\x2\x2"+
-		"\x2\xA2\x492\x3\x2\x2\x2\xA4\x49C\x3\x2\x2\x2\xA6\x49E\x3\x2\x2\x2\xA8"+
-		"\x4B7\x3\x2\x2\x2\xAA\x4BC\x3\x2\x2\x2\xAC\x4CA\x3\x2\x2\x2\xAE\x4D7\x3"+
-		"\x2\x2\x2\xB0\x4D9\x3\x2\x2\x2\xB2\x4E9\x3\x2\x2\x2\xB4\x4F0\x3\x2\x2"+
-		"\x2\xB6\x4FA\x3\x2\x2\x2\xB8\x4FC\x3\x2\x2\x2\xBA\x50D\x3\x2\x2\x2\xBC"+
-		"\x526\x3\x2\x2\x2\xBE\x541\x3\x2\x2\x2\xC0\x543\x3\x2\x2\x2\xC2\x547\x3"+
-		"\x2\x2\x2\xC4\x54B\x3\x2\x2\x2\xC6\x56F\x3\x2\x2\x2\xC8\x571\x3\x2\x2"+
-		"\x2\xCA\x577\x3\x2\x2\x2\xCC\x579\x3\x2\x2\x2\xCE\x58B\x3\x2\x2\x2\xD0"+
-		"\x59A\x3\x2\x2\x2\xD2\x5C7\x3\x2\x2\x2\xD4\x5C9\x3\x2\x2\x2\xD6\x5CB\x3"+
-		"\x2\x2\x2\xD8\x5CD\x3\x2\x2\x2\xDA\x5D3\x3\x2\x2\x2\xDC\x5DF\x3\x2\x2"+
-		"\x2\xDE\x5EB\x3\x2\x2\x2\xE0\x5F7\x3\x2\x2\x2\xE2\x60B\x3\x2\x2\x2\xE4"+
-		"\x622\x3\x2\x2\x2\xE6\x63D\x3\x2\x2\x2\xE8\x653\x3\x2\x2\x2\xEA\x666\x3"+
-		"\x2\x2\x2\xEC\x679\x3\x2\x2\x2\xEE\x687\x3\x2\x2\x2\xF0\x689\x3\x2\x2"+
-		"\x2\xF2\x691\x3\x2\x2\x2\xF4\x69F\x3\x2\x2\x2\xF6\x6A5\x3\x2\x2\x2\xF8"+
-		"\x6B1\x3\x2\x2\x2\xFA\x6B3\x3\x2\x2\x2\xFC\x6BB\x3\x2\x2\x2\xFE\x6BD\x3"+
-		"\x2\x2\x2\x100\x6C9\x3\x2\x2\x2\x102\x6CB\x3\x2\x2\x2\x104\x6E0\x3\x2"+
-		"\x2\x2\x106\x6E2\x3\x2\x2\x2\x108\x6F5\x3\x2\x2\x2\x10A\x710\x3\x2\x2"+
-		"\x2\x10C\x712\x3\x2\x2\x2\x10E\x714\x3\x2\x2\x2\x110\x716\x3\x2\x2\x2"+
-		"\x112\x725\x3\x2\x2\x2\x114\x73A\x3\x2\x2\x2\x116\x73F\x3\x2\x2\x2\x118"+
-		"\x74D\x3\x2\x2\x2\x11A\x768\x3\x2\x2\x2\x11C\x771\x3\x2\x2\x2\x11E\x77F"+
-		"\x3\x2\x2\x2\x120\x798\x3\x2\x2\x2\x122\x79F\x3\x2\x2\x2\x124\x7AE\x3"+
-		"\x2\x2\x2\x126\x7CD\x3\x2\x2\x2\x128\x7DB\x3\x2\x2\x2\x12A\x7ED\x3\x2"+
-		"\x2\x2\x12C\x800\x3\x2\x2\x2\x12E\x807\x3\x2\x2\x2\x130\x80B\x3\x2\x2"+
-		"\x2\x132\x80D\x3\x2\x2\x2\x134\x80F\x3\x2\x2\x2\x136\x815\x3\x2\x2\x2"+
-		"\x138\x817\x3\x2\x2\x2\x13A\x822\x3\x2\x2\x2\x13C\x824\x3\x2\x2\x2\x13E"+
-		"\x833\x3\x2\x2\x2\x140\x835\x3\x2\x2\x2\x142\x837\x3\x2\x2\x2\x144\x839"+
-		"\x3\x2\x2\x2\x146\x83F\x3\x2\x2\x2\x148\x847\x3\x2\x2\x2\x14A\x849\x3"+
-		"\x2\x2\x2\x14C\x84B\x3\x2\x2\x2\x14E\x84D\x3\x2\x2\x2\x150\x851\x3\x2"+
-		"\x2\x2\x152\x85D\x3\x2\x2\x2\x154\x85F\x3\x2\x2\x2\x156\x883\x3\x2\x2"+
-		"\x2\x158\x8FD\x3\x2\x2\x2\x15A\x902\x3\x2\x2\x2\x15C\x904\x3\x2\x2\x2"+
-		"\x15E\x906\x3\x2\x2\x2\x160\x908\x3\x2\x2\x2\x162\x917\x3\x2\x2\x2\x164"+
-		"\x954\x3\x2\x2\x2\x166\x956\x3\x2\x2\x2\x168\x96C\x3\x2\x2\x2\x16A\x978"+
-		"\x3\x2\x2\x2\x16C\x97A\x3\x2\x2\x2\x16E\x97C\x3\x2\x2\x2\x170\x97E\x3"+
-		"\x2\x2\x2\x172\x98C\x3\x2\x2\x2\x174\x9A2\x3\x2\x2\x2\x176\x9A4\x3\x2"+
-		"\x2\x2\x178\x9A6\x3\x2\x2\x2\x17A\x9A8\x3\x2\x2\x2\x17C\x9AC\x3\x2\x2"+
-		"\x2\x17E\x9AE\x3\x2\x2\x2\x180\x9B0\x3\x2\x2\x2\x182\x9BD\x3\x2\x2\x2"+
-		"\x184\x9C9\x3\x2\x2\x2\x186\x9CF\x3\x2\x2\x2\x188\x9D1\x3\x2\x2\x2\x18A"+
-		"\x9D7\x3\x2\x2\x2\x18C\x9DE\x3\x2\x2\x2\x18E\x9E1\x3\x2\x2\x2\x190\x9EB"+
-		"\x3\x2\x2\x2\x192\x9EF\x3\x2\x2\x2\x194\xA2D\x3\x2\x2\x2\x196\xA2F\x3"+
-		"\x2\x2\x2\x198\xA31\x3\x2\x2\x2\x19A\xA39\x3\x2\x2\x2\x19C\x19D\x5\x4"+
-		"\x3\x2\x19D\x19E\a\x2\x2\x3\x19E\x3\x3\x2\x2\x2\x19F\x1A0\x5\x184\xC3"+
-		"\x2\x1A0\x1A2\x5\f\a\x2\x1A1\x1A3\x5\x6\x4\x2\x1A2\x1A1\x3\x2\x2\x2\x1A2"+
-		"\x1A3\x3\x2\x2\x2\x1A3\x1A4\x3\x2\x2\x2\x1A4\x1A6\x5\f\a\x2\x1A5\x1A7"+
-		"\x5\b\x5\x2\x1A6\x1A5\x3\x2\x2\x2\x1A6\x1A7\x3\x2\x2\x2\x1A7\x1A8\x3\x2"+
-		"\x2\x2\x1A8\x1A9\x5\f\a\x2\x1A9\x1AA\x5\x14\v\x2\x1AA\x1AB\x5\f\a\x2\x1AB"+
-		"\x1AC\x5\x1A\xE\x2\x1AC\x1AE\x5\f\a\x2\x1AD\x1AF\x5\x19A\xCE\x2\x1AE\x1AD"+
-		"\x3\x2\x2\x2\x1AE\x1AF\x3\x2\x2\x2\x1AF\x5\x3\x2\x2\x2\x1B0\x1B1\a\xC6"+
-		"\x2\x2\x1B1\x1B2\x5\x19A\xCE\x2\x1B2\x1B4\x5\x14E\xA8\x2\x1B3\x1B5\x5"+
-		"\x19A\xCE\x2\x1B4\x1B3\x3\x2\x2\x2\x1B4\x1B5\x3\x2\x2\x2\x1B5\x1B7\x3"+
-		"\x2\x2\x2\x1B6\x1B8\a\x42\x2\x2\x1B7\x1B6\x3\x2\x2\x2\x1B7\x1B8\x3\x2"+
-		"\x2\x2\x1B8\x1B9\x3\x2\x2\x2\x1B9\x1BA\x5\x184\xC3\x2\x1BA\a\x3\x2\x2"+
-		"\x2\x1BB\x1C3\a:\x2\x2\x1BC\x1BD\x5\x19A\xCE\x2\x1BD\x1BE\a\xE9\x2\x2"+
-		"\x1BE\x1BF\x5\x19A\xCE\x2\x1BF\x1C1\x5\x12E\x98\x2\x1C0\x1C2\x5\x19A\xCE"+
-		"\x2\x1C1\x1C0\x3\x2\x2\x2\x1C1\x1C2\x3\x2\x2\x2\x1C2\x1C4\x3\x2\x2\x2"+
-		"\x1C3\x1BC\x3\x2\x2\x2\x1C3\x1C4\x3\x2\x2\x2\x1C4\x1C5\x3\x2\x2\x2\x1C5"+
-		"\x1C7\x5\x184\xC3\x2\x1C6\x1C8\x5\n\x6\x2\x1C7\x1C6\x3\x2\x2\x2\x1C8\x1C9"+
-		"\x3\x2\x2\x2\x1C9\x1C7\x3\x2\x2\x2\x1C9\x1CA\x3\x2\x2\x2\x1CA\x1CB\x3"+
-		"\x2\x2\x2\x1CB\x1CC\a\x64\x2\x2\x1CC\x1CD\x5\x184\xC3\x2\x1CD\t\x3\x2"+
-		"\x2\x2\x1CE\x1D2\x5\x12E\x98\x2\x1CF\x1D1\x5\x19A\xCE\x2\x1D0\x1CF\x3"+
-		"\x2\x2\x2\x1D1\x1D4\x3\x2\x2\x2\x1D2\x1D0\x3\x2\x2\x2\x1D2\x1D3\x3\x2"+
-		"\x2\x2\x1D3\x1D5\x3\x2\x2\x2\x1D4\x1D2\x3\x2\x2\x2\x1D5\x1D9\a\xD1\x2"+
-		"\x2\x1D6\x1D8\x5\x19A\xCE\x2\x1D7\x1D6\x3\x2\x2\x2\x1D8\x1DB\x3\x2\x2"+
-		"\x2\x1D9\x1D7\x3\x2\x2\x2\x1D9\x1DA\x3\x2\x2\x2\x1DA\x1DC\x3\x2\x2\x2"+
-		"\x1DB\x1D9\x3\x2\x2\x2\x1DC\x1DF\x5\x156\xAC\x2\x1DD\x1DE\a*\x2\x2\x1DE"+
-		"\x1E0\x5\x14E\xA8\x2\x1DF\x1DD\x3\x2\x2\x2\x1DF\x1E0\x3\x2\x2\x2\x1E0"+
-		"\x1E1\x3\x2\x2\x2\x1E1\x1E2\x5\x184\xC3\x2\x1E2\v\x3\x2\x2\x2\x1E3\x1E4"+
-		"\x5\xE\b\x2\x1E4\x1E5\x5\x184\xC3\x2\x1E5\x1E7\x3\x2\x2\x2\x1E6\x1E3\x3"+
-		"\x2\x2\x2\x1E7\x1EA\x3\x2\x2\x2\x1E8\x1E6\x3\x2\x2\x2\x1E8\x1E9\x3\x2"+
-		"\x2\x2\x1E9\r\x3\x2\x2\x2\x1EA\x1E8\x3\x2\x2\x2\x1EB\x1EC\a\x37\x2\x2"+
-		"\x1EC\x1ED\x5\x19A\xCE\x2\x1ED\x1EF\x5\x10\t\x2\x1EE\x1F0\x5\x19A\xCE"+
-		"\x2\x1EF\x1EE\x3\x2\x2\x2\x1EF\x1F0\x3\x2\x2\x2\x1F0\x1F1\x3\x2\x2\x2"+
-		"\x1F1\x1F3\a\xD1\x2\x2\x1F2\x1F4\x5\x19A\xCE\x2\x1F3\x1F2\x3\x2\x2\x2"+
-		"\x1F3\x1F4\x3\x2\x2\x2\x1F4\x1F5\x3\x2\x2\x2\x1F5\x200\x5\x12\n\x2\x1F6"+
-		"\x1F8\x5\x19A\xCE\x2\x1F7\x1F6\x3\x2\x2\x2\x1F7\x1F8\x3\x2\x2\x2\x1F8"+
-		"\x1F9\x3\x2\x2\x2\x1F9\x1FB\a)\x2\x2\x1FA\x1FC\x5\x19A\xCE\x2\x1FB\x1FA"+
-		"\x3\x2\x2\x2\x1FB\x1FC\x3\x2\x2\x2\x1FC\x1FD\x3\x2\x2\x2\x1FD\x1FF\x5"+
-		"\x12\n\x2\x1FE\x1F7\x3\x2\x2\x2\x1FF\x202\x3\x2\x2\x2\x200\x1FE\x3\x2"+
-		"\x2\x2\x200\x201\x3\x2\x2\x2\x201\xF\x3\x2\x2\x2\x202\x200\x3\x2\x2\x2"+
-		"\x203\x204\x5\x162\xB2\x2\x204\x11\x3\x2\x2\x2\x205\x206\x5\x156\xAC\x2"+
-		"\x206\x13\x3\x2\x2\x2\x207\x208\x5\x18\r\x2\x208\x209\x5\x184\xC3\x2\x209"+
-		"\x20B\x3\x2\x2\x2\x20A\x207\x3\x2\x2\x2\x20B\x20E\x3\x2\x2\x2\x20C\x20A"+
-		"\x3\x2\x2\x2\x20C\x20D\x3\x2\x2\x2\x20D\x15\x3\x2\x2\x2\x20E\x20C\x3\x2"+
-		"\x2\x2\x20F\x210\a\x97\x2\x2\x210\x211\x5\x19A\xCE\x2\x211\x212\x5\x14E"+
-		"\xA8\x2\x212\x21A\x3\x2\x2\x2\x213\x214\a\x99\x2\x2\x214\x215\x5\x19A"+
-		"\xCE\x2\x215\x216\t\x2\x2\x2\x216\x21A\x3\x2\x2\x2\x217\x21A\a\x98\x2"+
-		"\x2\x218\x21A\a\x9A\x2\x2\x219\x20F\x3\x2\x2\x2\x219\x213\x3\x2\x2\x2"+
-		"\x219\x217\x3\x2\x2\x2\x219\x218\x3\x2\x2\x2\x21A\x17\x3\x2\x2\x2\x21B"+
-		"\x21D\x5\x19A\xCE\x2\x21C\x21B\x3\x2\x2\x2\x21C\x21D\x3\x2\x2\x2\x21D"+
-		"\x228\x3\x2\x2\x2\x21E\x229\x5\xE\b\x2\x21F\x229\x5\x8CG\x2\x220\x229"+
-		"\x5\x94K\x2\x221\x229\x5\xAAV\x2\x222\x229\x5\xB4[\x2\x223\x229\x5\x88"+
-		"\x45\x2\x224\x229\x5\xD8m\x2\x225\x229\x5\x11A\x8E\x2\x226\x229\x5\x16"+
-		"\f\x2\x227\x229\x5\x116\x8C\x2\x228\x21E\x3\x2\x2\x2\x228\x21F\x3\x2\x2"+
-		"\x2\x228\x220\x3\x2\x2\x2\x228\x221\x3\x2\x2\x2\x228\x222\x3\x2\x2\x2"+
-		"\x228\x223\x3\x2\x2\x2\x228\x224\x3\x2\x2\x2\x228\x225\x3\x2\x2\x2\x228"+
-		"\x226\x3\x2\x2\x2\x228\x227\x3\x2\x2\x2\x229\x19\x3\x2\x2\x2\x22A\x22C"+
-		"\x5\x19A\xCE\x2\x22B\x22A\x3\x2\x2\x2\x22B\x22C\x3\x2\x2\x2\x22C\x232"+
-		"\x3\x2\x2\x2\x22D\x22E\x5\x1C\xF\x2\x22E\x22F\x5\x184\xC3\x2\x22F\x231"+
-		"\x3\x2\x2\x2\x230\x22D\x3\x2\x2\x2\x231\x234\x3\x2\x2\x2\x232\x230\x3"+
-		"\x2\x2\x2\x232\x233\x3\x2\x2\x2\x233\x1B\x3\x2\x2\x2\x234\x232\x3\x2\x2"+
-		"\x2\x235\x23B\x5\xBC_\x2\x236\x23B\x5\xE4s\x2\x237\x23B\x5\xE6t\x2\x238"+
-		"\x23B\x5\xE8u\x2\x239\x23B\x5\x112\x8A\x2\x23A\x235\x3\x2\x2\x2\x23A\x236"+
-		"\x3\x2\x2\x2\x23A\x237\x3\x2\x2\x2\x23A\x238\x3\x2\x2\x2\x23A\x239\x3"+
-		"\x2\x2\x2\x23B\x1D\x3\x2\x2\x2\x23C\x23D\x5 \x11\x2\x23D\x23E\x5\x184"+
-		"\xC3\x2\x23E\x240\x3\x2\x2\x2\x23F\x23C\x3\x2\x2\x2\x240\x243\x3\x2\x2"+
-		"\x2\x241\x23F\x3\x2\x2\x2\x241\x242\x3\x2\x2\x2\x242\x1F\x3\x2\x2\x2\x243"+
-		"\x241\x3\x2\x2\x2\x244\x268\x5\x146\xA4\x2\x245\x268\x5\"\x12\x2\x246"+
-		"\x268\x5\xE\b\x2\x247\x268\x5\x88\x45\x2\x248\x268\x5\xA8U\x2\x249\x268"+
-		"\x5\xAEX\x2\x24A\x268\x5\xB0Y\x2\x24B\x268\x5\xB2Z\x2\x24C\x268\x5\xB6"+
-		"\\\x2\x24D\x268\x5\xB8]\x2\x24E\x268\x5\xBA^\x2\x24F\x268\x5\xC0\x61\x2"+
-		"\x250\x268\x5\xC2\x62\x2\x251\x268\x5\xC4\x63\x2\x252\x268\x5\xCA\x66"+
-		"\x2\x253\x268\x5\xD8m\x2\x254\x268\x5\xDAn\x2\x255\x268\x5\xDCo\x2\x256"+
-		"\x268\x5\xDEp\x2\x257\x268\x5\xE0q\x2\x258\x268\x5\xE2r\x2\x259\x268\x5"+
-		"\xEAv\x2\x25A\x268\x5\xF0y\x2\x25B\x268\x5\xFA~\x2\x25C\x268\x5\xFC\x7F"+
-		"\x2\x25D\x268\x5\xFE\x80\x2\x25E\x268\x5\x102\x82\x2\x25F\x268\x5\x110"+
-		"\x89\x2\x260\x268\x5\x100\x81\x2\x261\x268\x5\x11A\x8E\x2\x262\x268\x5"+
-		"\x120\x91\x2\x263\x268\x5\x122\x92\x2\x264\x268\x5\x124\x93\x2\x265\x268"+
-		"\x5\x126\x94\x2\x266\x268\x5\xF8}\x2\x267\x244\x3\x2\x2\x2\x267\x245\x3"+
-		"\x2\x2\x2\x267\x246\x3\x2\x2\x2\x267\x247\x3\x2\x2\x2\x267\x248\x3\x2"+
-		"\x2\x2\x267\x249\x3\x2\x2\x2\x267\x24A\x3\x2\x2\x2\x267\x24B\x3\x2\x2"+
-		"\x2\x267\x24C\x3\x2\x2\x2\x267\x24D\x3\x2\x2\x2\x267\x24E\x3\x2\x2\x2"+
-		"\x267\x24F\x3\x2\x2\x2\x267\x250\x3\x2\x2\x2\x267\x251\x3\x2\x2\x2\x267"+
-		"\x252\x3\x2\x2\x2\x267\x253\x3\x2\x2\x2\x267\x254\x3\x2\x2\x2\x267\x255"+
-		"\x3\x2\x2\x2\x267\x256\x3\x2\x2\x2\x267\x257\x3\x2\x2\x2\x267\x258\x3"+
-		"\x2\x2\x2\x267\x259\x3\x2\x2\x2\x267\x25A\x3\x2\x2\x2\x267\x25B\x3\x2"+
-		"\x2\x2\x267\x25C\x3\x2\x2\x2\x267\x25D\x3\x2\x2\x2\x267\x25E\x3\x2\x2"+
-		"\x2\x267\x25F\x3\x2\x2\x2\x267\x260\x3\x2\x2\x2\x267\x261\x3\x2\x2\x2"+
-		"\x267\x262\x3\x2\x2\x2\x267\x263\x3\x2\x2\x2\x267\x264\x3\x2\x2\x2\x267"+
-		"\x265\x3\x2\x2\x2\x267\x266\x3\x2\x2\x2\x268!\x3\x2\x2\x2\x269\x278\x5"+
-		"$\x13\x2\x26A\x278\x5> \x2\x26B\x278\x5<\x1F\x2\x26C\x278\x5\x42\"\x2"+
-		"\x26D\x278\x5\x46$\x2\x26E\x278\x5N(\x2\x26F\x278\x5P)\x2\x270\x278\x5"+
-		"T+\x2\x271\x278\x5X-\x2\x272\x278\x5`\x31\x2\x273\x278\x5v<\x2\x274\x278"+
-		"\x5x=\x2\x275\x278\x5~@\x2\x276\x278\x5\x84\x43\x2\x277\x269\x3\x2\x2"+
-		"\x2\x277\x26A\x3\x2\x2\x2\x277\x26B\x3\x2\x2\x2\x277\x26C\x3\x2\x2\x2"+
-		"\x277\x26D\x3\x2\x2\x2\x277\x26E\x3\x2\x2\x2\x277\x26F\x3\x2\x2\x2\x277"+
-		"\x270\x3\x2\x2\x2\x277\x271\x3\x2\x2\x2\x277\x272\x3\x2\x2\x2\x277\x273"+
-		"\x3\x2\x2\x2\x277\x274\x3\x2\x2\x2\x277\x275\x3\x2\x2\x2\x277\x276\x3"+
-		"\x2\x2\x2\x278#\x3\x2\x2\x2\x279\x27A\a\x95\x2\x2\x27A\x27B\x5\x19A\xCE"+
-		"\x2\x27B\x27F\x5&\x14\x2\x27C\x27D\x5\x19A\xCE\x2\x27D\x27E\x5(\x15\x2"+
-		"\x27E\x280\x3\x2\x2\x2\x27F\x27C\x3\x2\x2\x2\x27F\x280\x3\x2\x2\x2\x280"+
-		"\x284\x3\x2\x2\x2\x281\x282\x5\x19A\xCE\x2\x282\x283\x5,\x17\x2\x283\x285"+
-		"\x3\x2\x2\x2\x284\x281\x3\x2\x2\x2\x284\x285\x3\x2\x2\x2\x285\x289\x3"+
-		"\x2\x2\x2\x286\x287\x5\x19A\xCE\x2\x287\x288\x5\x30\x19\x2\x288\x28A\x3"+
-		"\x2\x2\x2\x289\x286\x3\x2\x2\x2\x289\x28A\x3\x2\x2\x2\x28A\x28B\x3\x2"+
-		"\x2\x2\x28B\x28C\x5\x19A\xCE\x2\x28C\x28D\a\x39\x2\x2\x28D\x28E\x5\x19A"+
-		"\xCE\x2\x28E\x292\x5\x36\x1C\x2\x28F\x290\x5\x19A\xCE\x2\x290\x291\x5"+
-		"\x32\x1A\x2\x291\x293\x3\x2\x2\x2\x292\x28F\x3\x2\x2\x2\x292\x293\x3\x2"+
-		"\x2\x2\x293%\x3\x2\x2\x2\x294\x295\x5\x156\xAC\x2\x295\'\x3\x2\x2\x2\x296"+
-		"\x297\aq\x2\x2\x297\x298\x5\x19A\xCE\x2\x298\x299\x5*\x16\x2\x299)\x3"+
-		"\x2\x2\x2\x29A\x29B\t\x3\x2\x2\x29B+\x3\x2\x2\x2\x29C\x29D\a\x33\x2\x2"+
-		"\x29D\x29E\x5\x19A\xCE\x2\x29E\x29F\x5.\x18\x2\x29F-\x3\x2\x2\x2\x2A0"+
-		"\x2A1\t\x4\x2\x2\x2A1/\x3\x2\x2\x2\x2A2\x2A3\t\x5\x2\x2\x2A3\x31\x3\x2"+
-		"\x2\x2\x2A4\x2A6\a\x1D\x2\x2\x2A5\x2A7\x5\x19A\xCE\x2\x2A6\x2A5\x3\x2"+
-		"\x2\x2\x2A6\x2A7\x3\x2\x2\x2\x2A7\x2A8\x3\x2\x2\x2\x2A8\x2AA\a\xD1\x2"+
-		"\x2\x2A9\x2AB\x5\x19A\xCE\x2\x2AA\x2A9\x3\x2\x2\x2\x2AA\x2AB\x3\x2\x2"+
-		"\x2\x2AB\x2AC\x3\x2\x2\x2\x2AC\x2AD\x5\x34\x1B\x2\x2AD\x33\x3\x2\x2\x2"+
-		"\x2AE\x2AF\x5\x156\xAC\x2\x2AF\x35\x3\x2\x2\x2\x2B0\x2B3\x5\x38\x1D\x2"+
-		"\x2B1\x2B3\x5:\x1E\x2\x2B2\x2B0\x3\x2\x2\x2\x2B2\x2B1\x3\x2\x2\x2\x2B3"+
-		"\x37\x3\x2\x2\x2\x2B4\x2B5\a.\x2\x2\x2B5\x2B6\x5\x156\xAC\x2\x2B6\x39"+
-		"\x3\x2\x2\x2\x2B7\x2B8\x5\x156\xAC\x2\x2B8;\x3\x2\x2\x2\x2B9\x2BD\a\x43"+
-		"\x2\x2\x2BA\x2BB\x5\x19A\xCE\x2\x2BB\x2BC\x5@!\x2\x2BC\x2BE\x3\x2\x2\x2"+
-		"\x2BD\x2BA\x3\x2\x2\x2\x2BD\x2BE\x3\x2\x2\x2\x2BE=\x3\x2\x2\x2\x2BF\x2C0"+
-		"\a\xAD\x2\x2\x2C0?\x3\x2\x2\x2\x2C1\x2CC\x5\x36\x1C\x2\x2C2\x2C4\x5\x19A"+
-		"\xCE\x2\x2C3\x2C2\x3\x2\x2\x2\x2C3\x2C4\x3\x2\x2\x2\x2C4\x2C5\x3\x2\x2"+
-		"\x2\x2C5\x2C7\a)\x2\x2\x2C6\x2C8\x5\x19A\xCE\x2\x2C7\x2C6\x3\x2\x2\x2"+
-		"\x2C7\x2C8\x3\x2\x2\x2\x2C8\x2C9\x3\x2\x2\x2\x2C9\x2CB\x5\x36\x1C\x2\x2CA"+
-		"\x2C3\x3\x2\x2\x2\x2CB\x2CE\x3\x2\x2\x2\x2CC\x2CA\x3\x2\x2\x2\x2CC\x2CD"+
-		"\x3\x2\x2\x2\x2CD\x41\x3\x2\x2\x2\x2CE\x2CC\x3\x2\x2\x2\x2CF\x2D0\a\xB1"+
-		"\x2\x2\x2D0\x2D1\x5\x19A\xCE\x2\x2D1\x2D3\x5\x36\x1C\x2\x2D2\x2D4\x5\x19A"+
-		"\xCE\x2\x2D3\x2D2\x3\x2\x2\x2\x2D3\x2D4\x3\x2\x2\x2\x2D4\x2D5\x3\x2\x2"+
-		"\x2\x2D5\x2D7\a)\x2\x2\x2D6\x2D8\x5\x19A\xCE\x2\x2D7\x2D6\x3\x2\x2\x2"+
-		"\x2D7\x2D8\x3\x2\x2\x2\x2D8\x2D9\x3\x2\x2\x2\x2D9\x2DA\x5\x44#\x2\x2DA"+
-		"\x43\x3\x2\x2\x2\x2DB\x2DC\x5\x156\xAC\x2\x2DC\x45\x3\x2\x2\x2\x2DD\x2DE"+
-		"\a~\x2\x2\x2DE\x2DF\x5\x19A\xCE\x2\x2DF\x2E8\x5\x36\x1C\x2\x2E0\x2E2\x5"+
-		"\x19A\xCE\x2\x2E1\x2E0\x3\x2\x2\x2\x2E1\x2E2\x3\x2\x2\x2\x2E2\x2E3\x3"+
-		"\x2\x2\x2\x2E3\x2E5\a)\x2\x2\x2E4\x2E6\x5\x19A\xCE\x2\x2E5\x2E4\x3\x2"+
-		"\x2\x2\x2E5\x2E6\x3\x2\x2\x2\x2E6\x2E7\x3\x2\x2\x2\x2E7\x2E9\x5H%\x2\x2E8"+
-		"\x2E1\x3\x2\x2\x2\x2E8\x2E9\x3\x2\x2\x2\x2E9G\x3\x2\x2\x2\x2EA\x2F5\x5"+
-		"J&\x2\x2EB\x2EC\x5J&\x2\x2EC\x2ED\x5\x19A\xCE\x2\x2ED\x2EF\x3\x2\x2\x2"+
-		"\x2EE\x2EB\x3\x2\x2\x2\x2EE\x2EF\x3\x2\x2\x2\x2EF\x2F0\x3\x2\x2\x2\x2F0"+
-		"\x2F1\a\xBF\x2\x2\x2F1\x2F2\x5\x19A\xCE\x2\x2F2\x2F3\x5L\'\x2\x2F3\x2F5"+
-		"\x3\x2\x2\x2\x2F4\x2EA\x3\x2\x2\x2\x2F4\x2EE\x3\x2\x2\x2\x2F5I\x3\x2\x2"+
-		"\x2\x2F6\x2F7\x5\x156\xAC\x2\x2F7K\x3\x2\x2\x2\x2F8\x2F9\x5\x156\xAC\x2"+
-		"\x2F9M\x3\x2\x2\x2\x2FA\x2FB\a\xC3\x2\x2\x2FB\x2FC\x5\x19A\xCE\x2\x2FC"+
-		"\x305\x5\x36\x1C\x2\x2FD\x2FF\x5\x19A\xCE\x2\x2FE\x2FD\x3\x2\x2\x2\x2FE"+
-		"\x2FF\x3\x2\x2\x2\x2FF\x300\x3\x2\x2\x2\x300\x302\a)\x2\x2\x301\x303\x5"+
-		"\x19A\xCE\x2\x302\x301\x3\x2\x2\x2\x302\x303\x3\x2\x2\x2\x303\x304\x3"+
-		"\x2\x2\x2\x304\x306\x5H%\x2\x305\x2FE\x3\x2\x2\x2\x305\x306\x3\x2\x2\x2"+
-		"\x306O\x3\x2\x2\x2\x307\x308\a\x84\x2\x2\x308\x309\x5\x19A\xCE\x2\x309"+
-		"\x30B\x5\x38\x1D\x2\x30A\x30C\x5\x19A\xCE\x2\x30B\x30A\x3\x2\x2\x2\x30B"+
-		"\x30C\x3\x2\x2\x2\x30C\x30D\x3\x2\x2\x2\x30D\x30F\a)\x2\x2\x30E\x310\x5"+
-		"\x19A\xCE\x2\x30F\x30E\x3\x2\x2\x2\x30F\x310\x3\x2\x2\x2\x310\x311\x3"+
-		"\x2\x2\x2\x311\x312\x5R*\x2\x312Q\x3\x2\x2\x2\x313\x314\x5\x156\xAC\x2"+
-		"\x314S\x3\x2\x2\x2\x315\x316\a\xC9\x2\x2\x316\x317\x5\x19A\xCE\x2\x317"+
-		"\x319\x5\x38\x1D\x2\x318\x31A\x5\x19A\xCE\x2\x319\x318\x3\x2\x2\x2\x319"+
-		"\x31A\x3\x2\x2\x2\x31A\x31B\x3\x2\x2\x2\x31B\x31D\a)\x2\x2\x31C\x31E\x5"+
-		"\x19A\xCE\x2\x31D\x31C\x3\x2\x2\x2\x31D\x31E\x3\x2\x2\x2\x31E\x31F\x3"+
-		"\x2\x2\x2\x31F\x320\x5V,\x2\x320U\x3\x2\x2\x2\x321\x322\x5\x156\xAC\x2"+
-		"\x322W\x3\x2\x2\x2\x323\x327\x5Z.\x2\x324\x325\x5\x19A\xCE\x2\x325\x326"+
-		"\x5\x62\x32\x2\x326\x328\x3\x2\x2\x2\x327\x324\x3\x2\x2\x2\x327\x328\x3"+
-		"\x2\x2\x2\x328Y\x3\x2\x2\x2\x329\x32B\x5\\/\x2\x32A\x32C\x5\x19A\xCE\x2"+
-		"\x32B\x32A\x3\x2\x2\x2\x32B\x32C\x3\x2\x2\x2\x32C\x32D\x3\x2\x2\x2\x32D"+
-		"\x32F\a-\x2\x2\x32E\x330\x5\x19A\xCE\x2\x32F\x32E\x3\x2\x2\x2\x32F\x330"+
-		"\x3\x2\x2\x2\x330\x331\x3\x2\x2\x2\x331\x332\x5^\x30\x2\x332[\x3\x2\x2"+
-		"\x2\x333\x334\a\x16\x2\x2\x334]\x3\x2\x2\x2\x335\x336\a\x9F\x2\x2\x336"+
-		"_\x3\x2\x2\x2\x337\x338\a\x9F\x2\x2\x338\x339\x5\x19A\xCE\x2\x339\x33B"+
-		"\x5\x38\x1D\x2\x33A\x33C\x5\x19A\xCE\x2\x33B\x33A\x3\x2\x2\x2\x33B\x33C"+
-		"\x3\x2\x2\x2\x33C\x33D\x3\x2\x2\x2\x33D\x342\a)\x2\x2\x33E\x340\x5\x19A"+
-		"\xCE\x2\x33F\x33E\x3\x2\x2\x2\x33F\x340\x3\x2\x2\x2\x340\x341\x3\x2\x2"+
-		"\x2\x341\x343\x5\x62\x32\x2\x342\x33F\x3\x2\x2\x2\x342\x343\x3\x2\x2\x2"+
-		"\x343\x61\x3\x2\x2\x2\x344\x34B\x5\x64\x33\x2\x345\x347\x5\x19A\xCE\x2"+
-		"\x346\x345\x3\x2\x2\x2\x346\x347\x3\x2\x2\x2\x347\x348\x3\x2\x2\x2\x348"+
-		"\x34A\x5\x64\x33\x2\x349\x346\x3\x2\x2\x2\x34A\x34D\x3\x2\x2\x2\x34B\x349"+
-		"\x3\x2\x2\x2\x34B\x34C\x3\x2\x2\x2\x34C\x63\x3\x2\x2\x2\x34D\x34B\x3\x2"+
-		"\x2\x2\x34E\x357\x5\x66\x34\x2\x34F\x357\x5h\x35\x2\x350\x352\x5\x66\x34"+
-		"\x2\x351\x353\x5\x19A\xCE\x2\x352\x351\x3\x2\x2\x2\x352\x353\x3\x2\x2"+
-		"\x2\x353\x354\x3\x2\x2\x2\x354\x355\x5h\x35\x2\x355\x357\x3\x2\x2\x2\x356"+
-		"\x34E\x3\x2\x2\x2\x356\x34F\x3\x2\x2\x2\x356\x350\x3\x2\x2\x2\x357\x65"+
-		"\x3\x2\x2\x2\x358\x35C\x5l\x37\x2\x359\x35C\x5p\x39\x2\x35A\x35C\x5j\x36"+
-		"\x2\x35B\x358\x3\x2\x2\x2\x35B\x359\x3\x2\x2\x2\x35B\x35A\x3\x2\x2\x2"+
-		"\x35Cg\x3\x2\x2\x2\x35D\x35E\t\x6\x2\x2\x35Ei\x3\x2\x2\x2\x35F\x360\x5"+
-		"\x156\xAC\x2\x360k\x3\x2\x2\x2\x361\x363\a\xB6\x2\x2\x362\x364\x5\x19A"+
-		"\xCE\x2\x363\x362\x3\x2\x2\x2\x363\x364\x3\x2\x2\x2\x364\x365\x3\x2\x2"+
-		"\x2\x365\x367\a\xD5\x2\x2\x366\x368\x5\x19A\xCE\x2\x367\x366\x3\x2\x2"+
-		"\x2\x367\x368\x3\x2\x2\x2\x368\x369\x3\x2\x2\x2\x369\x36B\x5n\x38\x2\x36A"+
-		"\x36C\x5\x19A\xCE\x2\x36B\x36A\x3\x2\x2\x2\x36B\x36C\x3\x2\x2\x2\x36C"+
-		"\x36D\x3\x2\x2\x2\x36D\x36E\a\xDC\x2\x2\x36Em\x3\x2\x2\x2\x36F\x370\x5"+
-		"\x156\xAC\x2\x370o\x3\x2\x2\x2\x371\x376\a\xBC\x2\x2\x372\x374\x5\x19A"+
-		"\xCE\x2\x373\x372\x3\x2\x2\x2\x373\x374\x3\x2\x2\x2\x374\x375\x3\x2\x2"+
-		"\x2\x375\x377\x5r:\x2\x376\x373\x3\x2\x2\x2\x376\x377\x3\x2\x2\x2\x377"+
-		"q\x3\x2\x2\x2\x378\x37A\a\xD5\x2\x2\x379\x37B\x5\x19A\xCE\x2\x37A\x379"+
-		"\x3\x2\x2\x2\x37A\x37B\x3\x2\x2\x2\x37B\x37C\x3\x2\x2\x2\x37C\x37E\x5"+
-		"t;\x2\x37D\x37F\x5\x19A\xCE\x2\x37E\x37D\x3\x2\x2\x2\x37E\x37F\x3\x2\x2"+
-		"\x2\x37F\x380\x3\x2\x2\x2\x380\x381\a\xDC\x2\x2\x381s\x3\x2\x2\x2\x382"+
-		"\x383\x5\x156\xAC\x2\x383u\x3\x2\x2\x2\x384\x385\a\xCC\x2\x2\x385\x386"+
-		"\x5\x19A\xCE\x2\x386\x388\x5\x38\x1D\x2\x387\x389\x5\x19A\xCE\x2\x388"+
-		"\x387\x3\x2\x2\x2\x388\x389\x3\x2\x2\x2\x389\x38A\x3\x2\x2\x2\x38A\x38F"+
-		"\a)\x2\x2\x38B\x38D\x5\x19A\xCE\x2\x38C\x38B\x3\x2\x2\x2\x38C\x38D\x3"+
-		"\x2\x2\x2\x38D\x38E\x3\x2\x2\x2\x38E\x390\x5\x62\x32\x2\x38F\x38C\x3\x2"+
-		"\x2\x2\x38F\x390\x3\x2\x2\x2\x390w\x3\x2\x2\x2\x391\x392\a{\x2\x2\x392"+
-		"\x393\x5\x19A\xCE\x2\x393\x395\x5\x38\x1D\x2\x394\x396\x5\x19A\xCE\x2"+
-		"\x395\x394\x3\x2\x2\x2\x395\x396\x3\x2\x2\x2\x396\x397\x3\x2\x2\x2\x397"+
-		"\x399\a)\x2\x2\x398\x39A\x5\x19A\xCE\x2\x399\x398\x3\x2\x2\x2\x399\x39A"+
-		"\x3\x2\x2\x2\x39A\x39B\x3\x2\x2\x2\x39B\x39C\x5z>\x2\x39Cy\x3\x2\x2\x2"+
-		"\x39D\x3A8\x5|?\x2\x39E\x3A0\x5\x19A\xCE\x2\x39F\x39E\x3\x2\x2\x2\x39F"+
-		"\x3A0\x3\x2\x2\x2\x3A0\x3A1\x3\x2\x2\x2\x3A1\x3A3\a)\x2\x2\x3A2\x3A4\x5"+
-		"\x19A\xCE\x2\x3A3\x3A2\x3\x2\x2\x2\x3A3\x3A4\x3\x2\x2\x2\x3A4\x3A5\x3"+
-		"\x2\x2\x2\x3A5\x3A7\x5|?\x2\x3A6\x39F\x3\x2\x2\x2\x3A7\x3AA\x3\x2\x2\x2"+
-		"\x3A8\x3A6\x3\x2\x2\x2\x3A8\x3A9\x3\x2\x2\x2\x3A9{\x3\x2\x2\x2\x3AA\x3A8"+
-		"\x3\x2\x2\x2\x3AB\x3AC\x5\x156\xAC\x2\x3AC}\x3\x2\x2\x2\x3AD\x3AE\a\xA6"+
-		"\x2\x2\x3AE\x3AF\x5\x19A\xCE\x2\x3AF\x3B1\x5\x36\x1C\x2\x3B0\x3B2\x5\x19A"+
-		"\xCE\x2\x3B1\x3B0\x3\x2\x2\x2\x3B1\x3B2\x3\x2\x2\x2\x3B2\x3B3\x3\x2\x2"+
-		"\x2\x3B3\x3B5\a)\x2\x2\x3B4\x3B6\x5\x19A\xCE\x2\x3B5\x3B4\x3\x2\x2\x2"+
-		"\x3B5\x3B6\x3\x2\x2\x2\x3B6\x3B8\x3\x2\x2\x2\x3B7\x3B9\x5\x80\x41\x2\x3B8"+
-		"\x3B7\x3\x2\x2\x2\x3B8\x3B9\x3\x2\x2\x2\x3B9\x3BB\x3\x2\x2\x2\x3BA\x3BC"+
-		"\x5\x19A\xCE\x2\x3BB\x3BA\x3\x2\x2\x2\x3BB\x3BC\x3\x2\x2\x2\x3BC\x3BD"+
-		"\x3\x2\x2\x2\x3BD\x3BF\a)\x2\x2\x3BE\x3C0\x5\x19A\xCE\x2\x3BF\x3BE\x3"+
-		"\x2\x2\x2\x3BF\x3C0\x3\x2\x2\x2\x3C0\x3C1\x3\x2\x2\x2\x3C1\x3C2\x5\x82"+
-		"\x42\x2\x3C2\x7F\x3\x2\x2\x2\x3C3\x3C4\x5\x156\xAC\x2\x3C4\x81\x3\x2\x2"+
-		"\x2\x3C5\x3C6\x5\x156\xAC\x2\x3C6\x83\x3\x2\x2\x2\x3C7\x3C8\as\x2\x2\x3C8"+
-		"\x3C9\x5\x19A\xCE\x2\x3C9\x3CB\x5\x36\x1C\x2\x3CA\x3CC\x5\x19A\xCE\x2"+
-		"\x3CB\x3CA\x3\x2\x2\x2\x3CB\x3CC\x3\x2\x2\x2\x3CC\x3CD\x3\x2\x2\x2\x3CD"+
-		"\x3CF\a)\x2\x2\x3CE\x3D0\x5\x19A\xCE\x2\x3CF\x3CE\x3\x2\x2\x2\x3CF\x3D0"+
-		"\x3\x2\x2\x2\x3D0\x3D2\x3\x2\x2\x2\x3D1\x3D3\x5\x80\x41\x2\x3D2\x3D1\x3"+
-		"\x2\x2\x2\x3D2\x3D3\x3\x2\x2\x2\x3D3\x3D5\x3\x2\x2\x2\x3D4\x3D6\x5\x19A"+
-		"\xCE\x2\x3D5\x3D4\x3\x2\x2\x2\x3D5\x3D6\x3\x2\x2\x2\x3D6\x3D7\x3\x2\x2"+
-		"\x2\x3D7\x3D9\a)\x2\x2\x3D8\x3DA\x5\x19A\xCE\x2\x3D9\x3D8\x3\x2\x2\x2"+
-		"\x3D9\x3DA\x3\x2\x2\x2\x3DA\x3DB\x3\x2\x2\x2\x3DB\x3DC\x5\x86\x44\x2\x3DC"+
-		"\x85\x3\x2\x2\x2\x3DD\x3DE\x5\x156\xAC\x2\x3DE\x87\x3\x2\x2\x2\x3DF\x3E0"+
-		"\x5\x154\xAB\x2\x3E0\x3E1\x5\x19A\xCE\x2\x3E1\x3E3\x3\x2\x2\x2\x3E2\x3DF"+
-		"\x3\x2\x2\x2\x3E2\x3E3\x3\x2\x2\x2\x3E3\x3E4\x3\x2\x2\x2\x3E4\x3E5\a\x44"+
-		"\x2\x2\x3E5\x3E6\x5\x19A\xCE\x2\x3E6\x3F1\x5\x8A\x46\x2\x3E7\x3E9\x5\x19A"+
-		"\xCE\x2\x3E8\x3E7\x3\x2\x2\x2\x3E8\x3E9\x3\x2\x2\x2\x3E9\x3EA\x3\x2\x2"+
-		"\x2\x3EA\x3EC\a)\x2\x2\x3EB\x3ED\x5\x19A\xCE\x2\x3EC\x3EB\x3\x2\x2\x2"+
-		"\x3EC\x3ED\x3\x2\x2\x2\x3ED\x3EE\x3\x2\x2\x2\x3EE\x3F0\x5\x8A\x46\x2\x3EF"+
-		"\x3E8\x3\x2\x2\x2\x3F0\x3F3\x3\x2\x2\x2\x3F1\x3EF\x3\x2\x2\x2\x3F1\x3F2"+
-		"\x3\x2\x2\x2\x3F2\x89\x3\x2\x2\x2\x3F3\x3F1\x3\x2\x2\x2\x3F4\x3F8\x5\x130"+
-		"\x99\x2\x3F5\x3F6\x5\x19A\xCE\x2\x3F6\x3F7\x5\x13C\x9F\x2\x3F7\x3F9\x3"+
-		"\x2\x2\x2\x3F8\x3F5\x3\x2\x2\x2\x3F8\x3F9\x3\x2\x2\x2\x3F9\x3FB\x3\x2"+
-		"\x2\x2\x3FA\x3FC\x5\x19A\xCE\x2\x3FB\x3FA\x3\x2\x2\x2\x3FB\x3FC\x3\x2"+
-		"\x2\x2\x3FC\x3FD\x3\x2\x2\x2\x3FD\x3FF\a\xD1\x2\x2\x3FE\x400\x5\x19A\xCE"+
-		"\x2\x3FF\x3FE\x3\x2\x2\x2\x3FF\x400\x3\x2\x2\x2\x400\x401\x3\x2\x2\x2"+
-		"\x401\x402\x5\x156\xAC\x2\x402\x8B\x3\x2\x2\x2\x403\x404\x5\x154\xAB\x2"+
-		"\x404\x405\x5\x19A\xCE\x2\x405\x407\x3\x2\x2\x2\x406\x403\x3\x2\x2\x2"+
-		"\x406\x407\x3\x2\x2\x2\x407\x408\x3\x2\x2\x2\x408\x409\aG\x2\x2\x409\x40C"+
-		"\x5\x19A\xCE\x2\x40A\x40B\a\xA4\x2\x2\x40B\x40D\x5\x19A\xCE\x2\x40C\x40A"+
-		"\x3\x2\x2\x2\x40C\x40D\x3\x2\x2\x2\x40D\x40E\x3\x2\x2\x2\x40E\x40F\t\a"+
-		"\x2\x2\x40F\x410\x5\x19A\xCE\x2\x410\x411\x5\x130\x99\x2\x411\x412\x5"+
-		"\x19A\xCE\x2\x412\x413\a\x82\x2\x2\x413\x414\x5\x19A\xCE\x2\x414\x41A"+
-		"\a\xDF\x2\x2\x415\x416\x5\x19A\xCE\x2\x416\x417\a\x35\x2\x2\x417\x418"+
-		"\x5\x19A\xCE\x2\x418\x419\a\xDF\x2\x2\x419\x41B\x3\x2\x2\x2\x41A\x415"+
-		"\x3\x2\x2\x2\x41A\x41B\x3\x2\x2\x2\x41B\x420\x3\x2\x2\x2\x41C\x41E\x5"+
-		"\x19A\xCE\x2\x41D\x41C\x3\x2\x2\x2\x41D\x41E\x3\x2\x2\x2\x41E\x41F\x3"+
-		"\x2\x2\x2\x41F\x421\x5\x8EH\x2\x420\x41D\x3\x2\x2\x2\x420\x421\x3\x2\x2"+
-		"\x2\x421\x425\x3\x2\x2\x2\x422\x423\x5\x19A\xCE\x2\x423\x424\x5\x13C\x9F"+
-		"\x2\x424\x426\x3\x2\x2\x2\x425\x422\x3\x2\x2\x2\x425\x426\x3\x2\x2\x2"+
-		"\x426\x8D\x3\x2\x2\x2\x427\x439\a\xD5\x2\x2\x428\x42A\x5\x19A\xCE\x2\x429"+
-		"\x428\x3\x2\x2\x2\x429\x42A\x3\x2\x2\x2\x42A\x42B\x3\x2\x2\x2\x42B\x436"+
-		"\x5\x90I\x2\x42C\x42E\x5\x19A\xCE\x2\x42D\x42C\x3\x2\x2\x2\x42D\x42E\x3"+
-		"\x2\x2\x2\x42E\x42F\x3\x2\x2\x2\x42F\x431\a)\x2\x2\x430\x432\x5\x19A\xCE"+
-		"\x2\x431\x430\x3\x2\x2\x2\x431\x432\x3\x2\x2\x2\x432\x433\x3\x2\x2\x2"+
-		"\x433\x435\x5\x90I\x2\x434\x42D\x3\x2\x2\x2\x435\x438\x3\x2\x2\x2\x436"+
-		"\x434\x3\x2\x2\x2\x436\x437\x3\x2\x2\x2\x437\x43A\x3\x2\x2\x2\x438\x436"+
-		"\x3\x2\x2\x2\x439\x429\x3\x2\x2\x2\x439\x43A\x3\x2\x2\x2\x43A\x43C\x3"+
-		"\x2\x2\x2\x43B\x43D\x5\x19A\xCE\x2\x43C\x43B\x3\x2\x2\x2\x43C\x43D\x3"+
-		"\x2\x2\x2\x43D\x43E\x3\x2\x2\x2\x43E\x43F\a\xDC\x2\x2\x43F\x8F\x3\x2\x2"+
-		"\x2\x440\x441\a\x96\x2\x2\x441\x443\x5\x19A\xCE\x2\x442\x440\x3\x2\x2"+
-		"\x2\x442\x443\x3\x2\x2\x2\x443\x446\x3\x2\x2\x2\x444\x445\t\b\x2\x2\x445"+
-		"\x447\x5\x19A\xCE\x2\x446\x444\x3\x2\x2\x2\x446\x447\x3\x2\x2\x2\x447"+
-		"\x44A\x3\x2\x2\x2\x448\x449\a\x9D\x2\x2\x449\x44B\x5\x19A\xCE\x2\x44A"+
-		"\x448\x3\x2\x2\x2\x44A\x44B\x3\x2\x2\x2\x44B\x44C\x3\x2\x2\x2\x44C\x455"+
-		"\x5\x12E\x98\x2\x44D\x44F\x5\x19A\xCE\x2\x44E\x44D\x3\x2\x2\x2\x44E\x44F"+
-		"\x3\x2\x2\x2\x44F\x450\x3\x2\x2\x2\x450\x452\a\xD5\x2\x2\x451\x453\x5"+
-		"\x19A\xCE\x2\x452\x451\x3\x2\x2\x2\x452\x453\x3\x2\x2\x2\x453\x454\x3"+
-		"\x2\x2\x2\x454\x456\a\xDC\x2\x2\x455\x44E\x3\x2\x2\x2\x455\x456\x3\x2"+
-		"\x2\x2\x456\x45B\x3\x2\x2\x2\x457\x459\x5\x19A\xCE\x2\x458\x457\x3\x2"+
-		"\x2\x2\x458\x459\x3\x2\x2\x2\x459\x45A\x3\x2\x2\x2\x45A\x45C\x5\x13C\x9F"+
-		"\x2\x45B\x458\x3\x2\x2\x2\x45B\x45C\x3\x2\x2\x2\x45C\x461\x3\x2\x2\x2"+
-		"\x45D\x45F\x5\x19A\xCE\x2\x45E\x45D\x3\x2\x2\x2\x45E\x45F\x3\x2\x2\x2"+
-		"\x45F\x460\x3\x2\x2\x2\x460\x462\x5\x92J\x2\x461\x45E\x3\x2\x2\x2\x461"+
-		"\x462\x3\x2\x2\x2\x462\x91\x3\x2\x2\x2\x463\x465\a\xD1\x2\x2\x464\x466"+
-		"\x5\x19A\xCE\x2\x465\x464\x3\x2\x2\x2\x465\x466\x3\x2\x2\x2\x466\x467"+
-		"\x3\x2\x2\x2\x467\x468\x5\x156\xAC\x2\x468\x93\x3\x2\x2\x2\x469\x46A\x5"+
-		"\x96L\x2\x46A\x46B\x5\x19A\xCE\x2\x46B\x476\x5\x98M\x2\x46C\x46E\x5\x19A"+
-		"\xCE\x2\x46D\x46C\x3\x2\x2\x2\x46D\x46E\x3\x2\x2\x2\x46E\x46F\x3\x2\x2"+
-		"\x2\x46F\x471\a)\x2\x2\x470\x472\x5\x19A\xCE\x2\x471\x470\x3\x2\x2\x2"+
-		"\x471\x472\x3\x2\x2\x2\x472\x473\x3\x2\x2\x2\x473\x475\x5\x98M\x2\x474"+
-		"\x46D\x3\x2\x2\x2\x475\x478\x3\x2\x2\x2\x476\x474\x3\x2\x2\x2\x476\x477"+
-		"\x3\x2\x2\x2\x477\x95\x3\x2\x2\x2\x478\x476\x3\x2\x2\x2\x479\x47A\t\t"+
-		"\x2\x2\x47A\x97\x3\x2\x2\x2\x47B\x47F\x5\x9AN\x2\x47C\x47F\x5\x9CO\x2"+
-		"\x47D\x47F\x5\xA2R\x2\x47E\x47B\x3\x2\x2\x2\x47E\x47C\x3\x2\x2\x2\x47E"+
-		"\x47D\x3\x2\x2\x2\x47F\x99\x3\x2\x2\x2\x480\x481\x5\x12E\x98\x2\x481\x9B"+
-		"\x3\x2\x2\x2\x482\x484\x5\x9EP\x2\x483\x485\x5\x19A\xCE\x2\x484\x483\x3"+
-		"\x2\x2\x2\x484\x485\x3\x2\x2\x2\x485\x486\x3\x2\x2\x2\x486\x488\a\xD7"+
-		"\x2\x2\x487\x489\x5\x19A\xCE\x2\x488\x487\x3\x2\x2\x2\x488\x489\x3\x2"+
-		"\x2\x2\x489\x48A\x3\x2\x2\x2\x48A\x48B\x5\xA0Q\x2\x48B\x9D\x3\x2\x2\x2"+
-		"\x48C\x48D\x6P\x2\x2\x48D\x48E\x5\x12E\x98\x2\x48E\x9F\x3\x2\x2\x2\x48F"+
-		"\x490\x6Q\x3\x2\x490\x491\x5\x12E\x98\x2\x491\xA1\x3\x2\x2\x2\x492\x494"+
-		"\x5\xA4S\x2\x493\x495\x5\x19A\xCE\x2\x494\x493\x3\x2\x2\x2\x494\x495\x3"+
-		"\x2\x2\x2\x495\x496\x3\x2\x2\x2\x496\x498\a\xD7\x2\x2\x497\x499\x5\x19A"+
-		"\xCE\x2\x498\x497\x3\x2\x2\x2\x498\x499\x3\x2\x2\x2\x499\x49A\x3\x2\x2"+
-		"\x2\x49A\x49B\x5\xA6T\x2\x49B\xA3\x3\x2\x2\x2\x49C\x49D\x5\x12E\x98\x2"+
-		"\x49D\xA5\x3\x2\x2\x2\x49E\x49F\x5\x12E\x98\x2\x49F\xA7\x3\x2\x2\x2\x4A0"+
-		"\x4A1\aV\x2\x2\x4A1\x4A2\x5\x184\xC3\x2\x4A2\x4A3\x5\x1E\x10\x2\x4A3\x4A4"+
-		"\a\x80\x2\x2\x4A4\x4B8\x3\x2\x2\x2\x4A5\x4A6\aV\x2\x2\x4A6\x4A7\x5\x19A"+
-		"\xCE\x2\x4A7\x4A8\t\n\x2\x2\x4A8\x4A9\x5\x19A\xCE\x2\x4A9\x4AA\x5\x156"+
-		"\xAC\x2\x4AA\x4AB\x5\x184\xC3\x2\x4AB\x4AC\x5\x1E\x10\x2\x4AC\x4AD\a\x80"+
-		"\x2\x2\x4AD\x4B8\x3\x2\x2\x2\x4AE\x4AF\aV\x2\x2\x4AF\x4B0\x5\x184\xC3"+
-		"\x2\x4B0\x4B1\x5\x1E\x10\x2\x4B1\x4B2\a\x80\x2\x2\x4B2\x4B3\x5\x19A\xCE"+
-		"\x2\x4B3\x4B4\t\n\x2\x2\x4B4\x4B5\x5\x19A\xCE\x2\x4B5\x4B6\x5\x156\xAC"+
-		"\x2\x4B6\x4B8\x3\x2\x2\x2\x4B7\x4A0\x3\x2\x2\x2\x4B7\x4A5\x3\x2\x2\x2"+
-		"\x4B7\x4AE\x3\x2\x2\x2\x4B8\xA9\x3\x2\x2\x2\x4B9\x4BA\x5\x154\xAB\x2\x4BA"+
-		"\x4BB\x5\x19A\xCE\x2\x4BB\x4BD\x3\x2\x2\x2\x4BC\x4B9\x3\x2\x2\x2\x4BC"+
-		"\x4BD\x3\x2\x2\x2\x4BD\x4BE\x3\x2\x2\x2\x4BE\x4BF\a\x65\x2\x2\x4BF\x4C0"+
-		"\x5\x19A\xCE\x2\x4C0\x4C1\x5\x130\x99\x2\x4C1\x4C5\x5\x184\xC3\x2\x4C2"+
-		"\x4C4\x5\xACW\x2\x4C3\x4C2\x3\x2\x2\x2\x4C4\x4C7\x3\x2\x2\x2\x4C5\x4C3"+
-		"\x3\x2\x2\x2\x4C5\x4C6\x3\x2\x2\x2\x4C6\x4C8\x3\x2\x2\x2\x4C7\x4C5\x3"+
-		"\x2\x2\x2\x4C8\x4C9\a\\\x2\x2\x4C9\xAB\x3\x2\x2\x2\x4CA\x4D3\x5\x130\x99"+
-		"\x2\x4CB\x4CD\x5\x19A\xCE\x2\x4CC\x4CB\x3\x2\x2\x2\x4CC\x4CD\x3\x2\x2"+
-		"\x2\x4CD\x4CE\x3\x2\x2\x2\x4CE\x4D0\a\xD1\x2\x2\x4CF\x4D1\x5\x19A\xCE"+
-		"\x2\x4D0\x4CF\x3\x2\x2\x2\x4D0\x4D1\x3\x2\x2\x2\x4D1\x4D2\x3\x2\x2\x2"+
-		"\x4D2\x4D4\x5\x156\xAC\x2\x4D3\x4CC\x3\x2\x2\x2\x4D3\x4D4\x3\x2\x2\x2"+
-		"\x4D4\x4D5\x3\x2\x2\x2\x4D5\x4D6\x5\x184\xC3\x2\x4D6\xAD\x3\x2\x2\x2\x4D7"+
-		"\x4D8\a\x64\x2\x2\x4D8\xAF\x3\x2\x2\x2\x4D9\x4DA\ag\x2\x2\x4DA\x4DB\x5"+
-		"\x19A\xCE\x2\x4DB\x4E6\x5\x156\xAC\x2\x4DC\x4DE\x5\x19A\xCE\x2\x4DD\x4DC"+
-		"\x3\x2\x2\x2\x4DD\x4DE\x3\x2\x2\x2\x4DE\x4DF\x3\x2\x2\x2\x4DF\x4E1\a)"+
-		"\x2\x2\x4E0\x4E2\x5\x19A\xCE\x2\x4E1\x4E0\x3\x2\x2\x2\x4E1\x4E2\x3\x2"+
-		"\x2\x2\x4E2\x4E3\x3\x2\x2\x2\x4E3\x4E5\x5\x156\xAC\x2\x4E4\x4DD\x3\x2"+
-		"\x2\x2\x4E5\x4E8\x3\x2\x2\x2\x4E6\x4E4\x3\x2\x2\x2\x4E6\x4E7\x3\x2\x2"+
-		"\x2\x4E7\xB1\x3\x2\x2\x2\x4E8\x4E6\x3\x2\x2\x2\x4E9\x4EA\ah\x2\x2\x4EA"+
-		"\x4EB\x5\x19A\xCE\x2\x4EB\x4EC\x5\x156\xAC\x2\x4EC\xB3\x3\x2\x2\x2\x4ED"+
-		"\x4EE\x5\x154\xAB\x2\x4EE\x4EF\x5\x19A\xCE\x2\x4EF\x4F1\x3\x2\x2\x2\x4F0"+
-		"\x4ED\x3\x2\x2\x2\x4F0\x4F1\x3\x2\x2\x2\x4F1\x4F2\x3\x2\x2\x2\x4F2\x4F3"+
-		"\ai\x2\x2\x4F3\x4F4\x5\x19A\xCE\x2\x4F4\x4F6\x5\x130\x99\x2\x4F5\x4F7"+
-		"\x5\x19A\xCE\x2\x4F6\x4F5\x3\x2\x2\x2\x4F6\x4F7\x3\x2\x2\x2\x4F7\x4F8"+
-		"\x3\x2\x2\x2\x4F8\x4F9\x5\x8EH\x2\x4F9\xB5\x3\x2\x2\x2\x4FA\x4FB\t\v\x2"+
-		"\x2\x4FB\xB7\x3\x2\x2\x2\x4FC\x4FD\aq\x2\x2\x4FD\x4FE\x5\x19A\xCE\x2\x4FE"+
-		"\x4FF\aX\x2\x2\x4FF\x500\x5\x19A\xCE\x2\x500\x501\x5\x156\xAC\x2\x501"+
-		"\x502\x5\x19A\xCE\x2\x502\x503\az\x2\x2\x503\x504\x5\x19A\xCE\x2\x504"+
-		"\x505\x5\x156\xAC\x2\x505\x506\x5\x184\xC3\x2\x506\x507\x5\x1E\x10\x2"+
-		"\x507\x50B\a\x8C\x2\x2\x508\x509\x5\x19A\xCE\x2\x509\x50A\x5\x156\xAC"+
-		"\x2\x50A\x50C\x3\x2\x2\x2\x50B\x508\x3\x2\x2\x2\x50B\x50C\x3\x2\x2\x2"+
-		"\x50C\xB9\x3\x2\x2\x2\x50D\x50E\aq\x2\x2\x50E\x50F\x5\x19A\xCE\x2\x50F"+
-		"\x510\x5\x156\xAC\x2\x510\x511\x5\x19A\xCE\x2\x511\x512\a\xBF\x2\x2\x512"+
-		"\x513\x5\x19A\xCE\x2\x513\x519\x5\x156\xAC\x2\x514\x515\x5\x19A\xCE\x2"+
-		"\x515\x516\a\xB8\x2\x2\x516\x517\x5\x19A\xCE\x2\x517\x518\x5\x156\xAC"+
-		"\x2\x518\x51A\x3\x2\x2\x2\x519\x514\x3\x2\x2\x2\x519\x51A\x3\x2\x2\x2"+
-		"\x51A\x51B\x3\x2\x2\x2\x51B\x51C\x5\x184\xC3\x2\x51C\x51D\x5\x1E\x10\x2"+
-		"\x51D\x521\a\x8C\x2\x2\x51E\x51F\x5\x19A\xCE\x2\x51F\x520\x5\x156\xAC"+
-		"\x2\x520\x522\x3\x2\x2\x2\x521\x51E\x3\x2\x2\x2\x521\x522\x3\x2\x2\x2"+
-		"\x522\xBB\x3\x2\x2\x2\x523\x524\x5\x154\xAB\x2\x524\x525\x5\x19A\xCE\x2"+
-		"\x525\x527\x3\x2\x2\x2\x526\x523\x3\x2\x2\x2\x526\x527\x3\x2\x2\x2\x527"+
-		"\x52A\x3\x2\x2\x2\x528\x529\a\xB7\x2\x2\x529\x52B\x5\x19A\xCE\x2\x52A"+
-		"\x528\x3\x2\x2\x2\x52A\x52B\x3\x2\x2\x2\x52B\x52C\x3\x2\x2\x2\x52C\x52E"+
-		"\ar\x2\x2\x52D\x52F\x5\x19A\xCE\x2\x52E\x52D\x3\x2\x2\x2\x52E\x52F\x3"+
-		"\x2\x2\x2\x52F\x530\x3\x2\x2\x2\x530\x535\x5\xBE`\x2\x531\x533\x5\x19A"+
-		"\xCE\x2\x532\x531\x3\x2\x2\x2\x532\x533\x3\x2\x2\x2\x533\x534\x3\x2\x2"+
-		"\x2\x534\x536\x5\x8EH\x2\x535\x532\x3\x2\x2\x2\x535\x536\x3\x2\x2\x2\x536"+
-		"\x53B\x3\x2\x2\x2\x537\x539\x5\x19A\xCE\x2\x538\x537\x3\x2\x2\x2\x538"+
-		"\x539\x3\x2\x2\x2\x539\x53A\x3\x2\x2\x2\x53A\x53C\x5\x13C\x9F\x2\x53B"+
-		"\x538\x3\x2\x2\x2\x53B\x53C\x3\x2\x2\x2\x53C\x53D\x3\x2\x2\x2\x53D\x53E"+
-		"\x5\x184\xC3\x2\x53E\x53F\x5\x1E\x10\x2\x53F\x540\a]\x2\x2\x540\xBD\x3"+
-		"\x2\x2\x2\x541\x542\x5\x130\x99\x2\x542\xBF\x3\x2\x2\x2\x543\x544\au\x2"+
-		"\x2\x544\x545\x5\x19A\xCE\x2\x545\x546\x5\x156\xAC\x2\x546\xC1\x3\x2\x2"+
-		"\x2\x547\x548\av\x2\x2\x548\x549\x5\x19A\xCE\x2\x549\x54A\x5\x156\xAC"+
-		"\x2\x54A\xC3\x3\x2\x2\x2\x54B\x54C\aw\x2\x2\x54C\x54D\x5\x19A\xCE\x2\x54D"+
-		"\x54E\x5\xD6l\x2\x54E\x54F\x5\x19A\xCE\x2\x54F\x550\a\xBE\x2\x2\x550\x551"+
-		"\x5\x184\xC3\x2\x551\x555\x5\x1E\x10\x2\x552\x554\x5\xC6\x64\x2\x553\x552"+
-		"\x3\x2\x2\x2\x554\x557\x3\x2\x2\x2\x555\x553\x3\x2\x2\x2\x555\x556\x3"+
-		"\x2\x2\x2\x556\x559\x3\x2\x2\x2\x557\x555\x3\x2\x2\x2\x558\x55A\x5\xC8"+
-		"\x65\x2\x559\x558\x3\x2\x2\x2\x559\x55A\x3\x2\x2\x2\x55A\x55B\x3\x2\x2"+
-		"\x2\x55B\x55C\a^\x2\x2\x55C\xC5\x3\x2\x2\x2\x55D\x55E\aZ\x2\x2\x55E\x55F"+
-		"\x5\x19A\xCE\x2\x55F\x560\x5\xD6l\x2\x560\x561\x5\x19A\xCE\x2\x561\x562"+
-		"\a\xBE\x2\x2\x562\x563\x5\x184\xC3\x2\x563\x564\x5\x1E\x10\x2\x564\x570"+
-		"\x3\x2\x2\x2\x565\x566\aZ\x2\x2\x566\x567\x5\x19A\xCE\x2\x567\x568\x5"+
-		"\xD6l\x2\x568\x569\x5\x19A\xCE\x2\x569\x56B\a\xBE\x2\x2\x56A\x56C\x5\x19A"+
-		"\xCE\x2\x56B\x56A\x3\x2\x2\x2\x56B\x56C\x3\x2\x2\x2\x56C\x56D\x3\x2\x2"+
-		"\x2\x56D\x56E\x5\x1E\x10\x2\x56E\x570\x3\x2\x2\x2\x56F\x55D\x3\x2\x2\x2"+
-		"\x56F\x565\x3\x2\x2\x2\x570\xC7\x3\x2\x2\x2\x571\x572\aY\x2\x2\x572\x573"+
-		"\x5\x184\xC3\x2\x573\x574\x5\x1E\x10\x2\x574\xC9\x3\x2\x2\x2\x575\x578"+
-		"\x5\xCCg\x2\x576\x578\x5\xCEh\x2\x577\x575\x3\x2\x2\x2\x577\x576\x3\x2"+
-		"\x2\x2\x578\xCB\x3\x2\x2\x2\x579\x57B\aw\x2\x2\x57A\x57C\x5\x19A\xCE\x2"+
-		"\x57B\x57A\x3\x2\x2\x2\x57B\x57C\x3\x2\x2\x2\x57C\x57D\x3\x2\x2\x2\x57D"+
-		"\x57F\x5\xD6l\x2\x57E\x580\x5\x19A\xCE\x2\x57F\x57E\x3\x2\x2\x2\x57F\x580"+
-		"\x3\x2\x2\x2\x580\x581\x3\x2\x2\x2\x581\x583\a\xBE\x2\x2\x582\x584\x5"+
-		"\x19A\xCE\x2\x583\x582\x3\x2\x2\x2\x583\x584\x3\x2\x2\x2\x584\x585\x3"+
-		"\x2\x2\x2\x585\x589\x5\xD2j\x2\x586\x587\x5\x19A\xCE\x2\x587\x588\x5\xD0"+
-		"i\x2\x588\x58A\x3\x2\x2\x2\x589\x586\x3\x2\x2\x2\x589\x58A\x3\x2\x2\x2"+
-		"\x58A\xCD\x3\x2\x2\x2\x58B\x58D\aw\x2\x2\x58C\x58E\x5\x19A\xCE\x2\x58D"+
-		"\x58C\x3\x2\x2\x2\x58D\x58E\x3\x2\x2\x2\x58E\x58F\x3\x2\x2\x2\x58F\x591"+
-		"\x5\xD6l\x2\x590\x592\x5\x19A\xCE\x2\x591\x590\x3\x2\x2\x2\x591\x592\x3"+
-		"\x2\x2\x2\x592\x593\x3\x2\x2\x2\x593\x594\a\xBE\x2\x2\x594\x596\x5\x184"+
-		"\xC3\x2\x595\x597\x5\x19A\xCE\x2\x596\x595\x3\x2\x2\x2\x596\x597\x3\x2"+
-		"\x2\x2\x597\x598\x3\x2\x2\x2\x598\x599\x5\xD0i\x2\x599\xCF\x3\x2\x2\x2"+
-		"\x59A\x59C\aY\x2\x2\x59B\x59D\x5\x19A\xCE\x2\x59C\x59B\x3\x2\x2\x2\x59C"+
-		"\x59D\x3\x2\x2\x2\x59D\x59F\x3\x2\x2\x2\x59E\x5A0\x5\xD2j\x2\x59F\x59E"+
-		"\x3\x2\x2\x2\x59F\x5A0\x3\x2\x2\x2\x5A0\xD1\x3\x2\x2\x2\x5A1\x5AE\x5\x14C"+
-		"\xA7\x2\x5A2\x5A4\x5\x19A\xCE\x2\x5A3\x5A2\x3\x2\x2\x2\x5A3\x5A4\x3\x2"+
-		"\x2\x2\x5A4\x5A5\x3\x2\x2\x2\x5A5\x5A7\a*\x2\x2\x5A6\x5A8\x5\x19A\xCE"+
-		"\x2\x5A7\x5A6\x3\x2\x2\x2\x5A7\x5A8\x3\x2\x2\x2\x5A8\x5AA\x3\x2\x2\x2"+
-		"\x5A9\x5AB\x5\xD4k\x2\x5AA\x5A9\x3\x2\x2\x2\x5AA\x5AB\x3\x2\x2\x2\x5AB"+
-		"\x5AD\x3\x2\x2\x2\x5AC\x5A3\x3\x2\x2\x2\x5AD\x5B0\x3\x2\x2\x2\x5AE\x5AC"+
-		"\x3\x2\x2\x2\x5AE\x5AF\x3\x2\x2\x2\x5AF\x5C8\x3\x2\x2\x2\x5B0\x5AE\x3"+
-		"\x2\x2\x2\x5B1\x5B3\a*\x2\x2\x5B2\x5B4\x5\x19A\xCE\x2\x5B3\x5B2\x3\x2"+
-		"\x2\x2\x5B3\x5B4\x3\x2\x2\x2\x5B4\x5B6\x3\x2\x2\x2\x5B5\x5B1\x3\x2\x2"+
-		"\x2\x5B5\x5B6\x3\x2\x2\x2\x5B6\x5B7\x3\x2\x2\x2\x5B7\x5C4\x5\xD4k\x2\x5B8"+
-		"\x5BA\x5\x19A\xCE\x2\x5B9\x5B8\x3\x2\x2\x2\x5B9\x5BA\x3\x2\x2\x2\x5BA"+
-		"\x5BB\x3\x2\x2\x2\x5BB\x5BD\a*\x2\x2\x5BC\x5BE\x5\x19A\xCE\x2\x5BD\x5BC"+
-		"\x3\x2\x2\x2\x5BD\x5BE\x3\x2\x2\x2\x5BE\x5C0\x3\x2\x2\x2\x5BF\x5C1\x5"+
-		"\xD4k\x2\x5C0\x5BF\x3\x2\x2\x2\x5C0\x5C1\x3\x2\x2\x2\x5C1\x5C3\x3\x2\x2"+
-		"\x2\x5C2\x5B9\x3\x2\x2\x2\x5C3\x5C6\x3\x2\x2\x2\x5C4\x5C2\x3\x2\x2\x2"+
-		"\x5C4\x5C5\x3\x2\x2\x2\x5C5\x5C8\x3\x2\x2\x2\x5C6\x5C4\x3\x2\x2\x2\x5C7"+
-		"\x5A1\x3\x2\x2\x2\x5C7\x5B5\x3\x2\x2\x2\x5C8\xD3\x3\x2\x2\x2\x5C9\x5CA"+
-		"\x5 \x11\x2\x5CA\xD5\x3\x2\x2\x2\x5CB\x5CC\x5\x156\xAC\x2\x5CC\xD7\x3"+
-		"\x2\x2\x2\x5CD\x5CE\ay\x2\x2\x5CE\x5CF\x5\x19A\xCE\x2\x5CF\x5D0\x5\x156"+
-		"\xAC\x2\x5D0\xD9\x3\x2\x2\x2\x5D1\x5D2\a\x81\x2\x2\x5D2\x5D4\x5\x19A\xCE"+
-		"\x2\x5D3\x5D1\x3\x2\x2\x2\x5D3\x5D4\x3\x2\x2\x2\x5D4\x5D5\x3\x2\x2\x2"+
-		"\x5D5\x5D7\x5\x162\xB2\x2\x5D6\x5D8\x5\x19A\xCE\x2\x5D7\x5D6\x3\x2\x2"+
-		"\x2\x5D7\x5D8\x3\x2\x2\x2\x5D8\x5D9\x3\x2\x2\x2\x5D9\x5DB\a\xD1\x2\x2"+
-		"\x5DA\x5DC\x5\x19A\xCE\x2\x5DB\x5DA\x3\x2\x2\x2\x5DB\x5DC\x3\x2\x2\x2"+
-		"\x5DC\x5DD\x3\x2\x2\x2\x5DD\x5DE\x5\x156\xAC\x2\x5DE\xDB\x3\x2\x2\x2\x5DF"+
-		"\x5E0\a\x88\x2\x2\x5E0\x5E1\x5\x19A\xCE\x2\x5E1\x5E3\x5\x156\xAC\x2\x5E2"+
-		"\x5E4\x5\x19A\xCE\x2\x5E3\x5E2\x3\x2\x2\x2\x5E3\x5E4\x3\x2\x2\x2\x5E4"+
-		"\x5E5\x3\x2\x2\x2\x5E5\x5E7\a\xD1\x2\x2\x5E6\x5E8\x5\x19A\xCE\x2\x5E7"+
-		"\x5E6\x3\x2\x2\x2\x5E7\x5E8\x3\x2\x2\x2\x5E8\x5E9\x3\x2\x2\x2\x5E9\x5EA"+
-		"\x5\x156\xAC\x2\x5EA\xDD\x3\x2\x2\x2\x5EB\x5EC\t\f\x2\x2\x5EC\x5F5\x5"+
-		"\x19A\xCE\x2\x5ED\x5EE\av\x2\x2\x5EE\x5EF\x5\x19A\xCE\x2\x5EF\x5F0\x5"+
-		"\x156\xAC\x2\x5F0\x5F6\x3\x2\x2\x2\x5F1\x5F2\a\xAE\x2\x2\x5F2\x5F3\x5"+
-		"\x19A\xCE\x2\x5F3\x5F4\a\x8C\x2\x2\x5F4\x5F6\x3\x2\x2\x2\x5F5\x5ED\x3"+
-		"\x2\x2\x2\x5F5\x5F1\x3\x2\x2\x2\x5F6\xDF\x3\x2\x2\x2\x5F7\x5F8\a\x92\x2"+
-		"\x2\x5F8\x5F9\x5\x19A\xCE\x2\x5F9\x5FA\x5\x156\xAC\x2\x5FA\x5FB\x5\x19A"+
-		"\xCE\x2\x5FB\x5FC\av\x2\x2\x5FC\x5FD\x5\x19A\xCE\x2\x5FD\x608\x5\x156"+
-		"\xAC\x2\x5FE\x600\x5\x19A\xCE\x2\x5FF\x5FE\x3\x2\x2\x2\x5FF\x600\x3\x2"+
-		"\x2\x2\x600\x601\x3\x2\x2\x2\x601\x603\a)\x2\x2\x602\x604\x5\x19A\xCE"+
-		"\x2\x603\x602\x3\x2\x2\x2\x603\x604\x3\x2\x2\x2\x604\x605\x3\x2\x2\x2"+
-		"\x605\x607\x5\x156\xAC\x2\x606\x5FF\x3\x2\x2\x2\x607\x60A\x3\x2\x2\x2"+
-		"\x608\x606\x3\x2\x2\x2\x608\x609\x3\x2\x2\x2\x609\xE1\x3\x2\x2\x2\x60A"+
-		"\x608\x3\x2\x2\x2\x60B\x60C\a\x92\x2\x2\x60C\x60D\x5\x19A\xCE\x2\x60D"+
-		"\x60E\x5\x156\xAC\x2\x60E\x60F\x5\x19A\xCE\x2\x60F\x610\au\x2\x2\x610"+
-		"\x611\x5\x19A\xCE\x2\x611\x61C\x5\x156\xAC\x2\x612\x614\x5\x19A\xCE\x2"+
-		"\x613\x612\x3\x2\x2\x2\x613\x614\x3\x2\x2\x2\x614\x615\x3\x2\x2\x2\x615"+
-		"\x617\a)\x2\x2\x616\x618\x5\x19A\xCE\x2\x617\x616\x3\x2\x2\x2\x617\x618"+
-		"\x3\x2\x2\x2\x618\x619\x3\x2\x2\x2\x619\x61B\x5\x156\xAC\x2\x61A\x613"+
-		"\x3\x2\x2\x2\x61B\x61E\x3\x2\x2\x2\x61C\x61A\x3\x2\x2\x2\x61C\x61D\x3"+
-		"\x2\x2\x2\x61D\xE3\x3\x2\x2\x2\x61E\x61C\x3\x2\x2\x2\x61F\x620\x5\x154"+
-		"\xAB\x2\x620\x621\x5\x19A\xCE\x2\x621\x623\x3\x2\x2\x2\x622\x61F\x3\x2"+
-		"\x2\x2\x622\x623\x3\x2\x2\x2\x623\x626\x3\x2\x2\x2\x624\x625\a\xB7\x2"+
-		"\x2\x625\x627\x5\x19A\xCE\x2\x626\x624\x3\x2\x2\x2\x626\x627\x3\x2\x2"+
-		"\x2\x627\x628\x3\x2\x2\x2\x628\x629\a\xA1\x2\x2\x629\x62A\x5\x19A\xCE"+
-		"\x2\x62A\x62F\x5\xBE`\x2\x62B\x62D\x5\x19A\xCE\x2\x62C\x62B\x3\x2\x2\x2"+
-		"\x62C\x62D\x3\x2\x2\x2\x62D\x62E\x3\x2\x2\x2\x62E\x630\x5\x8EH\x2\x62F"+
-		"\x62C\x3\x2\x2\x2\x62F\x630\x3\x2\x2\x2\x630\x634\x3\x2\x2\x2\x631\x632"+
-		"\x5\x19A\xCE\x2\x632\x633\x5\x13C\x9F\x2\x633\x635\x3\x2\x2\x2\x634\x631"+
-		"\x3\x2\x2\x2\x634\x635\x3\x2\x2\x2\x635\x636\x3\x2\x2\x2\x636\x637\x5"+
-		"\x184\xC3\x2\x637\x638\x5\x1E\x10\x2\x638\x639\a_\x2\x2\x639\xE5\x3\x2"+
-		"\x2\x2\x63A\x63B\x5\x154\xAB\x2\x63B\x63C\x5\x19A\xCE\x2\x63C\x63E\x3"+
-		"\x2\x2\x2\x63D\x63A\x3\x2\x2\x2\x63D\x63E\x3\x2\x2\x2\x63E\x641\x3\x2"+
-		"\x2\x2\x63F\x640\a\xB7\x2\x2\x640\x642\x5\x19A\xCE\x2\x641\x63F\x3\x2"+
-		"\x2\x2\x641\x642\x3\x2\x2\x2\x642\x643\x3\x2\x2\x2\x643\x644\a\xA3\x2"+
-		"\x2\x644\x645\x5\x19A\xCE\x2\x645\x64A\x5\x114\x8B\x2\x646\x648\x5\x19A"+
-		"\xCE\x2\x647\x646\x3\x2\x2\x2\x647\x648\x3\x2\x2\x2\x648\x649\x3\x2\x2"+
-		"\x2\x649\x64B\x5\x8EH\x2\x64A\x647\x3\x2\x2\x2\x64A\x64B\x3\x2\x2\x2\x64B"+
-		"\x64C\x3\x2\x2\x2\x64C\x64D\x5\x184\xC3\x2\x64D\x64E\x5\x1E\x10\x2\x64E"+
-		"\x64F\a_\x2\x2\x64F\xE7\x3\x2\x2\x2\x650\x651\x5\x154\xAB\x2\x651\x652"+
-		"\x5\x19A\xCE\x2\x652\x654\x3\x2\x2\x2\x653\x650\x3\x2\x2\x2\x653\x654"+
-		"\x3\x2\x2\x2\x654\x657\x3\x2\x2\x2\x655\x656\a\xB7\x2\x2\x656\x658\x5"+
-		"\x19A\xCE\x2\x657\x655\x3\x2\x2\x2\x657\x658\x3\x2\x2\x2\x658\x659\x3"+
-		"\x2\x2\x2\x659\x65A\a\xA2\x2\x2\x65A\x65B\x5\x19A\xCE\x2\x65B\x660\x5"+
-		"\x114\x8B\x2\x65C\x65E\x5\x19A\xCE\x2\x65D\x65C\x3\x2\x2\x2\x65D\x65E"+
-		"\x3\x2\x2\x2\x65E\x65F\x3\x2\x2\x2\x65F\x661\x5\x8EH\x2\x660\x65D\x3\x2"+
-		"\x2\x2\x660\x661\x3\x2\x2\x2\x661\x662\x3\x2\x2\x2\x662\x663\x5\x184\xC3"+
-		"\x2\x663\x664\x5\x1E\x10\x2\x664\x665\a_\x2\x2\x665\xE9\x3\x2\x2\x2\x666"+
-		"\x667\a\xA8\x2\x2\x667\x668\x5\x19A\xCE\x2\x668\x677\x5\x130\x99\x2\x669"+
-		"\x66B\x5\x19A\xCE\x2\x66A\x669\x3\x2\x2\x2\x66A\x66B\x3\x2\x2\x2\x66B"+
-		"\x66C\x3\x2\x2\x2\x66C\x66E\a\xD5\x2\x2\x66D\x66F\x5\x19A\xCE\x2\x66E"+
-		"\x66D\x3\x2\x2\x2\x66E\x66F\x3\x2\x2\x2\x66F\x671\x3\x2\x2\x2\x670\x672"+
-		"\x5\xECw\x2\x671\x670\x3\x2\x2\x2\x671\x672\x3\x2\x2\x2\x672\x674\x3\x2"+
-		"\x2\x2\x673\x675\x5\x19A\xCE\x2\x674\x673\x3\x2\x2\x2\x674\x675\x3\x2"+
-		"\x2\x2\x675\x676\x3\x2\x2\x2\x676\x678\a\xDC\x2\x2\x677\x66A\x3\x2\x2"+
-		"\x2\x677\x678\x3\x2\x2\x2\x678\xEB\x3\x2\x2\x2\x679\x684\x5\xEEx\x2\x67A"+
-		"\x67C\x5\x19A\xCE\x2\x67B\x67A\x3\x2\x2\x2\x67B\x67C\x3\x2\x2\x2\x67C"+
-		"\x67D\x3\x2\x2\x2\x67D\x67F\a)\x2\x2\x67E\x680\x5\x19A\xCE\x2\x67F\x67E"+
-		"\x3\x2\x2\x2\x67F\x680\x3\x2\x2\x2\x680\x681\x3\x2\x2\x2\x681\x683\x5"+
-		"\xEEx\x2\x682\x67B\x3\x2\x2\x2\x683\x686\x3\x2\x2\x2\x684\x682\x3\x2\x2"+
-		"\x2\x684\x685\x3\x2\x2\x2\x685\xED\x3\x2\x2\x2\x686\x684\x3\x2\x2\x2\x687"+
-		"\x688\x5\x156\xAC\x2\x688\xEF\x3\x2\x2\x2\x689\x68A\a\xAB\x2\x2\x68A\x68D"+
-		"\x5\x19A\xCE\x2\x68B\x68C\a\x9E\x2\x2\x68C\x68E\x5\x19A\xCE\x2\x68D\x68B"+
-		"\x3\x2\x2\x2\x68D\x68E\x3\x2\x2\x2\x68E\x68F\x3\x2\x2\x2\x68F\x690\x5"+
-		"\xF2z\x2\x690\xF1\x3\x2\x2\x2\x691\x69C\x5\xF4{\x2\x692\x694\x5\x19A\xCE"+
-		"\x2\x693\x692\x3\x2\x2\x2\x693\x694\x3\x2\x2\x2\x694\x695\x3\x2\x2\x2"+
-		"\x695\x697\a)\x2\x2\x696\x698\x5\x19A\xCE\x2\x697\x696\x3\x2\x2\x2\x697"+
-		"\x698\x3\x2\x2\x2\x698\x699\x3\x2\x2\x2\x699\x69B\x5\xF4{\x2\x69A\x693"+
-		"\x3\x2\x2\x2\x69B\x69E\x3\x2\x2\x2\x69C\x69A\x3\x2\x2\x2\x69C\x69D\x3"+
-		"\x2\x2\x2\x69D\xF3\x3\x2\x2\x2\x69E\x69C\x3\x2\x2\x2\x69F\x6A3\x5\x156"+
-		"\xAC\x2\x6A0\x6A1\x5\x19A\xCE\x2\x6A1\x6A2\x5\x13C\x9F\x2\x6A2\x6A4\x3"+
-		"\x2\x2\x2\x6A3\x6A0\x3\x2\x2\x2\x6A3\x6A4\x3\x2\x2\x2\x6A4\xF5\x3\x2\x2"+
-		"\x2\x6A5\x6A6\x5\x156\xAC\x2\x6A6\xF7\x3\x2\x2\x2\x6A7\x6A8\a@\x2\x2\x6A8"+
-		"\x6A9\x5\x19A\xCE\x2\x6A9\x6AA\x5\x156\xAC\x2\x6AA\x6B2\x3\x2\x2\x2\x6AB"+
-		"\x6AF\x5\x156\xAC\x2\x6AC\x6AD\x5\x19A\xCE\x2\x6AD\x6AE\x5\x166\xB4\x2"+
-		"\x6AE\x6B0\x3\x2\x2\x2\x6AF\x6AC\x3\x2\x2\x2\x6AF\x6B0\x3\x2\x2\x2\x6B0"+
-		"\x6B2\x3\x2\x2\x2\x6B1\x6A7\x3\x2\x2\x2\x6B1\x6AB\x3\x2\x2\x2\x6B2\xF9"+
-		"\x3\x2\x2\x2\x6B3\x6B9\a\xAE\x2\x2\x6B4\x6B7\x5\x19A\xCE\x2\x6B5\x6B8"+
-		"\a\x8C\x2\x2\x6B6\x6B8\x5\x156\xAC\x2\x6B7\x6B5\x3\x2\x2\x2\x6B7\x6B6"+
-		"\x3\x2\x2\x2\x6B8\x6BA\x3\x2\x2\x2\x6B9\x6B4\x3\x2\x2\x2\x6B9\x6BA\x3"+
-		"\x2\x2\x2\x6BA\xFB\x3\x2\x2\x2\x6BB\x6BC\a\xAF\x2\x2\x6BC\xFD\x3\x2\x2"+
-		"\x2\x6BD\x6BE\a\xB0\x2\x2\x6BE\x6BF\x5\x19A\xCE\x2\x6BF\x6C1\x5\x156\xAC"+
-		"\x2\x6C0\x6C2\x5\x19A\xCE\x2\x6C1\x6C0\x3\x2\x2\x2\x6C1\x6C2\x3\x2\x2"+
-		"\x2\x6C2\x6C3\x3\x2\x2\x2\x6C3\x6C5\a\xD1\x2\x2\x6C4\x6C6\x5\x19A\xCE"+
-		"\x2\x6C5\x6C4\x3\x2\x2\x2\x6C5\x6C6\x3\x2\x2\x2\x6C6\x6C7\x3\x2\x2\x2"+
-		"\x6C7\x6C8\x5\x156\xAC\x2\x6C8\xFF\x3\x2\x2\x2\x6C9\x6CA\a\xB9\x2\x2\x6CA"+
-		"\x101\x3\x2\x2\x2\x6CB\x6CD\a\xB2\x2\x2\x6CC\x6CE\x5\x19A\xCE\x2\x6CD"+
-		"\x6CC\x3\x2\x2\x2\x6CD\x6CE\x3\x2\x2\x2\x6CE\x6CF\x3\x2\x2\x2\x6CF\x6D1"+
-		"\a\x41\x2\x2\x6D0\x6D2\x5\x19A\xCE\x2\x6D1\x6D0\x3\x2\x2\x2\x6D1\x6D2"+
-		"\x3\x2\x2\x2\x6D2\x6D3\x3\x2\x2\x2\x6D3\x6D4\x5\x104\x83\x2\x6D4\x6D8"+
-		"\x5\x184\xC3\x2\x6D5\x6D7\x5\x106\x84\x2\x6D6\x6D5\x3\x2\x2\x2\x6D7\x6DA"+
-		"\x3\x2\x2\x2\x6D8\x6D6\x3\x2\x2\x2\x6D8\x6D9\x3\x2\x2\x2\x6D9\x6DC\x3"+
-		"\x2\x2\x2\x6DA\x6D8\x3\x2\x2\x2\x6DB\x6DD\x5\x108\x85\x2\x6DC\x6DB\x3"+
-		"\x2\x2\x2\x6DC\x6DD\x3\x2\x2\x2\x6DD\x6DE\x3\x2\x2\x2\x6DE\x6DF\a`\x2"+
-		"\x2\x6DF\x103\x3\x2\x2\x2\x6E0\x6E1\x5\x156\xAC\x2\x6E1\x105\x3\x2\x2"+
-		"\x2\x6E2\x6E3\a\x41\x2\x2\x6E3\x6E4\x5\x19A\xCE\x2\x6E4\x6EF\x5\x10A\x86"+
-		"\x2\x6E5\x6E7\x5\x19A\xCE\x2\x6E6\x6E5\x3\x2\x2\x2\x6E6\x6E7\x3\x2\x2"+
-		"\x2\x6E7\x6E8\x3\x2\x2\x2\x6E8\x6EA\a)\x2\x2\x6E9\x6EB\x5\x19A\xCE\x2"+
-		"\x6EA\x6E9\x3\x2\x2\x2\x6EA\x6EB\x3\x2\x2\x2\x6EB\x6EC\x3\x2\x2\x2\x6EC"+
-		"\x6EE\x5\x10A\x86\x2\x6ED\x6E6\x3\x2\x2\x2\x6EE\x6F1\x3\x2\x2\x2\x6EF"+
-		"\x6ED\x3\x2\x2\x2\x6EF\x6F0\x3\x2\x2\x2\x6F0\x6F2\x3\x2\x2\x2\x6F1\x6EF"+
-		"\x3\x2\x2\x2\x6F2\x6F3\x5\x184\xC3\x2\x6F3\x6F4\x5\x1E\x10\x2\x6F4\x107"+
-		"\x3\x2\x2\x2\x6F5\x6F7\a\x41\x2\x2\x6F6\x6F8\x5\x19A\xCE\x2\x6F7\x6F6"+
-		"\x3\x2\x2\x2\x6F7\x6F8\x3\x2\x2\x2\x6F8\x6F9\x3\x2\x2\x2\x6F9\x6FA\aY"+
-		"\x2\x2\x6FA\x6FB\x5\x184\xC3\x2\x6FB\x6FC\x5\x1E\x10\x2\x6FC\x109\x3\x2"+
-		"\x2\x2\x6FD\x711\x5\x156\xAC\x2\x6FE\x6FF\x5\x10C\x87\x2\x6FF\x700\x5"+
-		"\x19A\xCE\x2\x700\x701\a\xBF\x2\x2\x701\x702\x5\x19A\xCE\x2\x702\x703"+
-		"\x5\x10E\x88\x2\x703\x711\x3\x2\x2\x2\x704\x706\a|\x2\x2\x705\x707\x5"+
-		"\x19A\xCE\x2\x706\x705\x3\x2\x2\x2\x706\x707\x3\x2\x2\x2\x707\x709\x3"+
-		"\x2\x2\x2\x708\x704\x3\x2\x2\x2\x708\x709\x3\x2\x2\x2\x709\x70A\x3\x2"+
-		"\x2\x2\x70A\x70C\x5\x140\xA1\x2\x70B\x70D\x5\x19A\xCE\x2\x70C\x70B\x3"+
-		"\x2\x2\x2\x70C\x70D\x3\x2\x2\x2\x70D\x70E\x3\x2\x2\x2\x70E\x70F\x5\x156"+
-		"\xAC\x2\x70F\x711\x3\x2\x2\x2\x710\x6FD\x3\x2\x2\x2\x710\x6FE\x3\x2\x2"+
-		"\x2\x710\x708\x3\x2\x2\x2\x711\x10B\x3\x2\x2\x2\x712\x713\x5\x156\xAC"+
-		"\x2\x713\x10D\x3\x2\x2\x2\x714\x715\x5\x156\xAC\x2\x715\x10F\x3\x2\x2"+
-		"\x2\x716\x717\a\xB3\x2\x2\x717\x718\x5\x19A\xCE\x2\x718\x71A\x5\x162\xB2"+
-		"\x2\x719\x71B\x5\x19A\xCE\x2\x71A\x719\x3\x2\x2\x2\x71A\x71B\x3\x2\x2"+
-		"\x2\x71B\x71C\x3\x2\x2\x2\x71C\x71E\a\xD1\x2\x2\x71D\x71F\x5\x19A\xCE"+
-		"\x2\x71E\x71D\x3\x2\x2\x2\x71E\x71F\x3\x2\x2\x2\x71F\x720\x3\x2\x2\x2"+
-		"\x720\x721\x5\x156\xAC\x2\x721\x111\x3\x2\x2\x2\x722\x723\x5\x154\xAB"+
-		"\x2\x723\x724\x5\x19A\xCE\x2\x724\x726\x3\x2\x2\x2\x725\x722\x3\x2\x2"+
-		"\x2\x725\x726\x3\x2\x2\x2\x726\x729\x3\x2\x2\x2\x727\x728\a\xB7\x2\x2"+
-		"\x728\x72A\x5\x19A\xCE\x2\x729\x727\x3\x2\x2\x2\x729\x72A\x3\x2\x2\x2"+
-		"\x72A\x72B\x3\x2\x2\x2\x72B\x72D\a\xBB\x2\x2\x72C\x72E\x5\x19A\xCE\x2"+
-		"\x72D\x72C\x3\x2\x2\x2\x72D\x72E\x3\x2\x2\x2\x72E\x72F\x3\x2\x2\x2\x72F"+
-		"\x734\x5\x114\x8B\x2\x730\x732\x5\x19A\xCE\x2\x731\x730\x3\x2\x2\x2\x731"+
-		"\x732\x3\x2\x2\x2\x732\x733\x3\x2\x2\x2\x733\x735\x5\x8EH\x2\x734\x731"+
-		"\x3\x2\x2\x2\x734\x735\x3\x2\x2\x2\x735\x736\x3\x2\x2\x2\x736\x737\x5"+
-		"\x184\xC3\x2\x737\x738\x5\x1E\x10\x2\x738\x739\a\x61\x2\x2\x739\x113\x3"+
-		"\x2\x2\x2\x73A\x73B\x5\x130\x99\x2\x73B\x115\x3\x2\x2\x2\x73C\x73D\x5"+
-		"\x154\xAB\x2\x73D\x73E\x5\x19A\xCE\x2\x73E\x740\x3\x2\x2\x2\x73F\x73C"+
-		"\x3\x2\x2\x2\x73F\x740\x3\x2\x2\x2\x740\x741\x3\x2\x2\x2\x741\x742\a\xC1"+
-		"\x2\x2\x742\x743\x5\x19A\xCE\x2\x743\x744\x5\x130\x99\x2\x744\x748\x5"+
-		"\x184\xC3\x2\x745\x747\x5\x118\x8D\x2\x746\x745\x3\x2\x2\x2\x747\x74A"+
-		"\x3\x2\x2\x2\x748\x746\x3\x2\x2\x2\x748\x749\x3\x2\x2\x2\x749\x74B\x3"+
-		"\x2\x2\x2\x74A\x748\x3\x2\x2\x2\x74B\x74C\a\x62\x2\x2\x74C\x117\x3\x2"+
-		"\x2\x2\x74D\x75C\x5\x130\x99\x2\x74E\x750\x5\x19A\xCE\x2\x74F\x74E\x3"+
-		"\x2\x2\x2\x74F\x750\x3\x2\x2\x2\x750\x751\x3\x2\x2\x2\x751\x756\a\xD5"+
-		"\x2\x2\x752\x754\x5\x19A\xCE\x2\x753\x752\x3\x2\x2\x2\x753\x754\x3\x2"+
-		"\x2\x2\x754\x755\x3\x2\x2\x2\x755\x757\x5\x12A\x96\x2\x756\x753\x3\x2"+
-		"\x2\x2\x756\x757\x3\x2\x2\x2\x757\x759\x3\x2\x2\x2\x758\x75A\x5\x19A\xCE"+
-		"\x2\x759\x758\x3\x2\x2\x2\x759\x75A\x3\x2\x2\x2\x75A\x75B\x3\x2\x2\x2"+
-		"\x75B\x75D\a\xDC\x2\x2\x75C\x74F\x3\x2\x2\x2\x75C\x75D\x3\x2\x2\x2\x75D"+
-		"\x761\x3\x2\x2\x2\x75E\x75F\x5\x19A\xCE\x2\x75F\x760\x5\x13C\x9F\x2\x760"+
-		"\x762\x3\x2\x2\x2\x761\x75E\x3\x2\x2\x2\x761\x762\x3\x2\x2\x2\x762\x763"+
-		"\x3\x2\x2\x2\x763\x764\x5\x184\xC3\x2\x764\x119\x3\x2\x2\x2\x765\x769"+
-		"\aU\x2\x2\x766\x769\a\xB7\x2\x2\x767\x769\x5\x154\xAB\x2\x768\x765\x3"+
-		"\x2\x2\x2\x768\x766\x3\x2\x2\x2\x768\x767\x3\x2\x2\x2\x769\x76A\x3\x2"+
-		"\x2\x2\x76A\x76D\x5\x19A\xCE\x2\x76B\x76C\a\xCB\x2\x2\x76C\x76E\x5\x19A"+
-		"\xCE\x2\x76D\x76B\x3\x2\x2\x2\x76D\x76E\x3\x2\x2\x2\x76E\x76F\x3\x2\x2"+
-		"\x2\x76F\x770\x5\x11C\x8F\x2\x770\x11B\x3\x2\x2\x2\x771\x77C\x5\x11E\x90"+
-		"\x2\x772\x774\x5\x19A\xCE\x2\x773\x772\x3\x2\x2\x2\x773\x774\x3\x2\x2"+
-		"\x2\x774\x775\x3\x2\x2\x2\x775\x777\a)\x2\x2\x776\x778\x5\x19A\xCE\x2"+
-		"\x777\x776\x3\x2\x2\x2\x777\x778\x3\x2\x2\x2\x778\x779\x3\x2\x2\x2\x779"+
-		"\x77B\x5\x11E\x90\x2\x77A\x773\x3\x2\x2\x2\x77B\x77E\x3\x2\x2\x2\x77C"+
-		"\x77A\x3\x2\x2\x2\x77C\x77D\x3\x2\x2\x2\x77D\x11D\x3\x2\x2\x2\x77E\x77C"+
-		"\x3\x2\x2\x2\x77F\x791\x5\x130\x99\x2\x780\x782\x5\x19A\xCE\x2\x781\x780"+
-		"\x3\x2\x2\x2\x781\x782\x3\x2\x2\x2\x782\x783\x3\x2\x2\x2\x783\x785\a\xD5"+
-		"\x2\x2\x784\x786\x5\x19A\xCE\x2\x785\x784\x3\x2\x2\x2\x785\x786\x3\x2"+
-		"\x2\x2\x786\x78B\x3\x2\x2\x2\x787\x789\x5\x12A\x96\x2\x788\x78A\x5\x19A"+
-		"\xCE\x2\x789\x788\x3\x2\x2\x2\x789\x78A\x3\x2\x2\x2\x78A\x78C\x3\x2\x2"+
-		"\x2\x78B\x787\x3\x2\x2\x2\x78B\x78C\x3\x2\x2\x2\x78C\x78D\x3\x2\x2\x2"+
-		"\x78D\x78F\a\xDC\x2\x2\x78E\x790\x5\x19A\xCE\x2\x78F\x78E\x3\x2\x2\x2"+
-		"\x78F\x790\x3\x2\x2\x2\x790\x792\x3\x2\x2\x2\x791\x781\x3\x2\x2\x2\x791"+
-		"\x792\x3\x2\x2\x2\x792\x796\x3\x2\x2\x2\x793\x794\x5\x19A\xCE\x2\x794"+
-		"\x795\x5\x13C\x9F\x2\x795\x797\x3\x2\x2\x2\x796\x793\x3\x2\x2\x2\x796"+
-		"\x797\x3\x2\x2\x2\x797\x11F\x3\x2\x2\x2\x798\x799\a\xC8\x2\x2\x799\x79A"+
-		"\x5\x19A\xCE\x2\x79A\x79B\x5\x156\xAC\x2\x79B\x79C\x5\x184\xC3\x2\x79C"+
-		"\x79D\x5\x1E\x10\x2\x79D\x79E\a\xC7\x2\x2\x79E\x121\x3\x2\x2\x2\x79F\x7A0"+
-		"\a\xCA\x2\x2\x7A0\x7A1\x5\x19A\xCE\x2\x7A1\x7A2\x5\x156\xAC\x2\x7A2\x7A3"+
-		"\x5\x184\xC3\x2\x7A3\x7A4\x5\x1E\x10\x2\x7A4\x7A5\a\x63\x2\x2\x7A5\x123"+
-		"\x3\x2\x2\x2\x7A6\x7A8\x5\x156\xAC\x2\x7A7\x7A9\x5\x19A\xCE\x2\x7A8\x7A7"+
-		"\x3\x2\x2\x2\x7A8\x7A9\x3\x2\x2\x2\x7A9\x7AA\x3\x2\x2\x2\x7AA\x7AC\a-"+
-		"\x2\x2\x7AB\x7AD\x5\x19A\xCE\x2\x7AC\x7AB\x3\x2\x2\x2\x7AC\x7AD\x3\x2"+
-		"\x2\x2\x7AD\x7AF\x3\x2\x2\x2\x7AE\x7A6\x3\x2\x2\x2\x7AE\x7AF\x3\x2\x2"+
-		"\x2\x7AF\x7B0\x3\x2\x2\x2\x7B0\x7B1\a\r\x2\x2\x7B1\x7B6\x5\x19A\xCE\x2"+
-		"\x7B2\x7B4\a\xB8\x2\x2\x7B3\x7B5\x5\x19A\xCE\x2\x7B4\x7B3\x3\x2\x2\x2"+
-		"\x7B4\x7B5\x3\x2\x2\x2\x7B5\x7B7\x3\x2\x2\x2\x7B6\x7B2\x3\x2\x2\x2\x7B6"+
-		"\x7B7\x3\x2\x2\x2\x7B7\x7B8\x3\x2\x2\x2\x7B8\x7C1\x5\x128\x95\x2\x7B9"+
-		"\x7BB\x5\x19A\xCE\x2\x7BA\x7B9\x3\x2\x2\x2\x7BA\x7BB\x3\x2\x2\x2\x7BB"+
-		"\x7BC\x3\x2\x2\x2\x7BC\x7BE\a)\x2\x2\x7BD\x7BF\x5\x19A\xCE\x2\x7BE\x7BD"+
-		"\x3\x2\x2\x2\x7BE\x7BF\x3\x2\x2\x2\x7BF\x7C0\x3\x2\x2\x2\x7C0\x7C2\x5"+
-		"\x156\xAC\x2\x7C1\x7BA\x3\x2\x2\x2\x7C2\x7C3\x3\x2\x2\x2\x7C3\x7C1\x3"+
-		"\x2\x2\x2\x7C3\x7C4\x3\x2\x2\x2\x7C4\x125\x3\x2\x2\x2\x7C5\x7C7\x5\x156"+
-		"\xAC\x2\x7C6\x7C8\x5\x19A\xCE\x2\x7C7\x7C6\x3\x2\x2\x2\x7C7\x7C8\x3\x2"+
-		"\x2\x2\x7C8\x7C9\x3\x2\x2\x2\x7C9\x7CB\a-\x2\x2\x7CA\x7CC\x5\x19A\xCE"+
-		"\x2\x7CB\x7CA\x3\x2\x2\x2\x7CB\x7CC\x3\x2\x2\x2\x7CC\x7CE\x3\x2\x2\x2"+
-		"\x7CD\x7C5\x3\x2\x2\x2\x7CD\x7CE\x3\x2\x2\x2\x7CE\x7CF\x3\x2\x2\x2\x7CF"+
-		"\x7D0\a&\x2\x2\x7D0\x7D1\x5\x19A\xCE\x2\x7D1\x7D3\x5\x128\x95\x2\x7D2"+
-		"\x7D4\x5\x19A\xCE\x2\x7D3\x7D2\x3\x2\x2\x2\x7D3\x7D4\x3\x2\x2\x2\x7D4"+
-		"\x7D5\x3\x2\x2\x2\x7D5\x7D7\a\xD7\x2\x2\x7D6\x7D8\x5\x19A\xCE\x2\x7D7"+
-		"\x7D6\x3\x2\x2\x2\x7D7\x7D8\x3\x2\x2\x2\x7D8\x7D9\x3\x2\x2\x2\x7D9\x7DA"+
-		"\x5\x128\x95\x2\x7DA\x127\x3\x2\x2\x2\x7DB\x7DD\a\xD5\x2\x2\x7DC\x7DE"+
-		"\x5\x19A\xCE\x2\x7DD\x7DC\x3\x2\x2\x2\x7DD\x7DE\x3\x2\x2\x2\x7DE\x7DF"+
-		"\x3\x2\x2\x2\x7DF\x7E1\x5\x156\xAC\x2\x7E0\x7E2\x5\x19A\xCE\x2\x7E1\x7E0"+
-		"\x3\x2\x2\x2\x7E1\x7E2\x3\x2\x2\x2\x7E2\x7E3\x3\x2\x2\x2\x7E3\x7E5\a)"+
-		"\x2\x2\x7E4\x7E6\x5\x19A\xCE\x2\x7E5\x7E4\x3\x2\x2\x2\x7E5\x7E6\x3\x2"+
-		"\x2\x2\x7E6\x7E7\x3\x2\x2\x2\x7E7\x7E9\x5\x156\xAC\x2\x7E8\x7EA\x5\x19A"+
-		"\xCE\x2\x7E9\x7E8\x3\x2\x2\x2\x7E9\x7EA\x3\x2\x2\x2\x7EA\x7EB\x3\x2\x2"+
-		"\x2\x7EB\x7EC\a\xDC\x2\x2\x7EC\x129\x3\x2\x2\x2\x7ED\x7F8\x5\x12C\x97"+
-		"\x2\x7EE\x7F0\x5\x19A\xCE\x2\x7EF\x7EE\x3\x2\x2\x2\x7EF\x7F0\x3\x2\x2"+
-		"\x2\x7F0\x7F1\x3\x2\x2\x2\x7F1\x7F3\a)\x2\x2\x7F2\x7F4\x5\x19A\xCE\x2"+
-		"\x7F3\x7F2\x3\x2\x2\x2\x7F3\x7F4\x3\x2\x2\x2\x7F4\x7F5\x3\x2\x2\x2\x7F5"+
-		"\x7F7\x5\x12C\x97\x2\x7F6\x7EF\x3\x2\x2\x2\x7F7\x7FA\x3\x2\x2\x2\x7F8"+
-		"\x7F6\x3\x2\x2\x2\x7F8\x7F9\x3\x2\x2\x2\x7F9\x12B\x3\x2\x2\x2\x7FA\x7F8"+
-		"\x3\x2\x2\x2\x7FB\x7FC\x5\x156\xAC\x2\x7FC\x7FD\x5\x19A\xCE\x2\x7FD\x7FE"+
-		"\a\xBF\x2\x2\x7FE\x7FF\x5\x19A\xCE\x2\x7FF\x801\x3\x2\x2\x2\x800\x7FB"+
-		"\x3\x2\x2\x2\x800\x801\x3\x2\x2\x2\x801\x802\x3\x2\x2\x2\x802\x803\x5"+
-		"\x156\xAC\x2\x803\x12D\x3\x2\x2\x2\x804\x808\x5\x130\x99\x2\x805\x808"+
-		"\x5\x180\xC1\x2\x806\x808\x5\x17E\xC0\x2\x807\x804\x3\x2\x2\x2\x807\x805"+
-		"\x3\x2\x2\x2\x807\x806\x3\x2\x2\x2\x808\x12F\x3\x2\x2\x2\x809\x80C\x5"+
-		"\x132\x9A\x2\x80A\x80C\x5\x134\x9B\x2\x80B\x809\x3\x2\x2\x2\x80B\x80A"+
-		"\x3\x2\x2\x2\x80C\x131\x3\x2\x2\x2\x80D\x80E\x5\x136\x9C\x2\x80E\x133"+
-		"\x3\x2\x2\x2\x80F\x810\x5\x136\x9C\x2\x810\x811\x5\x152\xAA\x2\x811\x135"+
-		"\x3\x2\x2\x2\x812\x816\a\xEA\x2\x2\x813\x816\x5\x17C\xBF\x2\x814\x816"+
-		"\x5\x138\x9D\x2\x815\x812\x3\x2\x2\x2\x815\x813\x3\x2\x2\x2\x815\x814"+
-		"\x3\x2\x2\x2\x816\x137\x3\x2\x2\x2\x817\x81B\a\xDD\x2\x2\x818\x81A\x5"+
-		"\x13A\x9E\x2\x819\x818\x3\x2\x2\x2\x81A\x81D\x3\x2\x2\x2\x81B\x819\x3"+
-		"\x2\x2\x2\x81B\x81C\x3\x2\x2\x2\x81C\x81E\x3\x2\x2\x2\x81D\x81B\x3\x2"+
-		"\x2\x2\x81E\x81F\a\xDE\x2\x2\x81F\x139\x3\x2\x2\x2\x820\x823\n\r\x2\x2"+
-		"\x821\x823\x5\x138\x9D\x2\x822\x820\x3\x2\x2\x2\x822\x821\x3\x2\x2\x2"+
-		"\x823\x13B\x3\x2\x2\x2\x824\x826\a\x39\x2\x2\x825\x827\x5\x19A\xCE\x2"+
-		"\x826\x825\x3\x2\x2\x2\x826\x827\x3\x2\x2\x2\x827\x82A\x3\x2\x2\x2\x828"+
-		"\x829\a\x8D\x2\x2\x829\x82B\x5\x19A\xCE\x2\x82A\x828\x3\x2\x2\x2\x82A"+
-		"\x82B\x3\x2\x2\x2\x82B\x82C\x3\x2\x2\x2\x82C\x831\x5\x150\xA9\x2\x82D"+
-		"\x82F\x5\x19A\xCE\x2\x82E\x82D\x3\x2\x2\x2\x82E\x82F\x3\x2\x2\x2\x82F"+
-		"\x830\x3\x2\x2\x2\x830\x832\x5\x144\xA3\x2\x831\x82E\x3\x2\x2\x2\x831"+
-		"\x832\x3\x2\x2\x2\x832\x13D\x3\x2\x2\x2\x833\x834\t\xE\x2\x2\x834\x13F"+
-		"\x3\x2\x2\x2\x835\x836\t\xF\x2\x2\x836\x141\x3\x2\x2\x2\x837\x838\x5\x156"+
-		"\xAC\x2\x838\x143\x3\x2\x2\x2\x839\x83B\a\xD8\x2\x2\x83A\x83C\x5\x19A"+
-		"\xCE\x2\x83B\x83A\x3\x2\x2\x2\x83B\x83C\x3\x2\x2\x2\x83C\x83D\x3\x2\x2"+
-		"\x2\x83D\x83E\x5\x156\xAC\x2\x83E\x145\x3\x2\x2\x2\x83F\x841\x5\x148\xA5"+
-		"\x2\x840\x842\x5\x19A\xCE\x2\x841\x840\x3\x2\x2\x2\x841\x842\x3\x2\x2"+
-		"\x2\x842\x843\x3\x2\x2\x2\x843\x844\a*\x2\x2\x844\x147\x3\x2\x2\x2\x845"+
-		"\x848\x5\x14A\xA6\x2\x846\x848\x5\x14C\xA7\x2\x847\x845\x3\x2\x2\x2\x847"+
-		"\x846\x3\x2\x2\x2\x848\x149\x3\x2\x2\x2\x849\x84A\x5\x12E\x98\x2\x84A"+
-		"\x14B\x3\x2\x2\x2\x84B\x84C\x5\x14E\xA8\x2\x84C\x14D\x3\x2\x2\x2\x84D"+
-		"\x84E\t\x10\x2\x2\x84E\x14F\x3\x2\x2\x2\x84F\x852\x5\x13E\xA0\x2\x850"+
-		"\x852\x5\x142\xA2\x2\x851\x84F\x3\x2\x2\x2\x851\x850\x3\x2\x2\x2\x852"+
-		"\x85B\x3\x2\x2\x2\x853\x855\x5\x19A\xCE\x2\x854\x853\x3\x2\x2\x2\x854"+
-		"\x855\x3\x2\x2\x2\x855\x856\x3\x2\x2\x2\x856\x858\a\xD5\x2\x2\x857\x859"+
-		"\x5\x19A\xCE\x2\x858\x857\x3\x2\x2\x2\x858\x859\x3\x2\x2\x2\x859\x85A"+
-		"\x3\x2\x2\x2\x85A\x85C\a\xDC\x2\x2\x85B\x854\x3\x2\x2\x2\x85B\x85C\x3"+
-		"\x2\x2\x2\x85C\x151\x3\x2\x2\x2\x85D\x85E\t\x11\x2\x2\x85E\x153\x3\x2"+
-		"\x2\x2\x85F\x860\t\x12\x2\x2\x860\x155\x3\x2\x2\x2\x861\x862\b\xAC\x1"+
-		"\x2\x862\x863\a\xC2\x2\x2\x863\x864\x5\x19A\xCE\x2\x864\x865\x5\x156\xAC"+
-		"\x13\x865\x884\x3\x2\x2\x2\x866\x867\a\x8D\x2\x2\x867\x868\x5\x19A\xCE"+
-		"\x2\x868\x869\x5\x156\xAC\x12\x869\x884\x3\x2\x2\x2\x86A\x86C\a\xD7\x2"+
-		"\x2\x86B\x86D\x5\x19A\xCE\x2\x86C\x86B\x3\x2\x2\x2\x86C\x86D\x3\x2\x2"+
-		"\x2\x86D\x86E\x3\x2\x2\x2\x86E\x884\x5\x156\xAC\x10\x86F\x871\a\x8E\x2"+
-		"\x2\x870\x872\x5\x19A\xCE\x2\x871\x870\x3\x2\x2\x2\x871\x872\x3\x2\x2"+
-		"\x2\x872\x873\x3\x2\x2\x2\x873\x884\x5\x156\xAC\t\x874\x875\a.\x2\x2\x875"+
-		"\x884\x5\x156\xAC\x3\x876\x884\x5\x158\xAD\x2\x877\x884\x5\x162\xB2\x2"+
-		"\x878\x884\x5\x164\xB3\x2\x879\x87B\a\xD5\x2\x2\x87A\x87C\x5\x19A\xCE"+
-		"\x2\x87B\x87A\x3\x2\x2\x2\x87B\x87C\x3\x2\x2\x2\x87C\x87D\x3\x2\x2\x2"+
-		"\x87D\x87F\x5\x156\xAC\x2\x87E\x880\x5\x19A\xCE\x2\x87F\x87E\x3\x2\x2"+
-		"\x2\x87F\x880\x3\x2\x2\x2\x880\x881\x3\x2\x2\x2\x881\x882\a\xDC\x2\x2"+
-		"\x882\x884\x3\x2\x2\x2\x883\x861\x3\x2\x2\x2\x883\x866\x3\x2\x2\x2\x883"+
-		"\x86A\x3\x2\x2\x2\x883\x86F\x3\x2\x2\x2\x883\x874\x3\x2\x2\x2\x883\x876"+
-		"\x3\x2\x2\x2\x883\x877\x3\x2\x2\x2\x883\x878\x3\x2\x2\x2\x883\x879\x3"+
-		"\x2\x2\x2\x884\x8F3\x3\x2\x2\x2\x885\x887\f\x11\x2\x2\x886\x888\x5\x19A"+
-		"\xCE\x2\x887\x886\x3\x2\x2\x2\x887\x888\x3\x2\x2\x2\x888\x889\x3\x2\x2"+
-		"\x2\x889\x88B\a\xDB\x2\x2\x88A\x88C\x5\x19A\xCE\x2\x88B\x88A\x3\x2\x2"+
-		"\x2\x88B\x88C\x3\x2\x2\x2\x88C\x88D\x3\x2\x2\x2\x88D\x8F2\x5\x156\xAC"+
-		"\x12\x88E\x890\f\xF\x2\x2\x88F\x891\x5\x19A\xCE\x2\x890\x88F\x3\x2\x2"+
-		"\x2\x890\x891\x3\x2\x2\x2\x891\x892\x3\x2\x2\x2\x892\x894\t\x13\x2\x2"+
-		"\x893\x895\x5\x19A\xCE\x2\x894\x893\x3\x2\x2\x2\x894\x895\x3\x2\x2\x2"+
-		"\x895\x896\x3\x2\x2\x2\x896\x8F2\x5\x156\xAC\x10\x897\x899\f\xE\x2\x2"+
-		"\x898\x89A\x5\x19A\xCE\x2\x899\x898\x3\x2\x2\x2\x899\x89A\x3\x2\x2\x2"+
-		"\x89A\x89B\x3\x2\x2\x2\x89B\x89D\a\xD0\x2\x2\x89C\x89E\x5\x19A\xCE\x2"+
-		"\x89D\x89C\x3\x2\x2\x2\x89D\x89E\x3\x2\x2\x2\x89E\x89F\x3\x2\x2\x2\x89F"+
-		"\x8F2\x5\x156\xAC\xF\x8A0\x8A2\f\r\x2\x2\x8A1\x8A3\x5\x19A\xCE\x2\x8A2"+
-		"\x8A1\x3\x2\x2\x2\x8A2\x8A3\x3\x2\x2\x2\x8A3\x8A4\x3\x2\x2\x2\x8A4\x8A6"+
-		"\a\x8B\x2\x2\x8A5\x8A7\x5\x19A\xCE\x2\x8A6\x8A5\x3\x2\x2\x2\x8A6\x8A7"+
-		"\x3\x2\x2\x2\x8A7\x8A8\x3\x2\x2\x2\x8A8\x8F2\x5\x156\xAC\xE\x8A9\x8AB"+
-		"\f\f\x2\x2\x8AA\x8AC\x5\x19A\xCE\x2\x8AB\x8AA\x3\x2\x2\x2\x8AB\x8AC\x3"+
-		"\x2\x2\x2\x8AC\x8AD\x3\x2\x2\x2\x8AD\x8AF\t\x14\x2\x2\x8AE\x8B0\x5\x19A"+
-		"\xCE\x2\x8AF\x8AE\x3\x2\x2\x2\x8AF\x8B0\x3\x2\x2\x2\x8B0\x8B1\x3\x2\x2"+
-		"\x2\x8B1\x8F2\x5\x156\xAC\r\x8B2\x8B4\f\v\x2\x2\x8B3\x8B5\x5\x19A\xCE"+
-		"\x2\x8B4\x8B3\x3\x2\x2\x2\x8B4\x8B5\x3\x2\x2\x2\x8B5\x8B6\x3\x2\x2\x2"+
-		"\x8B6\x8B8\a\x32\x2\x2\x8B7\x8B9\x5\x19A\xCE\x2\x8B8\x8B7\x3\x2\x2\x2"+
-		"\x8B8\x8B9\x3\x2\x2\x2\x8B9\x8BA\x3\x2\x2\x2\x8BA\x8F2\x5\x156\xAC\f\x8BB"+
-		"\x8BD\f\n\x2\x2\x8BC\x8BE\x5\x19A\xCE\x2\x8BD\x8BC\x3\x2\x2\x2\x8BD\x8BE"+
-		"\x3\x2\x2\x2\x8BE\x8BF\x3\x2\x2\x2\x8BF\x8C1\t\xF\x2\x2\x8C0\x8C2\x5\x19A"+
-		"\xCE\x2\x8C1\x8C0\x3\x2\x2\x2\x8C1\x8C2\x3\x2\x2\x2\x8C2\x8C3\x3\x2\x2"+
-		"\x2\x8C3\x8F2\x5\x156\xAC\v\x8C4\x8C6\f\b\x2\x2\x8C5\x8C7\x5\x19A\xCE"+
-		"\x2\x8C6\x8C5\x3\x2\x2\x2\x8C6\x8C7\x3\x2\x2\x2\x8C7\x8C8\x3\x2\x2\x2"+
-		"\x8C8\x8CA\a\x36\x2\x2\x8C9\x8CB\x5\x19A\xCE\x2\x8CA\x8C9\x3\x2\x2\x2"+
-		"\x8CA\x8CB\x3\x2\x2\x2\x8CB\x8CC\x3\x2\x2\x2\x8CC\x8F2\x5\x156\xAC\t\x8CD"+
-		"\x8CF\f\a\x2\x2\x8CE\x8D0\x5\x19A\xCE\x2\x8CF\x8CE\x3\x2\x2\x2\x8CF\x8D0"+
-		"\x3\x2\x2\x2\x8D0\x8D1\x3\x2\x2\x2\x8D1\x8D3\a\x9B\x2\x2\x8D2\x8D4\x5"+
-		"\x19A\xCE\x2\x8D3\x8D2\x3\x2\x2\x2\x8D3\x8D4\x3\x2\x2\x2\x8D4\x8D5\x3"+
-		"\x2\x2\x2\x8D5\x8F2\x5\x156\xAC\b\x8D6\x8D8\f\x6\x2\x2\x8D7\x8D9\x5\x19A"+
-		"\xCE\x2\x8D8\x8D7\x3\x2\x2\x2\x8D8\x8D9\x3\x2\x2\x2\x8D9\x8DA\x3\x2\x2"+
-		"\x2\x8DA\x8DC\a\xCD\x2\x2\x8DB\x8DD\x5\x19A\xCE\x2\x8DC\x8DB\x3\x2\x2"+
-		"\x2\x8DC\x8DD\x3\x2\x2\x2\x8DD\x8DE\x3\x2\x2\x2\x8DE\x8F2\x5\x156\xAC"+
-		"\a\x8DF\x8E1\f\x5\x2\x2\x8E0\x8E2\x5\x19A\xCE\x2\x8E1\x8E0\x3\x2\x2\x2"+
-		"\x8E1\x8E2\x3\x2\x2\x2\x8E2\x8E3\x3\x2\x2\x2\x8E3\x8E5\a\x66\x2\x2\x8E4"+
-		"\x8E6\x5\x19A\xCE\x2\x8E5\x8E4\x3\x2\x2\x2\x8E5\x8E6\x3\x2\x2\x2\x8E6"+
-		"\x8E7\x3\x2\x2\x2\x8E7\x8F2\x5\x156\xAC\x6\x8E8\x8EA\f\x4\x2\x2\x8E9\x8EB"+
-		"\x5\x19A\xCE\x2\x8EA\x8E9\x3\x2\x2\x2\x8EA\x8EB\x3\x2\x2\x2\x8EB\x8EC"+
-		"\x3\x2\x2\x2\x8EC\x8EE\ax\x2\x2\x8ED\x8EF\x5\x19A\xCE\x2\x8EE\x8ED\x3"+
-		"\x2\x2\x2\x8EE\x8EF\x3\x2\x2\x2\x8EF\x8F0\x3\x2\x2\x2\x8F0\x8F2\x5\x156"+
-		"\xAC\x5\x8F1\x885\x3\x2\x2\x2\x8F1\x88E\x3\x2\x2\x2\x8F1\x897\x3\x2\x2"+
-		"\x2\x8F1\x8A0\x3\x2\x2\x2\x8F1\x8A9\x3\x2\x2\x2\x8F1\x8B2\x3\x2\x2\x2"+
-		"\x8F1\x8BB\x3\x2\x2\x2\x8F1\x8C4\x3\x2\x2\x2\x8F1\x8CD\x3\x2\x2\x2\x8F1"+
-		"\x8D6\x3\x2\x2\x2\x8F1\x8DF\x3\x2\x2\x2\x8F1\x8E8\x3\x2\x2\x2\x8F2\x8F5"+
-		"\x3\x2\x2\x2\x8F3\x8F1\x3\x2\x2\x2\x8F3\x8F4\x3\x2\x2\x2\x8F4\x157\x3"+
-		"\x2\x2\x2\x8F5\x8F3\x3\x2\x2\x2\x8F6\x8FE\x5\x14E\xA8\x2\x8F7\x8FE\a\xE4"+
-		"\x2\x2\x8F8\x8FE\a\xDF\x2\x2\x8F9\x8FB\x5\x15A\xAE\x2\x8FA\x8FC\x5\x152"+
-		"\xAA\x2\x8FB\x8FA\x3\x2\x2\x2\x8FB\x8FC\x3\x2\x2\x2\x8FC\x8FE\x3\x2\x2"+
-		"\x2\x8FD\x8F6\x3\x2\x2\x2\x8FD\x8F7\x3\x2\x2\x2\x8FD\x8F8\x3\x2\x2\x2"+
-		"\x8FD\x8F9\x3\x2\x2\x2\x8FE\x159\x3\x2\x2\x2\x8FF\x903\x5\x15C\xAF\x2"+
-		"\x900\x903\x5\x15E\xB0\x2\x901\x903\x5\x160\xB1\x2\x902\x8FF\x3\x2\x2"+
-		"\x2\x902\x900\x3\x2\x2\x2\x902\x901\x3\x2\x2\x2\x903\x15B\x3\x2\x2\x2"+
-		"\x904\x905\t\x15\x2\x2\x905\x15D\x3\x2\x2\x2\x906\x907\a\x8F\x2\x2\x907"+
-		"\x15F\x3\x2\x2\x2\x908\x909\t\x16\x2\x2\x909\x161\x3\x2\x2\x2\x90A\x90B"+
-		"\b\xB2\x1\x2\x90B\x918\a\x89\x2\x2\x90C\x918\x5\x130\x99\x2\x90D\x90F"+
-		"\a-\x2\x2\x90E\x910\x5\x198\xCD\x2\x90F\x90E\x3\x2\x2\x2\x90F\x910\x3"+
-		"\x2\x2\x2\x910\x911\x3\x2\x2\x2\x911\x918\x5\x12E\x98\x2\x912\x914\a,"+
-		"\x2\x2\x913\x915\x5\x198\xCD\x2\x914\x913\x3\x2\x2\x2\x914\x915\x3\x2"+
-		"\x2\x2\x915\x916\x3\x2\x2\x2\x916\x918\x5\x12E\x98\x2\x917\x90A\x3\x2"+
-		"\x2\x2\x917\x90C\x3\x2\x2\x2\x917\x90D\x3\x2\x2\x2\x917\x912\x3\x2\x2"+
-		"\x2\x918\x93C\x3\x2\x2\x2\x919\x91B\f\t\x2\x2\x91A\x91C\x5\x19A\xCE\x2"+
-		"\x91B\x91A\x3\x2\x2\x2\x91B\x91C\x3\x2\x2\x2\x91C\x91D\x3\x2\x2\x2\x91D"+
-		"\x91F\a\xD5\x2\x2\x91E\x920\x5\x19A\xCE\x2\x91F\x91E\x3\x2\x2\x2\x91F"+
-		"\x920\x3\x2\x2\x2\x920\x922\x3\x2\x2\x2\x921\x923\x5\x166\xB4\x2\x922"+
-		"\x921\x3\x2\x2\x2\x922\x923\x3\x2\x2\x2\x923\x925\x3\x2\x2\x2\x924\x926"+
-		"\x5\x19A\xCE\x2\x925\x924\x3\x2\x2\x2\x925\x926\x3\x2\x2\x2\x926\x927"+
-		"\x3\x2\x2\x2\x927\x93B\a\xDC\x2\x2\x928\x92A\f\b\x2\x2\x929\x92B\x5\x198"+
-		"\xCD\x2\x92A\x929\x3\x2\x2\x2\x92A\x92B\x3\x2\x2\x2\x92B\x92C\x3\x2\x2"+
-		"\x2\x92C\x92E\a-\x2\x2\x92D\x92F\x5\x198\xCD\x2\x92E\x92D\x3\x2\x2\x2"+
-		"\x92E\x92F\x3\x2\x2\x2\x92F\x930\x3\x2\x2\x2\x930\x93B\x5\x12E\x98\x2"+
-		"\x931\x933\f\a\x2\x2\x932\x934\x5\x198\xCD\x2\x933\x932\x3\x2\x2\x2\x933"+
-		"\x934\x3\x2\x2\x2\x934\x935\x3\x2\x2\x2\x935\x937\a,\x2\x2\x936\x938\x5"+
-		"\x198\xCD\x2\x937\x936\x3\x2\x2\x2\x937\x938\x3\x2\x2\x2\x938\x939\x3"+
-		"\x2\x2\x2\x939\x93B\x5\x12E\x98\x2\x93A\x919\x3\x2\x2\x2\x93A\x928\x3"+
-		"\x2\x2\x2\x93A\x931\x3\x2\x2\x2\x93B\x93E\x3\x2\x2\x2\x93C\x93A\x3\x2"+
-		"\x2\x2\x93C\x93D\x3\x2\x2\x2\x93D\x163\x3\x2\x2\x2\x93E\x93C\x3\x2\x2"+
-		"\x2\x93F\x955\x5\x13E\xA0\x2\x940\x942\a\xDD\x2\x2\x941\x943\x5\x19A\xCE"+
-		"\x2\x942\x941\x3\x2\x2\x2\x942\x943\x3\x2\x2\x2\x943\x944\x3\x2\x2\x2"+
-		"\x944\x946\x5\x13E\xA0\x2\x945\x947\x5\x19A\xCE\x2\x946\x945\x3\x2\x2"+
-		"\x2\x946\x947\x3\x2\x2\x2\x947\x948\x3\x2\x2\x2\x948\x949\a\xDE\x2\x2"+
-		"\x949\x955\x3\x2\x2\x2\x94A\x955\a\x91\x2\x2\x94B\x94D\a\xDD\x2\x2\x94C"+
-		"\x94E\x5\x19A\xCE\x2\x94D\x94C\x3\x2\x2\x2\x94D\x94E\x3\x2\x2\x2\x94E"+
-		"\x94F\x3\x2\x2\x2\x94F\x951\a\x91\x2\x2\x950\x952\x5\x19A\xCE\x2\x951"+
-		"\x950\x3\x2\x2\x2\x951\x952\x3\x2\x2\x2\x952\x953\x3\x2\x2\x2\x953\x955"+
-		"\a\xDE\x2\x2\x954\x93F\x3\x2\x2\x2\x954\x940\x3\x2\x2\x2\x954\x94A\x3"+
-		"\x2\x2\x2\x954\x94B\x3\x2\x2\x2\x955\x165\x3\x2\x2\x2\x956\x957\x5\x168"+
-		"\xB5\x2\x957\x167\x3\x2\x2\x2\x958\x95A\x5\x16A\xB6\x2\x959\x95B\x5\x19A"+
-		"\xCE\x2\x95A\x959\x3\x2\x2\x2\x95A\x95B\x3\x2\x2\x2\x95B\x95D\x3\x2\x2"+
-		"\x2\x95C\x958\x3\x2\x2\x2\x95D\x960\x3\x2\x2\x2\x95E\x95C\x3\x2\x2\x2"+
-		"\x95E\x95F\x3\x2\x2\x2\x95F\x961\x3\x2\x2\x2\x960\x95E\x3\x2\x2\x2\x961"+
-		"\x96D\x5\x16E\xB8\x2\x962\x964\x5\x16A\xB6\x2\x963\x965\x5\x19A\xCE\x2"+
-		"\x964\x963\x3\x2\x2\x2\x964\x965\x3\x2\x2\x2\x965\x967\x3\x2\x2\x2\x966"+
-		"\x962\x3\x2\x2\x2\x967\x96A\x3\x2\x2\x2\x968\x966\x3\x2\x2\x2\x968\x969"+
-		"\x3\x2\x2\x2\x969\x96B\x3\x2\x2\x2\x96A\x968\x3\x2\x2\x2\x96B\x96D\x5"+
-		"\x170\xB9\x2\x96C\x95E\x3\x2\x2\x2\x96C\x968\x3\x2\x2\x2\x96D\x169\x3"+
-		"\x2\x2\x2\x96E\x970\x5\x16C\xB7\x2\x96F\x971\x5\x19A\xCE\x2\x970\x96F"+
-		"\x3\x2\x2\x2\x970\x971\x3\x2\x2\x2\x971\x972\x3\x2\x2\x2\x972\x973\a)"+
-		"\x2\x2\x973\x979\x3\x2\x2\x2\x974\x976\x5\x19A\xCE\x2\x975\x974\x3\x2"+
-		"\x2\x2\x975\x976\x3\x2\x2\x2\x976\x977\x3\x2\x2\x2\x977\x979\a)\x2\x2"+
-		"\x978\x96E\x3\x2\x2\x2\x978\x975\x3\x2\x2\x2\x979\x16B\x3\x2\x2\x2\x97A"+
-		"\x97B\x5\x174\xBB\x2\x97B\x16D\x3\x2\x2\x2\x97C\x97D\x5\x174\xBB\x2\x97D"+
-		"\x16F\x3\x2\x2\x2\x97E\x989\x5\x172\xBA\x2\x97F\x981\x5\x19A\xCE\x2\x980"+
-		"\x97F\x3\x2\x2\x2\x980\x981\x3\x2\x2\x2\x981\x982\x3\x2\x2\x2\x982\x984"+
-		"\a)\x2\x2\x983\x985\x5\x19A\xCE\x2\x984\x983\x3\x2\x2\x2\x984\x985\x3"+
-		"\x2\x2\x2\x985\x986\x3\x2\x2\x2\x986\x988\x5\x172\xBA\x2\x987\x980\x3"+
-		"\x2\x2\x2\x988\x98B\x3\x2\x2\x2\x989\x987\x3\x2\x2\x2\x989\x98A\x3\x2"+
-		"\x2\x2\x98A\x171\x3\x2\x2\x2\x98B\x989\x3\x2\x2\x2\x98C\x98E\x5\x12E\x98"+
-		"\x2\x98D\x98F\x5\x19A\xCE\x2\x98E\x98D\x3\x2\x2\x2\x98E\x98F\x3\x2\x2"+
-		"\x2\x98F\x990\x3\x2\x2\x2\x990\x992\a\xCE\x2\x2\x991\x993\x5\x19A\xCE"+
+		"\xC4\xC8\xC8\x3\x2jn\x3\x2\x93\x94\x4\x2tt\xA5\xA5\x3\x2\xDD\xDE\xE\x2"+
+		"\x4\x4\x13\x13\x1F <<??\x46\x46WW}}\x7F\x7F\xB5\xB5\xBA\xBA\xC5\xC5\a"+
+		"\x2||\x83\x83\xD1\xD4\xD6\xD6\xD9\xD9\x3\x2\xE0\xE3\x5\x2,,.\x32\xDB\xDB"+
+		"\x6\x2pptt\xA0\xA0\xA5\xA5\x4\x2\xCF\xCF\xD8\xD8\x4\x2\xD7\xD7\xDA\xDA"+
+		"\x4\x2oo\xC0\xC0\x4\x2[[\x90\x90&\x2\x3\f\xE\x17\x19#%%\'(\x33\x38:?\x42"+
+		"\x43\x45\x46WW\x64\x64\x66\x66hhoossxxz\x7F\x82\x87\x89\x8B\x8D\x91\x93"+
+		"\x93\x95\x96\x9B\x9F\xA4\xA4\xA6\xA7\xA9\xAA\xAC\xAD\xB1\xB1\xB4\xB6\xB8"+
+		"\xB8\xBA\xBA\xBC\xC0\xC2\xC6\xC9\xC9\xCB\xCD\xED\xEE \x2\x18\x18$$@\x41"+
+		"\x44\x44GVYZ``\x63\x63\x65\x65gginprtwyy\x80\x81\x88\x88\x8C\x8C\x92\x92"+
+		"\xA0\xA0\xA5\xA5\xA8\xA8\xAB\xAB\xAE\xB0\xB2\xB3\xB7\xB7\xB9\xB9\xBB\xBB"+
+		"\xC1\xC1\xC7\xC8\xCA\xCA\x3\x2\xE5\xE5\x4\x2\xE8\xE8\xEB\xEB\xB9D\x2\x1B4"+
+		"\x3\x2\x2\x2\x4\x1B7\x3\x2\x2\x2\x6\x1C8\x3\x2\x2\x2\b\x1D3\x3\x2\x2\x2"+
+		"\n\x1E6\x3\x2\x2\x2\f\x200\x3\x2\x2\x2\xE\x203\x3\x2\x2\x2\x10\x21B\x3"+
+		"\x2\x2\x2\x12\x21D\x3\x2\x2\x2\x14\x224\x3\x2\x2\x2\x16\x231\x3\x2\x2"+
+		"\x2\x18\x234\x3\x2\x2\x2\x1A\x244\x3\x2\x2\x2\x1C\x253\x3\x2\x2\x2\x1E"+
+		"\x25A\x3\x2\x2\x2 \x280\x3\x2\x2\x2\"\x290\x3\x2\x2\x2$\x292\x3\x2\x2"+
+		"\x2&\x2AD\x3\x2\x2\x2(\x2AF\x3\x2\x2\x2*\x2B3\x3\x2\x2\x2,\x2B5\x3\x2"+
+		"\x2\x2.\x2B9\x3\x2\x2\x2\x30\x2BB\x3\x2\x2\x2\x32\x2BD\x3\x2\x2\x2\x34"+
+		"\x2C7\x3\x2\x2\x2\x36\x2CB\x3\x2\x2\x2\x38\x2CD\x3\x2\x2\x2:\x2D0\x3\x2"+
+		"\x2\x2<\x2D2\x3\x2\x2\x2>\x2D8\x3\x2\x2\x2@\x2DA\x3\x2\x2\x2\x42\x2E8"+
+		"\x3\x2\x2\x2\x44\x2F4\x3\x2\x2\x2\x46\x2F6\x3\x2\x2\x2H\x30D\x3\x2\x2"+
+		"\x2J\x30F\x3\x2\x2\x2L\x311\x3\x2\x2\x2N\x313\x3\x2\x2\x2P\x320\x3\x2"+
+		"\x2\x2R\x32C\x3\x2\x2\x2T\x32E\x3\x2\x2\x2V\x33A\x3\x2\x2\x2X\x33C\x3"+
+		"\x2\x2\x2Z\x342\x3\x2\x2\x2\\\x34C\x3\x2\x2\x2^\x34E\x3\x2\x2\x2`\x350"+
+		"\x3\x2\x2\x2\x62\x35D\x3\x2\x2\x2\x64\x36F\x3\x2\x2\x2\x66\x374\x3\x2"+
+		"\x2\x2h\x376\x3\x2\x2\x2j\x378\x3\x2\x2\x2l\x37A\x3\x2\x2\x2n\x388\x3"+
+		"\x2\x2\x2p\x38A\x3\x2\x2\x2r\x391\x3\x2\x2\x2t\x39B\x3\x2\x2\x2v\x39D"+
+		"\x3\x2\x2\x2x\x3AA\x3\x2\x2\x2z\x3B6\x3\x2\x2\x2|\x3C4\x3\x2\x2\x2~\x3C6"+
+		"\x3\x2\x2\x2\x80\x3DC\x3\x2\x2\x2\x82\x3DE\x3\x2\x2\x2\x84\x3E0\x3\x2"+
+		"\x2\x2\x86\x3F6\x3\x2\x2\x2\x88\x3FB\x3\x2\x2\x2\x8A\x40D\x3\x2\x2\x2"+
+		"\x8C\x41F\x3\x2\x2\x2\x8E\x440\x3\x2\x2\x2\x90\x45B\x3\x2\x2\x2\x92\x47C"+
+		"\x3\x2\x2\x2\x94\x482\x3\x2\x2\x2\x96\x492\x3\x2\x2\x2\x98\x497\x3\x2"+
+		"\x2\x2\x9A\x499\x3\x2\x2\x2\x9C\x49B\x3\x2\x2\x2\x9E\x4A5\x3\x2\x2\x2"+
+		"\xA0\x4A8\x3\x2\x2\x2\xA2\x4AB\x3\x2\x2\x2\xA4\x4B5\x3\x2\x2\x2\xA6\x4B7"+
+		"\x3\x2\x2\x2\xA8\x4D0\x3\x2\x2\x2\xAA\x4D5\x3\x2\x2\x2\xAC\x4E3\x3\x2"+
+		"\x2\x2\xAE\x4F0\x3\x2\x2\x2\xB0\x4F2\x3\x2\x2\x2\xB2\x502\x3\x2\x2\x2"+
+		"\xB4\x509\x3\x2\x2\x2\xB6\x513\x3\x2\x2\x2\xB8\x515\x3\x2\x2\x2\xBA\x526"+
+		"\x3\x2\x2\x2\xBC\x53F\x3\x2\x2\x2\xBE\x55A\x3\x2\x2\x2\xC0\x55C\x3\x2"+
+		"\x2\x2\xC2\x560\x3\x2\x2\x2\xC4\x564\x3\x2\x2\x2\xC6\x588\x3\x2\x2\x2"+
+		"\xC8\x58A\x3\x2\x2\x2\xCA\x590\x3\x2\x2\x2\xCC\x592\x3\x2\x2\x2\xCE\x5A4"+
+		"\x3\x2\x2\x2\xD0\x5B3\x3\x2\x2\x2\xD2\x5E0\x3\x2\x2\x2\xD4\x5E2\x3\x2"+
+		"\x2\x2\xD6\x5E4\x3\x2\x2\x2\xD8\x5E6\x3\x2\x2\x2\xDA\x5EC\x3\x2\x2\x2"+
+		"\xDC\x5F8\x3\x2\x2\x2\xDE\x604\x3\x2\x2\x2\xE0\x610\x3\x2\x2\x2\xE2\x624"+
+		"\x3\x2\x2\x2\xE4\x63B\x3\x2\x2\x2\xE6\x656\x3\x2\x2\x2\xE8\x66C\x3\x2"+
+		"\x2\x2\xEA\x67F\x3\x2\x2\x2\xEC\x692\x3\x2\x2\x2\xEE\x6A0\x3\x2\x2\x2"+
+		"\xF0\x6A2\x3\x2\x2\x2\xF2\x6AA\x3\x2\x2\x2\xF4\x6B8\x3\x2\x2\x2\xF6\x6BE"+
+		"\x3\x2\x2\x2\xF8\x6CA\x3\x2\x2\x2\xFA\x6CC\x3\x2\x2\x2\xFC\x6D4\x3\x2"+
+		"\x2\x2\xFE\x6D6\x3\x2\x2\x2\x100\x6E2\x3\x2\x2\x2\x102\x6E4\x3\x2\x2\x2"+
+		"\x104\x6F9\x3\x2\x2\x2\x106\x6FB\x3\x2\x2\x2\x108\x70E\x3\x2\x2\x2\x10A"+
+		"\x729\x3\x2\x2\x2\x10C\x72B\x3\x2\x2\x2\x10E\x72D\x3\x2\x2\x2\x110\x72F"+
+		"\x3\x2\x2\x2\x112\x73E\x3\x2\x2\x2\x114\x753\x3\x2\x2\x2\x116\x757\x3"+
+		"\x2\x2\x2\x118\x75B\x3\x2\x2\x2\x11A\x75F\x3\x2\x2\x2\x11C\x767\x3\x2"+
+		"\x2\x2\x11E\x772\x3\x2\x2\x2\x120\x774\x3\x2\x2\x2\x122\x77A\x3\x2\x2"+
+		"\x2\x124\x781\x3\x2\x2\x2\x126\x785\x3\x2\x2\x2\x128\x791\x3\x2\x2\x2"+
+		"\x12A\x7A3\x3\x2\x2\x2\x12C\x7A7\x3\x2\x2\x2\x12E\x7AD\x3\x2\x2\x2\x130"+
+		"\x7AF\x3\x2\x2\x2\x132\x7B4\x3\x2\x2\x2\x134\x7BD\x3\x2\x2\x2\x136\x7CB"+
+		"\x3\x2\x2\x2\x138\x7E4\x3\x2\x2\x2\x13A\x7EB\x3\x2\x2\x2\x13C\x7FA\x3"+
+		"\x2\x2\x2\x13E\x819\x3\x2\x2\x2\x140\x827\x3\x2\x2\x2\x142\x839\x3\x2"+
+		"\x2\x2\x144\x84C\x3\x2\x2\x2\x146\x853\x3\x2\x2\x2\x148\x857\x3\x2\x2"+
+		"\x2\x14A\x859\x3\x2\x2\x2\x14C\x85B\x3\x2\x2\x2\x14E\x861\x3\x2\x2\x2"+
+		"\x150\x863\x3\x2\x2\x2\x152\x86E\x3\x2\x2\x2\x154\x870\x3\x2\x2\x2\x156"+
+		"\x87F\x3\x2\x2\x2\x158\x881\x3\x2\x2\x2\x15A\x883\x3\x2\x2\x2\x15C\x885"+
+		"\x3\x2\x2\x2\x15E\x88B\x3\x2\x2\x2\x160\x893\x3\x2\x2\x2\x162\x895\x3"+
+		"\x2\x2\x2\x164\x897\x3\x2\x2\x2\x166\x899\x3\x2\x2\x2\x168\x89D\x3\x2"+
+		"\x2\x2\x16A\x8A9\x3\x2\x2\x2\x16C\x8AB\x3\x2\x2\x2\x16E\x8CF\x3\x2\x2"+
+		"\x2\x170\x949\x3\x2\x2\x2\x172\x94E\x3\x2\x2\x2\x174\x950\x3\x2\x2\x2"+
+		"\x176\x952\x3\x2\x2\x2\x178\x954\x3\x2\x2\x2\x17A\x963\x3\x2\x2\x2\x17C"+
+		"\x9A0\x3\x2\x2\x2\x17E\x9A2\x3\x2\x2\x2\x180\x9B8\x3\x2\x2\x2\x182\x9C4"+
+		"\x3\x2\x2\x2\x184\x9C6\x3\x2\x2\x2\x186\x9C8\x3\x2\x2\x2\x188\x9CA\x3"+
+		"\x2\x2\x2\x18A\x9D8\x3\x2\x2\x2\x18C\x9EE\x3\x2\x2\x2\x18E\x9F0\x3\x2"+
+		"\x2\x2\x190\x9F2\x3\x2\x2\x2\x192\x9F4\x3\x2\x2\x2\x194\x9F8\x3\x2\x2"+
+		"\x2\x196\x9FA\x3\x2\x2\x2\x198\x9FC\x3\x2\x2\x2\x19A\xA09\x3\x2\x2\x2"+
+		"\x19C\xA15\x3\x2\x2\x2\x19E\xA1B\x3\x2\x2\x2\x1A0\xA1D\x3\x2\x2\x2\x1A2"+
+		"\xA23\x3\x2\x2\x2\x1A4\xA2A\x3\x2\x2\x2\x1A6\xA2D\x3\x2\x2\x2\x1A8\xA37"+
+		"\x3\x2\x2\x2\x1AA\xA3B\x3\x2\x2\x2\x1AC\xA79\x3\x2\x2\x2\x1AE\xA7B\x3"+
+		"\x2\x2\x2\x1B0\xA7D\x3\x2\x2\x2\x1B2\xA85\x3\x2\x2\x2\x1B4\x1B5\x5\x4"+
+		"\x3\x2\x1B5\x1B6\a\x2\x2\x3\x1B6\x3\x3\x2\x2\x2\x1B7\x1B8\x5\x19C\xCF"+
+		"\x2\x1B8\x1BA\x5\f\a\x2\x1B9\x1BB\x5\x6\x4\x2\x1BA\x1B9\x3\x2\x2\x2\x1BA"+
+		"\x1BB\x3\x2\x2\x2\x1BB\x1BC\x3\x2\x2\x2\x1BC\x1BE\x5\f\a\x2\x1BD\x1BF"+
+		"\x5\b\x5\x2\x1BE\x1BD\x3\x2\x2\x2\x1BE\x1BF\x3\x2\x2\x2\x1BF\x1C0\x3\x2"+
+		"\x2\x2\x1C0\x1C1\x5\f\a\x2\x1C1\x1C2\x5\x14\v\x2\x1C2\x1C3\x5\f\a\x2\x1C3"+
+		"\x1C4\x5\x1A\xE\x2\x1C4\x1C6\x5\f\a\x2\x1C5\x1C7\x5\x1B2\xDA\x2\x1C6\x1C5"+
+		"\x3\x2\x2\x2\x1C6\x1C7\x3\x2\x2\x2\x1C7\x5\x3\x2\x2\x2\x1C8\x1C9\a\xC6"+
+		"\x2\x2\x1C9\x1CA\x5\x1B2\xDA\x2\x1CA\x1CC\x5\x166\xB4\x2\x1CB\x1CD\x5"+
+		"\x1B2\xDA\x2\x1CC\x1CB\x3\x2\x2\x2\x1CC\x1CD\x3\x2\x2\x2\x1CD\x1CF\x3"+
+		"\x2\x2\x2\x1CE\x1D0\a\x42\x2\x2\x1CF\x1CE\x3\x2\x2\x2\x1CF\x1D0\x3\x2"+
+		"\x2\x2\x1D0\x1D1\x3\x2\x2\x2\x1D1\x1D2\x5\x19C\xCF\x2\x1D2\a\x3\x2\x2"+
+		"\x2\x1D3\x1DB\a:\x2\x2\x1D4\x1D5\x5\x1B2\xDA\x2\x1D5\x1D6\a\xE9\x2\x2"+
+		"\x1D6\x1D7\x5\x1B2\xDA\x2\x1D7\x1D9\x5\x146\xA4\x2\x1D8\x1DA\x5\x1B2\xDA"+
+		"\x2\x1D9\x1D8\x3\x2\x2\x2\x1D9\x1DA\x3\x2\x2\x2\x1DA\x1DC\x3\x2\x2\x2"+
+		"\x1DB\x1D4\x3\x2\x2\x2\x1DB\x1DC\x3\x2\x2\x2\x1DC\x1DD\x3\x2\x2\x2\x1DD"+
+		"\x1DF\x5\x19C\xCF\x2\x1DE\x1E0\x5\n\x6\x2\x1DF\x1DE\x3\x2\x2\x2\x1E0\x1E1"+
+		"\x3\x2\x2\x2\x1E1\x1DF\x3\x2\x2\x2\x1E1\x1E2\x3\x2\x2\x2\x1E2\x1E3\x3"+
+		"\x2\x2\x2\x1E3\x1E4\a\x64\x2\x2\x1E4\x1E5\x5\x19C\xCF\x2\x1E5\t\x3\x2"+
+		"\x2\x2\x1E6\x1EA\x5\x146\xA4\x2\x1E7\x1E9\x5\x1B2\xDA\x2\x1E8\x1E7\x3"+
+		"\x2\x2\x2\x1E9\x1EC\x3\x2\x2\x2\x1EA\x1E8\x3\x2\x2\x2\x1EA\x1EB\x3\x2"+
+		"\x2\x2\x1EB\x1ED\x3\x2\x2\x2\x1EC\x1EA\x3\x2\x2\x2\x1ED\x1F1\a\xD1\x2"+
+		"\x2\x1EE\x1F0\x5\x1B2\xDA\x2\x1EF\x1EE\x3\x2\x2\x2\x1F0\x1F3\x3\x2\x2"+
+		"\x2\x1F1\x1EF\x3\x2\x2\x2\x1F1\x1F2\x3\x2\x2\x2\x1F2\x1F4\x3\x2\x2\x2"+
+		"\x1F3\x1F1\x3\x2\x2\x2\x1F4\x1F7\x5\x16E\xB8\x2\x1F5\x1F6\a*\x2\x2\x1F6"+
+		"\x1F8\x5\x166\xB4\x2\x1F7\x1F5\x3\x2\x2\x2\x1F7\x1F8\x3\x2\x2\x2\x1F8"+
+		"\x1F9\x3\x2\x2\x2\x1F9\x1FA\x5\x19C\xCF\x2\x1FA\v\x3\x2\x2\x2\x1FB\x1FC"+
+		"\x5\xE\b\x2\x1FC\x1FD\x5\x19C\xCF\x2\x1FD\x1FF\x3\x2\x2\x2\x1FE\x1FB\x3"+
+		"\x2\x2\x2\x1FF\x202\x3\x2\x2\x2\x200\x1FE\x3\x2\x2\x2\x200\x201\x3\x2"+
+		"\x2\x2\x201\r\x3\x2\x2\x2\x202\x200\x3\x2\x2\x2\x203\x204\a\x37\x2\x2"+
+		"\x204\x205\x5\x1B2\xDA\x2\x205\x207\x5\x10\t\x2\x206\x208\x5\x1B2\xDA"+
+		"\x2\x207\x206\x3\x2\x2\x2\x207\x208\x3\x2\x2\x2\x208\x209\x3\x2\x2\x2"+
+		"\x209\x20B\a\xD1\x2\x2\x20A\x20C\x5\x1B2\xDA\x2\x20B\x20A\x3\x2\x2\x2"+
+		"\x20B\x20C\x3\x2\x2\x2\x20C\x20D\x3\x2\x2\x2\x20D\x218\x5\x12\n\x2\x20E"+
+		"\x210\x5\x1B2\xDA\x2\x20F\x20E\x3\x2\x2\x2\x20F\x210\x3\x2\x2\x2\x210"+
+		"\x211\x3\x2\x2\x2\x211\x213\a)\x2\x2\x212\x214\x5\x1B2\xDA\x2\x213\x212"+
+		"\x3\x2\x2\x2\x213\x214\x3\x2\x2\x2\x214\x215\x3\x2\x2\x2\x215\x217\x5"+
+		"\x12\n\x2\x216\x20F\x3\x2\x2\x2\x217\x21A\x3\x2\x2\x2\x218\x216\x3\x2"+
+		"\x2\x2\x218\x219\x3\x2\x2\x2\x219\xF\x3\x2\x2\x2\x21A\x218\x3\x2\x2\x2"+
+		"\x21B\x21C\x5\x17A\xBE\x2\x21C\x11\x3\x2\x2\x2\x21D\x21E\x5\x16E\xB8\x2"+
+		"\x21E\x13\x3\x2\x2\x2\x21F\x220\x5\x18\r\x2\x220\x221\x5\x19C\xCF\x2\x221"+
+		"\x223\x3\x2\x2\x2\x222\x21F\x3\x2\x2\x2\x223\x226\x3\x2\x2\x2\x224\x222"+
+		"\x3\x2\x2\x2\x224\x225\x3\x2\x2\x2\x225\x15\x3\x2\x2\x2\x226\x224\x3\x2"+
+		"\x2\x2\x227\x228\a\x97\x2\x2\x228\x229\x5\x1B2\xDA\x2\x229\x22A\x5\x166"+
+		"\xB4\x2\x22A\x232\x3\x2\x2\x2\x22B\x22C\a\x99\x2\x2\x22C\x22D\x5\x1B2"+
+		"\xDA\x2\x22D\x22E\t\x2\x2\x2\x22E\x232\x3\x2\x2\x2\x22F\x232\a\x98\x2"+
+		"\x2\x230\x232\a\x9A\x2\x2\x231\x227\x3\x2\x2\x2\x231\x22B\x3\x2\x2\x2"+
+		"\x231\x22F\x3\x2\x2\x2\x231\x230\x3\x2\x2\x2\x232\x17\x3\x2\x2\x2\x233"+
+		"\x235\x5\x1B2\xDA\x2\x234\x233\x3\x2\x2\x2\x234\x235\x3\x2\x2\x2\x235"+
+		"\x241\x3\x2\x2\x2\x236\x242\x5\xE\b\x2\x237\x242\x5\x8CG\x2\x238\x242"+
+		"\x5\x94K\x2\x239\x242\x5\xAAV\x2\x23A\x242\x5\xB4[\x2\x23B\x242\x5\x88"+
+		"\x45\x2\x23C\x242\x5\xD8m\x2\x23D\x242\x5\x132\x9A\x2\x23E\x242\x5\x16"+
+		"\f\x2\x23F\x242\x5\x116\x8C\x2\x240\x242\x5\x118\x8D\x2\x241\x236\x3\x2"+
+		"\x2\x2\x241\x237\x3\x2\x2\x2\x241\x238\x3\x2\x2\x2\x241\x239\x3\x2\x2"+
+		"\x2\x241\x23A\x3\x2\x2\x2\x241\x23B\x3\x2\x2\x2\x241\x23C\x3\x2\x2\x2"+
+		"\x241\x23D\x3\x2\x2\x2\x241\x23E\x3\x2\x2\x2\x241\x23F\x3\x2\x2\x2\x241"+
+		"\x240\x3\x2\x2\x2\x242\x19\x3\x2\x2\x2\x243\x245\x5\x1B2\xDA\x2\x244\x243"+
+		"\x3\x2\x2\x2\x244\x245\x3\x2\x2\x2\x245\x24B\x3\x2\x2\x2\x246\x247\x5"+
+		"\x1C\xF\x2\x247\x248\x5\x19C\xCF\x2\x248\x24A\x3\x2\x2\x2\x249\x246\x3"+
+		"\x2\x2\x2\x24A\x24D\x3\x2\x2\x2\x24B\x249\x3\x2\x2\x2\x24B\x24C\x3\x2"+
+		"\x2\x2\x24C\x1B\x3\x2\x2\x2\x24D\x24B\x3\x2\x2\x2\x24E\x254\x5\xBC_\x2"+
+		"\x24F\x254\x5\xE4s\x2\x250\x254\x5\xE6t\x2\x251\x254\x5\xE8u\x2\x252\x254"+
+		"\x5\x112\x8A\x2\x253\x24E\x3\x2\x2\x2\x253\x24F\x3\x2\x2\x2\x253\x250"+
+		"\x3\x2\x2\x2\x253\x251\x3\x2\x2\x2\x253\x252\x3\x2\x2\x2\x254\x1D\x3\x2"+
+		"\x2\x2\x255\x256\x5 \x11\x2\x256\x257\x5\x19C\xCF\x2\x257\x259\x3\x2\x2"+
+		"\x2\x258\x255\x3\x2\x2\x2\x259\x25C\x3\x2\x2\x2\x25A\x258\x3\x2\x2\x2"+
+		"\x25A\x25B\x3\x2\x2\x2\x25B\x1F\x3\x2\x2\x2\x25C\x25A\x3\x2\x2\x2\x25D"+
+		"\x281\x5\x15E\xB0\x2\x25E\x281\x5\"\x12\x2\x25F\x281\x5\xE\b\x2\x260\x281"+
+		"\x5\x88\x45\x2\x261\x281\x5\xA8U\x2\x262\x281\x5\xAEX\x2\x263\x281\x5"+
+		"\xB0Y\x2\x264\x281\x5\xB2Z\x2\x265\x281\x5\xB6\\\x2\x266\x281\x5\xB8]"+
+		"\x2\x267\x281\x5\xBA^\x2\x268\x281\x5\xC0\x61\x2\x269\x281\x5\xC2\x62"+
+		"\x2\x26A\x281\x5\xC4\x63\x2\x26B\x281\x5\xCA\x66\x2\x26C\x281\x5\xD8m"+
+		"\x2\x26D\x281\x5\xDAn\x2\x26E\x281\x5\xDCo\x2\x26F\x281\x5\xDEp\x2\x270"+
+		"\x281\x5\xE0q\x2\x271\x281\x5\xE2r\x2\x272\x281\x5\xEAv\x2\x273\x281\x5"+
+		"\xF0y\x2\x274\x281\x5\xFA~\x2\x275\x281\x5\xFC\x7F\x2\x276\x281\x5\xFE"+
+		"\x80\x2\x277\x281\x5\x102\x82\x2\x278\x281\x5\x110\x89\x2\x279\x281\x5"+
+		"\x100\x81\x2\x27A\x281\x5\x132\x9A\x2\x27B\x281\x5\x138\x9D\x2\x27C\x281"+
+		"\x5\x13A\x9E\x2\x27D\x281\x5\x13C\x9F\x2\x27E\x281\x5\x13E\xA0\x2\x27F"+
+		"\x281\x5\xF8}\x2\x280\x25D\x3\x2\x2\x2\x280\x25E\x3\x2\x2\x2\x280\x25F"+
+		"\x3\x2\x2\x2\x280\x260\x3\x2\x2\x2\x280\x261\x3\x2\x2\x2\x280\x262\x3"+
+		"\x2\x2\x2\x280\x263\x3\x2\x2\x2\x280\x264\x3\x2\x2\x2\x280\x265\x3\x2"+
+		"\x2\x2\x280\x266\x3\x2\x2\x2\x280\x267\x3\x2\x2\x2\x280\x268\x3\x2\x2"+
+		"\x2\x280\x269\x3\x2\x2\x2\x280\x26A\x3\x2\x2\x2\x280\x26B\x3\x2\x2\x2"+
+		"\x280\x26C\x3\x2\x2\x2\x280\x26D\x3\x2\x2\x2\x280\x26E\x3\x2\x2\x2\x280"+
+		"\x26F\x3\x2\x2\x2\x280\x270\x3\x2\x2\x2\x280\x271\x3\x2\x2\x2\x280\x272"+
+		"\x3\x2\x2\x2\x280\x273\x3\x2\x2\x2\x280\x274\x3\x2\x2\x2\x280\x275\x3"+
+		"\x2\x2\x2\x280\x276\x3\x2\x2\x2\x280\x277\x3\x2\x2\x2\x280\x278\x3\x2"+
+		"\x2\x2\x280\x279\x3\x2\x2\x2\x280\x27A\x3\x2\x2\x2\x280\x27B\x3\x2\x2"+
+		"\x2\x280\x27C\x3\x2\x2\x2\x280\x27D\x3\x2\x2\x2\x280\x27E\x3\x2\x2\x2"+
+		"\x280\x27F\x3\x2\x2\x2\x281!\x3\x2\x2\x2\x282\x291\x5$\x13\x2\x283\x291"+
+		"\x5> \x2\x284\x291\x5<\x1F\x2\x285\x291\x5\x42\"\x2\x286\x291\x5\x46$"+
+		"\x2\x287\x291\x5N(\x2\x288\x291\x5P)\x2\x289\x291\x5T+\x2\x28A\x291\x5"+
+		"X-\x2\x28B\x291\x5`\x31\x2\x28C\x291\x5v<\x2\x28D\x291\x5x=\x2\x28E\x291"+
+		"\x5~@\x2\x28F\x291\x5\x84\x43\x2\x290\x282\x3\x2\x2\x2\x290\x283\x3\x2"+
+		"\x2\x2\x290\x284\x3\x2\x2\x2\x290\x285\x3\x2\x2\x2\x290\x286\x3\x2\x2"+
+		"\x2\x290\x287\x3\x2\x2\x2\x290\x288\x3\x2\x2\x2\x290\x289\x3\x2\x2\x2"+
+		"\x290\x28A\x3\x2\x2\x2\x290\x28B\x3\x2\x2\x2\x290\x28C\x3\x2\x2\x2\x290"+
+		"\x28D\x3\x2\x2\x2\x290\x28E\x3\x2\x2\x2\x290\x28F\x3\x2\x2\x2\x291#\x3"+
+		"\x2\x2\x2\x292\x293\a\x95\x2\x2\x293\x294\x5\x1B2\xDA\x2\x294\x298\x5"+
+		"&\x14\x2\x295\x296\x5\x1B2\xDA\x2\x296\x297\x5(\x15\x2\x297\x299\x3\x2"+
+		"\x2\x2\x298\x295\x3\x2\x2\x2\x298\x299\x3\x2\x2\x2\x299\x29D\x3\x2\x2"+
+		"\x2\x29A\x29B\x5\x1B2\xDA\x2\x29B\x29C\x5,\x17\x2\x29C\x29E\x3\x2\x2\x2"+
+		"\x29D\x29A\x3\x2\x2\x2\x29D\x29E\x3\x2\x2\x2\x29E\x2A2\x3\x2\x2\x2\x29F"+
+		"\x2A0\x5\x1B2\xDA\x2\x2A0\x2A1\x5\x30\x19\x2\x2A1\x2A3\x3\x2\x2\x2\x2A2"+
+		"\x29F\x3\x2\x2\x2\x2A2\x2A3\x3\x2\x2\x2\x2A3\x2A4\x3\x2\x2\x2\x2A4\x2A5"+
+		"\x5\x1B2\xDA\x2\x2A5\x2A6\a\x39\x2\x2\x2A6\x2A7\x5\x1B2\xDA\x2\x2A7\x2AB"+
+		"\x5\x36\x1C\x2\x2A8\x2A9\x5\x1B2\xDA\x2\x2A9\x2AA\x5\x32\x1A\x2\x2AA\x2AC"+
+		"\x3\x2\x2\x2\x2AB\x2A8\x3\x2\x2\x2\x2AB\x2AC\x3\x2\x2\x2\x2AC%\x3\x2\x2"+
+		"\x2\x2AD\x2AE\x5\x16E\xB8\x2\x2AE\'\x3\x2\x2\x2\x2AF\x2B0\aq\x2\x2\x2B0"+
+		"\x2B1\x5\x1B2\xDA\x2\x2B1\x2B2\x5*\x16\x2\x2B2)\x3\x2\x2\x2\x2B3\x2B4"+
+		"\t\x3\x2\x2\x2B4+\x3\x2\x2\x2\x2B5\x2B6\a\x33\x2\x2\x2B6\x2B7\x5\x1B2"+
+		"\xDA\x2\x2B7\x2B8\x5.\x18\x2\x2B8-\x3\x2\x2\x2\x2B9\x2BA\t\x4\x2\x2\x2BA"+
+		"/\x3\x2\x2\x2\x2BB\x2BC\t\x5\x2\x2\x2BC\x31\x3\x2\x2\x2\x2BD\x2BF\a\x1D"+
+		"\x2\x2\x2BE\x2C0\x5\x1B2\xDA\x2\x2BF\x2BE\x3\x2\x2\x2\x2BF\x2C0\x3\x2"+
+		"\x2\x2\x2C0\x2C1\x3\x2\x2\x2\x2C1\x2C3\a\xD1\x2\x2\x2C2\x2C4\x5\x1B2\xDA"+
+		"\x2\x2C3\x2C2\x3\x2\x2\x2\x2C3\x2C4\x3\x2\x2\x2\x2C4\x2C5\x3\x2\x2\x2"+
+		"\x2C5\x2C6\x5\x34\x1B\x2\x2C6\x33\x3\x2\x2\x2\x2C7\x2C8\x5\x16E\xB8\x2"+
+		"\x2C8\x35\x3\x2\x2\x2\x2C9\x2CC\x5\x38\x1D\x2\x2CA\x2CC\x5:\x1E\x2\x2CB"+
+		"\x2C9\x3\x2\x2\x2\x2CB\x2CA\x3\x2\x2\x2\x2CC\x37\x3\x2\x2\x2\x2CD\x2CE"+
+		"\a.\x2\x2\x2CE\x2CF\x5\x16E\xB8\x2\x2CF\x39\x3\x2\x2\x2\x2D0\x2D1\x5\x16E"+
+		"\xB8\x2\x2D1;\x3\x2\x2\x2\x2D2\x2D6\a\x43\x2\x2\x2D3\x2D4\x5\x1B2\xDA"+
+		"\x2\x2D4\x2D5\x5@!\x2\x2D5\x2D7\x3\x2\x2\x2\x2D6\x2D3\x3\x2\x2\x2\x2D6"+
+		"\x2D7\x3\x2\x2\x2\x2D7=\x3\x2\x2\x2\x2D8\x2D9\a\xAD\x2\x2\x2D9?\x3\x2"+
+		"\x2\x2\x2DA\x2E5\x5\x36\x1C\x2\x2DB\x2DD\x5\x1B2\xDA\x2\x2DC\x2DB\x3\x2"+
+		"\x2\x2\x2DC\x2DD\x3\x2\x2\x2\x2DD\x2DE\x3\x2\x2\x2\x2DE\x2E0\a)\x2\x2"+
+		"\x2DF\x2E1\x5\x1B2\xDA\x2\x2E0\x2DF\x3\x2\x2\x2\x2E0\x2E1\x3\x2\x2\x2"+
+		"\x2E1\x2E2\x3\x2\x2\x2\x2E2\x2E4\x5\x36\x1C\x2\x2E3\x2DC\x3\x2\x2\x2\x2E4"+
+		"\x2E7\x3\x2\x2\x2\x2E5\x2E3\x3\x2\x2\x2\x2E5\x2E6\x3\x2\x2\x2\x2E6\x41"+
+		"\x3\x2\x2\x2\x2E7\x2E5\x3\x2\x2\x2\x2E8\x2E9\a\xB1\x2\x2\x2E9\x2EA\x5"+
+		"\x1B2\xDA\x2\x2EA\x2EC\x5\x36\x1C\x2\x2EB\x2ED\x5\x1B2\xDA\x2\x2EC\x2EB"+
+		"\x3\x2\x2\x2\x2EC\x2ED\x3\x2\x2\x2\x2ED\x2EE\x3\x2\x2\x2\x2EE\x2F0\a)"+
+		"\x2\x2\x2EF\x2F1\x5\x1B2\xDA\x2\x2F0\x2EF\x3\x2\x2\x2\x2F0\x2F1\x3\x2"+
+		"\x2\x2\x2F1\x2F2\x3\x2\x2\x2\x2F2\x2F3\x5\x44#\x2\x2F3\x43\x3\x2\x2\x2"+
+		"\x2F4\x2F5\x5\x16E\xB8\x2\x2F5\x45\x3\x2\x2\x2\x2F6\x2F7\a~\x2\x2\x2F7"+
+		"\x2F8\x5\x1B2\xDA\x2\x2F8\x301\x5\x36\x1C\x2\x2F9\x2FB\x5\x1B2\xDA\x2"+
+		"\x2FA\x2F9\x3\x2\x2\x2\x2FA\x2FB\x3\x2\x2\x2\x2FB\x2FC\x3\x2\x2\x2\x2FC"+
+		"\x2FE\a)\x2\x2\x2FD\x2FF\x5\x1B2\xDA\x2\x2FE\x2FD\x3\x2\x2\x2\x2FE\x2FF"+
+		"\x3\x2\x2\x2\x2FF\x300\x3\x2\x2\x2\x300\x302\x5H%\x2\x301\x2FA\x3\x2\x2"+
+		"\x2\x301\x302\x3\x2\x2\x2\x302G\x3\x2\x2\x2\x303\x30E\x5J&\x2\x304\x305"+
+		"\x5J&\x2\x305\x306\x5\x1B2\xDA\x2\x306\x308\x3\x2\x2\x2\x307\x304\x3\x2"+
+		"\x2\x2\x307\x308\x3\x2\x2\x2\x308\x309\x3\x2\x2\x2\x309\x30A\a\xBF\x2"+
+		"\x2\x30A\x30B\x5\x1B2\xDA\x2\x30B\x30C\x5L\'\x2\x30C\x30E\x3\x2\x2\x2"+
+		"\x30D\x303\x3\x2\x2\x2\x30D\x307\x3\x2\x2\x2\x30EI\x3\x2\x2\x2\x30F\x310"+
+		"\x5\x16E\xB8\x2\x310K\x3\x2\x2\x2\x311\x312\x5\x16E\xB8\x2\x312M\x3\x2"+
+		"\x2\x2\x313\x314\a\xC3\x2\x2\x314\x315\x5\x1B2\xDA\x2\x315\x31E\x5\x36"+
+		"\x1C\x2\x316\x318\x5\x1B2\xDA\x2\x317\x316\x3\x2\x2\x2\x317\x318\x3\x2"+
+		"\x2\x2\x318\x319\x3\x2\x2\x2\x319\x31B\a)\x2\x2\x31A\x31C\x5\x1B2\xDA"+
+		"\x2\x31B\x31A\x3\x2\x2\x2\x31B\x31C\x3\x2\x2\x2\x31C\x31D\x3\x2\x2\x2"+
+		"\x31D\x31F\x5H%\x2\x31E\x317\x3\x2\x2\x2\x31E\x31F\x3\x2\x2\x2\x31FO\x3"+
+		"\x2\x2\x2\x320\x321\a\x84\x2\x2\x321\x322\x5\x1B2\xDA\x2\x322\x324\x5"+
+		"\x38\x1D\x2\x323\x325\x5\x1B2\xDA\x2\x324\x323\x3\x2\x2\x2\x324\x325\x3"+
+		"\x2\x2\x2\x325\x326\x3\x2\x2\x2\x326\x328\a)\x2\x2\x327\x329\x5\x1B2\xDA"+
+		"\x2\x328\x327\x3\x2\x2\x2\x328\x329\x3\x2\x2\x2\x329\x32A\x3\x2\x2\x2"+
+		"\x32A\x32B\x5R*\x2\x32BQ\x3\x2\x2\x2\x32C\x32D\x5\x16E\xB8\x2\x32DS\x3"+
+		"\x2\x2\x2\x32E\x32F\a\xC9\x2\x2\x32F\x330\x5\x1B2\xDA\x2\x330\x332\x5"+
+		"\x38\x1D\x2\x331\x333\x5\x1B2\xDA\x2\x332\x331\x3\x2\x2\x2\x332\x333\x3"+
+		"\x2\x2\x2\x333\x334\x3\x2\x2\x2\x334\x336\a)\x2\x2\x335\x337\x5\x1B2\xDA"+
+		"\x2\x336\x335\x3\x2\x2\x2\x336\x337\x3\x2\x2\x2\x337\x338\x3\x2\x2\x2"+
+		"\x338\x339\x5V,\x2\x339U\x3\x2\x2\x2\x33A\x33B\x5\x16E\xB8\x2\x33BW\x3"+
+		"\x2\x2\x2\x33C\x340\x5Z.\x2\x33D\x33E\x5\x1B2\xDA\x2\x33E\x33F\x5\x62"+
+		"\x32\x2\x33F\x341\x3\x2\x2\x2\x340\x33D\x3\x2\x2\x2\x340\x341\x3\x2\x2"+
+		"\x2\x341Y\x3\x2\x2\x2\x342\x344\x5\\/\x2\x343\x345\x5\x1B2\xDA\x2\x344"+
+		"\x343\x3\x2\x2\x2\x344\x345\x3\x2\x2\x2\x345\x346\x3\x2\x2\x2\x346\x348"+
+		"\a-\x2\x2\x347\x349\x5\x1B2\xDA\x2\x348\x347\x3\x2\x2\x2\x348\x349\x3"+
+		"\x2\x2\x2\x349\x34A\x3\x2\x2\x2\x34A\x34B\x5^\x30\x2\x34B[\x3\x2\x2\x2"+
+		"\x34C\x34D\a\x16\x2\x2\x34D]\x3\x2\x2\x2\x34E\x34F\a\x9F\x2\x2\x34F_\x3"+
+		"\x2\x2\x2\x350\x351\a\x9F\x2\x2\x351\x352\x5\x1B2\xDA\x2\x352\x354\x5"+
+		"\x38\x1D\x2\x353\x355\x5\x1B2\xDA\x2\x354\x353\x3\x2\x2\x2\x354\x355\x3"+
+		"\x2\x2\x2\x355\x356\x3\x2\x2\x2\x356\x35B\a)\x2\x2\x357\x359\x5\x1B2\xDA"+
+		"\x2\x358\x357\x3\x2\x2\x2\x358\x359\x3\x2\x2\x2\x359\x35A\x3\x2\x2\x2"+
+		"\x35A\x35C\x5\x62\x32\x2\x35B\x358\x3\x2\x2\x2\x35B\x35C\x3\x2\x2\x2\x35C"+
+		"\x61\x3\x2\x2\x2\x35D\x364\x5\x64\x33\x2\x35E\x360\x5\x1B2\xDA\x2\x35F"+
+		"\x35E\x3\x2\x2\x2\x35F\x360\x3\x2\x2\x2\x360\x361\x3\x2\x2\x2\x361\x363"+
+		"\x5\x64\x33\x2\x362\x35F\x3\x2\x2\x2\x363\x366\x3\x2\x2\x2\x364\x362\x3"+
+		"\x2\x2\x2\x364\x365\x3\x2\x2\x2\x365\x63\x3\x2\x2\x2\x366\x364\x3\x2\x2"+
+		"\x2\x367\x370\x5\x66\x34\x2\x368\x370\x5h\x35\x2\x369\x36B\x5\x66\x34"+
+		"\x2\x36A\x36C\x5\x1B2\xDA\x2\x36B\x36A\x3\x2\x2\x2\x36B\x36C\x3\x2\x2"+
+		"\x2\x36C\x36D\x3\x2\x2\x2\x36D\x36E\x5h\x35\x2\x36E\x370\x3\x2\x2\x2\x36F"+
+		"\x367\x3\x2\x2\x2\x36F\x368\x3\x2\x2\x2\x36F\x369\x3\x2\x2\x2\x370\x65"+
+		"\x3\x2\x2\x2\x371\x375\x5l\x37\x2\x372\x375\x5p\x39\x2\x373\x375\x5j\x36"+
+		"\x2\x374\x371\x3\x2\x2\x2\x374\x372\x3\x2\x2\x2\x374\x373\x3\x2\x2\x2"+
+		"\x375g\x3\x2\x2\x2\x376\x377\t\x6\x2\x2\x377i\x3\x2\x2\x2\x378\x379\x5"+
+		"\x16E\xB8\x2\x379k\x3\x2\x2\x2\x37A\x37C\a\xB6\x2\x2\x37B\x37D\x5\x1B2"+
+		"\xDA\x2\x37C\x37B\x3\x2\x2\x2\x37C\x37D\x3\x2\x2\x2\x37D\x37E\x3\x2\x2"+
+		"\x2\x37E\x380\a\xD5\x2\x2\x37F\x381\x5\x1B2\xDA\x2\x380\x37F\x3\x2\x2"+
+		"\x2\x380\x381\x3\x2\x2\x2\x381\x382\x3\x2\x2\x2\x382\x384\x5n\x38\x2\x383"+
+		"\x385\x5\x1B2\xDA\x2\x384\x383\x3\x2\x2\x2\x384\x385\x3\x2\x2\x2\x385"+
+		"\x386\x3\x2\x2\x2\x386\x387\a\xDC\x2\x2\x387m\x3\x2\x2\x2\x388\x389\x5"+
+		"\x16E\xB8\x2\x389o\x3\x2\x2\x2\x38A\x38F\a\xBC\x2\x2\x38B\x38D\x5\x1B2"+
+		"\xDA\x2\x38C\x38B\x3\x2\x2\x2\x38C\x38D\x3\x2\x2\x2\x38D\x38E\x3\x2\x2"+
+		"\x2\x38E\x390\x5r:\x2\x38F\x38C\x3\x2\x2\x2\x38F\x390\x3\x2\x2\x2\x390"+
+		"q\x3\x2\x2\x2\x391\x393\a\xD5\x2\x2\x392\x394\x5\x1B2\xDA\x2\x393\x392"+
+		"\x3\x2\x2\x2\x393\x394\x3\x2\x2\x2\x394\x395\x3\x2\x2\x2\x395\x397\x5"+
+		"t;\x2\x396\x398\x5\x1B2\xDA\x2\x397\x396\x3\x2\x2\x2\x397\x398\x3\x2\x2"+
+		"\x2\x398\x399\x3\x2\x2\x2\x399\x39A\a\xDC\x2\x2\x39As\x3\x2\x2\x2\x39B"+
+		"\x39C\x5\x16E\xB8\x2\x39Cu\x3\x2\x2\x2\x39D\x39E\a\xCC\x2\x2\x39E\x39F"+
+		"\x5\x1B2\xDA\x2\x39F\x3A1\x5\x38\x1D\x2\x3A0\x3A2\x5\x1B2\xDA\x2\x3A1"+
+		"\x3A0\x3\x2\x2\x2\x3A1\x3A2\x3\x2\x2\x2\x3A2\x3A3\x3\x2\x2\x2\x3A3\x3A8"+
+		"\a)\x2\x2\x3A4\x3A6\x5\x1B2\xDA\x2\x3A5\x3A4\x3\x2\x2\x2\x3A5\x3A6\x3"+
+		"\x2\x2\x2\x3A6\x3A7\x3\x2\x2\x2\x3A7\x3A9\x5\x62\x32\x2\x3A8\x3A5\x3\x2"+
+		"\x2\x2\x3A8\x3A9\x3\x2\x2\x2\x3A9w\x3\x2\x2\x2\x3AA\x3AB\a{\x2\x2\x3AB"+
+		"\x3AC\x5\x1B2\xDA\x2\x3AC\x3AE\x5\x38\x1D\x2\x3AD\x3AF\x5\x1B2\xDA\x2"+
+		"\x3AE\x3AD\x3\x2\x2\x2\x3AE\x3AF\x3\x2\x2\x2\x3AF\x3B0\x3\x2\x2\x2\x3B0"+
+		"\x3B2\a)\x2\x2\x3B1\x3B3\x5\x1B2\xDA\x2\x3B2\x3B1\x3\x2\x2\x2\x3B2\x3B3"+
+		"\x3\x2\x2\x2\x3B3\x3B4\x3\x2\x2\x2\x3B4\x3B5\x5z>\x2\x3B5y\x3\x2\x2\x2"+
+		"\x3B6\x3C1\x5|?\x2\x3B7\x3B9\x5\x1B2\xDA\x2\x3B8\x3B7\x3\x2\x2\x2\x3B8"+
+		"\x3B9\x3\x2\x2\x2\x3B9\x3BA\x3\x2\x2\x2\x3BA\x3BC\a)\x2\x2\x3BB\x3BD\x5"+
+		"\x1B2\xDA\x2\x3BC\x3BB\x3\x2\x2\x2\x3BC\x3BD\x3\x2\x2\x2\x3BD\x3BE\x3"+
+		"\x2\x2\x2\x3BE\x3C0\x5|?\x2\x3BF\x3B8\x3\x2\x2\x2\x3C0\x3C3\x3\x2\x2\x2"+
+		"\x3C1\x3BF\x3\x2\x2\x2\x3C1\x3C2\x3\x2\x2\x2\x3C2{\x3\x2\x2\x2\x3C3\x3C1"+
+		"\x3\x2\x2\x2\x3C4\x3C5\x5\x16E\xB8\x2\x3C5}\x3\x2\x2\x2\x3C6\x3C7\a\xA6"+
+		"\x2\x2\x3C7\x3C8\x5\x1B2\xDA\x2\x3C8\x3CA\x5\x36\x1C\x2\x3C9\x3CB\x5\x1B2"+
+		"\xDA\x2\x3CA\x3C9\x3\x2\x2\x2\x3CA\x3CB\x3\x2\x2\x2\x3CB\x3CC\x3\x2\x2"+
+		"\x2\x3CC\x3CE\a)\x2\x2\x3CD\x3CF\x5\x1B2\xDA\x2\x3CE\x3CD\x3\x2\x2\x2"+
+		"\x3CE\x3CF\x3\x2\x2\x2\x3CF\x3D1\x3\x2\x2\x2\x3D0\x3D2\x5\x80\x41\x2\x3D1"+
+		"\x3D0\x3\x2\x2\x2\x3D1\x3D2\x3\x2\x2\x2\x3D2\x3D4\x3\x2\x2\x2\x3D3\x3D5"+
+		"\x5\x1B2\xDA\x2\x3D4\x3D3\x3\x2\x2\x2\x3D4\x3D5\x3\x2\x2\x2\x3D5\x3D6"+
+		"\x3\x2\x2\x2\x3D6\x3D8\a)\x2\x2\x3D7\x3D9\x5\x1B2\xDA\x2\x3D8\x3D7\x3"+
+		"\x2\x2\x2\x3D8\x3D9\x3\x2\x2\x2\x3D9\x3DA\x3\x2\x2\x2\x3DA\x3DB\x5\x82"+
+		"\x42\x2\x3DB\x7F\x3\x2\x2\x2\x3DC\x3DD\x5\x16E\xB8\x2\x3DD\x81\x3\x2\x2"+
+		"\x2\x3DE\x3DF\x5\x16E\xB8\x2\x3DF\x83\x3\x2\x2\x2\x3E0\x3E1\as\x2\x2\x3E1"+
+		"\x3E2\x5\x1B2\xDA\x2\x3E2\x3E4\x5\x36\x1C\x2\x3E3\x3E5\x5\x1B2\xDA\x2"+
+		"\x3E4\x3E3\x3\x2\x2\x2\x3E4\x3E5\x3\x2\x2\x2\x3E5\x3E6\x3\x2\x2\x2\x3E6"+
+		"\x3E8\a)\x2\x2\x3E7\x3E9\x5\x1B2\xDA\x2\x3E8\x3E7\x3\x2\x2\x2\x3E8\x3E9"+
+		"\x3\x2\x2\x2\x3E9\x3EB\x3\x2\x2\x2\x3EA\x3EC\x5\x80\x41\x2\x3EB\x3EA\x3"+
+		"\x2\x2\x2\x3EB\x3EC\x3\x2\x2\x2\x3EC\x3EE\x3\x2\x2\x2\x3ED\x3EF\x5\x1B2"+
+		"\xDA\x2\x3EE\x3ED\x3\x2\x2\x2\x3EE\x3EF\x3\x2\x2\x2\x3EF\x3F0\x3\x2\x2"+
+		"\x2\x3F0\x3F2\a)\x2\x2\x3F1\x3F3\x5\x1B2\xDA\x2\x3F2\x3F1\x3\x2\x2\x2"+
+		"\x3F2\x3F3\x3\x2\x2\x2\x3F3\x3F4\x3\x2\x2\x2\x3F4\x3F5\x5\x86\x44\x2\x3F5"+
+		"\x85\x3\x2\x2\x2\x3F6\x3F7\x5\x16E\xB8\x2\x3F7\x87\x3\x2\x2\x2\x3F8\x3F9"+
+		"\x5\x16C\xB7\x2\x3F9\x3FA\x5\x1B2\xDA\x2\x3FA\x3FC\x3\x2\x2\x2\x3FB\x3F8"+
+		"\x3\x2\x2\x2\x3FB\x3FC\x3\x2\x2\x2\x3FC\x3FD\x3\x2\x2\x2\x3FD\x3FE\a\x44"+
+		"\x2\x2\x3FE\x3FF\x5\x1B2\xDA\x2\x3FF\x40A\x5\x8A\x46\x2\x400\x402\x5\x1B2"+
+		"\xDA\x2\x401\x400\x3\x2\x2\x2\x401\x402\x3\x2\x2\x2\x402\x403\x3\x2\x2"+
+		"\x2\x403\x405\a)\x2\x2\x404\x406\x5\x1B2\xDA\x2\x405\x404\x3\x2\x2\x2"+
+		"\x405\x406\x3\x2\x2\x2\x406\x407\x3\x2\x2\x2\x407\x409\x5\x8A\x46\x2\x408"+
+		"\x401\x3\x2\x2\x2\x409\x40C\x3\x2\x2\x2\x40A\x408\x3\x2\x2\x2\x40A\x40B"+
+		"\x3\x2\x2\x2\x40B\x89\x3\x2\x2\x2\x40C\x40A\x3\x2\x2\x2\x40D\x411\x5\x148"+
+		"\xA5\x2\x40E\x40F\x5\x1B2\xDA\x2\x40F\x410\x5\x154\xAB\x2\x410\x412\x3"+
+		"\x2\x2\x2\x411\x40E\x3\x2\x2\x2\x411\x412\x3\x2\x2\x2\x412\x414\x3\x2"+
+		"\x2\x2\x413\x415\x5\x1B2\xDA\x2\x414\x413\x3\x2\x2\x2\x414\x415\x3\x2"+
+		"\x2\x2\x415\x416\x3\x2\x2\x2\x416\x418\a\xD1\x2\x2\x417\x419\x5\x1B2\xDA"+
+		"\x2\x418\x417\x3\x2\x2\x2\x418\x419\x3\x2\x2\x2\x419\x41A\x3\x2\x2\x2"+
+		"\x41A\x41B\x5\x16E\xB8\x2\x41B\x8B\x3\x2\x2\x2\x41C\x41D\x5\x16C\xB7\x2"+
+		"\x41D\x41E\x5\x1B2\xDA\x2\x41E\x420\x3\x2\x2\x2\x41F\x41C\x3\x2\x2\x2"+
+		"\x41F\x420\x3\x2\x2\x2\x420\x421\x3\x2\x2\x2\x421\x422\aG\x2\x2\x422\x425"+
+		"\x5\x1B2\xDA\x2\x423\x424\a\xA4\x2\x2\x424\x426\x5\x1B2\xDA\x2\x425\x423"+
+		"\x3\x2\x2\x2\x425\x426\x3\x2\x2\x2\x426\x427\x3\x2\x2\x2\x427\x428\t\a"+
+		"\x2\x2\x428\x429\x5\x1B2\xDA\x2\x429\x42A\x5\x148\xA5\x2\x42A\x42B\x5"+
+		"\x1B2\xDA\x2\x42B\x42C\a\x82\x2\x2\x42C\x42D\x5\x1B2\xDA\x2\x42D\x433"+
+		"\a\xDF\x2\x2\x42E\x42F\x5\x1B2\xDA\x2\x42F\x430\a\x35\x2\x2\x430\x431"+
+		"\x5\x1B2\xDA\x2\x431\x432\a\xDF\x2\x2\x432\x434\x3\x2\x2\x2\x433\x42E"+
+		"\x3\x2\x2\x2\x433\x434\x3\x2\x2\x2\x434\x439\x3\x2\x2\x2\x435\x437\x5"+
+		"\x1B2\xDA\x2\x436\x435\x3\x2\x2\x2\x436\x437\x3\x2\x2\x2\x437\x438\x3"+
+		"\x2\x2\x2\x438\x43A\x5\x8EH\x2\x439\x436\x3\x2\x2\x2\x439\x43A\x3\x2\x2"+
+		"\x2\x43A\x43E\x3\x2\x2\x2\x43B\x43C\x5\x1B2\xDA\x2\x43C\x43D\x5\x154\xAB"+
+		"\x2\x43D\x43F\x3\x2\x2\x2\x43E\x43B\x3\x2\x2\x2\x43E\x43F\x3\x2\x2\x2"+
+		"\x43F\x8D\x3\x2\x2\x2\x440\x452\a\xD5\x2\x2\x441\x443\x5\x1B2\xDA\x2\x442"+
+		"\x441\x3\x2\x2\x2\x442\x443\x3\x2\x2\x2\x443\x444\x3\x2\x2\x2\x444\x44F"+
+		"\x5\x90I\x2\x445\x447\x5\x1B2\xDA\x2\x446\x445\x3\x2\x2\x2\x446\x447\x3"+
+		"\x2\x2\x2\x447\x448\x3\x2\x2\x2\x448\x44A\a)\x2\x2\x449\x44B\x5\x1B2\xDA"+
+		"\x2\x44A\x449\x3\x2\x2\x2\x44A\x44B\x3\x2\x2\x2\x44B\x44C\x3\x2\x2\x2"+
+		"\x44C\x44E\x5\x90I\x2\x44D\x446\x3\x2\x2\x2\x44E\x451\x3\x2\x2\x2\x44F"+
+		"\x44D\x3\x2\x2\x2\x44F\x450\x3\x2\x2\x2\x450\x453\x3\x2\x2\x2\x451\x44F"+
+		"\x3\x2\x2\x2\x452\x442\x3\x2\x2\x2\x452\x453\x3\x2\x2\x2\x453\x455\x3"+
+		"\x2\x2\x2\x454\x456\x5\x1B2\xDA\x2\x455\x454\x3\x2\x2\x2\x455\x456\x3"+
+		"\x2\x2\x2\x456\x457\x3\x2\x2\x2\x457\x458\a\xDC\x2\x2\x458\x8F\x3\x2\x2"+
+		"\x2\x459\x45A\a\x96\x2\x2\x45A\x45C\x5\x1B2\xDA\x2\x45B\x459\x3\x2\x2"+
+		"\x2\x45B\x45C\x3\x2\x2\x2\x45C\x45F\x3\x2\x2\x2\x45D\x45E\t\b\x2\x2\x45E"+
+		"\x460\x5\x1B2\xDA\x2\x45F\x45D\x3\x2\x2\x2\x45F\x460\x3\x2\x2\x2\x460"+
+		"\x463\x3\x2\x2\x2\x461\x462\a\x9D\x2\x2\x462\x464\x5\x1B2\xDA\x2\x463"+
+		"\x461\x3\x2\x2\x2\x463\x464\x3\x2\x2\x2\x464\x465\x3\x2\x2\x2\x465\x46E"+
+		"\x5\x146\xA4\x2\x466\x468\x5\x1B2\xDA\x2\x467\x466\x3\x2\x2\x2\x467\x468"+
+		"\x3\x2\x2\x2\x468\x469\x3\x2\x2\x2\x469\x46B\a\xD5\x2\x2\x46A\x46C\x5"+
+		"\x1B2\xDA\x2\x46B\x46A\x3\x2\x2\x2\x46B\x46C\x3\x2\x2\x2\x46C\x46D\x3"+
+		"\x2\x2\x2\x46D\x46F\a\xDC\x2\x2\x46E\x467\x3\x2\x2\x2\x46E\x46F\x3\x2"+
+		"\x2\x2\x46F\x474\x3\x2\x2\x2\x470\x472\x5\x1B2\xDA\x2\x471\x470\x3\x2"+
+		"\x2\x2\x471\x472\x3\x2\x2\x2\x472\x473\x3\x2\x2\x2\x473\x475\x5\x154\xAB"+
+		"\x2\x474\x471\x3\x2\x2\x2\x474\x475\x3\x2\x2\x2\x475\x47A\x3\x2\x2\x2"+
+		"\x476\x478\x5\x1B2\xDA\x2\x477\x476\x3\x2\x2\x2\x477\x478\x3\x2\x2\x2"+
+		"\x478\x479\x3\x2\x2\x2\x479\x47B\x5\x92J\x2\x47A\x477\x3\x2\x2\x2\x47A"+
+		"\x47B\x3\x2\x2\x2\x47B\x91\x3\x2\x2\x2\x47C\x47E\a\xD1\x2\x2\x47D\x47F"+
+		"\x5\x1B2\xDA\x2\x47E\x47D\x3\x2\x2\x2\x47E\x47F\x3\x2\x2\x2\x47F\x480"+
+		"\x3\x2\x2\x2\x480\x481\x5\x16E\xB8\x2\x481\x93\x3\x2\x2\x2\x482\x483\x5"+
+		"\x96L\x2\x483\x484\x5\x1B2\xDA\x2\x484\x48F\x5\x98M\x2\x485\x487\x5\x1B2"+
+		"\xDA\x2\x486\x485\x3\x2\x2\x2\x486\x487\x3\x2\x2\x2\x487\x488\x3\x2\x2"+
+		"\x2\x488\x48A\a)\x2\x2\x489\x48B\x5\x1B2\xDA\x2\x48A\x489\x3\x2\x2\x2"+
+		"\x48A\x48B\x3\x2\x2\x2\x48B\x48C\x3\x2\x2\x2\x48C\x48E\x5\x98M\x2\x48D"+
+		"\x486\x3\x2\x2\x2\x48E\x491\x3\x2\x2\x2\x48F\x48D\x3\x2\x2\x2\x48F\x490"+
+		"\x3\x2\x2\x2\x490\x95\x3\x2\x2\x2\x491\x48F\x3\x2\x2\x2\x492\x493\t\t"+
+		"\x2\x2\x493\x97\x3\x2\x2\x2\x494\x498\x5\x9AN\x2\x495\x498\x5\x9CO\x2"+
+		"\x496\x498\x5\xA2R\x2\x497\x494\x3\x2\x2\x2\x497\x495\x3\x2\x2\x2\x497"+
+		"\x496\x3\x2\x2\x2\x498\x99\x3\x2\x2\x2\x499\x49A\x5\x146\xA4\x2\x49A\x9B"+
+		"\x3\x2\x2\x2\x49B\x49D\x5\x9EP\x2\x49C\x49E\x5\x1B2\xDA\x2\x49D\x49C\x3"+
+		"\x2\x2\x2\x49D\x49E\x3\x2\x2\x2\x49E\x49F\x3\x2\x2\x2\x49F\x4A1\a\xD7"+
+		"\x2\x2\x4A0\x4A2\x5\x1B2\xDA\x2\x4A1\x4A0\x3\x2\x2\x2\x4A1\x4A2\x3\x2"+
+		"\x2\x2\x4A2\x4A3\x3\x2\x2\x2\x4A3\x4A4\x5\xA0Q\x2\x4A4\x9D\x3\x2\x2\x2"+
+		"\x4A5\x4A6\x6P\x2\x2\x4A6\x4A7\x5\x146\xA4\x2\x4A7\x9F\x3\x2\x2\x2\x4A8"+
+		"\x4A9\x6Q\x3\x2\x4A9\x4AA\x5\x146\xA4\x2\x4AA\xA1\x3\x2\x2\x2\x4AB\x4AD"+
+		"\x5\xA4S\x2\x4AC\x4AE\x5\x1B2\xDA\x2\x4AD\x4AC\x3\x2\x2\x2\x4AD\x4AE\x3"+
+		"\x2\x2\x2\x4AE\x4AF\x3\x2\x2\x2\x4AF\x4B1\a\xD7\x2\x2\x4B0\x4B2\x5\x1B2"+
+		"\xDA\x2\x4B1\x4B0\x3\x2\x2\x2\x4B1\x4B2\x3\x2\x2\x2\x4B2\x4B3\x3\x2\x2"+
+		"\x2\x4B3\x4B4\x5\xA6T\x2\x4B4\xA3\x3\x2\x2\x2\x4B5\x4B6\x5\x146\xA4\x2"+
+		"\x4B6\xA5\x3\x2\x2\x2\x4B7\x4B8\x5\x146\xA4\x2\x4B8\xA7\x3\x2\x2\x2\x4B9"+
+		"\x4BA\aV\x2\x2\x4BA\x4BB\x5\x19C\xCF\x2\x4BB\x4BC\x5\x1E\x10\x2\x4BC\x4BD"+
+		"\a\x80\x2\x2\x4BD\x4D1\x3\x2\x2\x2\x4BE\x4BF\aV\x2\x2\x4BF\x4C0\x5\x1B2"+
+		"\xDA\x2\x4C0\x4C1\t\n\x2\x2\x4C1\x4C2\x5\x1B2\xDA\x2\x4C2\x4C3\x5\x16E"+
+		"\xB8\x2\x4C3\x4C4\x5\x19C\xCF\x2\x4C4\x4C5\x5\x1E\x10\x2\x4C5\x4C6\a\x80"+
+		"\x2\x2\x4C6\x4D1\x3\x2\x2\x2\x4C7\x4C8\aV\x2\x2\x4C8\x4C9\x5\x19C\xCF"+
+		"\x2\x4C9\x4CA\x5\x1E\x10\x2\x4CA\x4CB\a\x80\x2\x2\x4CB\x4CC\x5\x1B2\xDA"+
+		"\x2\x4CC\x4CD\t\n\x2\x2\x4CD\x4CE\x5\x1B2\xDA\x2\x4CE\x4CF\x5\x16E\xB8"+
+		"\x2\x4CF\x4D1\x3\x2\x2\x2\x4D0\x4B9\x3\x2\x2\x2\x4D0\x4BE\x3\x2\x2\x2"+
+		"\x4D0\x4C7\x3\x2\x2\x2\x4D1\xA9\x3\x2\x2\x2\x4D2\x4D3\x5\x16C\xB7\x2\x4D3"+
+		"\x4D4\x5\x1B2\xDA\x2\x4D4\x4D6\x3\x2\x2\x2\x4D5\x4D2\x3\x2\x2\x2\x4D5"+
+		"\x4D6\x3\x2\x2\x2\x4D6\x4D7\x3\x2\x2\x2\x4D7\x4D8\a\x65\x2\x2\x4D8\x4D9"+
+		"\x5\x1B2\xDA\x2\x4D9\x4DA\x5\x148\xA5\x2\x4DA\x4DE\x5\x19C\xCF\x2\x4DB"+
+		"\x4DD\x5\xACW\x2\x4DC\x4DB\x3\x2\x2\x2\x4DD\x4E0\x3\x2\x2\x2\x4DE\x4DC"+
+		"\x3\x2\x2\x2\x4DE\x4DF\x3\x2\x2\x2\x4DF\x4E1\x3\x2\x2\x2\x4E0\x4DE\x3"+
+		"\x2\x2\x2\x4E1\x4E2\a\\\x2\x2\x4E2\xAB\x3\x2\x2\x2\x4E3\x4EC\x5\x148\xA5"+
+		"\x2\x4E4\x4E6\x5\x1B2\xDA\x2\x4E5\x4E4\x3\x2\x2\x2\x4E5\x4E6\x3\x2\x2"+
+		"\x2\x4E6\x4E7\x3\x2\x2\x2\x4E7\x4E9\a\xD1\x2\x2\x4E8\x4EA\x5\x1B2\xDA"+
+		"\x2\x4E9\x4E8\x3\x2\x2\x2\x4E9\x4EA\x3\x2\x2\x2\x4EA\x4EB\x3\x2\x2\x2"+
+		"\x4EB\x4ED\x5\x16E\xB8\x2\x4EC\x4E5\x3\x2\x2\x2\x4EC\x4ED\x3\x2\x2\x2"+
+		"\x4ED\x4EE\x3\x2\x2\x2\x4EE\x4EF\x5\x19C\xCF\x2\x4EF\xAD\x3\x2\x2\x2\x4F0"+
+		"\x4F1\a\x64\x2\x2\x4F1\xAF\x3\x2\x2\x2\x4F2\x4F3\ag\x2\x2\x4F3\x4F4\x5"+
+		"\x1B2\xDA\x2\x4F4\x4FF\x5\x16E\xB8\x2\x4F5\x4F7\x5\x1B2\xDA\x2\x4F6\x4F5"+
+		"\x3\x2\x2\x2\x4F6\x4F7\x3\x2\x2\x2\x4F7\x4F8\x3\x2\x2\x2\x4F8\x4FA\a)"+
+		"\x2\x2\x4F9\x4FB\x5\x1B2\xDA\x2\x4FA\x4F9\x3\x2\x2\x2\x4FA\x4FB\x3\x2"+
+		"\x2\x2\x4FB\x4FC\x3\x2\x2\x2\x4FC\x4FE\x5\x16E\xB8\x2\x4FD\x4F6\x3\x2"+
+		"\x2\x2\x4FE\x501\x3\x2\x2\x2\x4FF\x4FD\x3\x2\x2\x2\x4FF\x500\x3\x2\x2"+
+		"\x2\x500\xB1\x3\x2\x2\x2\x501\x4FF\x3\x2\x2\x2\x502\x503\ah\x2\x2\x503"+
+		"\x504\x5\x1B2\xDA\x2\x504\x505\x5\x16E\xB8\x2\x505\xB3\x3\x2\x2\x2\x506"+
+		"\x507\x5\x16C\xB7\x2\x507\x508\x5\x1B2\xDA\x2\x508\x50A\x3\x2\x2\x2\x509"+
+		"\x506\x3\x2\x2\x2\x509\x50A\x3\x2\x2\x2\x50A\x50B\x3\x2\x2\x2\x50B\x50C"+
+		"\ai\x2\x2\x50C\x50D\x5\x1B2\xDA\x2\x50D\x50F\x5\x148\xA5\x2\x50E\x510"+
+		"\x5\x1B2\xDA\x2\x50F\x50E\x3\x2\x2\x2\x50F\x510\x3\x2\x2\x2\x510\x511"+
+		"\x3\x2\x2\x2\x511\x512\x5\x8EH\x2\x512\xB5\x3\x2\x2\x2\x513\x514\t\v\x2"+
+		"\x2\x514\xB7\x3\x2\x2\x2\x515\x516\aq\x2\x2\x516\x517\x5\x1B2\xDA\x2\x517"+
+		"\x518\aX\x2\x2\x518\x519\x5\x1B2\xDA\x2\x519\x51A\x5\x16E\xB8\x2\x51A"+
+		"\x51B\x5\x1B2\xDA\x2\x51B\x51C\az\x2\x2\x51C\x51D\x5\x1B2\xDA\x2\x51D"+
+		"\x51E\x5\x16E\xB8\x2\x51E\x51F\x5\x19C\xCF\x2\x51F\x520\x5\x1E\x10\x2"+
+		"\x520\x524\a\x8C\x2\x2\x521\x522\x5\x1B2\xDA\x2\x522\x523\x5\x16E\xB8"+
+		"\x2\x523\x525\x3\x2\x2\x2\x524\x521\x3\x2\x2\x2\x524\x525\x3\x2\x2\x2"+
+		"\x525\xB9\x3\x2\x2\x2\x526\x527\aq\x2\x2\x527\x528\x5\x1B2\xDA\x2\x528"+
+		"\x529\x5\x16E\xB8\x2\x529\x52A\x5\x1B2\xDA\x2\x52A\x52B\a\xBF\x2\x2\x52B"+
+		"\x52C\x5\x1B2\xDA\x2\x52C\x532\x5\x16E\xB8\x2\x52D\x52E\x5\x1B2\xDA\x2"+
+		"\x52E\x52F\a\xB8\x2\x2\x52F\x530\x5\x1B2\xDA\x2\x530\x531\x5\x16E\xB8"+
+		"\x2\x531\x533\x3\x2\x2\x2\x532\x52D\x3\x2\x2\x2\x532\x533\x3\x2\x2\x2"+
+		"\x533\x534\x3\x2\x2\x2\x534\x535\x5\x19C\xCF\x2\x535\x536\x5\x1E\x10\x2"+
+		"\x536\x53A\a\x8C\x2\x2\x537\x538\x5\x1B2\xDA\x2\x538\x539\x5\x16E\xB8"+
+		"\x2\x539\x53B\x3\x2\x2\x2\x53A\x537\x3\x2\x2\x2\x53A\x53B\x3\x2\x2\x2"+
+		"\x53B\xBB\x3\x2\x2\x2\x53C\x53D\x5\x16C\xB7\x2\x53D\x53E\x5\x1B2\xDA\x2"+
+		"\x53E\x540\x3\x2\x2\x2\x53F\x53C\x3\x2\x2\x2\x53F\x540\x3\x2\x2\x2\x540"+
+		"\x543\x3\x2\x2\x2\x541\x542\a\xB7\x2\x2\x542\x544\x5\x1B2\xDA\x2\x543"+
+		"\x541\x3\x2\x2\x2\x543\x544\x3\x2\x2\x2\x544\x545\x3\x2\x2\x2\x545\x547"+
+		"\ar\x2\x2\x546\x548\x5\x1B2\xDA\x2\x547\x546\x3\x2\x2\x2\x547\x548\x3"+
+		"\x2\x2\x2\x548\x549\x3\x2\x2\x2\x549\x54E\x5\xBE`\x2\x54A\x54C\x5\x1B2"+
+		"\xDA\x2\x54B\x54A\x3\x2\x2\x2\x54B\x54C\x3\x2\x2\x2\x54C\x54D\x3\x2\x2"+
+		"\x2\x54D\x54F\x5\x8EH\x2\x54E\x54B\x3\x2\x2\x2\x54E\x54F\x3\x2\x2\x2\x54F"+
+		"\x554\x3\x2\x2\x2\x550\x552\x5\x1B2\xDA\x2\x551\x550\x3\x2\x2\x2\x551"+
+		"\x552\x3\x2\x2\x2\x552\x553\x3\x2\x2\x2\x553\x555\x5\x154\xAB\x2\x554"+
+		"\x551\x3\x2\x2\x2\x554\x555\x3\x2\x2\x2\x555\x556\x3\x2\x2\x2\x556\x557"+
+		"\x5\x19C\xCF\x2\x557\x558\x5\x1E\x10\x2\x558\x559\a]\x2\x2\x559\xBD\x3"+
+		"\x2\x2\x2\x55A\x55B\x5\x148\xA5\x2\x55B\xBF\x3\x2\x2\x2\x55C\x55D\au\x2"+
+		"\x2\x55D\x55E\x5\x1B2\xDA\x2\x55E\x55F\x5\x16E\xB8\x2\x55F\xC1\x3\x2\x2"+
+		"\x2\x560\x561\av\x2\x2\x561\x562\x5\x1B2\xDA\x2\x562\x563\x5\x16E\xB8"+
+		"\x2\x563\xC3\x3\x2\x2\x2\x564\x565\aw\x2\x2\x565\x566\x5\x1B2\xDA\x2\x566"+
+		"\x567\x5\xD6l\x2\x567\x568\x5\x1B2\xDA\x2\x568\x569\a\xBE\x2\x2\x569\x56A"+
+		"\x5\x19C\xCF\x2\x56A\x56E\x5\x1E\x10\x2\x56B\x56D\x5\xC6\x64\x2\x56C\x56B"+
+		"\x3\x2\x2\x2\x56D\x570\x3\x2\x2\x2\x56E\x56C\x3\x2\x2\x2\x56E\x56F\x3"+
+		"\x2\x2\x2\x56F\x572\x3\x2\x2\x2\x570\x56E\x3\x2\x2\x2\x571\x573\x5\xC8"+
+		"\x65\x2\x572\x571\x3\x2\x2\x2\x572\x573\x3\x2\x2\x2\x573\x574\x3\x2\x2"+
+		"\x2\x574\x575\a^\x2\x2\x575\xC5\x3\x2\x2\x2\x576\x577\aZ\x2\x2\x577\x578"+
+		"\x5\x1B2\xDA\x2\x578\x579\x5\xD6l\x2\x579\x57A\x5\x1B2\xDA\x2\x57A\x57B"+
+		"\a\xBE\x2\x2\x57B\x57C\x5\x19C\xCF\x2\x57C\x57D\x5\x1E\x10\x2\x57D\x589"+
+		"\x3\x2\x2\x2\x57E\x57F\aZ\x2\x2\x57F\x580\x5\x1B2\xDA\x2\x580\x581\x5"+
+		"\xD6l\x2\x581\x582\x5\x1B2\xDA\x2\x582\x584\a\xBE\x2\x2\x583\x585\x5\x1B2"+
+		"\xDA\x2\x584\x583\x3\x2\x2\x2\x584\x585\x3\x2\x2\x2\x585\x586\x3\x2\x2"+
+		"\x2\x586\x587\x5\x1E\x10\x2\x587\x589\x3\x2\x2\x2\x588\x576\x3\x2\x2\x2"+
+		"\x588\x57E\x3\x2\x2\x2\x589\xC7\x3\x2\x2\x2\x58A\x58B\aY\x2\x2\x58B\x58C"+
+		"\x5\x19C\xCF\x2\x58C\x58D\x5\x1E\x10\x2\x58D\xC9\x3\x2\x2\x2\x58E\x591"+
+		"\x5\xCCg\x2\x58F\x591\x5\xCEh\x2\x590\x58E\x3\x2\x2\x2\x590\x58F\x3\x2"+
+		"\x2\x2\x591\xCB\x3\x2\x2\x2\x592\x594\aw\x2\x2\x593\x595\x5\x1B2\xDA\x2"+
+		"\x594\x593\x3\x2\x2\x2\x594\x595\x3\x2\x2\x2\x595\x596\x3\x2\x2\x2\x596"+
+		"\x598\x5\xD6l\x2\x597\x599\x5\x1B2\xDA\x2\x598\x597\x3\x2\x2\x2\x598\x599"+
+		"\x3\x2\x2\x2\x599\x59A\x3\x2\x2\x2\x59A\x59C\a\xBE\x2\x2\x59B\x59D\x5"+
+		"\x1B2\xDA\x2\x59C\x59B\x3\x2\x2\x2\x59C\x59D\x3\x2\x2\x2\x59D\x59E\x3"+
+		"\x2\x2\x2\x59E\x5A2\x5\xD2j\x2\x59F\x5A0\x5\x1B2\xDA\x2\x5A0\x5A1\x5\xD0"+
+		"i\x2\x5A1\x5A3\x3\x2\x2\x2\x5A2\x59F\x3\x2\x2\x2\x5A2\x5A3\x3\x2\x2\x2"+
+		"\x5A3\xCD\x3\x2\x2\x2\x5A4\x5A6\aw\x2\x2\x5A5\x5A7\x5\x1B2\xDA\x2\x5A6"+
+		"\x5A5\x3\x2\x2\x2\x5A6\x5A7\x3\x2\x2\x2\x5A7\x5A8\x3\x2\x2\x2\x5A8\x5AA"+
+		"\x5\xD6l\x2\x5A9\x5AB\x5\x1B2\xDA\x2\x5AA\x5A9\x3\x2\x2\x2\x5AA\x5AB\x3"+
+		"\x2\x2\x2\x5AB\x5AC\x3\x2\x2\x2\x5AC\x5AD\a\xBE\x2\x2\x5AD\x5AF\x5\x19C"+
+		"\xCF\x2\x5AE\x5B0\x5\x1B2\xDA\x2\x5AF\x5AE\x3\x2\x2\x2\x5AF\x5B0\x3\x2"+
+		"\x2\x2\x5B0\x5B1\x3\x2\x2\x2\x5B1\x5B2\x5\xD0i\x2\x5B2\xCF\x3\x2\x2\x2"+
+		"\x5B3\x5B5\aY\x2\x2\x5B4\x5B6\x5\x1B2\xDA\x2\x5B5\x5B4\x3\x2\x2\x2\x5B5"+
+		"\x5B6\x3\x2\x2\x2\x5B6\x5B8\x3\x2\x2\x2\x5B7\x5B9\x5\xD2j\x2\x5B8\x5B7"+
+		"\x3\x2\x2\x2\x5B8\x5B9\x3\x2\x2\x2\x5B9\xD1\x3\x2\x2\x2\x5BA\x5C7\x5\x164"+
+		"\xB3\x2\x5BB\x5BD\x5\x1B2\xDA\x2\x5BC\x5BB\x3\x2\x2\x2\x5BC\x5BD\x3\x2"+
+		"\x2\x2\x5BD\x5BE\x3\x2\x2\x2\x5BE\x5C0\a*\x2\x2\x5BF\x5C1\x5\x1B2\xDA"+
+		"\x2\x5C0\x5BF\x3\x2\x2\x2\x5C0\x5C1\x3\x2\x2\x2\x5C1\x5C3\x3\x2\x2\x2"+
+		"\x5C2\x5C4\x5\xD4k\x2\x5C3\x5C2\x3\x2\x2\x2\x5C3\x5C4\x3\x2\x2\x2\x5C4"+
+		"\x5C6\x3\x2\x2\x2\x5C5\x5BC\x3\x2\x2\x2\x5C6\x5C9\x3\x2\x2\x2\x5C7\x5C5"+
+		"\x3\x2\x2\x2\x5C7\x5C8\x3\x2\x2\x2\x5C8\x5E1\x3\x2\x2\x2\x5C9\x5C7\x3"+
+		"\x2\x2\x2\x5CA\x5CC\a*\x2\x2\x5CB\x5CD\x5\x1B2\xDA\x2\x5CC\x5CB\x3\x2"+
+		"\x2\x2\x5CC\x5CD\x3\x2\x2\x2\x5CD\x5CF\x3\x2\x2\x2\x5CE\x5CA\x3\x2\x2"+
+		"\x2\x5CE\x5CF\x3\x2\x2\x2\x5CF\x5D0\x3\x2\x2\x2\x5D0\x5DD\x5\xD4k\x2\x5D1"+
+		"\x5D3\x5\x1B2\xDA\x2\x5D2\x5D1\x3\x2\x2\x2\x5D2\x5D3\x3\x2\x2\x2\x5D3"+
+		"\x5D4\x3\x2\x2\x2\x5D4\x5D6\a*\x2\x2\x5D5\x5D7\x5\x1B2\xDA\x2\x5D6\x5D5"+
+		"\x3\x2\x2\x2\x5D6\x5D7\x3\x2\x2\x2\x5D7\x5D9\x3\x2\x2\x2\x5D8\x5DA\x5"+
+		"\xD4k\x2\x5D9\x5D8\x3\x2\x2\x2\x5D9\x5DA\x3\x2\x2\x2\x5DA\x5DC\x3\x2\x2"+
+		"\x2\x5DB\x5D2\x3\x2\x2\x2\x5DC\x5DF\x3\x2\x2\x2\x5DD\x5DB\x3\x2\x2\x2"+
+		"\x5DD\x5DE\x3\x2\x2\x2\x5DE\x5E1\x3\x2\x2\x2\x5DF\x5DD\x3\x2\x2\x2\x5E0"+
+		"\x5BA\x3\x2\x2\x2\x5E0\x5CE\x3\x2\x2\x2\x5E1\xD3\x3\x2\x2\x2\x5E2\x5E3"+
+		"\x5 \x11\x2\x5E3\xD5\x3\x2\x2\x2\x5E4\x5E5\x5\x16E\xB8\x2\x5E5\xD7\x3"+
+		"\x2\x2\x2\x5E6\x5E7\ay\x2\x2\x5E7\x5E8\x5\x1B2\xDA\x2\x5E8\x5E9\x5\x16E"+
+		"\xB8\x2\x5E9\xD9\x3\x2\x2\x2\x5EA\x5EB\a\x81\x2\x2\x5EB\x5ED\x5\x1B2\xDA"+
+		"\x2\x5EC\x5EA\x3\x2\x2\x2\x5EC\x5ED\x3\x2\x2\x2\x5ED\x5EE\x3\x2\x2\x2"+
+		"\x5EE\x5F0\x5\x17A\xBE\x2\x5EF\x5F1\x5\x1B2\xDA\x2\x5F0\x5EF\x3\x2\x2"+
+		"\x2\x5F0\x5F1\x3\x2\x2\x2\x5F1\x5F2\x3\x2\x2\x2\x5F2\x5F4\a\xD1\x2\x2"+
+		"\x5F3\x5F5\x5\x1B2\xDA\x2\x5F4\x5F3\x3\x2\x2\x2\x5F4\x5F5\x3\x2\x2\x2"+
+		"\x5F5\x5F6\x3\x2\x2\x2\x5F6\x5F7\x5\x16E\xB8\x2\x5F7\xDB\x3\x2\x2\x2\x5F8"+
+		"\x5F9\a\x88\x2\x2\x5F9\x5FA\x5\x1B2\xDA\x2\x5FA\x5FC\x5\x16E\xB8\x2\x5FB"+
+		"\x5FD\x5\x1B2\xDA\x2\x5FC\x5FB\x3\x2\x2\x2\x5FC\x5FD\x3\x2\x2\x2\x5FD"+
+		"\x5FE\x3\x2\x2\x2\x5FE\x600\a\xD1\x2\x2\x5FF\x601\x5\x1B2\xDA\x2\x600"+
+		"\x5FF\x3\x2\x2\x2\x600\x601\x3\x2\x2\x2\x601\x602\x3\x2\x2\x2\x602\x603"+
+		"\x5\x16E\xB8\x2\x603\xDD\x3\x2\x2\x2\x604\x605\t\f\x2\x2\x605\x60E\x5"+
+		"\x1B2\xDA\x2\x606\x607\av\x2\x2\x607\x608\x5\x1B2\xDA\x2\x608\x609\x5"+
+		"\x16E\xB8\x2\x609\x60F\x3\x2\x2\x2\x60A\x60B\a\xAE\x2\x2\x60B\x60C\x5"+
+		"\x1B2\xDA\x2\x60C\x60D\a\x8C\x2\x2\x60D\x60F\x3\x2\x2\x2\x60E\x606\x3"+
+		"\x2\x2\x2\x60E\x60A\x3\x2\x2\x2\x60F\xDF\x3\x2\x2\x2\x610\x611\a\x92\x2"+
+		"\x2\x611\x612\x5\x1B2\xDA\x2\x612\x613\x5\x16E\xB8\x2\x613\x614\x5\x1B2"+
+		"\xDA\x2\x614\x615\av\x2\x2\x615\x616\x5\x1B2\xDA\x2\x616\x621\x5\x16E"+
+		"\xB8\x2\x617\x619\x5\x1B2\xDA\x2\x618\x617\x3\x2\x2\x2\x618\x619\x3\x2"+
+		"\x2\x2\x619\x61A\x3\x2\x2\x2\x61A\x61C\a)\x2\x2\x61B\x61D\x5\x1B2\xDA"+
+		"\x2\x61C\x61B\x3\x2\x2\x2\x61C\x61D\x3\x2\x2\x2\x61D\x61E\x3\x2\x2\x2"+
+		"\x61E\x620\x5\x16E\xB8\x2\x61F\x618\x3\x2\x2\x2\x620\x623\x3\x2\x2\x2"+
+		"\x621\x61F\x3\x2\x2\x2\x621\x622\x3\x2\x2\x2\x622\xE1\x3\x2\x2\x2\x623"+
+		"\x621\x3\x2\x2\x2\x624\x625\a\x92\x2\x2\x625\x626\x5\x1B2\xDA\x2\x626"+
+		"\x627\x5\x16E\xB8\x2\x627\x628\x5\x1B2\xDA\x2\x628\x629\au\x2\x2\x629"+
+		"\x62A\x5\x1B2\xDA\x2\x62A\x635\x5\x16E\xB8\x2\x62B\x62D\x5\x1B2\xDA\x2"+
+		"\x62C\x62B\x3\x2\x2\x2\x62C\x62D\x3\x2\x2\x2\x62D\x62E\x3\x2\x2\x2\x62E"+
+		"\x630\a)\x2\x2\x62F\x631\x5\x1B2\xDA\x2\x630\x62F\x3\x2\x2\x2\x630\x631"+
+		"\x3\x2\x2\x2\x631\x632\x3\x2\x2\x2\x632\x634\x5\x16E\xB8\x2\x633\x62C"+
+		"\x3\x2\x2\x2\x634\x637\x3\x2\x2\x2\x635\x633\x3\x2\x2\x2\x635\x636\x3"+
+		"\x2\x2\x2\x636\xE3\x3\x2\x2\x2\x637\x635\x3\x2\x2\x2\x638\x639\x5\x16C"+
+		"\xB7\x2\x639\x63A\x5\x1B2\xDA\x2\x63A\x63C\x3\x2\x2\x2\x63B\x638\x3\x2"+
+		"\x2\x2\x63B\x63C\x3\x2\x2\x2\x63C\x63F\x3\x2\x2\x2\x63D\x63E\a\xB7\x2"+
+		"\x2\x63E\x640\x5\x1B2\xDA\x2\x63F\x63D\x3\x2\x2\x2\x63F\x640\x3\x2\x2"+
+		"\x2\x640\x641\x3\x2\x2\x2\x641\x642\a\xA1\x2\x2\x642\x643\x5\x1B2\xDA"+
+		"\x2\x643\x648\x5\xBE`\x2\x644\x646\x5\x1B2\xDA\x2\x645\x644\x3\x2\x2\x2"+
+		"\x645\x646\x3\x2\x2\x2\x646\x647\x3\x2\x2\x2\x647\x649\x5\x8EH\x2\x648"+
+		"\x645\x3\x2\x2\x2\x648\x649\x3\x2\x2\x2\x649\x64D\x3\x2\x2\x2\x64A\x64B"+
+		"\x5\x1B2\xDA\x2\x64B\x64C\x5\x154\xAB\x2\x64C\x64E\x3\x2\x2\x2\x64D\x64A"+
+		"\x3\x2\x2\x2\x64D\x64E\x3\x2\x2\x2\x64E\x64F\x3\x2\x2\x2\x64F\x650\x5"+
+		"\x19C\xCF\x2\x650\x651\x5\x1E\x10\x2\x651\x652\a_\x2\x2\x652\xE5\x3\x2"+
+		"\x2\x2\x653\x654\x5\x16C\xB7\x2\x654\x655\x5\x1B2\xDA\x2\x655\x657\x3"+
+		"\x2\x2\x2\x656\x653\x3\x2\x2\x2\x656\x657\x3\x2\x2\x2\x657\x65A\x3\x2"+
+		"\x2\x2\x658\x659\a\xB7\x2\x2\x659\x65B\x5\x1B2\xDA\x2\x65A\x658\x3\x2"+
+		"\x2\x2\x65A\x65B\x3\x2\x2\x2\x65B\x65C\x3\x2\x2\x2\x65C\x65D\a\xA3\x2"+
+		"\x2\x65D\x65E\x5\x1B2\xDA\x2\x65E\x663\x5\x114\x8B\x2\x65F\x661\x5\x1B2"+
+		"\xDA\x2\x660\x65F\x3\x2\x2\x2\x660\x661\x3\x2\x2\x2\x661\x662\x3\x2\x2"+
+		"\x2\x662\x664\x5\x8EH\x2\x663\x660\x3\x2\x2\x2\x663\x664\x3\x2\x2\x2\x664"+
+		"\x665\x3\x2\x2\x2\x665\x666\x5\x19C\xCF\x2\x666\x667\x5\x1E\x10\x2\x667"+
+		"\x668\a_\x2\x2\x668\xE7\x3\x2\x2\x2\x669\x66A\x5\x16C\xB7\x2\x66A\x66B"+
+		"\x5\x1B2\xDA\x2\x66B\x66D\x3\x2\x2\x2\x66C\x669\x3\x2\x2\x2\x66C\x66D"+
+		"\x3\x2\x2\x2\x66D\x670\x3\x2\x2\x2\x66E\x66F\a\xB7\x2\x2\x66F\x671\x5"+
+		"\x1B2\xDA\x2\x670\x66E\x3\x2\x2\x2\x670\x671\x3\x2\x2\x2\x671\x672\x3"+
+		"\x2\x2\x2\x672\x673\a\xA2\x2\x2\x673\x674\x5\x1B2\xDA\x2\x674\x679\x5"+
+		"\x114\x8B\x2\x675\x677\x5\x1B2\xDA\x2\x676\x675\x3\x2\x2\x2\x676\x677"+
+		"\x3\x2\x2\x2\x677\x678\x3\x2\x2\x2\x678\x67A\x5\x8EH\x2\x679\x676\x3\x2"+
+		"\x2\x2\x679\x67A\x3\x2\x2\x2\x67A\x67B\x3\x2\x2\x2\x67B\x67C\x5\x19C\xCF"+
+		"\x2\x67C\x67D\x5\x1E\x10\x2\x67D\x67E\a_\x2\x2\x67E\xE9\x3\x2\x2\x2\x67F"+
+		"\x680\a\xA8\x2\x2\x680\x681\x5\x1B2\xDA\x2\x681\x690\x5\x148\xA5\x2\x682"+
+		"\x684\x5\x1B2\xDA\x2\x683\x682\x3\x2\x2\x2\x683\x684\x3\x2\x2\x2\x684"+
+		"\x685\x3\x2\x2\x2\x685\x687\a\xD5\x2\x2\x686\x688\x5\x1B2\xDA\x2\x687"+
+		"\x686\x3\x2\x2\x2\x687\x688\x3\x2\x2\x2\x688\x68A\x3\x2\x2\x2\x689\x68B"+
+		"\x5\xECw\x2\x68A\x689\x3\x2\x2\x2\x68A\x68B\x3\x2\x2\x2\x68B\x68D\x3\x2"+
+		"\x2\x2\x68C\x68E\x5\x1B2\xDA\x2\x68D\x68C\x3\x2\x2\x2\x68D\x68E\x3\x2"+
+		"\x2\x2\x68E\x68F\x3\x2\x2\x2\x68F\x691\a\xDC\x2\x2\x690\x683\x3\x2\x2"+
+		"\x2\x690\x691\x3\x2\x2\x2\x691\xEB\x3\x2\x2\x2\x692\x69D\x5\xEEx\x2\x693"+
+		"\x695\x5\x1B2\xDA\x2\x694\x693\x3\x2\x2\x2\x694\x695\x3\x2\x2\x2\x695"+
+		"\x696\x3\x2\x2\x2\x696\x698\a)\x2\x2\x697\x699\x5\x1B2\xDA\x2\x698\x697"+
+		"\x3\x2\x2\x2\x698\x699\x3\x2\x2\x2\x699\x69A\x3\x2\x2\x2\x69A\x69C\x5"+
+		"\xEEx\x2\x69B\x694\x3\x2\x2\x2\x69C\x69F\x3\x2\x2\x2\x69D\x69B\x3\x2\x2"+
+		"\x2\x69D\x69E\x3\x2\x2\x2\x69E\xED\x3\x2\x2\x2\x69F\x69D\x3\x2\x2\x2\x6A0"+
+		"\x6A1\x5\x16E\xB8\x2\x6A1\xEF\x3\x2\x2\x2\x6A2\x6A3\a\xAB\x2\x2\x6A3\x6A6"+
+		"\x5\x1B2\xDA\x2\x6A4\x6A5\a\x9E\x2\x2\x6A5\x6A7\x5\x1B2\xDA\x2\x6A6\x6A4"+
+		"\x3\x2\x2\x2\x6A6\x6A7\x3\x2\x2\x2\x6A7\x6A8\x3\x2\x2\x2\x6A8\x6A9\x5"+
+		"\xF2z\x2\x6A9\xF1\x3\x2\x2\x2\x6AA\x6B5\x5\xF4{\x2\x6AB\x6AD\x5\x1B2\xDA"+
+		"\x2\x6AC\x6AB\x3\x2\x2\x2\x6AC\x6AD\x3\x2\x2\x2\x6AD\x6AE\x3\x2\x2\x2"+
+		"\x6AE\x6B0\a)\x2\x2\x6AF\x6B1\x5\x1B2\xDA\x2\x6B0\x6AF\x3\x2\x2\x2\x6B0"+
+		"\x6B1\x3\x2\x2\x2\x6B1\x6B2\x3\x2\x2\x2\x6B2\x6B4\x5\xF4{\x2\x6B3\x6AC"+
+		"\x3\x2\x2\x2\x6B4\x6B7\x3\x2\x2\x2\x6B5\x6B3\x3\x2\x2\x2\x6B5\x6B6\x3"+
+		"\x2\x2\x2\x6B6\xF3\x3\x2\x2\x2\x6B7\x6B5\x3\x2\x2\x2\x6B8\x6BC\x5\x16E"+
+		"\xB8\x2\x6B9\x6BA\x5\x1B2\xDA\x2\x6BA\x6BB\x5\x154\xAB\x2\x6BB\x6BD\x3"+
+		"\x2\x2\x2\x6BC\x6B9\x3\x2\x2\x2\x6BC\x6BD\x3\x2\x2\x2\x6BD\xF5\x3\x2\x2"+
+		"\x2\x6BE\x6BF\x5\x16E\xB8\x2\x6BF\xF7\x3\x2\x2\x2\x6C0\x6C1\a@\x2\x2\x6C1"+
+		"\x6C2\x5\x1B2\xDA\x2\x6C2\x6C3\x5\x16E\xB8\x2\x6C3\x6CB\x3\x2\x2\x2\x6C4"+
+		"\x6C8\x5\x16E\xB8\x2\x6C5\x6C6\x5\x1B2\xDA\x2\x6C6\x6C7\x5\x17E\xC0\x2"+
+		"\x6C7\x6C9\x3\x2\x2\x2\x6C8\x6C5\x3\x2\x2\x2\x6C8\x6C9\x3\x2\x2\x2\x6C9"+
+		"\x6CB\x3\x2\x2\x2\x6CA\x6C0\x3\x2\x2\x2\x6CA\x6C4\x3\x2\x2\x2\x6CB\xF9"+
+		"\x3\x2\x2\x2\x6CC\x6D2\a\xAE\x2\x2\x6CD\x6D0\x5\x1B2\xDA\x2\x6CE\x6D1"+
+		"\a\x8C\x2\x2\x6CF\x6D1\x5\x16E\xB8\x2\x6D0\x6CE\x3\x2\x2\x2\x6D0\x6CF"+
+		"\x3\x2\x2\x2\x6D1\x6D3\x3\x2\x2\x2\x6D2\x6CD\x3\x2\x2\x2\x6D2\x6D3\x3"+
+		"\x2\x2\x2\x6D3\xFB\x3\x2\x2\x2\x6D4\x6D5\a\xAF\x2\x2\x6D5\xFD\x3\x2\x2"+
+		"\x2\x6D6\x6D7\a\xB0\x2\x2\x6D7\x6D8\x5\x1B2\xDA\x2\x6D8\x6DA\x5\x16E\xB8"+
+		"\x2\x6D9\x6DB\x5\x1B2\xDA\x2\x6DA\x6D9\x3\x2\x2\x2\x6DA\x6DB\x3\x2\x2"+
+		"\x2\x6DB\x6DC\x3\x2\x2\x2\x6DC\x6DE\a\xD1\x2\x2\x6DD\x6DF\x5\x1B2\xDA"+
+		"\x2\x6DE\x6DD\x3\x2\x2\x2\x6DE\x6DF\x3\x2\x2\x2\x6DF\x6E0\x3\x2\x2\x2"+
+		"\x6E0\x6E1\x5\x16E\xB8\x2\x6E1\xFF\x3\x2\x2\x2\x6E2\x6E3\a\xB9\x2\x2\x6E3"+
+		"\x101\x3\x2\x2\x2\x6E4\x6E6\a\xB2\x2\x2\x6E5\x6E7\x5\x1B2\xDA\x2\x6E6"+
+		"\x6E5\x3\x2\x2\x2\x6E6\x6E7\x3\x2\x2\x2\x6E7\x6E8\x3\x2\x2\x2\x6E8\x6EA"+
+		"\a\x41\x2\x2\x6E9\x6EB\x5\x1B2\xDA\x2\x6EA\x6E9\x3\x2\x2\x2\x6EA\x6EB"+
+		"\x3\x2\x2\x2\x6EB\x6EC\x3\x2\x2\x2\x6EC\x6ED\x5\x104\x83\x2\x6ED\x6F1"+
+		"\x5\x19C\xCF\x2\x6EE\x6F0\x5\x106\x84\x2\x6EF\x6EE\x3\x2\x2\x2\x6F0\x6F3"+
+		"\x3\x2\x2\x2\x6F1\x6EF\x3\x2\x2\x2\x6F1\x6F2\x3\x2\x2\x2\x6F2\x6F5\x3"+
+		"\x2\x2\x2\x6F3\x6F1\x3\x2\x2\x2\x6F4\x6F6\x5\x108\x85\x2\x6F5\x6F4\x3"+
+		"\x2\x2\x2\x6F5\x6F6\x3\x2\x2\x2\x6F6\x6F7\x3\x2\x2\x2\x6F7\x6F8\a`\x2"+
+		"\x2\x6F8\x103\x3\x2\x2\x2\x6F9\x6FA\x5\x16E\xB8\x2\x6FA\x105\x3\x2\x2"+
+		"\x2\x6FB\x6FC\a\x41\x2\x2\x6FC\x6FD\x5\x1B2\xDA\x2\x6FD\x708\x5\x10A\x86"+
+		"\x2\x6FE\x700\x5\x1B2\xDA\x2\x6FF\x6FE\x3\x2\x2\x2\x6FF\x700\x3\x2\x2"+
+		"\x2\x700\x701\x3\x2\x2\x2\x701\x703\a)\x2\x2\x702\x704\x5\x1B2\xDA\x2"+
+		"\x703\x702\x3\x2\x2\x2\x703\x704\x3\x2\x2\x2\x704\x705\x3\x2\x2\x2\x705"+
+		"\x707\x5\x10A\x86\x2\x706\x6FF\x3\x2\x2\x2\x707\x70A\x3\x2\x2\x2\x708"+
+		"\x706\x3\x2\x2\x2\x708\x709\x3\x2\x2\x2\x709\x70B\x3\x2\x2\x2\x70A\x708"+
+		"\x3\x2\x2\x2\x70B\x70C\x5\x19C\xCF\x2\x70C\x70D\x5\x1E\x10\x2\x70D\x107"+
+		"\x3\x2\x2\x2\x70E\x710\a\x41\x2\x2\x70F\x711\x5\x1B2\xDA\x2\x710\x70F"+
+		"\x3\x2\x2\x2\x710\x711\x3\x2\x2\x2\x711\x712\x3\x2\x2\x2\x712\x713\aY"+
+		"\x2\x2\x713\x714\x5\x19C\xCF\x2\x714\x715\x5\x1E\x10\x2\x715\x109\x3\x2"+
+		"\x2\x2\x716\x72A\x5\x16E\xB8\x2\x717\x718\x5\x10C\x87\x2\x718\x719\x5"+
+		"\x1B2\xDA\x2\x719\x71A\a\xBF\x2\x2\x71A\x71B\x5\x1B2\xDA\x2\x71B\x71C"+
+		"\x5\x10E\x88\x2\x71C\x72A\x3\x2\x2\x2\x71D\x71F\a|\x2\x2\x71E\x720\x5"+
+		"\x1B2\xDA\x2\x71F\x71E\x3\x2\x2\x2\x71F\x720\x3\x2\x2\x2\x720\x722\x3"+
+		"\x2\x2\x2\x721\x71D\x3\x2\x2\x2\x721\x722\x3\x2\x2\x2\x722\x723\x3\x2"+
+		"\x2\x2\x723\x725\x5\x158\xAD\x2\x724\x726\x5\x1B2\xDA\x2\x725\x724\x3"+
+		"\x2\x2\x2\x725\x726\x3\x2\x2\x2\x726\x727\x3\x2\x2\x2\x727\x728\x5\x16E"+
+		"\xB8\x2\x728\x72A\x3\x2\x2\x2\x729\x716\x3\x2\x2\x2\x729\x717\x3\x2\x2"+
+		"\x2\x729\x721\x3\x2\x2\x2\x72A\x10B\x3\x2\x2\x2\x72B\x72C\x5\x16E\xB8"+
+		"\x2\x72C\x10D\x3\x2\x2\x2\x72D\x72E\x5\x16E\xB8\x2\x72E\x10F\x3\x2\x2"+
+		"\x2\x72F\x730\a\xB3\x2\x2\x730\x731\x5\x1B2\xDA\x2\x731\x733\x5\x17A\xBE"+
+		"\x2\x732\x734\x5\x1B2\xDA\x2\x733\x732\x3\x2\x2\x2\x733\x734\x3\x2\x2"+
+		"\x2\x734\x735\x3\x2\x2\x2\x735\x737\a\xD1\x2\x2\x736\x738\x5\x1B2\xDA"+
+		"\x2\x737\x736\x3\x2\x2\x2\x737\x738\x3\x2\x2\x2\x738\x739\x3\x2\x2\x2"+
+		"\x739\x73A\x5\x16E\xB8\x2\x73A\x111\x3\x2\x2\x2\x73B\x73C\x5\x16C\xB7"+
+		"\x2\x73C\x73D\x5\x1B2\xDA\x2\x73D\x73F\x3\x2\x2\x2\x73E\x73B\x3\x2\x2"+
+		"\x2\x73E\x73F\x3\x2\x2\x2\x73F\x742\x3\x2\x2\x2\x740\x741\a\xB7\x2\x2"+
+		"\x741\x743\x5\x1B2\xDA\x2\x742\x740\x3\x2\x2\x2\x742\x743\x3\x2\x2\x2"+
+		"\x743\x744\x3\x2\x2\x2\x744\x746\a\xBB\x2\x2\x745\x747\x5\x1B2\xDA\x2"+
+		"\x746\x745\x3\x2\x2\x2\x746\x747\x3\x2\x2\x2\x747\x748\x3\x2\x2\x2\x748"+
+		"\x74D\x5\x114\x8B\x2\x749\x74B\x5\x1B2\xDA\x2\x74A\x749\x3\x2\x2\x2\x74A"+
+		"\x74B\x3\x2\x2\x2\x74B\x74C\x3\x2\x2\x2\x74C\x74E\x5\x8EH\x2\x74D\x74A"+
+		"\x3\x2\x2\x2\x74D\x74E\x3\x2\x2\x2\x74E\x74F\x3\x2\x2\x2\x74F\x750\x5"+
+		"\x19C\xCF\x2\x750\x751\x5\x1E\x10\x2\x751\x752\a\x61\x2\x2\x752\x113\x3"+
+		"\x2\x2\x2\x753\x754\x5\x148\xA5\x2\x754\x115\x3\x2\x2\x2\x755\x756\t\r"+
+		"\x2\x2\x756\x758\x5\x1B2\xDA\x2\x757\x755\x3\x2\x2\x2\x757\x758\x3\x2"+
+		"\x2\x2\x758\x759\x3\x2\x2\x2\x759\x75A\x5\x11A\x8E\x2\x75A\x117\x3\x2"+
+		"\x2\x2\x75B\x75C\a\xA0\x2\x2\x75C\x75D\x5\x1B2\xDA\x2\x75D\x75E\x5\x11A"+
+		"\x8E\x2\x75E\x119\x3\x2\x2\x2\x75F\x760\a\xC1\x2\x2\x760\x761\x5\x1B2"+
+		"\xDA\x2\x761\x762\x5\x14A\xA6\x2\x762\x763\x5\x19C\xCF\x2\x763\x764\x5"+
+		"\x11C\x8F\x2\x764\x765\x5\x19C\xCF\x2\x765\x766\a\x62\x2\x2\x766\x11B"+
+		"\x3\x2\x2\x2\x767\x76D\x5\x11E\x90\x2\x768\x769\x5\x19C\xCF\x2\x769\x76A"+
+		"\x5\x11E\x90\x2\x76A\x76C\x3\x2\x2\x2\x76B\x768\x3\x2\x2\x2\x76C\x76F"+
+		"\x3\x2\x2\x2\x76D\x76B\x3\x2\x2\x2\x76D\x76E\x3\x2\x2\x2\x76E\x11D\x3"+
+		"\x2\x2\x2\x76F\x76D\x3\x2\x2\x2\x770\x773\x5\x122\x92\x2\x771\x773\x5"+
+		"\x120\x91\x2\x772\x770\x3\x2\x2\x2\x772\x771\x3\x2\x2\x2\x773\x11F\x3"+
+		"\x2\x2\x2\x774\x776\x5\x14A\xA6\x2\x775\x777\x5\x1B2\xDA\x2\x776\x775"+
+		"\x3\x2\x2\x2\x776\x777\x3\x2\x2\x2\x777\x778\x3\x2\x2\x2\x778\x779\x5"+
+		"\x124\x93\x2\x779\x121\x3\x2\x2\x2\x77A\x77B\x5\x146\xA4\x2\x77B\x77C"+
+		"\x5\x1B2\xDA\x2\x77C\x77D\x5\x154\xAB\x2\x77D\x123\x3\x2\x2\x2\x77E\x77F"+
+		"\x5\x126\x94\x2\x77F\x780\x5\x1B2\xDA\x2\x780\x782\x3\x2\x2\x2\x781\x77E"+
+		"\x3\x2\x2\x2\x781\x782\x3\x2\x2\x2\x782\x783\x3\x2\x2\x2\x783\x784\x5"+
+		"\x154\xAB\x2\x784\x125\x3\x2\x2\x2\x785\x787\a\xD5\x2\x2\x786\x788\x5"+
+		"\x1B2\xDA\x2\x787\x786\x3\x2\x2\x2\x787\x788\x3\x2\x2\x2\x788\x78A\x3"+
+		"\x2\x2\x2\x789\x78B\x5\x128\x95\x2\x78A\x789\x3\x2\x2\x2\x78A\x78B\x3"+
+		"\x2\x2\x2\x78B\x78D\x3\x2\x2\x2\x78C\x78E\x5\x1B2\xDA\x2\x78D\x78C\x3"+
+		"\x2\x2\x2\x78D\x78E\x3\x2\x2\x2\x78E\x78F\x3\x2\x2\x2\x78F\x790\a\xDC"+
+		"\x2\x2\x790\x127\x3\x2\x2\x2\x791\x79C\x5\x12A\x96\x2\x792\x794\x5\x1B2"+
+		"\xDA\x2\x793\x792\x3\x2\x2\x2\x793\x794\x3\x2\x2\x2\x794\x795\x3\x2\x2"+
+		"\x2\x795\x797\a)\x2\x2\x796\x798\x5\x1B2\xDA\x2\x797\x796\x3\x2\x2\x2"+
+		"\x797\x798\x3\x2\x2\x2\x798\x799\x3\x2\x2\x2\x799\x79B\x5\x12A\x96\x2"+
+		"\x79A\x793\x3\x2\x2\x2\x79B\x79E\x3\x2\x2\x2\x79C\x79A\x3\x2\x2\x2\x79C"+
+		"\x79D\x3\x2\x2\x2\x79D\x129\x3\x2\x2\x2\x79E\x79C\x3\x2\x2\x2\x79F\x7A1"+
+		"\x5\x12C\x97\x2\x7A0\x7A2\x5\x1B2\xDA\x2\x7A1\x7A0\x3\x2\x2\x2\x7A1\x7A2"+
+		"\x3\x2\x2\x2\x7A2\x7A4\x3\x2\x2\x2\x7A3\x79F\x3\x2\x2\x2\x7A3\x7A4\x3"+
+		"\x2\x2\x2\x7A4\x7A5\x3\x2\x2\x2\x7A5\x7A6\x5\x12E\x98\x2\x7A6\x12B\x3"+
+		"\x2\x2\x2\x7A7\x7A9\x5\x130\x99\x2\x7A8\x7AA\x5\x1B2\xDA\x2\x7A9\x7A8"+
+		"\x3\x2\x2\x2\x7A9\x7AA\x3\x2\x2\x2\x7AA\x7AB\x3\x2\x2\x2\x7AB\x7AC\a\xBF"+
+		"\x2\x2\x7AC\x12D\x3\x2\x2\x2\x7AD\x7AE\x5\x130\x99\x2\x7AE\x12F\x3\x2"+
+		"\x2\x2\x7AF\x7B0\x5\x16E\xB8\x2\x7B0\x131\x3\x2\x2\x2\x7B1\x7B5\aU\x2"+
+		"\x2\x7B2\x7B5\a\xB7\x2\x2\x7B3\x7B5\x5\x16C\xB7\x2\x7B4\x7B1\x3\x2\x2"+
+		"\x2\x7B4\x7B2\x3\x2\x2\x2\x7B4\x7B3\x3\x2\x2\x2\x7B5\x7B6\x3\x2\x2\x2"+
+		"\x7B6\x7B9\x5\x1B2\xDA\x2\x7B7\x7B8\a\xCB\x2\x2\x7B8\x7BA\x5\x1B2\xDA"+
+		"\x2\x7B9\x7B7\x3\x2\x2\x2\x7B9\x7BA\x3\x2\x2\x2\x7BA\x7BB\x3\x2\x2\x2"+
+		"\x7BB\x7BC\x5\x134\x9B\x2\x7BC\x133\x3\x2\x2\x2\x7BD\x7C8\x5\x136\x9C"+
+		"\x2\x7BE\x7C0\x5\x1B2\xDA\x2\x7BF\x7BE\x3\x2\x2\x2\x7BF\x7C0\x3\x2\x2"+
+		"\x2\x7C0\x7C1\x3\x2\x2\x2\x7C1\x7C3\a)\x2\x2\x7C2\x7C4\x5\x1B2\xDA\x2"+
+		"\x7C3\x7C2\x3\x2\x2\x2\x7C3\x7C4\x3\x2\x2\x2\x7C4\x7C5\x3\x2\x2\x2\x7C5"+
+		"\x7C7\x5\x136\x9C\x2\x7C6\x7BF\x3\x2\x2\x2\x7C7\x7CA\x3\x2\x2\x2\x7C8"+
+		"\x7C6\x3\x2\x2\x2\x7C8\x7C9\x3\x2\x2\x2\x7C9\x135\x3\x2\x2\x2\x7CA\x7C8"+
+		"\x3\x2\x2\x2\x7CB\x7DD\x5\x148\xA5\x2\x7CC\x7CE\x5\x1B2\xDA\x2\x7CD\x7CC"+
+		"\x3\x2\x2\x2\x7CD\x7CE\x3\x2\x2\x2\x7CE\x7CF\x3\x2\x2\x2\x7CF\x7D1\a\xD5"+
+		"\x2\x2\x7D0\x7D2\x5\x1B2\xDA\x2\x7D1\x7D0\x3\x2\x2\x2\x7D1\x7D2\x3\x2"+
+		"\x2\x2\x7D2\x7D7\x3\x2\x2\x2\x7D3\x7D5\x5\x142\xA2\x2\x7D4\x7D6\x5\x1B2"+
+		"\xDA\x2\x7D5\x7D4\x3\x2\x2\x2\x7D5\x7D6\x3\x2\x2\x2\x7D6\x7D8\x3\x2\x2"+
+		"\x2\x7D7\x7D3\x3\x2\x2\x2\x7D7\x7D8\x3\x2\x2\x2\x7D8\x7D9\x3\x2\x2\x2"+
+		"\x7D9\x7DB\a\xDC\x2\x2\x7DA\x7DC\x5\x1B2\xDA\x2\x7DB\x7DA\x3\x2\x2\x2"+
+		"\x7DB\x7DC\x3\x2\x2\x2\x7DC\x7DE\x3\x2\x2\x2\x7DD\x7CD\x3\x2\x2\x2\x7DD"+
+		"\x7DE\x3\x2\x2\x2\x7DE\x7E2\x3\x2\x2\x2\x7DF\x7E0\x5\x1B2\xDA\x2\x7E0"+
+		"\x7E1\x5\x154\xAB\x2\x7E1\x7E3\x3\x2\x2\x2\x7E2\x7DF\x3\x2\x2\x2\x7E2"+
+		"\x7E3\x3\x2\x2\x2\x7E3\x137\x3\x2\x2\x2\x7E4\x7E5\a\xC8\x2\x2\x7E5\x7E6"+
+		"\x5\x1B2\xDA\x2\x7E6\x7E7\x5\x16E\xB8\x2\x7E7\x7E8\x5\x19C\xCF\x2\x7E8"+
+		"\x7E9\x5\x1E\x10\x2\x7E9\x7EA\a\xC7\x2\x2\x7EA\x139\x3\x2\x2\x2\x7EB\x7EC"+
+		"\a\xCA\x2\x2\x7EC\x7ED\x5\x1B2\xDA\x2\x7ED\x7EE\x5\x16E\xB8\x2\x7EE\x7EF"+
+		"\x5\x19C\xCF\x2\x7EF\x7F0\x5\x1E\x10\x2\x7F0\x7F1\a\x63\x2\x2\x7F1\x13B"+
+		"\x3\x2\x2\x2\x7F2\x7F4\x5\x16E\xB8\x2\x7F3\x7F5\x5\x1B2\xDA\x2\x7F4\x7F3"+
+		"\x3\x2\x2\x2\x7F4\x7F5\x3\x2\x2\x2\x7F5\x7F6\x3\x2\x2\x2\x7F6\x7F8\a-"+
+		"\x2\x2\x7F7\x7F9\x5\x1B2\xDA\x2\x7F8\x7F7\x3\x2\x2\x2\x7F8\x7F9\x3\x2"+
+		"\x2\x2\x7F9\x7FB\x3\x2\x2\x2\x7FA\x7F2\x3\x2\x2\x2\x7FA\x7FB\x3\x2\x2"+
+		"\x2\x7FB\x7FC\x3\x2\x2\x2\x7FC\x7FD\a\r\x2\x2\x7FD\x802\x5\x1B2\xDA\x2"+
+		"\x7FE\x800\a\xB8\x2\x2\x7FF\x801\x5\x1B2\xDA\x2\x800\x7FF\x3\x2\x2\x2"+
+		"\x800\x801\x3\x2\x2\x2\x801\x803\x3\x2\x2\x2\x802\x7FE\x3\x2\x2\x2\x802"+
+		"\x803\x3\x2\x2\x2\x803\x804\x3\x2\x2\x2\x804\x80D\x5\x140\xA1\x2\x805"+
+		"\x807\x5\x1B2\xDA\x2\x806\x805\x3\x2\x2\x2\x806\x807\x3\x2\x2\x2\x807"+
+		"\x808\x3\x2\x2\x2\x808\x80A\a)\x2\x2\x809\x80B\x5\x1B2\xDA\x2\x80A\x809"+
+		"\x3\x2\x2\x2\x80A\x80B\x3\x2\x2\x2\x80B\x80C\x3\x2\x2\x2\x80C\x80E\x5"+
+		"\x16E\xB8\x2\x80D\x806\x3\x2\x2\x2\x80E\x80F\x3\x2\x2\x2\x80F\x80D\x3"+
+		"\x2\x2\x2\x80F\x810\x3\x2\x2\x2\x810\x13D\x3\x2\x2\x2\x811\x813\x5\x16E"+
+		"\xB8\x2\x812\x814\x5\x1B2\xDA\x2\x813\x812\x3\x2\x2\x2\x813\x814\x3\x2"+
+		"\x2\x2\x814\x815\x3\x2\x2\x2\x815\x817\a-\x2\x2\x816\x818\x5\x1B2\xDA"+
+		"\x2\x817\x816\x3\x2\x2\x2\x817\x818\x3\x2\x2\x2\x818\x81A\x3\x2\x2\x2"+
+		"\x819\x811\x3\x2\x2\x2\x819\x81A\x3\x2\x2\x2\x81A\x81B\x3\x2\x2\x2\x81B"+
+		"\x81C\a&\x2\x2\x81C\x81D\x5\x1B2\xDA\x2\x81D\x81F\x5\x140\xA1\x2\x81E"+
+		"\x820\x5\x1B2\xDA\x2\x81F\x81E\x3\x2\x2\x2\x81F\x820\x3\x2\x2\x2\x820"+
+		"\x821\x3\x2\x2\x2\x821\x823\a\xD7\x2\x2\x822\x824\x5\x1B2\xDA\x2\x823"+
+		"\x822\x3\x2\x2\x2\x823\x824\x3\x2\x2\x2\x824\x825\x3\x2\x2\x2\x825\x826"+
+		"\x5\x140\xA1\x2\x826\x13F\x3\x2\x2\x2\x827\x829\a\xD5\x2\x2\x828\x82A"+
+		"\x5\x1B2\xDA\x2\x829\x828\x3\x2\x2\x2\x829\x82A\x3\x2\x2\x2\x82A\x82B"+
+		"\x3\x2\x2\x2\x82B\x82D\x5\x16E\xB8\x2\x82C\x82E\x5\x1B2\xDA\x2\x82D\x82C"+
+		"\x3\x2\x2\x2\x82D\x82E\x3\x2\x2\x2\x82E\x82F\x3\x2\x2\x2\x82F\x831\a)"+
+		"\x2\x2\x830\x832\x5\x1B2\xDA\x2\x831\x830\x3\x2\x2\x2\x831\x832\x3\x2"+
+		"\x2\x2\x832\x833\x3\x2\x2\x2\x833\x835\x5\x16E\xB8\x2\x834\x836\x5\x1B2"+
+		"\xDA\x2\x835\x834\x3\x2\x2\x2\x835\x836\x3\x2\x2\x2\x836\x837\x3\x2\x2"+
+		"\x2\x837\x838\a\xDC\x2\x2\x838\x141\x3\x2\x2\x2\x839\x844\x5\x144\xA3"+
+		"\x2\x83A\x83C\x5\x1B2\xDA\x2\x83B\x83A\x3\x2\x2\x2\x83B\x83C\x3\x2\x2"+
+		"\x2\x83C\x83D\x3\x2\x2\x2\x83D\x83F\a)\x2\x2\x83E\x840\x5\x1B2\xDA\x2"+
+		"\x83F\x83E\x3\x2\x2\x2\x83F\x840\x3\x2\x2\x2\x840\x841\x3\x2\x2\x2\x841"+
+		"\x843\x5\x144\xA3\x2\x842\x83B\x3\x2\x2\x2\x843\x846\x3\x2\x2\x2\x844"+
+		"\x842\x3\x2\x2\x2\x844\x845\x3\x2\x2\x2\x845\x143\x3\x2\x2\x2\x846\x844"+
+		"\x3\x2\x2\x2\x847\x848\x5\x16E\xB8\x2\x848\x849\x5\x1B2\xDA\x2\x849\x84A"+
+		"\a\xBF\x2\x2\x84A\x84B\x5\x1B2\xDA\x2\x84B\x84D\x3\x2\x2\x2\x84C\x847"+
+		"\x3\x2\x2\x2\x84C\x84D\x3\x2\x2\x2\x84D\x84E\x3\x2\x2\x2\x84E\x84F\x5"+
+		"\x16E\xB8\x2\x84F\x145\x3\x2\x2\x2\x850\x854\x5\x148\xA5\x2\x851\x854"+
+		"\x5\x198\xCD\x2\x852\x854\x5\x196\xCC\x2\x853\x850\x3\x2\x2\x2\x853\x851"+
+		"\x3\x2\x2\x2\x853\x852\x3\x2\x2\x2\x854\x147\x3\x2\x2\x2\x855\x858\x5"+
+		"\x14A\xA6\x2\x856\x858\x5\x14C\xA7\x2\x857\x855\x3\x2\x2\x2\x857\x856"+
+		"\x3\x2\x2\x2\x858\x149\x3\x2\x2\x2\x859\x85A\x5\x14E\xA8\x2\x85A\x14B"+
+		"\x3\x2\x2\x2\x85B\x85C\x5\x14E\xA8\x2\x85C\x85D\x5\x16A\xB6\x2\x85D\x14D"+
+		"\x3\x2\x2\x2\x85E\x862\a\xEA\x2\x2\x85F\x862\x5\x194\xCB\x2\x860\x862"+
+		"\x5\x150\xA9\x2\x861\x85E\x3\x2\x2\x2\x861\x85F\x3\x2\x2\x2\x861\x860"+
+		"\x3\x2\x2\x2\x862\x14F\x3\x2\x2\x2\x863\x867\a\xDD\x2\x2\x864\x866\x5"+
+		"\x152\xAA\x2\x865\x864\x3\x2\x2\x2\x866\x869\x3\x2\x2\x2\x867\x865\x3"+
+		"\x2\x2\x2\x867\x868\x3\x2\x2\x2\x868\x86A\x3\x2\x2\x2\x869\x867\x3\x2"+
+		"\x2\x2\x86A\x86B\a\xDE\x2\x2\x86B\x151\x3\x2\x2\x2\x86C\x86F\n\xE\x2\x2"+
+		"\x86D\x86F\x5\x150\xA9\x2\x86E\x86C\x3\x2\x2\x2\x86E\x86D\x3\x2\x2\x2"+
+		"\x86F\x153\x3\x2\x2\x2\x870\x872\a\x39\x2\x2\x871\x873\x5\x1B2\xDA\x2"+
+		"\x872\x871\x3\x2\x2\x2\x872\x873\x3\x2\x2\x2\x873\x876\x3\x2\x2\x2\x874"+
+		"\x875\a\x8D\x2\x2\x875\x877\x5\x1B2\xDA\x2\x876\x874\x3\x2\x2\x2\x876"+
+		"\x877\x3\x2\x2\x2\x877\x878\x3\x2\x2\x2\x878\x87D\x5\x168\xB5\x2\x879"+
+		"\x87B\x5\x1B2\xDA\x2\x87A\x879\x3\x2\x2\x2\x87A\x87B\x3\x2\x2\x2\x87B"+
+		"\x87C\x3\x2\x2\x2\x87C\x87E\x5\x15C\xAF\x2\x87D\x87A\x3\x2\x2\x2\x87D"+
+		"\x87E\x3\x2\x2\x2\x87E\x155\x3\x2\x2\x2\x87F\x880\t\xF\x2\x2\x880\x157"+
+		"\x3\x2\x2\x2\x881\x882\t\x10\x2\x2\x882\x159\x3\x2\x2\x2\x883\x884\x5"+
+		"\x16E\xB8\x2\x884\x15B\x3\x2\x2\x2\x885\x887\a\xD8\x2\x2\x886\x888\x5"+
+		"\x1B2\xDA\x2\x887\x886\x3\x2\x2\x2\x887\x888\x3\x2\x2\x2\x888\x889\x3"+
+		"\x2\x2\x2\x889\x88A\x5\x16E\xB8\x2\x88A\x15D\x3\x2\x2\x2\x88B\x88D\x5"+
+		"\x160\xB1\x2\x88C\x88E\x5\x1B2\xDA\x2\x88D\x88C\x3\x2\x2\x2\x88D\x88E"+
+		"\x3\x2\x2\x2\x88E\x88F\x3\x2\x2\x2\x88F\x890\a*\x2\x2\x890\x15F\x3\x2"+
+		"\x2\x2\x891\x894\x5\x162\xB2\x2\x892\x894\x5\x164\xB3\x2\x893\x891\x3"+
+		"\x2\x2\x2\x893\x892\x3\x2\x2\x2\x894\x161\x3\x2\x2\x2\x895\x896\x5\x146"+
+		"\xA4\x2\x896\x163\x3\x2\x2\x2\x897\x898\x5\x166\xB4\x2\x898\x165\x3\x2"+
+		"\x2\x2\x899\x89A\t\x11\x2\x2\x89A\x167\x3\x2\x2\x2\x89B\x89E\x5\x156\xAC"+
+		"\x2\x89C\x89E\x5\x15A\xAE\x2\x89D\x89B\x3\x2\x2\x2\x89D\x89C\x3\x2\x2"+
+		"\x2\x89E\x8A7\x3\x2\x2\x2\x89F\x8A1\x5\x1B2\xDA\x2\x8A0\x89F\x3\x2\x2"+
+		"\x2\x8A0\x8A1\x3\x2\x2\x2\x8A1\x8A2\x3\x2\x2\x2\x8A2\x8A4\a\xD5\x2\x2"+
+		"\x8A3\x8A5\x5\x1B2\xDA\x2\x8A4\x8A3\x3\x2\x2\x2\x8A4\x8A5\x3\x2\x2\x2"+
+		"\x8A5\x8A6\x3\x2\x2\x2\x8A6\x8A8\a\xDC\x2\x2\x8A7\x8A0\x3\x2\x2\x2\x8A7"+
+		"\x8A8\x3\x2\x2\x2\x8A8\x169\x3\x2\x2\x2\x8A9\x8AA\t\x12\x2\x2\x8AA\x16B"+
+		"\x3\x2\x2\x2\x8AB\x8AC\t\x13\x2\x2\x8AC\x16D\x3\x2\x2\x2\x8AD\x8AE\b\xB8"+
+		"\x1\x2\x8AE\x8AF\a\xC2\x2\x2\x8AF\x8B0\x5\x1B2\xDA\x2\x8B0\x8B1\x5\x16E"+
+		"\xB8\x13\x8B1\x8D0\x3\x2\x2\x2\x8B2\x8B3\a\x8D\x2\x2\x8B3\x8B4\x5\x1B2"+
+		"\xDA\x2\x8B4\x8B5\x5\x16E\xB8\x12\x8B5\x8D0\x3\x2\x2\x2\x8B6\x8B8\a\xD7"+
+		"\x2\x2\x8B7\x8B9\x5\x1B2\xDA\x2\x8B8\x8B7\x3\x2\x2\x2\x8B8\x8B9\x3\x2"+
+		"\x2\x2\x8B9\x8BA\x3\x2\x2\x2\x8BA\x8D0\x5\x16E\xB8\x10\x8BB\x8BD\a\x8E"+
+		"\x2\x2\x8BC\x8BE\x5\x1B2\xDA\x2\x8BD\x8BC\x3\x2\x2\x2\x8BD\x8BE\x3\x2"+
+		"\x2\x2\x8BE\x8BF\x3\x2\x2\x2\x8BF\x8D0\x5\x16E\xB8\t\x8C0\x8C1\a.\x2\x2"+
+		"\x8C1\x8D0\x5\x16E\xB8\x3\x8C2\x8D0\x5\x170\xB9\x2\x8C3\x8D0\x5\x17A\xBE"+
+		"\x2\x8C4\x8D0\x5\x17C\xBF\x2\x8C5\x8C7\a\xD5\x2\x2\x8C6\x8C8\x5\x1B2\xDA"+
+		"\x2\x8C7\x8C6\x3\x2\x2\x2\x8C7\x8C8\x3\x2\x2\x2\x8C8\x8C9\x3\x2\x2\x2"+
+		"\x8C9\x8CB\x5\x16E\xB8\x2\x8CA\x8CC\x5\x1B2\xDA\x2\x8CB\x8CA\x3\x2\x2"+
+		"\x2\x8CB\x8CC\x3\x2\x2\x2\x8CC\x8CD\x3\x2\x2\x2\x8CD\x8CE\a\xDC\x2\x2"+
+		"\x8CE\x8D0\x3\x2\x2\x2\x8CF\x8AD\x3\x2\x2\x2\x8CF\x8B2\x3\x2\x2\x2\x8CF"+
+		"\x8B6\x3\x2\x2\x2\x8CF\x8BB\x3\x2\x2\x2\x8CF\x8C0\x3\x2\x2\x2\x8CF\x8C2"+
+		"\x3\x2\x2\x2\x8CF\x8C3\x3\x2\x2\x2\x8CF\x8C4\x3\x2\x2\x2\x8CF\x8C5\x3"+
+		"\x2\x2\x2\x8D0\x93F\x3\x2\x2\x2\x8D1\x8D3\f\x11\x2\x2\x8D2\x8D4\x5\x1B2"+
+		"\xDA\x2\x8D3\x8D2\x3\x2\x2\x2\x8D3\x8D4\x3\x2\x2\x2\x8D4\x8D5\x3\x2\x2"+
+		"\x2\x8D5\x8D7\a\xDB\x2\x2\x8D6\x8D8\x5\x1B2\xDA\x2\x8D7\x8D6\x3\x2\x2"+
+		"\x2\x8D7\x8D8\x3\x2\x2\x2\x8D8\x8D9\x3\x2\x2\x2\x8D9\x93E\x5\x16E\xB8"+
+		"\x12\x8DA\x8DC\f\xF\x2\x2\x8DB\x8DD\x5\x1B2\xDA\x2\x8DC\x8DB\x3\x2\x2"+
+		"\x2\x8DC\x8DD\x3\x2\x2\x2\x8DD\x8DE\x3\x2\x2\x2\x8DE\x8E0\t\x14\x2\x2"+
+		"\x8DF\x8E1\x5\x1B2\xDA\x2\x8E0\x8DF\x3\x2\x2\x2\x8E0\x8E1\x3\x2\x2\x2"+
+		"\x8E1\x8E2\x3\x2\x2\x2\x8E2\x93E\x5\x16E\xB8\x10\x8E3\x8E5\f\xE\x2\x2"+
+		"\x8E4\x8E6\x5\x1B2\xDA\x2\x8E5\x8E4\x3\x2\x2\x2\x8E5\x8E6\x3\x2\x2\x2"+
+		"\x8E6\x8E7\x3\x2\x2\x2\x8E7\x8E9\a\xD0\x2\x2\x8E8\x8EA\x5\x1B2\xDA\x2"+
+		"\x8E9\x8E8\x3\x2\x2\x2\x8E9\x8EA\x3\x2\x2\x2\x8EA\x8EB\x3\x2\x2\x2\x8EB"+
+		"\x93E\x5\x16E\xB8\xF\x8EC\x8EE\f\r\x2\x2\x8ED\x8EF\x5\x1B2\xDA\x2\x8EE"+
+		"\x8ED\x3\x2\x2\x2\x8EE\x8EF\x3\x2\x2\x2\x8EF\x8F0\x3\x2\x2\x2\x8F0\x8F2"+
+		"\a\x8B\x2\x2\x8F1\x8F3\x5\x1B2\xDA\x2\x8F2\x8F1\x3\x2\x2\x2\x8F2\x8F3"+
+		"\x3\x2\x2\x2\x8F3\x8F4\x3\x2\x2\x2\x8F4\x93E\x5\x16E\xB8\xE\x8F5\x8F7"+
+		"\f\f\x2\x2\x8F6\x8F8\x5\x1B2\xDA\x2\x8F7\x8F6\x3\x2\x2\x2\x8F7\x8F8\x3"+
+		"\x2\x2\x2\x8F8\x8F9\x3\x2\x2\x2\x8F9\x8FB\t\x15\x2\x2\x8FA\x8FC\x5\x1B2"+
+		"\xDA\x2\x8FB\x8FA\x3\x2\x2\x2\x8FB\x8FC\x3\x2\x2\x2\x8FC\x8FD\x3\x2\x2"+
+		"\x2\x8FD\x93E\x5\x16E\xB8\r\x8FE\x900\f\v\x2\x2\x8FF\x901\x5\x1B2\xDA"+
+		"\x2\x900\x8FF\x3\x2\x2\x2\x900\x901\x3\x2\x2\x2\x901\x902\x3\x2\x2\x2"+
+		"\x902\x904\a\x32\x2\x2\x903\x905\x5\x1B2\xDA\x2\x904\x903\x3\x2\x2\x2"+
+		"\x904\x905\x3\x2\x2\x2\x905\x906\x3\x2\x2\x2\x906\x93E\x5\x16E\xB8\f\x907"+
+		"\x909\f\n\x2\x2\x908\x90A\x5\x1B2\xDA\x2\x909\x908\x3\x2\x2\x2\x909\x90A"+
+		"\x3\x2\x2\x2\x90A\x90B\x3\x2\x2\x2\x90B\x90D\t\x10\x2\x2\x90C\x90E\x5"+
+		"\x1B2\xDA\x2\x90D\x90C\x3\x2\x2\x2\x90D\x90E\x3\x2\x2\x2\x90E\x90F\x3"+
+		"\x2\x2\x2\x90F\x93E\x5\x16E\xB8\v\x910\x912\f\b\x2\x2\x911\x913\x5\x1B2"+
+		"\xDA\x2\x912\x911\x3\x2\x2\x2\x912\x913\x3\x2\x2\x2\x913\x914\x3\x2\x2"+
+		"\x2\x914\x916\a\x36\x2\x2\x915\x917\x5\x1B2\xDA\x2\x916\x915\x3\x2\x2"+
+		"\x2\x916\x917\x3\x2\x2\x2\x917\x918\x3\x2\x2\x2\x918\x93E\x5\x16E\xB8"+
+		"\t\x919\x91B\f\a\x2\x2\x91A\x91C\x5\x1B2\xDA\x2\x91B\x91A\x3\x2\x2\x2"+
+		"\x91B\x91C\x3\x2\x2\x2\x91C\x91D\x3\x2\x2\x2\x91D\x91F\a\x9B\x2\x2\x91E"+
+		"\x920\x5\x1B2\xDA\x2\x91F\x91E\x3\x2\x2\x2\x91F\x920\x3\x2\x2\x2\x920"+
+		"\x921\x3\x2\x2\x2\x921\x93E\x5\x16E\xB8\b\x922\x924\f\x6\x2\x2\x923\x925"+
+		"\x5\x1B2\xDA\x2\x924\x923\x3\x2\x2\x2\x924\x925\x3\x2\x2\x2\x925\x926"+
+		"\x3\x2\x2\x2\x926\x928\a\xCD\x2\x2\x927\x929\x5\x1B2\xDA\x2\x928\x927"+
+		"\x3\x2\x2\x2\x928\x929\x3\x2\x2\x2\x929\x92A\x3\x2\x2\x2\x92A\x93E\x5"+
+		"\x16E\xB8\a\x92B\x92D\f\x5\x2\x2\x92C\x92E\x5\x1B2\xDA\x2\x92D\x92C\x3"+
+		"\x2\x2\x2\x92D\x92E\x3\x2\x2\x2\x92E\x92F\x3\x2\x2\x2\x92F\x931\a\x66"+
+		"\x2\x2\x930\x932\x5\x1B2\xDA\x2\x931\x930\x3\x2\x2\x2\x931\x932\x3\x2"+
+		"\x2\x2\x932\x933\x3\x2\x2\x2\x933\x93E\x5\x16E\xB8\x6\x934\x936\f\x4\x2"+
+		"\x2\x935\x937\x5\x1B2\xDA\x2\x936\x935\x3\x2\x2\x2\x936\x937\x3\x2\x2"+
+		"\x2\x937\x938\x3\x2\x2\x2\x938\x93A\ax\x2\x2\x939\x93B\x5\x1B2\xDA\x2"+
+		"\x93A\x939\x3\x2\x2\x2\x93A\x93B\x3\x2\x2\x2\x93B\x93C\x3\x2\x2\x2\x93C"+
+		"\x93E\x5\x16E\xB8\x5\x93D\x8D1\x3\x2\x2\x2\x93D\x8DA\x3\x2\x2\x2\x93D"+
+		"\x8E3\x3\x2\x2\x2\x93D\x8EC\x3\x2\x2\x2\x93D\x8F5\x3\x2\x2\x2\x93D\x8FE"+
+		"\x3\x2\x2\x2\x93D\x907\x3\x2\x2\x2\x93D\x910\x3\x2\x2\x2\x93D\x919\x3"+
+		"\x2\x2\x2\x93D\x922\x3\x2\x2\x2\x93D\x92B\x3\x2\x2\x2\x93D\x934\x3\x2"+
+		"\x2\x2\x93E\x941\x3\x2\x2\x2\x93F\x93D\x3\x2\x2\x2\x93F\x940\x3\x2\x2"+
+		"\x2\x940\x16F\x3\x2\x2\x2\x941\x93F\x3\x2\x2\x2\x942\x94A\x5\x166\xB4"+
+		"\x2\x943\x94A\a\xE4\x2\x2\x944\x94A\a\xDF\x2\x2\x945\x947\x5\x172\xBA"+
+		"\x2\x946\x948\x5\x16A\xB6\x2\x947\x946\x3\x2\x2\x2\x947\x948\x3\x2\x2"+
+		"\x2\x948\x94A\x3\x2\x2\x2\x949\x942\x3\x2\x2\x2\x949\x943\x3\x2\x2\x2"+
+		"\x949\x944\x3\x2\x2\x2\x949\x945\x3\x2\x2\x2\x94A\x171\x3\x2\x2\x2\x94B"+
+		"\x94F\x5\x174\xBB\x2\x94C\x94F\x5\x176\xBC\x2\x94D\x94F\x5\x178\xBD\x2"+
+		"\x94E\x94B\x3\x2\x2\x2\x94E\x94C\x3\x2\x2\x2\x94E\x94D\x3\x2\x2\x2\x94F"+
+		"\x173\x3\x2\x2\x2\x950\x951\t\x16\x2\x2\x951\x175\x3\x2\x2\x2\x952\x953"+
+		"\a\x8F\x2\x2\x953\x177\x3\x2\x2\x2\x954\x955\t\x17\x2\x2\x955\x179\x3"+
+		"\x2\x2\x2\x956\x957\b\xBE\x1\x2\x957\x964\a\x89\x2\x2\x958\x964\x5\x148"+
+		"\xA5\x2\x959\x95B\a-\x2\x2\x95A\x95C\x5\x1B0\xD9\x2\x95B\x95A\x3\x2\x2"+
+		"\x2\x95B\x95C\x3\x2\x2\x2\x95C\x95D\x3\x2\x2\x2\x95D\x964\x5\x146\xA4"+
+		"\x2\x95E\x960\a,\x2\x2\x95F\x961\x5\x1B0\xD9\x2\x960\x95F\x3\x2\x2\x2"+
+		"\x960\x961\x3\x2\x2\x2\x961\x962\x3\x2\x2\x2\x962\x964\x5\x146\xA4\x2"+
+		"\x963\x956\x3\x2\x2\x2\x963\x958\x3\x2\x2\x2\x963\x959\x3\x2\x2\x2\x963"+
+		"\x95E\x3\x2\x2\x2\x964\x988\x3\x2\x2\x2\x965\x967\f\t\x2\x2\x966\x968"+
+		"\x5\x1B2\xDA\x2\x967\x966\x3\x2\x2\x2\x967\x968\x3\x2\x2\x2\x968\x969"+
+		"\x3\x2\x2\x2\x969\x96B\a\xD5\x2\x2\x96A\x96C\x5\x1B2\xDA\x2\x96B\x96A"+
+		"\x3\x2\x2\x2\x96B\x96C\x3\x2\x2\x2\x96C\x96E\x3\x2\x2\x2\x96D\x96F\x5"+
+		"\x17E\xC0\x2\x96E\x96D\x3\x2\x2\x2\x96E\x96F\x3\x2\x2\x2\x96F\x971\x3"+
+		"\x2\x2\x2\x970\x972\x5\x1B2\xDA\x2\x971\x970\x3\x2\x2\x2\x971\x972\x3"+
+		"\x2\x2\x2\x972\x973\x3\x2\x2\x2\x973\x987\a\xDC\x2\x2\x974\x976\f\b\x2"+
+		"\x2\x975\x977\x5\x1B0\xD9\x2\x976\x975\x3\x2\x2\x2\x976\x977\x3\x2\x2"+
+		"\x2\x977\x978\x3\x2\x2\x2\x978\x97A\a-\x2\x2\x979\x97B\x5\x1B0\xD9\x2"+
+		"\x97A\x979\x3\x2\x2\x2\x97A\x97B\x3\x2\x2\x2\x97B\x97C\x3\x2\x2\x2\x97C"+
+		"\x987\x5\x146\xA4\x2\x97D\x97F\f\a\x2\x2\x97E\x980\x5\x1B0\xD9\x2\x97F"+
+		"\x97E\x3\x2\x2\x2\x97F\x980\x3\x2\x2\x2\x980\x981\x3\x2\x2\x2\x981\x983"+
+		"\a,\x2\x2\x982\x984\x5\x1B0\xD9\x2\x983\x982\x3\x2\x2\x2\x983\x984\x3"+
+		"\x2\x2\x2\x984\x985\x3\x2\x2\x2\x985\x987\x5\x146\xA4\x2\x986\x965\x3"+
+		"\x2\x2\x2\x986\x974\x3\x2\x2\x2\x986\x97D\x3\x2\x2\x2\x987\x98A\x3\x2"+
+		"\x2\x2\x988\x986\x3\x2\x2\x2\x988\x989\x3\x2\x2\x2\x989\x17B\x3\x2\x2"+
+		"\x2\x98A\x988\x3\x2\x2\x2\x98B\x9A1\x5\x156\xAC\x2\x98C\x98E\a\xDD\x2"+
+		"\x2\x98D\x98F\x5\x1B2\xDA\x2\x98E\x98D\x3\x2\x2\x2\x98E\x98F\x3\x2\x2"+
+		"\x2\x98F\x990\x3\x2\x2\x2\x990\x992\x5\x156\xAC\x2\x991\x993\x5\x1B2\xDA"+
 		"\x2\x992\x991\x3\x2\x2\x2\x992\x993\x3\x2\x2\x2\x993\x994\x3\x2\x2\x2"+
-		"\x994\x995\x5\x174\xBB\x2\x995\x173\x3\x2\x2\x2\x996\x997\a=\x2\x2\x997"+
-		"\x999\x5\x19A\xCE\x2\x998\x996\x3\x2\x2\x2\x998\x999\x3\x2\x2\x2\x999"+
-		"\x99A\x3\x2\x2\x2\x99A\x9A3\x5\x156\xAC\x2\x99B\x9A3\x5\x17A\xBE\x2\x99C"+
-		"\x99D\x5\x176\xBC\x2\x99D\x99E\x5\x19A\xCE\x2\x99E\x99F\a\xBF\x2\x2\x99F"+
-		"\x9A0\x5\x19A\xCE\x2\x9A0\x9A1\x5\x178\xBD\x2\x9A1\x9A3\x3\x2\x2\x2\x9A2"+
-		"\x998\x3\x2\x2\x2\x9A2\x99B\x3\x2\x2\x2\x9A2\x99C\x3\x2\x2\x2\x9A3\x175"+
-		"\x3\x2\x2\x2\x9A4\x9A5\x5\x156\xAC\x2\x9A5\x177\x3\x2\x2\x2\x9A6\x9A7"+
-		"\x5\x156\xAC\x2\x9A7\x179\x3\x2\x2\x2\x9A8\x9A9\a\x34\x2\x2\x9A9\x9AA"+
-		"\x5\x19A\xCE\x2\x9AA\x9AB\x5\x156\xAC\x2\x9AB\x17B\x3\x2\x2\x2\x9AC\x9AD"+
-		"\t\x17\x2\x2\x9AD\x17D\x3\x2\x2\x2\x9AE\x9AF\a\x39\x2\x2\x9AF\x17F\x3"+
-		"\x2\x2\x2\x9B0\x9B1\t\x18\x2\x2\x9B1\x181\x3\x2\x2\x2\x9B2\x9B4\x5\x19A"+
-		"\xCE\x2\x9B3\x9B2\x3\x2\x2\x2\x9B3\x9B4\x3\x2\x2\x2\x9B4\x9B5\x3\x2\x2"+
-		"\x2\x9B5\x9B7\a\xE5\x2\x2\x9B6\x9B8\x5\x19A\xCE\x2\x9B7\x9B6\x3\x2\x2"+
-		"\x2\x9B7\x9B8\x3\x2\x2\x2\x9B8\x9BE\x3\x2\x2\x2\x9B9\x9BB\x5\x19A\xCE"+
-		"\x2\x9BA\x9B9\x3\x2\x2\x2\x9BA\x9BB\x3\x2\x2\x2\x9BB\x9BC\x3\x2\x2\x2"+
-		"\x9BC\x9BE\x5\x186\xC4\x2\x9BD\x9B3\x3\x2\x2\x2\x9BD\x9BA\x3\x2\x2\x2"+
-		"\x9BE\x183\x3\x2\x2\x2\x9BF\x9C8\x5\x182\xC2\x2\x9C0\x9C2\x5\x19A\xCE"+
-		"\x2\x9C1\x9C0\x3\x2\x2\x2\x9C1\x9C2\x3\x2\x2\x2\x9C2\x9C3\x3\x2\x2\x2"+
-		"\x9C3\x9C5\a*\x2\x2\x9C4\x9C6\x5\x19A\xCE\x2\x9C5\x9C4\x3\x2\x2\x2\x9C5"+
-		"\x9C6\x3\x2\x2\x2\x9C6\x9C8\x3\x2\x2\x2\x9C7\x9BF\x3\x2\x2\x2\x9C7\x9C1"+
-		"\x3\x2\x2\x2\x9C8\x9CB\x3\x2\x2\x2\x9C9\x9C7\x3\x2\x2\x2\x9C9\x9CA\x3"+
-		"\x2\x2\x2\x9CA\x185\x3\x2\x2\x2\x9CB\x9C9\x3\x2\x2\x2\x9CC\x9D0\x5\x18E"+
-		"\xC8\x2\x9CD\x9D0\x5\x18A\xC6\x2\x9CE\x9D0\x5\x188\xC5\x2\x9CF\x9CC\x3"+
-		"\x2\x2\x2\x9CF\x9CD\x3\x2\x2\x2\x9CF\x9CE\x3\x2\x2\x2\x9D0\x187\x3\x2"+
-		"\x2\x2\x9D1\x9D3\a\xAC\x2\x2\x9D2\x9D4\x5\x19A\xCE\x2\x9D3\x9D2\x3\x2"+
-		"\x2\x2\x9D3\x9D4\x3\x2\x2\x2\x9D4\x9D5\x3\x2\x2\x2\x9D5\x9D6\x5\x18C\xC7"+
-		"\x2\x9D6\x189\x3\x2\x2\x2\x9D7\x9D8\a\xE6\x2\x2\x9D8\x9D9\x5\x18C\xC7"+
-		"\x2\x9D9\x18B\x3\x2\x2\x2\x9DA\x9DD\a\xEB\x2\x2\x9DB\x9DD\n\x19\x2\x2"+
-		"\x9DC\x9DA\x3\x2\x2\x2\x9DC\x9DB\x3\x2\x2\x2\x9DD\x9E0\x3\x2\x2\x2\x9DE"+
-		"\x9DC\x3\x2\x2\x2\x9DE\x9DF\x3\x2\x2\x2\x9DF\x18D\x3\x2\x2\x2\x9E0\x9DE"+
-		"\x3\x2\x2\x2\x9E1\x9E7\a\xE6\x2\x2\x9E2\x9E3\a/\x2\x2\x9E3\x9E5\x5\x190"+
-		"\xC9\x2\x9E4\x9E6\x5\x19A\xCE\x2\x9E5\x9E4\x3\x2\x2\x2\x9E5\x9E6\x3\x2"+
-		"\x2\x2\x9E6\x9E8\x3\x2\x2\x2\x9E7\x9E2\x3\x2\x2\x2\x9E8\x9E9\x3\x2\x2"+
-		"\x2\x9E9\x9E7\x3\x2\x2\x2\x9E9\x9EA\x3\x2\x2\x2\x9EA\x18F\x3\x2\x2\x2"+
-		"\x9EB\x9ED\x5\x192\xCA\x2\x9EC\x9EE\x5\x194\xCB\x2\x9ED\x9EC\x3\x2\x2"+
-		"\x2\x9ED\x9EE\x3\x2\x2\x2\x9EE\x191\x3\x2\x2\x2\x9EF\x9F0\x5\x12E\x98"+
-		"\x2\x9F0\x193\x3\x2\x2\x2\x9F1\x9F2\x5\x19A\xCE\x2\x9F2\x9F3\x5\x196\xCC"+
-		"\x2\x9F3\xA2E\x3\x2\x2\x2\x9F4\x9F5\x5\x19A\xCE\x2\x9F5\x9FE\x5\x196\xCC"+
-		"\x2\x9F6\x9F8\x5\x19A\xCE\x2\x9F7\x9F6\x3\x2\x2\x2\x9F7\x9F8\x3\x2\x2"+
-		"\x2\x9F8\x9F9\x3\x2\x2\x2\x9F9\x9FB\a)\x2\x2\x9FA\x9FC\x5\x19A\xCE\x2"+
-		"\x9FB\x9FA\x3\x2\x2\x2\x9FB\x9FC\x3\x2\x2\x2\x9FC\x9FD\x3\x2\x2\x2\x9FD"+
-		"\x9FF\x5\x196\xCC\x2\x9FE\x9F7\x3\x2\x2\x2\x9FF\xA00\x3\x2\x2\x2\xA00"+
-		"\x9FE\x3\x2\x2\x2\xA00\xA01\x3\x2\x2\x2\xA01\xA2E\x3\x2\x2\x2\xA02\xA04"+
-		"\x5\x19A\xCE\x2\xA03\xA02\x3\x2\x2\x2\xA03\xA04\x3\x2\x2\x2\xA04\xA05"+
-		"\x3\x2\x2\x2\xA05\xA07\a\xD5\x2\x2\xA06\xA08\x5\x19A\xCE\x2\xA07\xA06"+
-		"\x3\x2\x2\x2\xA07\xA08\x3\x2\x2\x2\xA08\xA09\x3\x2\x2\x2\xA09\xA2E\a\xDC"+
-		"\x2\x2\xA0A\xA0C\x5\x19A\xCE\x2\xA0B\xA0A\x3\x2\x2\x2\xA0B\xA0C\x3\x2"+
-		"\x2\x2\xA0C\xA0D\x3\x2\x2\x2\xA0D\xA0F\a\xD5\x2\x2\xA0E\xA10\x5\x19A\xCE"+
-		"\x2\xA0F\xA0E\x3\x2\x2\x2\xA0F\xA10\x3\x2\x2\x2\xA10\xA11\x3\x2\x2\x2"+
-		"\xA11\xA13\x5\x196\xCC\x2\xA12\xA14\x5\x19A\xCE\x2\xA13\xA12\x3\x2\x2"+
-		"\x2\xA13\xA14\x3\x2\x2\x2\xA14\xA15\x3\x2\x2\x2\xA15\xA16\a\xDC\x2\x2"+
-		"\xA16\xA2E\x3\x2\x2\x2\xA17\xA19\x5\x19A\xCE\x2\xA18\xA17\x3\x2\x2\x2"+
-		"\xA18\xA19\x3\x2\x2\x2\xA19\xA1A\x3\x2\x2\x2\xA1A\xA1B\a\xD5\x2\x2\xA1B"+
-		"\xA24\x5\x196\xCC\x2\xA1C\xA1E\x5\x19A\xCE\x2\xA1D\xA1C\x3\x2\x2\x2\xA1D"+
-		"\xA1E\x3\x2\x2\x2\xA1E\xA1F\x3\x2\x2\x2\xA1F\xA21\a)\x2\x2\xA20\xA22\x5"+
-		"\x19A\xCE\x2\xA21\xA20\x3\x2\x2\x2\xA21\xA22\x3\x2\x2\x2\xA22\xA23\x3"+
-		"\x2\x2\x2\xA23\xA25\x5\x196\xCC\x2\xA24\xA1D\x3\x2\x2\x2\xA25\xA26\x3"+
-		"\x2\x2\x2\xA26\xA24\x3\x2\x2\x2\xA26\xA27\x3\x2\x2\x2\xA27\xA29\x3\x2"+
-		"\x2\x2\xA28\xA2A\x5\x19A\xCE\x2\xA29\xA28\x3\x2\x2\x2\xA29\xA2A\x3\x2"+
-		"\x2\x2\xA2A\xA2B\x3\x2\x2\x2\xA2B\xA2C\a\xDC\x2\x2\xA2C\xA2E\x3\x2\x2"+
-		"\x2\xA2D\x9F1\x3\x2\x2\x2\xA2D\x9F4\x3\x2\x2\x2\xA2D\xA03\x3\x2\x2\x2"+
-		"\xA2D\xA0B\x3\x2\x2\x2\xA2D\xA18\x3\x2\x2\x2\xA2E\x195\x3\x2\x2\x2\xA2F"+
-		"\xA30\x5\x156\xAC\x2\xA30\x197\x3\x2\x2\x2\xA31\xA35\a\xEB\x2\x2\xA32"+
-		"\xA34\a\xE8\x2\x2\xA33\xA32\x3\x2\x2\x2\xA34\xA37\x3\x2\x2\x2\xA35\xA33"+
-		"\x3\x2\x2\x2\xA35\xA36\x3\x2\x2\x2\xA36\x199\x3\x2\x2\x2\xA37\xA35\x3"+
-		"\x2\x2\x2\xA38\xA3A\t\x1A\x2\x2\xA39\xA38\x3\x2\x2\x2\xA3A\xA3B\x3\x2"+
-		"\x2\x2\xA3B\xA39\x3\x2\x2\x2\xA3B\xA3C\x3\x2\x2\x2\xA3C\x19B\x3\x2\x2"+
-		"\x2\x188\x1A2\x1A6\x1AE\x1B4\x1B7\x1C1\x1C3\x1C9\x1D2\x1D9\x1DF\x1E8\x1EF"+
-		"\x1F3\x1F7\x1FB\x200\x20C\x219\x21C\x228\x22B\x232\x23A\x241\x267\x277"+
-		"\x27F\x284\x289\x292\x2A6\x2AA\x2B2\x2BD\x2C3\x2C7\x2CC\x2D3\x2D7\x2E1"+
-		"\x2E5\x2E8\x2EE\x2F4\x2FE\x302\x305\x30B\x30F\x319\x31D\x327\x32B\x32F"+
-		"\x33B\x33F\x342\x346\x34B\x352\x356\x35B\x363\x367\x36B\x373\x376\x37A"+
-		"\x37E\x388\x38C\x38F\x395\x399\x39F\x3A3\x3A8\x3B1\x3B5\x3B8\x3BB\x3BF"+
-		"\x3CB\x3CF\x3D2\x3D5\x3D9\x3E2\x3E8\x3EC\x3F1\x3F8\x3FB\x3FF\x406\x40C"+
-		"\x41A\x41D\x420\x425\x429\x42D\x431\x436\x439\x43C\x442\x446\x44A\x44E"+
-		"\x452\x455\x458\x45B\x45E\x461\x465\x46D\x471\x476\x47E\x484\x488\x494"+
-		"\x498\x4B7\x4BC\x4C5\x4CC\x4D0\x4D3\x4DD\x4E1\x4E6\x4F0\x4F6\x50B\x519"+
-		"\x521\x526\x52A\x52E\x532\x535\x538\x53B\x555\x559\x56B\x56F\x577\x57B"+
-		"\x57F\x583\x589\x58D\x591\x596\x59C\x59F\x5A3\x5A7\x5AA\x5AE\x5B3\x5B5"+
-		"\x5B9\x5BD\x5C0\x5C4\x5C7\x5D3\x5D7\x5DB\x5E3\x5E7\x5F5\x5FF\x603\x608"+
-		"\x613\x617\x61C\x622\x626\x62C\x62F\x634\x63D\x641\x647\x64A\x653\x657"+
-		"\x65D\x660\x66A\x66E\x671\x674\x677\x67B\x67F\x684\x68D\x693\x697\x69C"+
-		"\x6A3\x6AF\x6B1\x6B7\x6B9\x6C1\x6C5\x6CD\x6D1\x6D8\x6DC\x6E6\x6EA\x6EF"+
-		"\x6F7\x706\x708\x70C\x710\x71A\x71E\x725\x729\x72D\x731\x734\x73F\x748"+
-		"\x74F\x753\x756\x759\x75C\x761\x768\x76D\x773\x777\x77C\x781\x785\x789"+
-		"\x78B\x78F\x791\x796\x7A8\x7AC\x7AE\x7B4\x7B6\x7BA\x7BE\x7C3\x7C7\x7CB"+
-		"\x7CD\x7D3\x7D7\x7DD\x7E1\x7E5\x7E9\x7EF\x7F3\x7F8\x800\x807\x80B\x815"+
-		"\x81B\x822\x826\x82A\x82E\x831\x83B\x841\x847\x851\x854\x858\x85B\x86C"+
-		"\x871\x87B\x87F\x883\x887\x88B\x890\x894\x899\x89D\x8A2\x8A6\x8AB\x8AF"+
-		"\x8B4\x8B8\x8BD\x8C1\x8C6\x8CA\x8CF\x8D3\x8D8\x8DC\x8E1\x8E5\x8EA\x8EE"+
-		"\x8F1\x8F3\x8FB\x8FD\x902\x90F\x914\x917\x91B\x91F\x922\x925\x92A\x92E"+
-		"\x933\x937\x93A\x93C\x942\x946\x94D\x951\x954\x95A\x95E\x964\x968\x96C"+
-		"\x970\x975\x978\x980\x984\x989\x98E\x992\x998\x9A2\x9B3\x9B7\x9BA\x9BD"+
-		"\x9C1\x9C5\x9C7\x9C9\x9CF\x9D3\x9DC\x9DE\x9E5\x9E9\x9ED\x9F7\x9FB\xA00"+
-		"\xA03\xA07\xA0B\xA0F\xA13\xA18\xA1D\xA21\xA26\xA29\xA2D\xA35\xA3B";
+		"\x994\x995\a\xDE\x2\x2\x995\x9A1\x3\x2\x2\x2\x996\x9A1\a\x91\x2\x2\x997"+
+		"\x999\a\xDD\x2\x2\x998\x99A\x5\x1B2\xDA\x2\x999\x998\x3\x2\x2\x2\x999"+
+		"\x99A\x3\x2\x2\x2\x99A\x99B\x3\x2\x2\x2\x99B\x99D\a\x91\x2\x2\x99C\x99E"+
+		"\x5\x1B2\xDA\x2\x99D\x99C\x3\x2\x2\x2\x99D\x99E\x3\x2\x2\x2\x99E\x99F"+
+		"\x3\x2\x2\x2\x99F\x9A1\a\xDE\x2\x2\x9A0\x98B\x3\x2\x2\x2\x9A0\x98C\x3"+
+		"\x2\x2\x2\x9A0\x996\x3\x2\x2\x2\x9A0\x997\x3\x2\x2\x2\x9A1\x17D\x3\x2"+
+		"\x2\x2\x9A2\x9A3\x5\x180\xC1\x2\x9A3\x17F\x3\x2\x2\x2\x9A4\x9A6\x5\x182"+
+		"\xC2\x2\x9A5\x9A7\x5\x1B2\xDA\x2\x9A6\x9A5\x3\x2\x2\x2\x9A6\x9A7\x3\x2"+
+		"\x2\x2\x9A7\x9A9\x3\x2\x2\x2\x9A8\x9A4\x3\x2\x2\x2\x9A9\x9AC\x3\x2\x2"+
+		"\x2\x9AA\x9A8\x3\x2\x2\x2\x9AA\x9AB\x3\x2\x2\x2\x9AB\x9AD\x3\x2\x2\x2"+
+		"\x9AC\x9AA\x3\x2\x2\x2\x9AD\x9B9\x5\x186\xC4\x2\x9AE\x9B0\x5\x182\xC2"+
+		"\x2\x9AF\x9B1\x5\x1B2\xDA\x2\x9B0\x9AF\x3\x2\x2\x2\x9B0\x9B1\x3\x2\x2"+
+		"\x2\x9B1\x9B3\x3\x2\x2\x2\x9B2\x9AE\x3\x2\x2\x2\x9B3\x9B6\x3\x2\x2\x2"+
+		"\x9B4\x9B2\x3\x2\x2\x2\x9B4\x9B5\x3\x2\x2\x2\x9B5\x9B7\x3\x2\x2\x2\x9B6"+
+		"\x9B4\x3\x2\x2\x2\x9B7\x9B9\x5\x188\xC5\x2\x9B8\x9AA\x3\x2\x2\x2\x9B8"+
+		"\x9B4\x3\x2\x2\x2\x9B9\x181\x3\x2\x2\x2\x9BA\x9BC\x5\x184\xC3\x2\x9BB"+
+		"\x9BD\x5\x1B2\xDA\x2\x9BC\x9BB\x3\x2\x2\x2\x9BC\x9BD\x3\x2\x2\x2\x9BD"+
+		"\x9BE\x3\x2\x2\x2\x9BE\x9BF\a)\x2\x2\x9BF\x9C5\x3\x2\x2\x2\x9C0\x9C2\x5"+
+		"\x1B2\xDA\x2\x9C1\x9C0\x3\x2\x2\x2\x9C1\x9C2\x3\x2\x2\x2\x9C2\x9C3\x3"+
+		"\x2\x2\x2\x9C3\x9C5\a)\x2\x2\x9C4\x9BA\x3\x2\x2\x2\x9C4\x9C1\x3\x2\x2"+
+		"\x2\x9C5\x183\x3\x2\x2\x2\x9C6\x9C7\x5\x18C\xC7\x2\x9C7\x185\x3\x2\x2"+
+		"\x2\x9C8\x9C9\x5\x18C\xC7\x2\x9C9\x187\x3\x2\x2\x2\x9CA\x9D5\x5\x18A\xC6"+
+		"\x2\x9CB\x9CD\x5\x1B2\xDA\x2\x9CC\x9CB\x3\x2\x2\x2\x9CC\x9CD\x3\x2\x2"+
+		"\x2\x9CD\x9CE\x3\x2\x2\x2\x9CE\x9D0\a)\x2\x2\x9CF\x9D1\x5\x1B2\xDA\x2"+
+		"\x9D0\x9CF\x3\x2\x2\x2\x9D0\x9D1\x3\x2\x2\x2\x9D1\x9D2\x3\x2\x2\x2\x9D2"+
+		"\x9D4\x5\x18A\xC6\x2\x9D3\x9CC\x3\x2\x2\x2\x9D4\x9D7\x3\x2\x2\x2\x9D5"+
+		"\x9D3\x3\x2\x2\x2\x9D5\x9D6\x3\x2\x2\x2\x9D6\x189\x3\x2\x2\x2\x9D7\x9D5"+
+		"\x3\x2\x2\x2\x9D8\x9DA\x5\x146\xA4\x2\x9D9\x9DB\x5\x1B2\xDA\x2\x9DA\x9D9"+
+		"\x3\x2\x2\x2\x9DA\x9DB\x3\x2\x2\x2\x9DB\x9DC\x3\x2\x2\x2\x9DC\x9DE\a\xCE"+
+		"\x2\x2\x9DD\x9DF\x5\x1B2\xDA\x2\x9DE\x9DD\x3\x2\x2\x2\x9DE\x9DF\x3\x2"+
+		"\x2\x2\x9DF\x9E0\x3\x2\x2\x2\x9E0\x9E1\x5\x18C\xC7\x2\x9E1\x18B\x3\x2"+
+		"\x2\x2\x9E2\x9E3\a=\x2\x2\x9E3\x9E5\x5\x1B2\xDA\x2\x9E4\x9E2\x3\x2\x2"+
+		"\x2\x9E4\x9E5\x3\x2\x2\x2\x9E5\x9E6\x3\x2\x2\x2\x9E6\x9EF\x5\x16E\xB8"+
+		"\x2\x9E7\x9EF\x5\x192\xCA\x2\x9E8\x9E9\x5\x18E\xC8\x2\x9E9\x9EA\x5\x1B2"+
+		"\xDA\x2\x9EA\x9EB\a\xBF\x2\x2\x9EB\x9EC\x5\x1B2\xDA\x2\x9EC\x9ED\x5\x190"+
+		"\xC9\x2\x9ED\x9EF\x3\x2\x2\x2\x9EE\x9E4\x3\x2\x2\x2\x9EE\x9E7\x3\x2\x2"+
+		"\x2\x9EE\x9E8\x3\x2\x2\x2\x9EF\x18D\x3\x2\x2\x2\x9F0\x9F1\x5\x16E\xB8"+
+		"\x2\x9F1\x18F\x3\x2\x2\x2\x9F2\x9F3\x5\x16E\xB8\x2\x9F3\x191\x3\x2\x2"+
+		"\x2\x9F4\x9F5\a\x34\x2\x2\x9F5\x9F6\x5\x1B2\xDA\x2\x9F6\x9F7\x5\x16E\xB8"+
+		"\x2\x9F7\x193\x3\x2\x2\x2\x9F8\x9F9\t\x18\x2\x2\x9F9\x195\x3\x2\x2\x2"+
+		"\x9FA\x9FB\a\x39\x2\x2\x9FB\x197\x3\x2\x2\x2\x9FC\x9FD\t\x19\x2\x2\x9FD"+
+		"\x199\x3\x2\x2\x2\x9FE\xA00\x5\x1B2\xDA\x2\x9FF\x9FE\x3\x2\x2\x2\x9FF"+
+		"\xA00\x3\x2\x2\x2\xA00\xA01\x3\x2\x2\x2\xA01\xA03\a\xE5\x2\x2\xA02\xA04"+
+		"\x5\x1B2\xDA\x2\xA03\xA02\x3\x2\x2\x2\xA03\xA04\x3\x2\x2\x2\xA04\xA0A"+
+		"\x3\x2\x2\x2\xA05\xA07\x5\x1B2\xDA\x2\xA06\xA05\x3\x2\x2\x2\xA06\xA07"+
+		"\x3\x2\x2\x2\xA07\xA08\x3\x2\x2\x2\xA08\xA0A\x5\x19E\xD0\x2\xA09\x9FF"+
+		"\x3\x2\x2\x2\xA09\xA06\x3\x2\x2\x2\xA0A\x19B\x3\x2\x2\x2\xA0B\xA14\x5"+
+		"\x19A\xCE\x2\xA0C\xA0E\x5\x1B2\xDA\x2\xA0D\xA0C\x3\x2\x2\x2\xA0D\xA0E"+
+		"\x3\x2\x2\x2\xA0E\xA0F\x3\x2\x2\x2\xA0F\xA11\a*\x2\x2\xA10\xA12\x5\x1B2"+
+		"\xDA\x2\xA11\xA10\x3\x2\x2\x2\xA11\xA12\x3\x2\x2\x2\xA12\xA14\x3\x2\x2"+
+		"\x2\xA13\xA0B\x3\x2\x2\x2\xA13\xA0D\x3\x2\x2\x2\xA14\xA17\x3\x2\x2\x2"+
+		"\xA15\xA13\x3\x2\x2\x2\xA15\xA16\x3\x2\x2\x2\xA16\x19D\x3\x2\x2\x2\xA17"+
+		"\xA15\x3\x2\x2\x2\xA18\xA1C\x5\x1A6\xD4\x2\xA19\xA1C\x5\x1A2\xD2\x2\xA1A"+
+		"\xA1C\x5\x1A0\xD1\x2\xA1B\xA18\x3\x2\x2\x2\xA1B\xA19\x3\x2\x2\x2\xA1B"+
+		"\xA1A\x3\x2\x2\x2\xA1C\x19F\x3\x2\x2\x2\xA1D\xA1F\a\xAC\x2\x2\xA1E\xA20"+
+		"\x5\x1B2\xDA\x2\xA1F\xA1E\x3\x2\x2\x2\xA1F\xA20\x3\x2\x2\x2\xA20\xA21"+
+		"\x3\x2\x2\x2\xA21\xA22\x5\x1A4\xD3\x2\xA22\x1A1\x3\x2\x2\x2\xA23\xA24"+
+		"\a\xE6\x2\x2\xA24\xA25\x5\x1A4\xD3\x2\xA25\x1A3\x3\x2\x2\x2\xA26\xA29"+
+		"\a\xEB\x2\x2\xA27\xA29\n\x1A\x2\x2\xA28\xA26\x3\x2\x2\x2\xA28\xA27\x3"+
+		"\x2\x2\x2\xA29\xA2C\x3\x2\x2\x2\xA2A\xA28\x3\x2\x2\x2\xA2A\xA2B\x3\x2"+
+		"\x2\x2\xA2B\x1A5\x3\x2\x2\x2\xA2C\xA2A\x3\x2\x2\x2\xA2D\xA33\a\xE6\x2"+
+		"\x2\xA2E\xA2F\a/\x2\x2\xA2F\xA31\x5\x1A8\xD5\x2\xA30\xA32\x5\x1B2\xDA"+
+		"\x2\xA31\xA30\x3\x2\x2\x2\xA31\xA32\x3\x2\x2\x2\xA32\xA34\x3\x2\x2\x2"+
+		"\xA33\xA2E\x3\x2\x2\x2\xA34\xA35\x3\x2\x2\x2\xA35\xA33\x3\x2\x2\x2\xA35"+
+		"\xA36\x3\x2\x2\x2\xA36\x1A7\x3\x2\x2\x2\xA37\xA39\x5\x1AA\xD6\x2\xA38"+
+		"\xA3A\x5\x1AC\xD7\x2\xA39\xA38\x3\x2\x2\x2\xA39\xA3A\x3\x2\x2\x2\xA3A"+
+		"\x1A9\x3\x2\x2\x2\xA3B\xA3C\x5\x146\xA4\x2\xA3C\x1AB\x3\x2\x2\x2\xA3D"+
+		"\xA3E\x5\x1B2\xDA\x2\xA3E\xA3F\x5\x1AE\xD8\x2\xA3F\xA7A\x3\x2\x2\x2\xA40"+
+		"\xA41\x5\x1B2\xDA\x2\xA41\xA4A\x5\x1AE\xD8\x2\xA42\xA44\x5\x1B2\xDA\x2"+
+		"\xA43\xA42\x3\x2\x2\x2\xA43\xA44\x3\x2\x2\x2\xA44\xA45\x3\x2\x2\x2\xA45"+
+		"\xA47\a)\x2\x2\xA46\xA48\x5\x1B2\xDA\x2\xA47\xA46\x3\x2\x2\x2\xA47\xA48"+
+		"\x3\x2\x2\x2\xA48\xA49\x3\x2\x2\x2\xA49\xA4B\x5\x1AE\xD8\x2\xA4A\xA43"+
+		"\x3\x2\x2\x2\xA4B\xA4C\x3\x2\x2\x2\xA4C\xA4A\x3\x2\x2\x2\xA4C\xA4D\x3"+
+		"\x2\x2\x2\xA4D\xA7A\x3\x2\x2\x2\xA4E\xA50\x5\x1B2\xDA\x2\xA4F\xA4E\x3"+
+		"\x2\x2\x2\xA4F\xA50\x3\x2\x2\x2\xA50\xA51\x3\x2\x2\x2\xA51\xA53\a\xD5"+
+		"\x2\x2\xA52\xA54\x5\x1B2\xDA\x2\xA53\xA52\x3\x2\x2\x2\xA53\xA54\x3\x2"+
+		"\x2\x2\xA54\xA55\x3\x2\x2\x2\xA55\xA7A\a\xDC\x2\x2\xA56\xA58\x5\x1B2\xDA"+
+		"\x2\xA57\xA56\x3\x2\x2\x2\xA57\xA58\x3\x2\x2\x2\xA58\xA59\x3\x2\x2\x2"+
+		"\xA59\xA5B\a\xD5\x2\x2\xA5A\xA5C\x5\x1B2\xDA\x2\xA5B\xA5A\x3\x2\x2\x2"+
+		"\xA5B\xA5C\x3\x2\x2\x2\xA5C\xA5D\x3\x2\x2\x2\xA5D\xA5F\x5\x1AE\xD8\x2"+
+		"\xA5E\xA60\x5\x1B2\xDA\x2\xA5F\xA5E\x3\x2\x2\x2\xA5F\xA60\x3\x2\x2\x2"+
+		"\xA60\xA61\x3\x2\x2\x2\xA61\xA62\a\xDC\x2\x2\xA62\xA7A\x3\x2\x2\x2\xA63"+
+		"\xA65\x5\x1B2\xDA\x2\xA64\xA63\x3\x2\x2\x2\xA64\xA65\x3\x2\x2\x2\xA65"+
+		"\xA66\x3\x2\x2\x2\xA66\xA67\a\xD5\x2\x2\xA67\xA70\x5\x1AE\xD8\x2\xA68"+
+		"\xA6A\x5\x1B2\xDA\x2\xA69\xA68\x3\x2\x2\x2\xA69\xA6A\x3\x2\x2\x2\xA6A"+
+		"\xA6B\x3\x2\x2\x2\xA6B\xA6D\a)\x2\x2\xA6C\xA6E\x5\x1B2\xDA\x2\xA6D\xA6C"+
+		"\x3\x2\x2\x2\xA6D\xA6E\x3\x2\x2\x2\xA6E\xA6F\x3\x2\x2\x2\xA6F\xA71\x5"+
+		"\x1AE\xD8\x2\xA70\xA69\x3\x2\x2\x2\xA71\xA72\x3\x2\x2\x2\xA72\xA70\x3"+
+		"\x2\x2\x2\xA72\xA73\x3\x2\x2\x2\xA73\xA75\x3\x2\x2\x2\xA74\xA76\x5\x1B2"+
+		"\xDA\x2\xA75\xA74\x3\x2\x2\x2\xA75\xA76\x3\x2\x2\x2\xA76\xA77\x3\x2\x2"+
+		"\x2\xA77\xA78\a\xDC\x2\x2\xA78\xA7A\x3\x2\x2\x2\xA79\xA3D\x3\x2\x2\x2"+
+		"\xA79\xA40\x3\x2\x2\x2\xA79\xA4F\x3\x2\x2\x2\xA79\xA57\x3\x2\x2\x2\xA79"+
+		"\xA64\x3\x2\x2\x2\xA7A\x1AD\x3\x2\x2\x2\xA7B\xA7C\x5\x16E\xB8\x2\xA7C"+
+		"\x1AF\x3\x2\x2\x2\xA7D\xA81\a\xEB\x2\x2\xA7E\xA80\a\xE8\x2\x2\xA7F\xA7E"+
+		"\x3\x2\x2\x2\xA80\xA83\x3\x2\x2\x2\xA81\xA7F\x3\x2\x2\x2\xA81\xA82\x3"+
+		"\x2\x2\x2\xA82\x1B1\x3\x2\x2\x2\xA83\xA81\x3\x2\x2\x2\xA84\xA86\t\x1B"+
+		"\x2\x2\xA85\xA84\x3\x2\x2\x2\xA86\xA87\x3\x2\x2\x2\xA87\xA85\x3\x2\x2"+
+		"\x2\xA87\xA88\x3\x2\x2\x2\xA88\x1B3\x3\x2\x2\x2\x18E\x1BA\x1BE\x1C6\x1CC"+
+		"\x1CF\x1D9\x1DB\x1E1\x1EA\x1F1\x1F7\x200\x207\x20B\x20F\x213\x218\x224"+
+		"\x231\x234\x241\x244\x24B\x253\x25A\x280\x290\x298\x29D\x2A2\x2AB\x2BF"+
+		"\x2C3\x2CB\x2D6\x2DC\x2E0\x2E5\x2EC\x2F0\x2FA\x2FE\x301\x307\x30D\x317"+
+		"\x31B\x31E\x324\x328\x332\x336\x340\x344\x348\x354\x358\x35B\x35F\x364"+
+		"\x36B\x36F\x374\x37C\x380\x384\x38C\x38F\x393\x397\x3A1\x3A5\x3A8\x3AE"+
+		"\x3B2\x3B8\x3BC\x3C1\x3CA\x3CE\x3D1\x3D4\x3D8\x3E4\x3E8\x3EB\x3EE\x3F2"+
+		"\x3FB\x401\x405\x40A\x411\x414\x418\x41F\x425\x433\x436\x439\x43E\x442"+
+		"\x446\x44A\x44F\x452\x455\x45B\x45F\x463\x467\x46B\x46E\x471\x474\x477"+
+		"\x47A\x47E\x486\x48A\x48F\x497\x49D\x4A1\x4AD\x4B1\x4D0\x4D5\x4DE\x4E5"+
+		"\x4E9\x4EC\x4F6\x4FA\x4FF\x509\x50F\x524\x532\x53A\x53F\x543\x547\x54B"+
+		"\x54E\x551\x554\x56E\x572\x584\x588\x590\x594\x598\x59C\x5A2\x5A6\x5AA"+
+		"\x5AF\x5B5\x5B8\x5BC\x5C0\x5C3\x5C7\x5CC\x5CE\x5D2\x5D6\x5D9\x5DD\x5E0"+
+		"\x5EC\x5F0\x5F4\x5FC\x600\x60E\x618\x61C\x621\x62C\x630\x635\x63B\x63F"+
+		"\x645\x648\x64D\x656\x65A\x660\x663\x66C\x670\x676\x679\x683\x687\x68A"+
+		"\x68D\x690\x694\x698\x69D\x6A6\x6AC\x6B0\x6B5\x6BC\x6C8\x6CA\x6D0\x6D2"+
+		"\x6DA\x6DE\x6E6\x6EA\x6F1\x6F5\x6FF\x703\x708\x710\x71F\x721\x725\x729"+
+		"\x733\x737\x73E\x742\x746\x74A\x74D\x757\x76D\x772\x776\x781\x787\x78A"+
+		"\x78D\x793\x797\x79C\x7A1\x7A3\x7A9\x7B4\x7B9\x7BF\x7C3\x7C8\x7CD\x7D1"+
+		"\x7D5\x7D7\x7DB\x7DD\x7E2\x7F4\x7F8\x7FA\x800\x802\x806\x80A\x80F\x813"+
+		"\x817\x819\x81F\x823\x829\x82D\x831\x835\x83B\x83F\x844\x84C\x853\x857"+
+		"\x861\x867\x86E\x872\x876\x87A\x87D\x887\x88D\x893\x89D\x8A0\x8A4\x8A7"+
+		"\x8B8\x8BD\x8C7\x8CB\x8CF\x8D3\x8D7\x8DC\x8E0\x8E5\x8E9\x8EE\x8F2\x8F7"+
+		"\x8FB\x900\x904\x909\x90D\x912\x916\x91B\x91F\x924\x928\x92D\x931\x936"+
+		"\x93A\x93D\x93F\x947\x949\x94E\x95B\x960\x963\x967\x96B\x96E\x971\x976"+
+		"\x97A\x97F\x983\x986\x988\x98E\x992\x999\x99D\x9A0\x9A6\x9AA\x9B0\x9B4"+
+		"\x9B8\x9BC\x9C1\x9C4\x9CC\x9D0\x9D5\x9DA\x9DE\x9E4\x9EE\x9FF\xA03\xA06"+
+		"\xA09\xA0D\xA11\xA13\xA15\xA1B\xA1F\xA28\xA2A\xA31\xA35\xA39\xA43\xA47"+
+		"\xA4C\xA4F\xA53\xA57\xA5B\xA5F\xA64\xA69\xA6D\xA72\xA75\xA79\xA81\xA87";
 	public static readonly ATN _ATN =
 		new ATNDeserializer().Deserialize(_serializedATN.ToCharArray());
 }

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -75,7 +75,8 @@ moduleDeclarationsElement :
     | implementsStmt
     | variableStmt
     | moduleOption
-    | typeStmt)
+    | publicTypeDeclaration
+    | privateTypeDeclaration)
 ;
 
 moduleBody : 
@@ -471,13 +472,24 @@ subStmt :
 ;
 subroutineName : identifier;
 
-typeStmt : 
-    (visibility whiteSpace)? TYPE whiteSpace identifier endOfStatement
-    typeStmt_Element*
-    END_TYPE
-;
+// 5.2.3.3 User Defined Type Declarations
+publicTypeDeclaration : ((GLOBAL | PUBLIC) whiteSpace)? udtDeclaration;
+privateTypeDeclaration : PRIVATE whiteSpace udtDeclaration;
+udtDeclaration : TYPE whiteSpace untypedIdentifier endOfStatement udtMemberList endOfStatement END_TYPE;  
+udtMemberList : udtMember (endOfStatement udtMember)*; 
+udtMember : reservedNameMemberDeclaration | untypedNameMemberDeclaration;
+untypedNameMemberDeclaration : untypedIdentifier whiteSpace? optionalArrayClause;
+reservedNameMemberDeclaration : unrestrictedIdentifier whiteSpace asTypeClause;
+optionalArrayClause : (arrayDim whiteSpace)? asTypeClause;
 
-typeStmt_Element : identifier (whiteSpace? LPAREN (whiteSpace? subscripts)? whiteSpace? RPAREN)? (whiteSpace asTypeClause)? endOfStatement;
+// 5.2.3.1.3 Array Dimensions and Bounds
+arrayDim : LPAREN whiteSpace? boundsList? whiteSpace? RPAREN;
+boundsList : dimSpec (whiteSpace? COMMA whiteSpace? dimSpec)*;
+dimSpec : (lowerBound whiteSpace?)? upperBound;
+lowerBound : constantExpression whiteSpace? TO;
+upperBound : constantExpression;
+
+constantExpression : expression;
 
 variableStmt : (DIM | STATIC | visibility) whiteSpace (WITHEVENTS whiteSpace)? variableListStmt;
 variableListStmt : variableSubStmt (whiteSpace? COMMA whiteSpace? variableSubStmt)*;

--- a/Rubberduck.Parsing/Grammar/VBAParserBaseListener.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserBaseListener.cs
@@ -60,6 +60,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitPowOp([NotNull] VBAParser.PowOpContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.udtMember"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterUdtMember([NotNull] VBAParser.UdtMemberContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.udtMember"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitUdtMember([NotNull] VBAParser.UdtMemberContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -294,6 +307,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitIndexExpr([NotNull] VBAParser.IndexExprContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.untypedNameMemberDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterUntypedNameMemberDeclaration([NotNull] VBAParser.UntypedNameMemberDeclarationContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.untypedNameMemberDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitUntypedNameMemberDeclaration([NotNull] VBAParser.UntypedNameMemberDeclarationContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -331,6 +357,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitModuleBody([NotNull] VBAParser.ModuleBodyContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.udtMemberList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterUdtMemberList([NotNull] VBAParser.UdtMemberListContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.udtMemberList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitUdtMemberList([NotNull] VBAParser.UdtMemberListContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.letterRange"/>.
@@ -489,6 +528,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitLineWidth([NotNull] VBAParser.LineWidthContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.publicTypeDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPublicTypeDeclaration([NotNull] VBAParser.PublicTypeDeclarationContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.publicTypeDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPublicTypeDeclaration([NotNull] VBAParser.PublicTypeDeclarationContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.asTypeClause"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -617,6 +669,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitAnnotation([NotNull] VBAParser.AnnotationContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.reservedNameMemberDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterReservedNameMemberDeclaration([NotNull] VBAParser.ReservedNameMemberDeclarationContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.reservedNameMemberDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitReservedNameMemberDeclaration([NotNull] VBAParser.ReservedNameMemberDeclarationContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.mandatoryLineContinuation"/>.
@@ -1230,6 +1295,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitAnnotationArgList([NotNull] VBAParser.AnnotationArgListContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.upperBound"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterUpperBound([NotNull] VBAParser.UpperBoundContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.upperBound"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitUpperBound([NotNull] VBAParser.UpperBoundContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.specifiedPositionalArgument"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1555,6 +1633,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitCallStmt([NotNull] VBAParser.CallStmtContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.optionalArrayClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterOptionalArrayClause([NotNull] VBAParser.OptionalArrayClauseContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.optionalArrayClause"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitOptionalArrayClause([NotNull] VBAParser.OptionalArrayClauseContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.debugPrintSub"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -1618,6 +1709,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.udtDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterUdtDeclaration([NotNull] VBAParser.UdtDeclarationContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.udtDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitUdtDeclaration([NotNull] VBAParser.UdtDeclarationContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.seekStmt"/>.
@@ -1709,19 +1813,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.type"/>.
@@ -1878,6 +1969,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.dimSpec"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterDimSpec([NotNull] VBAParser.DimSpecContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.dimSpec"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitDimSpec([NotNull] VBAParser.DimSpecContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.identifier"/>.
@@ -2062,6 +2166,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.boundsList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterBoundsList([NotNull] VBAParser.BoundsListContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.boundsList"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitBoundsList([NotNull] VBAParser.BoundsListContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.literalIdentifier"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -2177,6 +2294,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.constantExpression"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterConstantExpression([NotNull] VBAParser.ConstantExpressionContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.constantExpression"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitConstantExpression([NotNull] VBAParser.ConstantExpressionContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.debugPrint"/>.
@@ -2322,6 +2452,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	public virtual void ExitCaseClause([NotNull] VBAParser.CaseClauseContext context) { }
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.lowerBound"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterLowerBound([NotNull] VBAParser.LowerBoundContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.lowerBound"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitLowerBound([NotNull] VBAParser.LowerBoundContext context) { }
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.exitStmt"/>.
 	/// <para>The default implementation does nothing.</para>
 	/// </summary>
@@ -2359,6 +2502,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitArgList([NotNull] VBAParser.ArgListContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.arrayDim"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterArrayDim([NotNull] VBAParser.ArrayDimContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.arrayDim"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitArrayDim([NotNull] VBAParser.ArrayDimContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.eventArgumentList"/>.
@@ -2450,19 +2606,6 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitMissingPositionalArgument([NotNull] VBAParser.MissingPositionalArgumentContext context) { }
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void EnterTypeStmt([NotNull] VBAParser.TypeStmtContext context) { }
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
-	/// <para>The default implementation does nothing.</para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	public virtual void ExitTypeStmt([NotNull] VBAParser.TypeStmtContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.multOp"/>.
@@ -2814,6 +2957,19 @@ public partial class VBAParserBaseListener : IVBAParserListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	public virtual void ExitIntegerExpression([NotNull] VBAParser.IntegerExpressionContext context) { }
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.privateTypeDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void EnterPrivateTypeDeclaration([NotNull] VBAParser.PrivateTypeDeclarationContext context) { }
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.privateTypeDeclaration"/>.
+	/// <para>The default implementation does nothing.</para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	public virtual void ExitPrivateTypeDeclaration([NotNull] VBAParser.PrivateTypeDeclarationContext context) { }
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.

--- a/Rubberduck.Parsing/Grammar/VBAParserBaseVisitor.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserBaseVisitor.cs
@@ -55,6 +55,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitPowOp([NotNull] VBAParser.PowOpContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.udtMember"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitUdtMember([NotNull] VBAParser.UdtMemberContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -253,6 +264,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitIndexExpr([NotNull] VBAParser.IndexExprContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.untypedNameMemberDeclaration"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitUntypedNameMemberDeclaration([NotNull] VBAParser.UntypedNameMemberDeclarationContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -284,6 +306,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitModuleBody([NotNull] VBAParser.ModuleBodyContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.udtMemberList"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitUdtMemberList([NotNull] VBAParser.UdtMemberListContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.letterRange"/>.
@@ -418,6 +451,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitLineWidth([NotNull] VBAParser.LineWidthContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.publicTypeDeclaration"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPublicTypeDeclaration([NotNull] VBAParser.PublicTypeDeclarationContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.asTypeClause"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -526,6 +570,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitAnnotation([NotNull] VBAParser.AnnotationContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.reservedNameMemberDeclaration"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitReservedNameMemberDeclaration([NotNull] VBAParser.ReservedNameMemberDeclarationContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.mandatoryLineContinuation"/>.
@@ -1045,6 +1100,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitAnnotationArgList([NotNull] VBAParser.AnnotationArgListContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.upperBound"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitUpperBound([NotNull] VBAParser.UpperBoundContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.specifiedPositionalArgument"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1320,6 +1386,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitCallStmt([NotNull] VBAParser.CallStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.optionalArrayClause"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitOptionalArrayClause([NotNull] VBAParser.OptionalArrayClauseContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.debugPrintSub"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1373,6 +1450,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.udtDeclaration"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitUdtDeclaration([NotNull] VBAParser.UdtDeclarationContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
@@ -1450,17 +1538,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.type"/>.
@@ -1593,6 +1670,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.dimSpec"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitDimSpec([NotNull] VBAParser.DimSpecContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.identifier"/>.
@@ -1749,6 +1837,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.boundsList"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitBoundsList([NotNull] VBAParser.BoundsListContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.literalIdentifier"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -1846,6 +1945,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitResumeStmt([NotNull] VBAParser.ResumeStmtContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.constantExpression"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitConstantExpression([NotNull] VBAParser.ConstantExpressionContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.debugPrint"/>.
@@ -1969,6 +2079,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	public virtual Result VisitCaseClause([NotNull] VBAParser.CaseClauseContext context) { return VisitChildren(context); }
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.lowerBound"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitLowerBound([NotNull] VBAParser.LowerBoundContext context) { return VisitChildren(context); }
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
 	/// <para>
 	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
@@ -2000,6 +2121,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitArgList([NotNull] VBAParser.ArgListContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.arrayDim"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitArrayDim([NotNull] VBAParser.ArrayDimContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.eventArgumentList"/>.
@@ -2077,17 +2209,6 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitMissingPositionalArgument([NotNull] VBAParser.MissingPositionalArgumentContext context) { return VisitChildren(context); }
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
-	/// <para>
-	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
-	/// on <paramref name="context"/>.
-	/// </para>
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	public virtual Result VisitTypeStmt([NotNull] VBAParser.TypeStmtContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.multOp"/>.
@@ -2385,6 +2506,17 @@ public partial class VBAParserBaseVisitor<Result> : AbstractParseTreeVisitor<Res
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	public virtual Result VisitIntegerExpression([NotNull] VBAParser.IntegerExpressionContext context) { return VisitChildren(context); }
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.privateTypeDeclaration"/>.
+	/// <para>
+	/// The default implementation returns the result of calling <see cref="AbstractParseTreeVisitor{Result}.VisitChildren(IRuleNode)"/>
+	/// on <paramref name="context"/>.
+	/// </para>
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	public virtual Result VisitPrivateTypeDeclaration([NotNull] VBAParser.PrivateTypeDeclarationContext context) { return VisitChildren(context); }
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.

--- a/Rubberduck.Parsing/Grammar/VBAParserListener.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserListener.cs
@@ -54,6 +54,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitPowOp([NotNull] VBAParser.PowOpContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.udtMember"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterUdtMember([NotNull] VBAParser.UdtMemberContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.udtMember"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitUdtMember([NotNull] VBAParser.UdtMemberContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -258,6 +269,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitIndexExpr([NotNull] VBAParser.IndexExprContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.untypedNameMemberDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterUntypedNameMemberDeclaration([NotNull] VBAParser.UntypedNameMemberDeclarationContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.untypedNameMemberDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitUntypedNameMemberDeclaration([NotNull] VBAParser.UntypedNameMemberDeclarationContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -289,6 +311,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitModuleBody([NotNull] VBAParser.ModuleBodyContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.udtMemberList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterUdtMemberList([NotNull] VBAParser.UdtMemberListContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.udtMemberList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitUdtMemberList([NotNull] VBAParser.UdtMemberListContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.letterRange"/>.
@@ -427,6 +460,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitLineWidth([NotNull] VBAParser.LineWidthContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.publicTypeDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPublicTypeDeclaration([NotNull] VBAParser.PublicTypeDeclarationContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.publicTypeDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPublicTypeDeclaration([NotNull] VBAParser.PublicTypeDeclarationContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.asTypeClause"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -541,6 +585,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitAnnotation([NotNull] VBAParser.AnnotationContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.reservedNameMemberDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterReservedNameMemberDeclaration([NotNull] VBAParser.ReservedNameMemberDeclarationContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.reservedNameMemberDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitReservedNameMemberDeclaration([NotNull] VBAParser.ReservedNameMemberDeclarationContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.mandatoryLineContinuation"/>.
@@ -1080,6 +1135,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitAnnotationArgList([NotNull] VBAParser.AnnotationArgListContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.upperBound"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterUpperBound([NotNull] VBAParser.UpperBoundContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.upperBound"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitUpperBound([NotNull] VBAParser.UpperBoundContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by the <c>specifiedPositionalArgument</c>
 	/// labeled alternative in <see cref="VBAParser.positionalArgumentOrMissing"/>.
 	/// </summary>
@@ -1359,6 +1425,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitCallStmt([NotNull] VBAParser.CallStmtContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.optionalArrayClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterOptionalArrayClause([NotNull] VBAParser.OptionalArrayClauseContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.optionalArrayClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitOptionalArrayClause([NotNull] VBAParser.OptionalArrayClauseContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.debugPrintSub"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1412,6 +1489,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.udtDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterUdtDeclaration([NotNull] VBAParser.UdtDeclarationContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.udtDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitUdtDeclaration([NotNull] VBAParser.UdtDeclarationContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.seekStmt"/>.
@@ -1489,17 +1577,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.type"/>.
@@ -1636,6 +1713,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.dimSpec"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterDimSpec([NotNull] VBAParser.DimSpecContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.dimSpec"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitDimSpec([NotNull] VBAParser.DimSpecContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.identifier"/>.
@@ -1798,6 +1886,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.boundsList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterBoundsList([NotNull] VBAParser.BoundsListContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.boundsList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitBoundsList([NotNull] VBAParser.BoundsListContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.literalIdentifier"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1895,6 +1994,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.constantExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterConstantExpression([NotNull] VBAParser.ConstantExpressionContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.constantExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitConstantExpression([NotNull] VBAParser.ConstantExpressionContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.debugPrint"/>.
@@ -2022,6 +2132,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	void ExitCaseClause([NotNull] VBAParser.CaseClauseContext context);
 
 	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.lowerBound"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterLowerBound([NotNull] VBAParser.LowerBoundContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.lowerBound"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitLowerBound([NotNull] VBAParser.LowerBoundContext context);
+
+	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.exitStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -2053,6 +2174,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitArgList([NotNull] VBAParser.ArgListContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.arrayDim"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterArrayDim([NotNull] VBAParser.ArrayDimContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.arrayDim"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitArrayDim([NotNull] VBAParser.ArrayDimContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.eventArgumentList"/>.
@@ -2134,17 +2266,6 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitMissingPositionalArgument([NotNull] VBAParser.MissingPositionalArgumentContext context);
-
-	/// <summary>
-	/// Enter a parse tree produced by <see cref="VBAParser.typeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void EnterTypeStmt([NotNull] VBAParser.TypeStmtContext context);
-	/// <summary>
-	/// Exit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	void ExitTypeStmt([NotNull] VBAParser.TypeStmtContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by the <c>multOp</c>
@@ -2446,6 +2567,17 @@ public interface IVBAParserListener : IParseTreeListener {
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
 	void ExitIntegerExpression([NotNull] VBAParser.IntegerExpressionContext context);
+
+	/// <summary>
+	/// Enter a parse tree produced by <see cref="VBAParser.privateTypeDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void EnterPrivateTypeDeclaration([NotNull] VBAParser.PrivateTypeDeclarationContext context);
+	/// <summary>
+	/// Exit a parse tree produced by <see cref="VBAParser.privateTypeDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	void ExitPrivateTypeDeclaration([NotNull] VBAParser.PrivateTypeDeclarationContext context);
 
 	/// <summary>
 	/// Enter a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.

--- a/Rubberduck.Parsing/Grammar/VBAParserVisitor.cs
+++ b/Rubberduck.Parsing/Grammar/VBAParserVisitor.cs
@@ -46,6 +46,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitPowOp([NotNull] VBAParser.PowOpContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.udtMember"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitUdtMember([NotNull] VBAParser.UdtMemberContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.tabNumber"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -175,6 +182,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitIndexExpr([NotNull] VBAParser.IndexExprContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.untypedNameMemberDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitUntypedNameMemberDeclaration([NotNull] VBAParser.UntypedNameMemberDeclarationContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.inputList"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -194,6 +208,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitModuleBody([NotNull] VBAParser.ModuleBodyContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.udtMemberList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitUdtMemberList([NotNull] VBAParser.UdtMemberListContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.letterRange"/>.
@@ -282,6 +303,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitLineWidth([NotNull] VBAParser.LineWidthContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.publicTypeDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPublicTypeDeclaration([NotNull] VBAParser.PublicTypeDeclarationContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.asTypeClause"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -353,6 +381,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitAnnotation([NotNull] VBAParser.AnnotationContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.reservedNameMemberDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitReservedNameMemberDeclaration([NotNull] VBAParser.ReservedNameMemberDeclarationContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.mandatoryLineContinuation"/>.
@@ -694,6 +729,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitAnnotationArgList([NotNull] VBAParser.AnnotationArgListContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.upperBound"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitUpperBound([NotNull] VBAParser.UpperBoundContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by the <c>specifiedPositionalArgument</c>
 	/// labeled alternative in <see cref="VBAParser.positionalArgumentOrMissing"/>.
 	/// </summary>
@@ -871,6 +913,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitCallStmt([NotNull] VBAParser.CallStmtContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.optionalArrayClause"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitOptionalArrayClause([NotNull] VBAParser.OptionalArrayClauseContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.debugPrintSub"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -904,6 +953,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitModuleBodyElement([NotNull] VBAParser.ModuleBodyElementContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.udtDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitUdtDeclaration([NotNull] VBAParser.UdtDeclarationContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.seekStmt"/>.
@@ -953,13 +1009,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitModuleAttributes([NotNull] VBAParser.ModuleAttributesContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt_Element"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitTypeStmt_Element([NotNull] VBAParser.TypeStmt_ElementContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.type"/>.
@@ -1046,6 +1095,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitOnErrorStmt([NotNull] VBAParser.OnErrorStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.dimSpec"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitDimSpec([NotNull] VBAParser.DimSpecContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.identifier"/>.
@@ -1149,6 +1205,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitRedimStmt([NotNull] VBAParser.RedimStmtContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.boundsList"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitBoundsList([NotNull] VBAParser.BoundsListContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.literalIdentifier"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1210,6 +1273,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitResumeStmt([NotNull] VBAParser.ResumeStmtContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.constantExpression"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitConstantExpression([NotNull] VBAParser.ConstantExpressionContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.debugPrint"/>.
@@ -1291,6 +1361,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	Result VisitCaseClause([NotNull] VBAParser.CaseClauseContext context);
 
 	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.lowerBound"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitLowerBound([NotNull] VBAParser.LowerBoundContext context);
+
+	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.exitStmt"/>.
 	/// </summary>
 	/// <param name="context">The parse tree.</param>
@@ -1310,6 +1387,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitArgList([NotNull] VBAParser.ArgListContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.arrayDim"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitArrayDim([NotNull] VBAParser.ArrayDimContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.eventArgumentList"/>.
@@ -1361,13 +1445,6 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitMissingPositionalArgument([NotNull] VBAParser.MissingPositionalArgumentContext context);
-
-	/// <summary>
-	/// Visit a parse tree produced by <see cref="VBAParser.typeStmt"/>.
-	/// </summary>
-	/// <param name="context">The parse tree.</param>
-	/// <return>The visitor result.</return>
-	Result VisitTypeStmt([NotNull] VBAParser.TypeStmtContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by the <c>multOp</c>
@@ -1559,6 +1636,13 @@ public interface IVBAParserVisitor<Result> : IParseTreeVisitor<Result> {
 	/// <param name="context">The parse tree.</param>
 	/// <return>The visitor result.</return>
 	Result VisitIntegerExpression([NotNull] VBAParser.IntegerExpressionContext context);
+
+	/// <summary>
+	/// Visit a parse tree produced by <see cref="VBAParser.privateTypeDeclaration"/>.
+	/// </summary>
+	/// <param name="context">The parse tree.</param>
+	/// <return>The visitor result.</return>
+	Result VisitPrivateTypeDeclaration([NotNull] VBAParser.PrivateTypeDeclarationContext context);
 
 	/// <summary>
 	/// Visit a parse tree produced by <see cref="VBAParser.markedFileNumber"/>.

--- a/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
@@ -8,6 +8,7 @@ using Rubberduck.VBEditor;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Antlr4.Runtime.Misc;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -149,34 +150,34 @@ namespace Rubberduck.Parsing.Symbols
                 // The as type declaration should be TextBox, CheckBox, etc. depending on the type.
                 var declaration = new Declaration(
                     _qualifiedName.QualifyMemberName(control.Name),
-                    _parentDeclaration, 
+                    _parentDeclaration,
                     _currentScopeDeclaration,
                     "Control",
                     null,
-                    true, 
-                    true, 
+                    true,
+                    true,
                     Accessibility.Public,
                     DeclarationType.Control,
-                    null, 
-                    Selection.Home, 
-                    false, 
-                    null, 
+                    null,
+                    Selection.Home,
+                    false,
+                    null,
                     false);
                 AddDeclaration(declaration);
             }
         }
 
         private Declaration CreateDeclaration(
-            string identifierName, 
-            string asTypeName, 
+            string identifierName,
+            string asTypeName,
             Accessibility accessibility,
             DeclarationType declarationType,
-            ParserRuleContext context, 
+            ParserRuleContext context,
             Selection selection,
             bool isArray,
             VBAParser.AsTypeClauseContext asTypeContext,
             string typeHint,
-            bool selfAssigned = false, 
+            bool selfAssigned = false,
             bool withEvents = false)
         {
             Declaration result;
@@ -199,15 +200,15 @@ namespace Rubberduck.Parsing.Symbols
                 var isParamArray = argContext.PARAMARRAY() != null;
                 result = new ParameterDeclaration(
                     new QualifiedMemberName(_qualifiedName, identifierName),
-                    _parentDeclaration, 
-                    context, 
-                    selection, 
+                    _parentDeclaration,
+                    context,
+                    selection,
                     asTypeName,
                     asTypeContext,
                     typeHint,
                     isOptional,
-                    isByRef, 
-                    isArray, 
+                    isByRef,
+                    isArray,
                     isParamArray);
                 if (_parentDeclaration is IDeclarationWithParameter)
                 {
@@ -232,16 +233,16 @@ namespace Rubberduck.Parsing.Symbols
                 {
                     result = new FunctionDeclaration(
                         new QualifiedMemberName(_qualifiedName, identifierName),
-                        _parentDeclaration, 
-                        _currentScopeDeclaration, 
+                        _parentDeclaration,
+                        _currentScopeDeclaration,
                         asTypeName,
                         asTypeContext,
                         typeHint,
                         accessibility,
-                        context, 
+                        context,
                         selection,
                         isArray,
-                        false, 
+                        false,
                         annotations,
                         attributes);
                 }
@@ -252,17 +253,17 @@ namespace Rubberduck.Parsing.Symbols
                 else if (declarationType == DeclarationType.PropertyGet)
                 {
                     result = new PropertyGetDeclaration(
-                        new QualifiedMemberName(_qualifiedName, identifierName), 
+                        new QualifiedMemberName(_qualifiedName, identifierName),
                         _parentDeclaration,
-                        _currentScopeDeclaration, 
+                        _currentScopeDeclaration,
                         asTypeName,
                         asTypeContext,
                         typeHint,
-                        accessibility, 
-                        context, 
+                        accessibility,
+                        context,
                         selection,
                         isArray,
-                        false, 
+                        false,
                         annotations,
                         attributes);
                 }
@@ -278,20 +279,20 @@ namespace Rubberduck.Parsing.Symbols
                 {
                     result = new Declaration(
                         new QualifiedMemberName(_qualifiedName, identifierName),
-                        _parentDeclaration, 
-                        _currentScopeDeclaration, 
+                        _parentDeclaration,
+                        _currentScopeDeclaration,
                         asTypeName,
                         typeHint,
-                        selfAssigned, 
-                        withEvents, 
+                        selfAssigned,
+                        withEvents,
                         accessibility,
-                        declarationType, 
-                        context, 
+                        declarationType,
+                        context,
                         selection,
                         isArray,
                         asTypeContext,
                         false,
-                        annotations, 
+                        annotations,
                         attributes);
                 }
                 if (_parentDeclaration.DeclarationType == DeclarationType.ClassModule && result is ICanBeDefaultMember && ((ICanBeDefaultMember)result).IsDefaultMember)
@@ -357,11 +358,11 @@ namespace Rubberduck.Parsing.Symbols
         public override void EnterOptionBaseStmt(VBAParser.OptionBaseStmtContext context)
         {
             AddDeclaration(CreateDeclaration(
-                context.GetText(), 
-                string.Empty, 
-                Accessibility.Implicit, 
+                context.GetText(),
+                string.Empty,
+                Accessibility.Implicit,
                 DeclarationType.ModuleOption,
-                context, 
+                context,
                 context.GetSelection(),
                 false,
                 null,
@@ -371,11 +372,11 @@ namespace Rubberduck.Parsing.Symbols
         public override void EnterOptionCompareStmt(VBAParser.OptionCompareStmtContext context)
         {
             AddDeclaration(CreateDeclaration(
-                context.GetText(), 
-                string.Empty, 
+                context.GetText(),
+                string.Empty,
                 Accessibility.Implicit,
-                DeclarationType.ModuleOption, 
-                context, 
+                DeclarationType.ModuleOption,
+                context,
                 context.GetSelection(),
                 false,
                 null,
@@ -385,11 +386,11 @@ namespace Rubberduck.Parsing.Symbols
         public override void EnterOptionExplicitStmt(VBAParser.OptionExplicitStmtContext context)
         {
             AddDeclaration(CreateDeclaration(
-                context.GetText(), 
-                string.Empty, 
-                Accessibility.Implicit, 
+                context.GetText(),
+                string.Empty,
+                Accessibility.Implicit,
                 DeclarationType.ModuleOption,
-                context, 
+                context,
                 context.GetSelection(),
                 false,
                 null,
@@ -405,10 +406,10 @@ namespace Rubberduck.Parsing.Symbols
             AddDeclaration(
                 CreateDeclaration(
                     context.GetText(),
-                    string.Empty, 
-                    Accessibility.Implicit, 
+                    string.Empty,
+                    Accessibility.Implicit,
                     DeclarationType.ModuleOption,
-                    context, 
+                    context,
                     context.GetSelection(),
                     false,
                     null,
@@ -425,11 +426,11 @@ namespace Rubberduck.Parsing.Symbols
             }
             var name = context.subroutineName().GetText();
             var declaration = CreateDeclaration(
-                name, 
-                null, 
+                name,
+                null,
                 accessibility,
-                DeclarationType.Procedure, 
-                context, 
+                DeclarationType.Procedure,
+                context,
                 context.subroutineName().GetSelection(),
                 false,
                 null,
@@ -460,11 +461,11 @@ namespace Rubberduck.Parsing.Symbols
             var typeHint = Identifier.GetTypeHintValue(identifier);
             var isArray = asTypeClause != null && asTypeClause.type().LPAREN() != null;
             var declaration = CreateDeclaration(
-                name, 
+                name,
                 asTypeName,
-                accessibility, 
-                DeclarationType.Function, 
-                context, 
+                accessibility,
+                DeclarationType.Function,
+                context,
                 context.functionName().identifier().GetSelection(),
                 isArray,
                 asTypeClause,
@@ -490,7 +491,7 @@ namespace Rubberduck.Parsing.Symbols
             var typeHint = Identifier.GetTypeHintValue(identifier);
             var isArray = asTypeClause != null && asTypeClause.type().LPAREN() != null;
             var declaration = CreateDeclaration(
-                name, 
+                name,
                 asTypeName,
                 accessibility,
                 DeclarationType.PropertyGet,
@@ -519,11 +520,11 @@ namespace Rubberduck.Parsing.Symbols
             }
             var name = Identifier.GetName(identifier.identifier());
             var declaration = CreateDeclaration(
-                name, 
-                null, 
+                name,
+                null,
                 accessibility,
-                DeclarationType.PropertyLet, 
-                context, 
+                DeclarationType.PropertyLet,
+                context,
                 context.subroutineName().GetSelection(),
                 false,
                 null,
@@ -548,11 +549,11 @@ namespace Rubberduck.Parsing.Symbols
             var name = Identifier.GetName(identifier.identifier());
 
             var declaration = CreateDeclaration(
-                name, 
-                null, 
+                name,
+                null,
                 accessibility,
-                DeclarationType.PropertySet, 
-                context, 
+                DeclarationType.PropertySet,
+                context,
                 context.subroutineName().GetSelection(),
                 false,
                 null,
@@ -578,11 +579,11 @@ namespace Rubberduck.Parsing.Symbols
             var name = Identifier.GetName(identifier);
 
             var declaration = CreateDeclaration(
-                name, 
-                null, 
+                name,
+                null,
                 accessibility,
-                DeclarationType.Event, 
-                context, 
+                DeclarationType.Event,
+                context,
                 context.identifier().GetSelection(),
                 false,
                 null,
@@ -623,11 +624,11 @@ namespace Rubberduck.Parsing.Symbols
                 : DeclarationType.LibraryProcedure;
 
             var declaration = CreateDeclaration(
-                name, 
-                asTypeName, 
-                accessibility, 
-                declarationType, 
-                context, 
+                name,
+                asTypeName,
+                accessibility,
+                declarationType,
+                context,
                 selection,
                 false,
                 asTypeClause,
@@ -658,9 +659,9 @@ namespace Rubberduck.Parsing.Symbols
                     CreateDeclaration(
                         Identifier.GetName(identifier),
                         asTypeName,
-                        Accessibility.Implicit, 
-                        DeclarationType.Parameter, 
-                        argContext, 
+                        Accessibility.Implicit,
+                        DeclarationType.Parameter,
+                        argContext,
                         identifier.GetSelection(),
                         isArray,
                         asTypeClause,
@@ -672,12 +673,12 @@ namespace Rubberduck.Parsing.Symbols
         {
             AddDeclaration(
                 CreateDeclaration(
-                    context.statementLabel().GetText(), 
+                    context.statementLabel().GetText(),
                     null,
                     Accessibility.Private,
-                    DeclarationType.LineLabel, 
-                    context, 
-                    context.statementLabel().GetSelection(), 
+                    DeclarationType.LineLabel,
+                    context,
+                    context.statementLabel().GetSelection(),
                     true,
                     null,
                     null));
@@ -703,11 +704,11 @@ namespace Rubberduck.Parsing.Symbols
             bool isArray = context.LPAREN() != null;
             AddDeclaration(
                 CreateDeclaration(
-                    name, 
-                    asTypeName, 
-                    accessibility, 
+                    name,
+                    asTypeName,
+                    accessibility,
                     DeclarationType.Variable,
-                    context, 
+                    context,
                     context.identifier().GetSelection(),
                     isArray,
                     asTypeClause,
@@ -730,9 +731,9 @@ namespace Rubberduck.Parsing.Symbols
             var name = Identifier.GetName(identifier);
             var value = context.expression().GetText();
             var declaration = new ConstantDeclaration(
-                new QualifiedMemberName(_qualifiedName, name), 
-                _parentDeclaration, 
-                _currentScope, 
+                new QualifiedMemberName(_qualifiedName, name),
+                _parentDeclaration,
+                _currentScope,
                 asTypeName,
                 asTypeClause,
                 typeHint,
@@ -745,50 +746,75 @@ namespace Rubberduck.Parsing.Symbols
             AddDeclaration(declaration);
         }
 
-        public override void EnterTypeStmt(VBAParser.TypeStmtContext context)
+        public override void EnterPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
         {
-            var accessibility = GetMemberAccessibility(context.visibility());
-            var identifier = context.identifier();
-            if (identifier == null)
-            {
-                return;
-            }
-            var name = Identifier.GetName(identifier);
-            var declaration = CreateDeclaration(
-                name, 
-                null,
-                accessibility, 
-                DeclarationType.UserDefinedType, 
-                context, context.identifier().GetSelection(),
-                false,
-                null,
-                null);
-
-            AddDeclaration(declaration);
-            _parentDeclaration = declaration; // treat members as child declarations, but keep them scoped to module
+            AddUdtDeclaration(context.udtDeclaration(), Accessibility.Public, context);
         }
 
-        public override void ExitTypeStmt(VBAParser.TypeStmtContext context)
+        public override void ExitPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
         {
             _parentDeclaration = _moduleDeclaration;
         }
 
-        public override void EnterTypeStmt_Element(VBAParser.TypeStmt_ElementContext context)
+        public override void EnterPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
         {
-            var asTypeClause = context.asTypeClause();
+            AddUdtDeclaration(context.udtDeclaration(), Accessibility.Private, context);
+        }
+
+        public override void ExitPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
+        {
+            _parentDeclaration = _moduleDeclaration;
+        }
+        
+        public void AddUdtDeclaration(VBAParser.UdtDeclarationContext udtDeclaration, Accessibility accessibility, ParserRuleContext context)
+        {
+            var identifier = Identifier.GetName(udtDeclaration.untypedIdentifier());
+            var identifierSelection = Identifier.GetNameSelection(udtDeclaration.untypedIdentifier());
+            var declaration = CreateDeclaration(
+                identifier,
+                null,
+                accessibility,
+                DeclarationType.UserDefinedType,
+                context,
+                identifierSelection,
+                false,
+                null,
+                null);
+            AddDeclaration(declaration);
+            _parentDeclaration = declaration; // treat members as child declarations, but keep them scoped to module
+        }
+
+        public override void EnterUdtMember(VBAParser.UdtMemberContext context)
+        {
+            VBAParser.AsTypeClauseContext asTypeClause = null;
+            bool isArray = false;
+            string typeHint = null;
+            string identifier;
+            Selection identifierSelection;
+            if (context.reservedNameMemberDeclaration() != null)
+            {
+                identifier = Identifier.GetName(context.reservedNameMemberDeclaration().unrestrictedIdentifier());
+                identifierSelection = Identifier.GetNameSelection(context.reservedNameMemberDeclaration().unrestrictedIdentifier());
+                asTypeClause = context.reservedNameMemberDeclaration().asTypeClause();
+            }
+            else
+            {
+                identifier = Identifier.GetName(context.untypedNameMemberDeclaration().untypedIdentifier());
+                identifierSelection = Identifier.GetNameSelection(context.untypedNameMemberDeclaration().untypedIdentifier());
+                asTypeClause = context.untypedNameMemberDeclaration().optionalArrayClause().asTypeClause();
+                isArray = context.untypedNameMemberDeclaration().optionalArrayClause().arrayDim() != null;
+            }
             var asTypeName = asTypeClause == null
                 ? Tokens.Variant
                 : asTypeClause.type().GetText();
-            bool isArray = context.LPAREN() != null;
-            string typeHint = Identifier.GetTypeHintValue(context.identifier());
             AddDeclaration(
                 CreateDeclaration(
-                    context.identifier().GetText(), 
+                    identifier,
                     asTypeName,
                     Accessibility.Implicit,
-                    DeclarationType.UserDefinedTypeMember, 
-                    context, 
-                    context.identifier().GetSelection(),
+                    DeclarationType.UserDefinedTypeMember,
+                    context,
+                    identifierSelection,
                     isArray,
                     asTypeClause,
                     typeHint));
@@ -805,11 +831,11 @@ namespace Rubberduck.Parsing.Symbols
             var name = Identifier.GetName(identifier);
 
             var declaration = CreateDeclaration(
-                name, 
-                "Long", 
-                accessibility, 
-                DeclarationType.Enumeration, 
-                context, 
+                name,
+                "Long",
+                accessibility,
+                DeclarationType.Enumeration,
+                context,
                 context.identifier().GetSelection(),
                 false,
                 null,
@@ -825,13 +851,13 @@ namespace Rubberduck.Parsing.Symbols
         }
 
         public override void EnterEnumerationStmt_Constant(VBAParser.EnumerationStmt_ConstantContext context)
-        {           
+        {
             AddDeclaration(CreateDeclaration(
                 context.identifier().GetText(),
                 "Long",
-                Accessibility.Implicit, 
-                DeclarationType.EnumerationMember, 
-                context, 
+                Accessibility.Implicit,
+                DeclarationType.EnumerationMember,
+                context,
                 context.identifier().GetSelection(),
                 false,
                 null,

--- a/Rubberduck.Parsing/Symbols/Identifier.cs
+++ b/Rubberduck.Parsing/Symbols/Identifier.cs
@@ -1,5 +1,6 @@
 ﻿using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Preprocessing;
+using Rubberduck.VBEditor;
 using System.Linq;
 
 namespace Rubberduck.Parsing.Symbols
@@ -33,6 +34,11 @@ namespace Rubberduck.Parsing.Symbols
             return GetName(GetIdentifierValueContext(context));
         }
 
+        public static string GetName(VBAParser.UntypedIdentifierContext context)
+        {
+            return GetName(GetIdentifierValueContext(context));
+        }
+
         public static string GetName(VBAParser.IdentifierValueContext value)
         {
             string name;
@@ -55,18 +61,6 @@ namespace Rubberduck.Parsing.Symbols
                 name = value.GetText();
             }
             return name;
-        }
-
-        public static VBAParser.IdentifierValueContext GetIdentifierValueContext(VBAParser.IdentifierContext context)
-        {
-            if (context.untypedIdentifier() != null)
-            {
-                return context.untypedIdentifier().identifierValue();
-            }
-            else
-            {
-                return context.typedIdentifier().identifierValue();
-            }
         }
 
         public static string GetName(VBAConditionalCompilationParser.NameContext context)
@@ -92,6 +86,45 @@ namespace Rubberduck.Parsing.Symbols
                 name = value.GetText();
             }
             return name;
+        }
+
+        public static Selection GetNameSelection(VBAParser.UnrestrictedIdentifierContext context)
+        {
+            if (context.identifier() != null)
+            {
+                return GetNameSelection(context.identifier());
+            }
+            else
+            {
+                return context.GetSelection();
+            }
+        }
+
+        public static Selection GetNameSelection(VBAParser.IdentifierContext context)
+        {
+            return GetIdentifierValueContext(context).GetSelection();
+        }
+
+        public static Selection GetNameSelection(VBAParser.UntypedIdentifierContext context)
+        {
+            return GetIdentifierValueContext(context).GetSelection();
+        }
+
+        public static VBAParser.IdentifierValueContext GetIdentifierValueContext(VBAParser.IdentifierContext context)
+        {
+            if (context.untypedIdentifier() != null)
+            {
+                return GetIdentifierValueContext(context.untypedIdentifier());
+            }
+            else
+            {
+                return context.typedIdentifier().identifierValue();
+            }
+        }
+
+        public static VBAParser.IdentifierValueContext GetIdentifierValueContext(VBAParser.UntypedIdentifierContext context)
+        {
+            return context.identifierValue();
         }
 
         public static string GetTypeHintValue(VBAParser.IdentifierContext identifier)

--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceListener.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceListener.cs
@@ -84,14 +84,29 @@ namespace Rubberduck.Parsing.Symbols
             SetCurrentScope();
         }
 
-        public override void EnterTypeStmt(VBAParser.TypeStmtContext context)
+        public override void EnterPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
         {
-            SetCurrentScope(Identifier.GetName(context.identifier()), DeclarationType.UserDefinedType);
+            SetCurrentScope(Identifier.GetName(context.udtDeclaration().untypedIdentifier()), DeclarationType.UserDefinedType);
         }
 
-        public override void ExitTypeStmt(VBAParser.TypeStmtContext context)
+        public override void ExitPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
         {
             SetCurrentScope();
+        }
+
+        public override void EnterPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
+        {
+            SetCurrentScope(Identifier.GetName(context.udtDeclaration().untypedIdentifier()), DeclarationType.UserDefinedType);
+        }
+
+        public override void ExitPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
+        {
+            SetCurrentScope();
+        }
+
+        public override void EnterArrayDim(VBAParser.ArrayDimContext context)
+        {
+            _resolver.Resolve(context);
         }
 
         public override void EnterWithStmt(VBAParser.WithStmtContext context)

--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
@@ -94,6 +94,22 @@ namespace Rubberduck.Parsing.Symbols
             _withBlockExpressions.Pop();
         }
 
+        public void Resolve(VBAParser.ArrayDimContext context)
+        {
+            if (context.boundsList() == null)
+            {
+                return;
+            }
+            foreach (var dimSpec in context.boundsList().dimSpec())
+            {
+                if (dimSpec.lowerBound() != null)
+                {
+                    ResolveDefault(dimSpec.lowerBound().constantExpression().expression());
+                }
+                ResolveDefault(dimSpec.upperBound().constantExpression().expression());
+            }
+        }
+
         public void Resolve(VBAParser.OnErrorStmtContext context)
         {
             if (context.expression() == null)
@@ -746,7 +762,7 @@ namespace Rubberduck.Parsing.Symbols
                 debugPrint,
                 context.debugPrint().debugPrintSub().GetSelection(),
                 _annotationService.FindAnnotations(_qualifiedModuleName, context.debugPrint().debugPrintSub().GetSelection().StartLine));
-            var outputList = context.outputList();            
+            var outputList = context.outputList();
             if (outputList != null)
             {
                 ResolveOutputList(outputList);

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -325,7 +325,7 @@ Type Test
     anything As Integer
 End             Type";
             var parseResult = Parse(code);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//typeStmt");
+            AssertTree(parseResult.Item1, parseResult.Item2, "//udtDeclaration");
         }
 
         [TestMethod]
@@ -1394,6 +1394,30 @@ Private Sub Foo()
 End Sub";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//literalExpression");
+        }
+
+        [TestMethod]
+        public void TestUdtReservedKeywords()
+        {
+            string code = @"
+Private Type Foo
+    If As Integer
+    Select As Integer
+    Split As String
+    For As Integer
+    Dim As Integer
+    Then As Integer
+    UBound As Variant
+    To As Integer
+    Or As Integer
+    Case As Integer
+    Type As Integer
+    Enum As Integer
+    End As Integer
+End Type
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//udtMember", matches => matches.Count == 13);
         }
 
         private Tuple<VBAParser, ParserRuleContext> Parse(string code)


### PR DESCRIPTION
* UDT parser rule looks more like the one in the VBA spec now. Not sure if it's preferrable to make one udt declaration instead of splitting it up into private/public (at least now it's clear what the default accessibility is)
* Enums don't seem to allow reserved keywords (unless I've missed one)
* Constant expressions inside of arraydims in udt members are resolved properly now ("dimspecs", e.g. udtMember(a To b))

With this PR all issues described in #1766 should be fixed.