### PR TITLE
Revert "Tweak inspection UI performance"

### DIFF
--- a/RetailCoder.VBE/Inspections/IInspector.cs
+++ b/RetailCoder.VBE/Inspections/IInspector.cs
@@ -8,7 +8,7 @@ namespace Rubberduck.Inspections
 {
     public interface IInspector
     {
-        List<ICodeInspectionResult> FindIssuesAsync(RubberduckParserState state, CancellationToken token);
+        Task<IEnumerable<ICodeInspectionResult>> FindIssuesAsync(RubberduckParserState state, CancellationToken token);
     }
 
     public class InspectorIssuesFoundEventArg : EventArgs

--- a/RetailCoder.VBE/Inspections/Inspector.cs
+++ b/RetailCoder.VBE/Inspections/Inspector.cs
@@ -48,11 +48,11 @@ namespace Rubberduck.Inspections
                 }
             }
 
-            public List<ICodeInspectionResult> FindIssuesAsync(RubberduckParserState state, CancellationToken token)
+            public async Task<IEnumerable<ICodeInspectionResult>> FindIssuesAsync(RubberduckParserState state, CancellationToken token)
             {
                 if (state == null || !state.AllUserDeclarations.Any())
                 {
-                    return new List<ICodeInspectionResult>();
+                    return new ICodeInspectionResult[] { };
                 }
 
                 state.OnStatusMessageUpdate(RubberduckUI.CodeInspections_Inspecting);
@@ -78,11 +78,11 @@ namespace Rubberduck.Inspections
                             {
                                 allIssues.Add(inspectionResult);
                             }
-                        }, token)).ToArray();
+                        })).ToList();
 
-                Task.WaitAll(inspections);
+                await Task.WhenAll(inspections);
                 state.OnStatusMessageUpdate(RubberduckUI.ResourceManager.GetString("ParserState_" + state.Status, UI.Settings.Settings.Culture)); // should be "Ready"
-                return allIssues.ToList();
+                return allIssues;
             }
 
             private ParseTreeResults GetParseTreeResults(RubberduckParserState state)

--- a/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
+++ b/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
@@ -259,12 +259,12 @@ namespace Rubberduck.UI.Inspections
             RefreshInspections();
         }
 
-        private void RefreshInspections()
+        private async void RefreshInspections()
         {
             var stopwatch = Stopwatch.StartNew();
             IsBusy = true;
 
-            var results = _inspector.FindIssuesAsync(_state, CancellationToken.None);
+            var results = (await _inspector.FindIssuesAsync(_state, CancellationToken.None)).ToList();
             if (GroupByInspectionType)
             {
                 results = results.OrderBy(o => o.Inspection.InspectionType)

--- a/RubberduckTests/Inspections/EmptyStringLiteralInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyStringLiteralInspectionTests.cs
@@ -47,9 +47,9 @@ End Sub";
             var inspection = new EmptyStringLiteralInspection(null);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [TestMethod]
@@ -79,9 +79,9 @@ End Sub";
             var inspection = new EmptyStringLiteralInspection(null);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [TestMethod]
@@ -111,9 +111,9 @@ End Sub";
             var inspection = new EmptyStringLiteralInspection(null);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count);
+            Assert.AreEqual(0, inspectionResults.Count());
         }
 
         [TestMethod]
@@ -150,7 +150,7 @@ End Sub";
             var inspection = new EmptyStringLiteralInspection(null);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 

--- a/RubberduckTests/Inspections/ObsoleteCallStatementInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteCallStatementInspectionTests.cs
@@ -44,7 +44,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(1, inspectionResults.Count());
         }
@@ -76,7 +76,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -108,7 +108,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -140,7 +140,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(1, inspectionResults.Count());
         }
@@ -172,7 +172,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(1, inspectionResults.Count());
         }
@@ -208,7 +208,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(2, inspectionResults.Count());
         }
@@ -244,7 +244,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(1, inspectionResults.Count());
         }
@@ -291,7 +291,7 @@ End Sub";
             var inspection = new ObsoleteCallStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             foreach (var inspectionResult in inspectionResults)
             {

--- a/RubberduckTests/Inspections/ObsoleteLetStatementInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteLetStatementInspectionTests.cs
@@ -47,7 +47,7 @@ End Sub";
             var inspection = new ObsoleteLetStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(1, inspectionResults.Count());
         }
@@ -83,7 +83,7 @@ End Sub";
             var inspection = new ObsoleteLetStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(2, inspectionResults.Count());
         }
@@ -118,7 +118,7 @@ End Sub";
             var inspection = new ObsoleteLetStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -154,7 +154,7 @@ End Sub";
             var inspection = new ObsoleteLetStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(1, inspectionResults.Count());
         }
@@ -199,7 +199,7 @@ End Sub";
             var inspection = new ObsoleteLetStatementInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 

--- a/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
@@ -44,7 +44,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
 
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
 
             Assert.AreEqual(1, inspectionResults.Count());
@@ -79,7 +79,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(2, inspectionResults.Count());
         }
@@ -111,7 +111,7 @@ End Function";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -142,7 +142,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -173,7 +173,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -204,7 +204,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -245,7 +245,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -285,7 +285,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             Assert.AreEqual(0, inspectionResults.Count());
         }
@@ -323,7 +323,7 @@ End Function";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 
@@ -373,7 +373,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 
@@ -420,7 +420,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 
@@ -467,7 +467,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 
@@ -517,7 +517,7 @@ End Function";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 
@@ -567,7 +567,7 @@ End Sub";
             var inspection = new ProcedureCanBeWrittenAsFunctionInspection(parser.State);
             var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
 
-            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None);
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
 
             inspectionResults.First().QuickFixes.First().Fix();
 


### PR DESCRIPTION
This reverts commit 1288f95ff6f65b497ada9b1887217fa136bdc8b4.

Reverting because I don't have any hard proof that this is better and because we need this to be an async method.