### PR TITLE
Prevent ctor throwing/create inspection for malformed annotations

### DIFF
--- a/RetailCoder.VBE/Inspections/IParseTreeInspection.cs
+++ b/RetailCoder.VBE/Inspections/IParseTreeInspection.cs
@@ -1,6 +1,7 @@
 ﻿using Rubberduck.Parsing;
 using System.Collections.Generic;
 using System.Linq;
+using Rubberduck.Parsing.Grammar;
 
 namespace Rubberduck.Inspections
 {
@@ -17,11 +18,13 @@ namespace Rubberduck.Inspections
             ObsoleteLetContexts = Enumerable.Empty<QualifiedContext>();
             ArgListsWithOneByRefParam = Enumerable.Empty<QualifiedContext>();
             EmptyStringLiterals = Enumerable.Empty<QualifiedContext>();
+            MalformedAnnotations = Enumerable.Empty<QualifiedContext<VBAParser.AnnotationContext>>();
         }
 
         public IEnumerable<QualifiedContext> ObsoleteCallContexts;
         public IEnumerable<QualifiedContext> ObsoleteLetContexts;
         public IEnumerable<QualifiedContext> ArgListsWithOneByRefParam;
         public IEnumerable<QualifiedContext> EmptyStringLiterals;
+        public IEnumerable<QualifiedContext<VBAParser.AnnotationContext>> MalformedAnnotations;
     }
 }

--- a/RetailCoder.VBE/Inspections/InspectionsUI.Designer.cs
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.Designer.cs
@@ -511,6 +511,33 @@ namespace Rubberduck.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An annotation comment is malformed..
+        /// </summary>
+        public static string MalformedAnnotationInspectionMeta {
+            get {
+                return ResourceManager.GetString("MalformedAnnotationInspectionMeta", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Malformed annotation..
+        /// </summary>
+        public static string MalformedAnnotationInspectionName {
+            get {
+                return ResourceManager.GetString("MalformedAnnotationInspectionName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The annotation &apos;{0}&apos; is malformed.
+        /// </summary>
+        public static string MalformedAnnotationInspectionResultFormat {
+            get {
+                return ResourceManager.GetString("MalformedAnnotationInspectionResultFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A module-level variable used only in one procedure should be declared in that procedure..
         /// </summary>
         public static string MoveFieldCloserToUsageInspectionMeta {

--- a/RetailCoder.VBE/Inspections/InspectionsUI.resx
+++ b/RetailCoder.VBE/Inspections/InspectionsUI.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -554,5 +554,14 @@
   </data>
   <data name="VariableTypeNotDeclaredInspectionResultFormat" xml:space="preserve">
     <value>{0} '{1}' is implicitly 'Variant'</value>
+  </data>
+  <data name="MalformedAnnotationInspectionMeta" xml:space="preserve">
+    <value>An annotation comment is malformed.</value>
+  </data>
+  <data name="MalformedAnnotationInspectionName" xml:space="preserve">
+    <value>Malformed annotation.</value>
+  </data>
+  <data name="MalformedAnnotationInspectionResultFormat" xml:space="preserve">
+    <value>The annotation '{0}' is malformed</value>
   </data>
 </root>

--- a/RetailCoder.VBE/Inspections/MalformedAnnotationInspection.cs
+++ b/RetailCoder.VBE/Inspections/MalformedAnnotationInspection.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.Grammar;
+
+namespace Rubberduck.Inspections
+{
+    public sealed class MalformedAnnotationInspection : InspectionBase, IParseTreeInspection
+    {
+        public MalformedAnnotationInspection(RubberduckParserState state)
+            : base(state, CodeInspectionSeverity.Error)
+        {
+        }
+
+        public override string Meta { get { return InspectionsUI.MalformedAnnotationInspectionMeta; } }
+        public override string Description { get { return InspectionsUI.MalformedAnnotationInspectionResultFormat; } }
+        public override CodeInspectionType InspectionType { get { return CodeInspectionType.CodeQualityIssues; } }
+        public ParseTreeResults ParseTreeResults { get; set; }
+
+        public override IEnumerable<InspectionResultBase> GetInspectionResults()
+        {
+            if (ParseTreeResults == null)
+            {
+                return new InspectionResultBase[] { };
+            }
+
+            var results = new List<MalformedAnnotationInspectionResult>();
+
+            foreach (var context in ParseTreeResults.MalformedAnnotations)
+            {
+                if (context.Context.annotationName().GetText() == AnnotationType.Ignore.ToString() ||
+                    context.Context.annotationName().GetText() == AnnotationType.Folder.ToString())
+                {
+                    if (context.Context.annotationArgList() == null)
+                    {
+                        results.Add(new MalformedAnnotationInspectionResult(this,
+                            new QualifiedContext<VBAParser.AnnotationContext>(context.ModuleName,
+                                context.Context)));
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        public class MalformedAnnotationStatementListener : VBAParserBaseListener
+        {
+            private readonly IList<VBAParser.AnnotationContext> _contexts = new List<VBAParser.AnnotationContext>();
+            public IEnumerable<VBAParser.AnnotationContext> Contexts { get { return _contexts; } }
+
+            public override void ExitAnnotation(VBAParser.AnnotationContext context)
+            {
+                if (context.annotationName() != null)
+                {
+                    _contexts.Add(context);
+                }
+            }
+        }
+    }
+
+    public class MalformedAnnotationInspectionResult : InspectionResultBase
+    {
+        public MalformedAnnotationInspectionResult(IInspection inspection, QualifiedContext<VBAParser.AnnotationContext> qualifiedContext)
+            : base(inspection, qualifiedContext.ModuleName, qualifiedContext.Context)
+        {
+        }
+
+        public override string Description
+        {
+            get { return string.Format(Inspection.Description, ((VBAParser.AnnotationContext)Context).annotationName()); }
+        }
+    }
+}

--- a/RetailCoder.VBE/Properties/AssemblyInfo.cs
+++ b/RetailCoder.VBE/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.4.*")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
+[assembly: AssemblyVersion("2.0.5.*")]
+[assembly: AssemblyFileVersion("2.0.5.0")]

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -376,6 +376,7 @@
     </Compile>
     <Compile Include="Inspections\IParseTreeInspection.cs" />
     <Compile Include="Inspections\MakeSingleLineParameterQuickFix.cs" />
+    <Compile Include="Inspections\MalformedAnnotationInspection.cs" />
     <Compile Include="Inspections\ObjectVariableNotSetInspection.cs" />
     <Compile Include="Inspections\RemoveExplicitCallStatmentQuickFix.cs" />
     <Compile Include="Navigation\CodeExplorer\ICodeExplorerDeclarationViewModel.cs" />

--- a/Rubberduck.Parsing/Annotations/FolderAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/FolderAnnotation.cs
@@ -13,11 +13,7 @@ namespace Rubberduck.Parsing.Annotations
             IEnumerable<string> parameters)
             : base(AnnotationType.Folder, qualifiedSelection)
         {
-            if (parameters.Count() != 1)
-            {
-                throw new InvalidAnnotationArgumentException(string.Format("{0} expects exactly one argument, the folder, but none or more than one were passed.", this.GetType().Name));
-            }
-            _folderName = parameters.First();
+            _folderName = parameters.FirstOrDefault() ?? string.Empty;
         }
 
         public string FolderName

--- a/Rubberduck.Parsing/Annotations/IgnoreAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/IgnoreAnnotation.cs
@@ -13,11 +13,7 @@ namespace Rubberduck.Parsing.Annotations
             IEnumerable<string> parameters)
             : base(AnnotationType.Ignore, qualifiedSelection)
         {
-            if (!parameters.Any())
-            {
-                throw new InvalidAnnotationArgumentException(string.Format("{0} expects at least one argument but none were given.", this.GetType().Name));
-            }
-            _inspectionNames = parameters.ToList();
+            _inspectionNames = parameters;
         }
 
         public IEnumerable<string> InspectionNames

--- a/RubberduckTests/Grammar/AnnotationTests.cs
+++ b/RubberduckTests/Grammar/AnnotationTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.VBEditor;
 
@@ -55,20 +54,6 @@ namespace RubberduckTests.Grammar
         {
             var annotation = new IgnoreTestAnnotation(new QualifiedSelection(), null);
             Assert.AreEqual(AnnotationType.IgnoreTest, annotation.AnnotationType);
-        }
-
-        [TestMethod, ExpectedException(typeof(InvalidAnnotationArgumentException))]
-        public void IgnoreAnnotation_TypeIsIgnore_NoParam()
-        {
-            var annotation = new IgnoreAnnotation(new QualifiedSelection(), new List<string>());
-            Assert.AreEqual(AnnotationType.Ignore, annotation.AnnotationType);
-        }
-
-        [TestMethod, ExpectedException(typeof(InvalidAnnotationArgumentException))]
-        public void FolderAnnotation_TypeIsFolder_NoParam()
-        {
-            var annotation = new FolderAnnotation(new QualifiedSelection(), new List<string>());
-            Assert.AreEqual(AnnotationType.Folder, annotation.AnnotationType);
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/MalformedAnnotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/MalformedAnnotationInspectionTests.cs
@@ -1,0 +1,202 @@
+using System.Linq;
+using Microsoft.Vbe.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Rubberduck.Inspections;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.VBEHost;
+using RubberduckTests.Mocks;
+using Rubberduck.Settings;
+using Rubberduck.Inspections.Rubberduck.Inspections;
+using System.Threading;
+using Rubberduck.Parsing;
+
+namespace RubberduckTests.Inspections
+{
+    [TestClass]
+    public class MalformedAnnotationInspectionTests
+    {
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void MalformedAnnotation_ReturnsResult_Folder()
+        {
+            const string inputCode =
+@"'@Folder";
+
+            //Arrange
+            var settings = new Mock<IGeneralConfigService>();
+            var config = GetTestConfig();
+            settings.Setup(x => x.LoadConfiguration()).Returns(config);
+
+            var builder = new MockVbeBuilder();
+            VBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new MalformedAnnotationInspection(parser.State);
+            var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
+
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void MalformedAnnotation_DoesNotReturnResult_Folder()
+        {
+            const string inputCode =
+@"'@Folder ""Foo""";
+
+            //Arrange
+            var settings = new Mock<IGeneralConfigService>();
+            var config = GetTestConfig();
+            settings.Setup(x => x.LoadConfiguration()).Returns(config);
+
+            var builder = new MockVbeBuilder();
+            VBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new MalformedAnnotationInspection(parser.State);
+            var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
+
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void MalformedAnnotation_ReturnsResult_Ignore()
+        {
+            const string inputCode =
+@"'@Ignore";
+
+            //Arrange
+            var settings = new Mock<IGeneralConfigService>();
+            var config = GetTestConfig();
+            settings.Setup(x => x.LoadConfiguration()).Returns(config);
+
+            var builder = new MockVbeBuilder();
+            VBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new MalformedAnnotationInspection(parser.State);
+            var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
+
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void MalformedAnnotation_DoesNotReturnResult_Ignore()
+        {
+            const string inputCode =
+@"'@Ignore ProcedureNotUsedInspection";
+
+            //Arrange
+            var settings = new Mock<IGeneralConfigService>();
+            var config = GetTestConfig();
+            settings.Setup(x => x.LoadConfiguration()).Returns(config);
+
+            var builder = new MockVbeBuilder();
+            VBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new MalformedAnnotationInspection(parser.State);
+            var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
+
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void MalformedAnnotation_ReturnsMultipleResults()
+        {
+            const string inputCode =
+@"'@Folder
+'@Ignore";
+
+            //Arrange
+            var settings = new Mock<IGeneralConfigService>();
+            var config = GetTestConfig();
+            settings.Setup(x => x.LoadConfiguration()).Returns(config);
+
+            var builder = new MockVbeBuilder();
+            VBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new MalformedAnnotationInspection(parser.State);
+            var inspector = new Inspector(settings.Object, new IInspection[] { inspection });
+
+            var inspectionResults = inspector.FindIssuesAsync(parser.State, CancellationToken.None).Result;
+
+            Assert.AreEqual(2, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void InspectionType()
+        {
+            var inspection = new MalformedAnnotationInspection(null);
+            Assert.AreEqual(CodeInspectionType.CodeQualityIssues, inspection.InspectionType);
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void InspectionName()
+        {
+            const string inspectionName = "MalformedAnnotationInspection";
+            var inspection = new MalformedAnnotationInspection(null);
+
+            Assert.AreEqual(inspectionName, inspection.Name);
+        }
+
+        private Configuration GetTestConfig()
+        {
+            var settings = new CodeInspectionSettings();
+            settings.CodeInspections.Add(new CodeInspectionSetting
+            {
+                Description = new MalformedAnnotationInspection(null).Description,
+                Severity = CodeInspectionSeverity.Error
+            });
+            return new Configuration
+            {
+                UserSettings = new UserSettings(null, null, null, settings, null, null)
+            };
+        }
+    }
+}

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Inspections\ImplicitActiveSheetReferenceInspectionTests.cs" />
     <Compile Include="Inspections\MultipleFolderAnnotationsInspectionTests.cs" />
     <Compile Include="Inspections\ObjectVariableNotSetInpsectionTests.cs" />
+    <Compile Include="Inspections\MalformedAnnotationInspectionTests.cs" />
     <Compile Include="Inspections\UntypedFunctionUsageInspectionTests.cs" />
     <Compile Include="Inspections\UnassignedVariableUsageInspectionTests.cs" />
     <Compile Include="Inspections\WriteOnlyPropertyInspectionTests.cs" />


### PR DESCRIPTION
Close #2012 and #2013