### PR TITLE
Make inspection quick fix menu use correct localization

### DIFF
--- a/RetailCoder.VBE/Inspections/CodeInspectionQuickFix.cs
+++ b/RetailCoder.VBE/Inspections/CodeInspectionQuickFix.cs
@@ -1,4 +1,5 @@
-﻿using Antlr4.Runtime;
+﻿using System.Windows.Threading;
+using Antlr4.Runtime;
 using Rubberduck.VBEditor;
 
 namespace Rubberduck.Inspections
@@ -11,6 +12,9 @@ namespace Rubberduck.Inspections
 
         public CodeInspectionQuickFix(ParserRuleContext context, QualifiedSelection selection, string description)
         {
+            Dispatcher.CurrentDispatcher.Thread.CurrentCulture = UI.Settings.Settings.Culture;
+            Dispatcher.CurrentDispatcher.Thread.CurrentUICulture = UI.Settings.Settings.Culture;
+
             _context = context;
             _selection = selection;
             _description = description;

--- a/RetailCoder.VBE/UI/Settings/Settings.cs
+++ b/RetailCoder.VBE/UI/Settings/Settings.cs
@@ -42,7 +42,7 @@ namespace Rubberduck.UI.Settings
         {
             if (_configService == null)
             {
-                _cultureInfo = RubberduckUI.Culture;
+                _cultureInfo = RubberduckUI.Culture ?? Dispatcher.CurrentDispatcher.Thread.CurrentUICulture;
                 return;
             }
 


### PR DESCRIPTION
Close #2035 

Note that this will not update the menu when the language is changed until the inspection list is refreshed.