### PR TITLE
Ensure projects reference the RD library before running tests

### DIFF
--- a/RetailCoder.VBE/UI/Command/RunAllTestsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/RunAllTestsCommand.cs
@@ -37,6 +37,8 @@ namespace Rubberduck.UI.Command
 
         protected override void ExecuteImpl(object parameter)
         {
+            EnsureRubberduckIsReferencedForEarlyBoundTests();
+
             if (!_state.IsDirty())
             {
                 RunTests();
@@ -45,6 +47,18 @@ namespace Rubberduck.UI.Command
             {
                 _model.TestsRefreshed += TestsRefreshed;
                 _model.Refresh();
+            }
+        }
+
+        private void EnsureRubberduckIsReferencedForEarlyBoundTests()
+        {
+            foreach (var member in _state.AllUserDeclarations)
+            {
+                if (member.AsTypeName == "Rubberduck.PermissiveAssertClass" ||
+                    member.AsTypeName == "Rubberduck.AssertClass")
+                {
+                    member.Project.EnsureReferenceToAddInLibrary();
+                }
             }
         }
 

--- a/RetailCoder.VBE/UI/UnitTesting/TestExplorerViewModel.cs
+++ b/RetailCoder.VBE/UI/UnitTesting/TestExplorerViewModel.cs
@@ -228,8 +228,22 @@ namespace Rubberduck.UI.UnitTesting
             return !Model.IsBusy && _state.IsDirty();
         }
 
+        private void EnsureRubberduckIsReferencedForEarlyBoundTests()
+        {
+            foreach (var member in _state.AllUserDeclarations)
+            {
+                if (member.AsTypeName == "Rubberduck.PermissiveAssertClass" ||
+                    member.AsTypeName == "Rubberduck.AssertClass")
+                {
+                    member.Project.EnsureReferenceToAddInLibrary();
+                }
+            }
+        }
+
         private void ExecuteRepeatLastRunCommand(object parameter)
         {
+            EnsureRubberduckIsReferencedForEarlyBoundTests();
+
             var tests = _model.LastRun.ToList();
             _model.ClearLastRun();
 
@@ -246,6 +260,8 @@ namespace Rubberduck.UI.UnitTesting
 
         private void ExecuteRunNotExecutedTestsCommand(object parameter)
         {
+            EnsureRubberduckIsReferencedForEarlyBoundTests();
+
             _model.ClearLastRun();
 
             var stopwatch = new Stopwatch();
@@ -261,6 +277,8 @@ namespace Rubberduck.UI.UnitTesting
 
         private void ExecuteRunFailedTestsCommand(object parameter)
         {
+            EnsureRubberduckIsReferencedForEarlyBoundTests();
+
             _model.ClearLastRun();
 
             var stopwatch = new Stopwatch();
@@ -276,6 +294,8 @@ namespace Rubberduck.UI.UnitTesting
 
         private void ExecuteRunPassedTestsCommand(object parameter)
         {
+            EnsureRubberduckIsReferencedForEarlyBoundTests();
+
             _model.ClearLastRun();
 
             var stopwatch = new Stopwatch();
@@ -300,6 +320,8 @@ namespace Rubberduck.UI.UnitTesting
             {
                 return;
             }
+
+            EnsureRubberduckIsReferencedForEarlyBoundTests();
 
             _model.ClearLastRun();
 


### PR DESCRIPTION
If any tests have the `AsTypeName` of `Rubberduck.PermissiveAssertClass` or `Rubberduck.AssertClass`, that is.

Close #2056