### PR TITLE
ObjectVariableNotSet adjustments for Functions and Property Get

### DIFF
--- a/RubberduckTests/Inspections/ObjectVariableNotSetInpsectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInpsectionTests.cs
@@ -215,5 +215,89 @@ End Sub";
 
             Assert.AreEqual(expectedCode, module.Lines());
         }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_ForFunctionAssignment_ReturnsResult()
+        {
+            const string inputCode = @"
+Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) As Range
+    If source Is Nothing Then
+        CombineRanges = toCombine 'no inspection result (but there should be one!)
+    Else
+        CombineRanges = Union(source, toCombine) 'no inspection result (but there should be one!)
+    End If
+End Function";
+
+            const string expectedCode = @"
+Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) As Range
+    If source Is Nothing Then
+        Set CombineRanges = toCombine 'no inspection result (but there should be one!)
+    Else
+        Set CombineRanges = Union(source, toCombine) 'no inspection result (but there should be one!)
+    End If
+End Function";
+
+            //Arrange
+            var builder = new MockVbeBuilder();
+            VBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var module = vbe.Object.VBProjects.Item(0).VBComponents.Item(0).CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ObjectVariableNotSetInspection(parser.State);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(2, inspectionResults.Count());
+            foreach (var fix in inspectionResults.SelectMany(result => result.QuickFixes.Where(s => s is SetObjectVariableQuickFix)))
+            {
+                fix.Fix();
+            }
+            Assert.AreEqual(expectedCode, module.Lines());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_ForPropertyGetAssignment_ReturnsResults()
+        {
+            const string inputCode = @"
+Private example As MyObject
+Public Property Get Example() As MyObject
+    Example = example
+End Property
+";
+            const string expectedCode = @"
+Private example As MyObject
+Public Property Get Example() As MyObject
+    Set Example = example
+End Property
+";
+            //Arrange
+            var builder = new MockVbeBuilder();
+            VBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var module = vbe.Object.VBProjects.Item(0).VBComponents.Item(0).CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ObjectVariableNotSetInspection(parser.State);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+            foreach (var fix in inspectionResults.SelectMany(result => result.QuickFixes.Where(s => s is SetObjectVariableQuickFix)))
+            {
+                fix.Fix();
+            }
+            Assert.AreEqual(expectedCode, module.Lines());
+        }
     }
 }


### PR DESCRIPTION
Expanded ObjectVariableNotSet to check Functions and PropertyGet, fixes #2199