### PR TITLE
Honor DoNotShow severity level for ParseTree inspections

### DIFF
--- a/RetailCoder.VBE/Inspections/Inspector.cs
+++ b/RetailCoder.VBE/Inspections/Inspector.cs
@@ -30,13 +30,12 @@ namespace Rubberduck.Inspections
 
             private void ConfigServiceSettingsChanged(object sender, EventArgs e)
             {
-                UpdateInspectionSeverity();
+                var config = _configService.LoadConfiguration();
+                UpdateInspectionSeverity(config);
             }
 
-            private void UpdateInspectionSeverity()
+            private void UpdateInspectionSeverity(Configuration config)
             {
-                var config = _configService.LoadConfiguration();
-
                 foreach (var inspection in _inspections)
                 {
                     foreach (var setting in config.UserSettings.CodeInspectionSettings.CodeInspections)
@@ -57,12 +56,14 @@ namespace Rubberduck.Inspections
                 }
 
                 state.OnStatusMessageUpdate(RubberduckUI.CodeInspections_Inspecting);
-                UpdateInspectionSeverity();
+
+                var config = _configService.LoadConfiguration();
+                UpdateInspectionSeverity(config);
 
                 var allIssues = new ConcurrentBag<ICodeInspectionResult>();
 
                 // Prepare ParseTreeWalker based inspections
-                var parseTreeWalkResults = GetParseTreeResults(state);
+                var parseTreeWalkResults = GetParseTreeResults(config, state);
                 foreach (var parseTreeInspection in _inspections.Where(inspection => inspection.Severity != CodeInspectionSeverity.DoNotShow && inspection is IParseTreeInspection))
                 {
                     (parseTreeInspection as IParseTreeInspection).ParseTreeResults = parseTreeWalkResults;
@@ -86,9 +87,10 @@ namespace Rubberduck.Inspections
                 return allIssues;
             }
 
-            private ParseTreeResults GetParseTreeResults(RubberduckParserState state)
+            private ParseTreeResults GetParseTreeResults(Configuration config, RubberduckParserState state)
             {
                 var result = new ParseTreeResults();
+                var settings = config.UserSettings.CodeInspectionSettings;
 
                 foreach (var componentTreePair in state.ParseTrees)
                 {
@@ -96,11 +98,11 @@ namespace Rubberduck.Inspections
                     Need to reinitialize these for each and every ParseTree we process, since the results are aggregated in the instances themselves 
                     before moving them into the ParseTreeResults after qualifying them 
                     */
-                    var obsoleteCallStatementListener = new ObsoleteCallStatementInspection.ObsoleteCallStatementListener();
-                    var obsoleteLetStatementListener = new ObsoleteLetStatementInspection.ObsoleteLetStatementListener();
-                    var emptyStringLiteralListener = new EmptyStringLiteralInspection.EmptyStringLiteralListener();
-                    var argListWithOneByRefParamListener = new ProcedureCanBeWrittenAsFunctionInspection.ArgListWithOneByRefParamListener();
-                    var malformedAnnotationListenter = new MalformedAnnotationInspection.MalformedAnnotationStatementListener();
+                    var obsoleteCallStatementListener = IsDisabled<ObsoleteCallStatementInspection>(settings) ? null : new ObsoleteCallStatementInspection.ObsoleteCallStatementListener();
+                    var obsoleteLetStatementListener = IsDisabled<ObsoleteLetStatementInspection>(settings) ? null : new ObsoleteLetStatementInspection.ObsoleteLetStatementListener();
+                    var emptyStringLiteralListener = IsDisabled<EmptyStringLiteralInspection>(settings) ? null : new EmptyStringLiteralInspection.EmptyStringLiteralListener();
+                    var argListWithOneByRefParamListener = IsDisabled<ProcedureCanBeWrittenAsFunctionInspection>(settings) ? null : new ProcedureCanBeWrittenAsFunctionInspection.ArgListWithOneByRefParamListener();
+                    var malformedAnnotationListenter = IsDisabled<MalformedAnnotationInspection>(settings) ? null : new MalformedAnnotationInspection.MalformedAnnotationStatementListener();
 
                     var combinedListener = new CombinedParseTreeListener(new IParseTreeListener[]{
                         obsoleteCallStatementListener,
@@ -112,13 +114,29 @@ namespace Rubberduck.Inspections
 
                     ParseTreeWalker.Default.Walk(combinedListener, componentTreePair.Value);
 
-                    result.ArgListsWithOneByRefParam = result.ArgListsWithOneByRefParam.Concat(argListWithOneByRefParamListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
-                    result.EmptyStringLiterals = result.EmptyStringLiterals.Concat(emptyStringLiteralListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
-                    result.ObsoleteLetContexts = result.ObsoleteLetContexts.Concat(obsoleteLetStatementListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
-                    result.ObsoleteCallContexts = result.ObsoleteCallContexts.Concat(obsoleteCallStatementListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
-                    result.MalformedAnnotations = result.MalformedAnnotations.Concat(malformedAnnotationListenter.Contexts.Select(context => new QualifiedContext<VBAParser.AnnotationContext>(componentTreePair.Key, context)));
+                    result.ArgListsWithOneByRefParam = argListWithOneByRefParamListener == null 
+                        ? Enumerable.Empty<QualifiedContext>() 
+                        : result.ArgListsWithOneByRefParam.Concat(argListWithOneByRefParamListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
+                    result.EmptyStringLiterals = emptyStringLiteralListener == null 
+                        ? Enumerable.Empty<QualifiedContext>() 
+                        : result.EmptyStringLiterals.Concat(emptyStringLiteralListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
+                    result.ObsoleteLetContexts = obsoleteLetStatementListener == null 
+                        ? Enumerable.Empty<QualifiedContext>() 
+                        : result.ObsoleteLetContexts.Concat(obsoleteLetStatementListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
+                    result.ObsoleteCallContexts = obsoleteCallStatementListener == null 
+                        ? Enumerable.Empty<QualifiedContext>() 
+                        : result.ObsoleteCallContexts.Concat(obsoleteCallStatementListener.Contexts.Select(context => new QualifiedContext(componentTreePair.Key, context)));
+                    result.MalformedAnnotations = malformedAnnotationListenter == null 
+                        ? Enumerable.Empty<QualifiedContext>() 
+                        : result.MalformedAnnotations.Concat(malformedAnnotationListenter.Contexts.Select(context => new QualifiedContext<VBAParser.AnnotationContext>(componentTreePair.Key, context)));
                 }
                 return result;
+            }
+
+            private bool IsDisabled<TInspection>(CodeInspectionSettings config) where TInspection : IInspection
+            {
+                var setting = config.GetSetting<TInspection>();
+                return setting != null && setting.Severity == CodeInspectionSeverity.DoNotShow;
             }
 
             public void Dispose()

--- a/RetailCoder.VBE/Inspections/ProcedureCanBeWrittenAsFunctionInspection.cs
+++ b/RetailCoder.VBE/Inspections/ProcedureCanBeWrittenAsFunctionInspection.cs
@@ -73,7 +73,8 @@ namespace Rubberduck.Inspections
             return ParseTreeResults.ArgListsWithOneByRefParam
                 .Where(context => context.Context.Parent is VBAParser.SubStmtContext &&
                                   subStmtsNotImplementingInterfaces.Contains(context.Context.Parent) &&
-                                  subStmtsNotImplementingEvents.Contains(context.Context.Parent))
+                                  subStmtsNotImplementingEvents.Contains(context.Context.Parent)
+                        && !IsInspectionDisabled(context.ModuleName.Component, context.Context.Start.Line))
                 .Select(context => new ProcedureShouldBeFunctionInspectionResult(this,
                     State,
                     new QualifiedContext<VBAParser.ArgListContext>(context.ModuleName,

--- a/RetailCoder.VBE/Settings/CodeInspectionSettings.cs
+++ b/RetailCoder.VBE/Settings/CodeInspectionSettings.cs
@@ -38,7 +38,25 @@ namespace Rubberduck.Settings
 
         public CodeInspectionSetting GetSetting<TInspection>() where TInspection : IInspection
         {
-            return CodeInspections.FirstOrDefault(s => s.Name.Equals(typeof(TInspection).Name.ToString()));
+            return CodeInspections.FirstOrDefault(s => typeof(TInspection).Name.ToString().Equals(s.Name))
+                ?? GetSetting(typeof(TInspection));
+        }
+
+        public CodeInspectionSetting GetSetting(Type inspection)
+        {
+            try
+            {
+                var proto = Convert.ChangeType(Activator.CreateInstance(inspection), inspection);
+                var existing = CodeInspections.FirstOrDefault(s => proto.GetType().ToString().Equals(s.Name));
+                if (existing != null) return existing;
+                var setting = new CodeInspectionSetting(proto as IInspectionModel);
+                CodeInspections.Add(setting);
+                return setting;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
     }
 

--- a/RetailCoder.VBE/Settings/CodeInspectionSettings.cs
+++ b/RetailCoder.VBE/Settings/CodeInspectionSettings.cs
@@ -36,14 +36,9 @@ namespace Rubberduck.Settings
             RunInspectionsOnSuccessfulParse = runInspectionsOnParse;
         }
 
-        public CodeInspectionSetting GetSetting(Type inspection)
+        public CodeInspectionSetting GetSetting<TInspection>() where TInspection : IInspection
         {
-            var proto = Convert.ChangeType(Activator.CreateInstance(inspection), inspection);
-            var existing = CodeInspections.FirstOrDefault(s => s.Name.Equals(proto.GetType().ToString()));
-            if (existing != null) return existing;
-            var setting = new CodeInspectionSetting(proto as IInspectionModel);
-            CodeInspections.Add(setting);
-            return setting;
+            return CodeInspections.FirstOrDefault(s => s.Name.Equals(typeof(TInspection).Name.ToString()));
         }
     }
 

--- a/Rubberduck.Parsing/VBA/CombinedParseTreeListener.cs
+++ b/Rubberduck.Parsing/VBA/CombinedParseTreeListener.cs
@@ -13,7 +13,7 @@ namespace Rubberduck.Parsing.VBA
         private readonly IReadOnlyList<IParseTreeListener> _listeners;
         public CombinedParseTreeListener(IEnumerable<IParseTreeListener> listeners)
         {
-            _listeners = listeners.ToList();
+            _listeners = listeners.Where(listener => listener != null).ToList();
         }
 
         public void EnterEveryRule(ParserRuleContext ctx)


### PR DESCRIPTION
fixes #2179 and now honors `@Ignore ProcedureCanBeWrittenAsFunction` annotation.