### PR TITLE
ignore functions returning arrays AND variable array assignments

### DIFF
--- a/RetailCoder.VBE/Inspections/ObjectVariableNotSetInspection.cs
+++ b/RetailCoder.VBE/Inspections/ObjectVariableNotSetInspection.cs
@@ -89,6 +89,7 @@ namespace Rubberduck.Inspections
             var interestingDeclarations =
                 State.AllUserDeclarations.Where(item =>
                         !item.IsSelfAssigned &&
+                        !item.IsArray &&
                         !ValueTypes.Contains(item.AsTypeName) &&
                         (item.AsTypeDeclaration == null ||
                         item.AsTypeDeclaration.DeclarationType != DeclarationType.Enumeration &&

--- a/RetailCoder.VBE/Inspections/ObjectVariableNotSetInspection.cs
+++ b/RetailCoder.VBE/Inspections/ObjectVariableNotSetInspection.cs
@@ -99,6 +99,7 @@ namespace Rubberduck.Inspections
             var interestingMembers =
                 State.AllUserDeclarations.Where(item =>
                     (item.DeclarationType == DeclarationType.Function || item.DeclarationType == DeclarationType.PropertyGet)
+                    && !item.IsArray
                     && item.IsTypeSpecified
                     && !ValueTypes.Contains(item.AsTypeName));
 


### PR DESCRIPTION
Partial fix for #2265. Requires a fix for #2266 before *all* functions
returning arrays are excluded.