### PR TITLE
Remove subclass from RubberduckHooks in Dispose(). 

### DIFF
--- a/RetailCoder.VBE/Common/RubberduckHooks.cs
+++ b/RetailCoder.VBE/Common/RubberduckHooks.cs
@@ -17,9 +17,7 @@ namespace Rubberduck.Common
     public class RubberduckHooks : IRubberduckHooks
     {
         private readonly IntPtr _mainWindowHandle;
-        private readonly IntPtr _oldWndPointer;
-        private readonly User32.WndProc _oldWndProc;
-        private User32.WndProc _newWndProc;
+        private readonly IntPtr _oldWndProc;
         private RawInput _rawinput;
         private IRawDevice _kb;
         private IRawDevice _mouse;
@@ -35,10 +33,8 @@ namespace Rubberduck.Common
                 _mainWindowHandle = (IntPtr)mainWindow.HWnd;
             }
 
-            _oldWndProc = WindowProc;
-            _newWndProc = WindowProc;
-            _oldWndPointer = User32.SetWindowLong(_mainWindowHandle, (int)WindowLongFlags.GWL_WNDPROC, _newWndProc);
-            _oldWndProc = (User32.WndProc)Marshal.GetDelegateForFunctionPointer(_oldWndPointer, typeof(User32.WndProc));
+            User32.WndProc newWndProc = WindowProc;
+            _oldWndProc = User32.SetWindowLong(_mainWindowHandle, (int)WindowLongFlags.GWL_WNDPROC, Marshal.GetFunctionPointerForDelegate(newWndProc));
 
             _commands = commands;
             _config = config;
@@ -186,6 +182,7 @@ namespace Rubberduck.Common
         public void Dispose()
         {
             Detach();
+            User32.SetWindowLong(_mainWindowHandle, (int)WindowLongFlags.GWL_WNDPROC, _oldWndProc);
         }
 
         private IntPtr WindowProc(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam)

--- a/RetailCoder.VBE/Common/WinAPI/User32.cs
+++ b/RetailCoder.VBE/Common/WinAPI/User32.cs
@@ -44,10 +44,10 @@ namespace Rubberduck.Common.WinAPI
         public static extern bool UnregisterHotKey(IntPtr hWnd, IntPtr id);
 
         [DllImport("user32.dll")]
-        public static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, WndProc dwNewLong);
+        public static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
         [DllImport("user32.dll")]
-        public static extern IntPtr CallWindowProc(WndProc lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+        public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
         public delegate IntPtr WndProc(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
 
         /// <summary>


### PR DESCRIPTION
Also fixed signature for `CallWindowProc`. `lpPrevWndFunc` can be a raw function pointer, also no need to create a delegate for the old WndProc, because it shouldn't ever be called directly.