### PR TITLE
Fix for issue #2347

### DIFF
--- a/RetailCoder.VBE/AutoSave/AutoSave.cs
+++ b/RetailCoder.VBE/AutoSave/AutoSave.cs
@@ -36,20 +36,26 @@ namespace Rubberduck.AutoSave
 
         private void _timer_Elapsed(object sender, ElapsedEventArgs e)
         {
-            var saveCommand = _vbe.CommandBars.FindControl(VbeSaveCommandId);
-            var activeProject = _vbe.ActiveVBProject;
-            var unsaved = _vbe
-                .VBProjects
-                .Where(project => !project.IsSaved && !string.IsNullOrEmpty(project.FileName));
+            SaveAllUnsavedProjects();
+        }
 
-            foreach (var project in unsaved)
+            private void SaveAllUnsavedProjects()
             {
-                _vbe.ActiveVBProject = project;
-                saveCommand.Execute();
+                var saveCommand = _vbe.CommandBars.FindControl(VbeSaveCommandId);
+                var activeProject = _vbe.ActiveVBProject;
+                var unsaved = _vbe
+                    .VBProjects
+                    .Where(project => !project.IsSaved && !string.IsNullOrEmpty(project.FileName));
+
+                foreach (var project in unsaved)
+                {
+                    _vbe.ActiveVBProject = project;
+                    saveCommand.Execute();
+                }
+
+                _vbe.ActiveVBProject = activeProject;
             }
 
-            _vbe.ActiveVBProject = activeProject;
-        }
 
         public void Dispose()
         {

--- a/RetailCoder.VBE/Extension.cs
+++ b/RetailCoder.VBE/Extension.cs
@@ -143,14 +143,15 @@ namespace Rubberduck
                 return;
             }
 
-            var config = new XmlPersistanceService<GeneralSettings>
+            var configLoader = new XmlPersistanceService<GeneralSettings>
             {
                 FilePath =
                     Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                         "Rubberduck", "rubberduck.config")
             };
-
-            var settings = config.Load(null);
+            var configProvider = new GeneralConfigProvider(configLoader);
+            
+            var settings = configProvider.Create();
             if (settings != null)
             {
                 try

--- a/Rubberduck.SettingsProvider/XmlPersistanceService.cs
+++ b/Rubberduck.SettingsProvider/XmlPersistanceService.cs
@@ -37,14 +37,14 @@ namespace Rubberduck.SettingsProvider
 
             if (!File.Exists(FilePath))
             {
-                return (T)Convert.ChangeType(null, type);
+                return FailedLoadReturnValue();
             }
             var doc = GetConfigurationDoc(FilePath);
             
             var node = doc.Descendants().FirstOrDefault(e => e.Name.LocalName.Equals(type.Name));
             if (node == null)
             {
-                return (T)Convert.ChangeType(null, type);
+                return FailedLoadReturnValue();
             }
 
             using (var reader = node.CreateReader())
@@ -57,10 +57,16 @@ namespace Rubberduck.SettingsProvider
                 }
                 catch
                 {
-                    return (T)Convert.ChangeType(null, type);
+                    return FailedLoadReturnValue();
                 }
             }  
         }
+
+            private static T FailedLoadReturnValue()
+            {
+                return (T)Convert.ChangeType(null, typeof(T));
+            }
+
 
         public void Save(T toSerialize)
         {


### PR DESCRIPTION
The method `InitializeAddIn` in Extension.cs now loads the settings via a `GeneralSettingsProvider` instead of directly querying the `XmlPersistencyService`.  

This should fix issue #2347.

Additionally, this contains two small refactorings for code clarity I made along the way.