### PR TITLE
IgnoreOnce quickfix for NonReturningFunction inspection in interface case

### DIFF
--- a/RetailCoder.VBE/Inspections/NonReturningFunctionInspectionResult.cs
+++ b/RetailCoder.VBE/Inspections/NonReturningFunctionInspectionResult.cs
@@ -17,7 +17,10 @@ namespace Rubberduck.Inspections
             : base(inspection, qualifiedContext.ModuleName, qualifiedContext.Context, target)
         {
             _quickFixes = isInterfaceImplementation 
-                ? new CodeInspectionQuickFix[] { }
+                ? new CodeInspectionQuickFix[] 
+                {
+                    new IgnoreOnceQuickFix(Context, QualifiedSelection, Inspection.AnnotationName),
+                }
                 : new CodeInspectionQuickFix[]
                 {
                     new ConvertToProcedureQuickFix(Context, QualifiedSelection, target),

--- a/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
@@ -477,7 +477,7 @@ End Sub";
 
         [TestMethod]
         [TestCategory("Inspections")]
-        public void NonReturningFunction_ReturnsResult_InterfaceImplementation_NoQuickFix()
+        public void NonReturningFunction_ReturnsResult_InterfaceImplementation_OnlyIgnoreOnceQuickFix()
         {
             //Input
             const string inputCode1 =
@@ -507,7 +507,8 @@ End Function";
             var inspection = new NonReturningFunctionInspection(parser.State);
             var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.First().QuickFixes.Count());
+            Assert.IsTrue(inspectionResults.First().QuickFixes.Any() 
+                && inspectionResults.First().QuickFixes.All(quickfix => quickfix.Description == InspectionsUI.IgnoreOnce));
         }
 
         [TestMethod]


### PR DESCRIPTION
I added the `IgnoreOnce` quickfix to the list of quickfixes for the `NonReturningFunction` inspection in the case that the function is part of implementing an interface. 

A viable case for this was presented in issue #2365.

I also amended the corresponding test that verified that no quickfixes are provided in the interface case. Now, it verifies that exactly the `IgnoreOnce` quickfix is provided.  