### PR TITLE
Standardized Reparsing from Code Explorer and Inspection Results toolwindows

### DIFF
--- a/RetailCoder.VBE/App.cs
+++ b/RetailCoder.VBE/App.cs
@@ -51,7 +51,6 @@ namespace Rubberduck
             _configService.SettingsChanged += _configService_SettingsChanged;
             _parser.State.StateChanged += Parser_StateChanged;
             _parser.State.StatusMessageUpdate += State_StatusMessageUpdate;
-            _stateBar.Refresh += _stateBar_Refresh;
 
             UiDispatcher.Initialize();
         }
@@ -119,7 +118,7 @@ namespace Rubberduck
             }
         }
 
-        private void EnsureDirectoriesExist()
+        private static void EnsureLogFolderPathExists()
         {
             try
             {
@@ -141,7 +140,7 @@ namespace Rubberduck
 
         public void Startup()
         {
-            EnsureDirectoriesExist();
+            EnsureLogFolderPathExists();
             LoadConfig();
             _appMenus.Initialize();
             _stateBar.Initialize();
@@ -161,13 +160,6 @@ namespace Rubberduck
             {
                 // Won't matter anymore since we're shutting everything down anyway.
             }
-        }
-
-        private void _stateBar_Refresh(object sender, EventArgs e)
-        {
-            // handles "refresh" button click on "Rubberduck" command bar
-            _parser.State.OnParseRequested(sender);
-            _parser.State.StartEventSinks(); // no-op if already started
         }
 
         private void Parser_StateChanged(object sender, EventArgs e)
@@ -219,11 +211,6 @@ namespace Rubberduck
             if (_configService != null)
             {
                 _configService.SettingsChanged -= _configService_SettingsChanged;
-            }
-
-            if (_stateBar != null)
-            {
-                _stateBar.Refresh -= _stateBar_Refresh;
             }
 
             if (_autoSave != null)

--- a/RetailCoder.VBE/Common/RubberduckHooks.cs
+++ b/RetailCoder.VBE/Common/RubberduckHooks.cs
@@ -45,7 +45,7 @@ namespace Rubberduck.Common
 
         private CommandBase Command(RubberduckHotkey hotkey)
         {
-            return _commands.SingleOrDefault(s => s.Hotkey == hotkey);
+            return _commands.FirstOrDefault(s => s.Hotkey == hotkey);
         }
 
         public void HookHotkeys()

--- a/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -31,8 +31,12 @@ namespace Rubberduck.Navigation.CodeExplorer
             _state.StateChanged += ParserState_StateChanged;
             _state.ModuleStateChanged += ParserState_ModuleStateChanged;
 
-            _refreshCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), param => _state.OnParseRequested(this),
-                param => !IsBusy && _state.IsDirty());
+            var reparseCommand = commands.OfType<ReparseCommand>().SingleOrDefault();
+
+            _refreshCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), 
+                reparseCommand == null ? (Action<object>)(o => { }) :
+                o => reparseCommand.Execute(o),
+                o => !IsBusy && reparseCommand != null && reparseCommand.CanExecute(o));
             
             _navigateCommand = commands.OfType<UI.CodeExplorer.Commands.NavigateCommand>().SingleOrDefault();
 

--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -30,7 +30,6 @@ using Ninject.Extensions.Interception.Infrastructure.Language;
 using Ninject.Extensions.NamedScope;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.UI.CodeExplorer.Commands;
-using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.Application;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;

--- a/RetailCoder.VBE/UI/CodeExplorer/Commands/AddClassModuleCommand.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/Commands/AddClassModuleCommand.cs
@@ -5,7 +5,6 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
-using Rubberduck.VBEditor.SafeComWrappers.VBA;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
 {

--- a/RetailCoder.VBE/UI/CodeExplorer/Commands/AddStdModuleCommand.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/Commands/AddStdModuleCommand.cs
@@ -5,7 +5,6 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
-using Rubberduck.VBEditor.SafeComWrappers.VBA;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
 {

--- a/RetailCoder.VBE/UI/CodeExplorer/Commands/AddUserFormCommand.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/Commands/AddUserFormCommand.cs
@@ -5,7 +5,6 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
-using Rubberduck.VBEditor.SafeComWrappers.VBA;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
 {

--- a/RetailCoder.VBE/UI/CodeExplorer/Commands/ExportCommand.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/Commands/ExportCommand.cs
@@ -7,7 +7,6 @@ using NLog;
 using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers;
-using Rubberduck.VBEditor.SafeComWrappers.VBA;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
 {

--- a/RetailCoder.VBE/UI/CodeExplorer/Commands/ImportCommand.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/Commands/ImportCommand.cs
@@ -5,7 +5,6 @@ using NLog;
 using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
-using Rubberduck.VBEditor.SafeComWrappers.VBA;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
 {

--- a/RetailCoder.VBE/UI/Command/MenuItems/RubberduckCommandBar.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/RubberduckCommandBar.cs
@@ -16,17 +16,19 @@ namespace Rubberduck.UI.Command.MenuItems
         private readonly RubberduckParserState _state;
         private readonly IVBE _vbe;
         private readonly IShowParserErrorsCommand _command;
+        private readonly ReparseCommand _reparseCommand;
 
         private ICommandBarButton _refreshButton;
         private ICommandBarButton _statusButton;
         private ICommandBarButton _selectionButton;
         private ICommandBar _commandbar;
 
-        public RubberduckCommandBar(RubberduckParserState state, IVBE vbe, IShowParserErrorsCommand command)
+        public RubberduckCommandBar(RubberduckParserState state, IVBE vbe, IShowParserErrorsCommand command, ReparseCommand reparseCommand)
         {
             _state = state;
             _vbe = vbe;
             _command = command;
+            _reparseCommand = reparseCommand;
         }
 
         public void SetSelectionText()
@@ -118,17 +120,6 @@ namespace Rubberduck.UI.Command.MenuItems
             }
         }
 
-        public event EventHandler Refresh;
-
-        private void OnRefresh()
-        {
-            var handler = Refresh;
-            if (handler != null)
-            {
-                handler.Invoke(this, EventArgs.Empty);
-            }
-        }
-
         public void Initialize()
         {
             _commandbar = _vbe.CommandBars.Add("Rubberduck", CommandBarPosition.Top);
@@ -163,7 +154,10 @@ namespace Rubberduck.UI.Command.MenuItems
 
         private void refreshButton_Click(object sender, CommandBarButtonClickEventArgs e)
         {
-            OnRefresh();
+            if (_reparseCommand.CanExecute(null))
+            {
+                _reparseCommand.Execute(null);
+            }
             e.Cancel = true;
         }
 

--- a/RetailCoder.VBE/UI/Command/ReparseCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ReparseCommand.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using NLog;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Settings;
+using Rubberduck.UI.CodeExplorer.Commands;
 using Rubberduck.UI.Command.MenuItems;
 
 namespace Rubberduck.UI.Command
@@ -20,6 +21,7 @@ namespace Rubberduck.UI.Command
     }
 
     [ComVisible(false)]
+    [CodeExplorerCommand]
     public class ReparseCommand : CommandBase
     {
         private readonly RubberduckParserState _state;
@@ -45,6 +47,7 @@ namespace Rubberduck.UI.Command
         protected override void ExecuteImpl(object parameter)
         {
             _state.OnParseRequested(this);
+            _state.StartEventSinks(); // no-op if already started
         }
     }
 }

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -430,12 +430,20 @@ namespace Rubberduck.Parsing.VBA
                             loadTasks.Add(
                                 Task.Run(() =>
                                 {
-                                    var comReflector = new ReferencedDeclarationsCollector(State);
-                                    var items = comReflector.GetDeclarationsForReference(localReference);
-
-                                    foreach (var declaration in items)
+                                    try
                                     {
-                                        State.AddDeclaration(declaration);
+                                        var comReflector = new ReferencedDeclarationsCollector(State);
+                                        var items = comReflector.GetDeclarationsForReference(localReference);
+
+                                        foreach (var declaration in items)
+                                        {
+                                            State.AddDeclaration(declaration);
+                                        }
+                                    }
+                                    catch (Exception exception)
+                                    {
+                                        Logger.Warn(string.Format("Types were not loaded from referenced type library '{0}'.", reference.Name));
+                                        Logger.Error(exception);
                                     }
                                 }));
                             map.IsLoaded = true;

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -393,6 +393,13 @@ namespace Rubberduck.Parsing.VBA
                     for (var priority = 1; priority <= references.Count; priority++)
                     {
                         var reference = references[priority];
+
+                        // skip loading Rubberduck.tlb (GUID is defined in AssemblyInfo.cs)
+                        if (reference.Guid == "{E07C841C-14B4-4890-83E9-8C80B06DD59D}")
+                        {
+                            // todo: figure out why Rubberduck.tlb can't be loaded that way
+                            continue;
+                        }
                         var referencedProjectId = GetReferenceProjectId(reference, projects);
 
                         ReferencePriorityMap map = null;


### PR DESCRIPTION
This PR potentially fixes a number of pending issues, by skipping the loading of type library `Rubberduck.tlb` (using GUID:{E07C841C-14B4-4890-83E9-8C80B06DD59D}) which has been seen "stalling' the *loading references* parser state; logging any ther type loader errors, so failing at that step shouldn't stall the parser state on "loading referenes" anymore.

The 'Refresh' command in Code Explorer and Inspection Results toolwindows now behaves more instinctively; also adjusted "busy" state in inspection results.