### PR TITLE
some cleanups

### DIFF
--- a/RetailCoder.VBE/Common/ExportFormatter.cs
+++ b/RetailCoder.VBE/Common/ExportFormatter.cs
@@ -43,14 +43,12 @@ namespace Rubberduck.Common
 
     public static class ExportFormatter
     {
-        public static string Csv(object[][] data, string Title, ColumnInfo[] ColumnInfos)
+        public static string Csv(object[][] data, string title, ColumnInfo[] columnInfos)
         {
-            string s = "";
-
-            string[] headerRow = new string[ColumnInfos.Length];
-            for (var c = 0; c < ColumnInfos.Length; c++)
+            var headerRow = new string[columnInfos.Length];
+            for (var c = 0; c < columnInfos.Length; c++)
             {
-                headerRow[c] = CsvEncode(ColumnInfos[c].Title);
+                headerRow[c] = CsvEncode(columnInfos[c].Title);
             }
 
             string[] rows = new string[data.Length];
@@ -63,7 +61,7 @@ namespace Rubberduck.Common
                 }
                 rows[r] = string.Join(",", row);
             }
-            return CsvEncode(Title.Replace("\r\n"," ")) + Environment.NewLine + string.Join(",", headerRow) + Environment.NewLine + string.Join(Environment.NewLine, rows);
+            return CsvEncode(title.Replace("\r\n"," ")) + Environment.NewLine + string.Join(",", headerRow) + Environment.NewLine + string.Join(Environment.NewLine, rows);
         }
 
         private static string CsvEncode(object value)

--- a/RetailCoder.VBE/Navigation/RegexSearchReplace/RegexSearchReplace.cs
+++ b/RetailCoder.VBE/Navigation/RegexSearchReplace/RegexSearchReplace.cs
@@ -13,7 +13,6 @@ namespace Rubberduck.Navigation.RegexSearchReplace
 {
     public class RegexSearchReplace : IRegexSearchReplace
     {
-        private readonly RegexSearchReplaceModel _model;
         private readonly IVBE _vbe;
         private readonly IRubberduckParser _parser;
 

--- a/RetailCoder.VBE/Navigation/RegexSearchReplace/RegexSearchReplacePresenter.cs
+++ b/RetailCoder.VBE/Navigation/RegexSearchReplace/RegexSearchReplacePresenter.cs
@@ -6,65 +6,65 @@ using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Navigation.RegexSearchReplace
 {
-    public class RegexSearchReplacePresenter : IPresenter
+    public class RegexSearchReplacePresenter //: IPresenter
     {
-        private readonly IVBE _vbe;
-        private readonly IRegexSearchReplaceDialog _view;
-        private readonly IRubberduckParser _parser;
+        //private readonly IVBE _vbe;
+        //private readonly IRegexSearchReplaceDialog _view;
+        //private readonly IRubberduckParser _parser;
 
-        public RegexSearchReplacePresenter(IVBE vbe, IRubberduckParser parser/*, IRegexSearchReplaceDialog view*/)
-        {
-            _vbe = vbe;
-            //_view = view;
-            _parser = parser;
+        //public RegexSearchReplacePresenter(IVBE vbe, IRubberduckParser parser/*, IRegexSearchReplaceDialog view*/)
+        //{
+        //    _vbe = vbe;
+        //    _view = view;
+        //    _parser = parser;
 
-            //_view.FindButtonClicked += _view_FindButtonClicked;
-            //_view.ReplaceButtonClicked += _view_ReplaceButtonClicked;
-            //_view.ReplaceAllButtonClicked += _view_ReplaceAllButtonClicked;
-            //_view.CancelButtonClicked += _view_CancelButtonClicked;
-        }
+        //    _view.FindButtonClicked += _view_FindButtonClicked;
+        //    _view.ReplaceButtonClicked += _view_ReplaceButtonClicked;
+        //    _view.ReplaceAllButtonClicked += _view_ReplaceAllButtonClicked;
+        //    _view.CancelButtonClicked += _view_CancelButtonClicked;
+        //}
 
-        public void Show()
-        {
-            //_view.ShowDialog();
-        }
+        //public void Show()
+        //{
+        //    _view.ShowDialog();
+        //}
 
-        public void Hide()
-        {
-            //_view.Close();
-        }
+        //public void Hide()
+        //{
+        //    _view.Close();
+        //}
 
-        public event EventHandler<IEnumerable<RegexSearchResult>> FindButtonResults;
-        protected virtual void OnFindButtonResults(IEnumerable<RegexSearchResult> results)
-        {
-            var handler = FindButtonResults;
-            if (handler != null)
-            {
-                handler(this, results);
-            }
-        }
+        //public event EventHandler<IEnumerable<RegexSearchResult>> FindButtonResults;
+        //protected virtual void OnFindButtonResults(IEnumerable<RegexSearchResult> results)
+        //{
+        //    var handler = FindButtonResults;
+        //    if (handler != null)
+        //    {
+        //        handler(this, results);
+        //    }
+        //}
 
-        private void _view_FindButtonClicked(object sender, EventArgs e)
-        {
-            var regexSearchReplace = new RegexSearchReplace(_vbe, _parser);
-            OnFindButtonResults(regexSearchReplace.Search(_view.SearchPattern, _view.Scope));
-        }
+        //private void _view_FindButtonClicked(object sender, EventArgs e)
+        //{
+        //    var regexSearchReplace = new RegexSearchReplace(_vbe, _parser);
+        //    OnFindButtonResults(regexSearchReplace.Search(_view.SearchPattern, _view.Scope));
+        //}
 
-        private void _view_ReplaceButtonClicked(object sender, EventArgs e)
-        {
-            var regexSearchReplace = new RegexSearchReplace(_vbe, _parser);
-            regexSearchReplace.Replace(_view.SearchPattern, _view.ReplacePattern, _view.Scope);
-        }
+        //private void _view_ReplaceButtonClicked(object sender, EventArgs e)
+        //{
+        //    var regexSearchReplace = new RegexSearchReplace(_vbe, _parser);
+        //    regexSearchReplace.Replace(_view.SearchPattern, _view.ReplacePattern, _view.Scope);
+        //}
 
-        private void _view_ReplaceAllButtonClicked(object sender, EventArgs e)
-        {
-            var regexSearchReplace = new RegexSearchReplace(_vbe, _parser);
-            regexSearchReplace.ReplaceAll(_view.SearchPattern, _view.ReplacePattern, _view.Scope);
-        }
+        //private void _view_ReplaceAllButtonClicked(object sender, EventArgs e)
+        //{
+        //    var regexSearchReplace = new RegexSearchReplace(_vbe, _parser);
+        //    regexSearchReplace.ReplaceAll(_view.SearchPattern, _view.ReplacePattern, _view.Scope);
+        //}
 
-        private void _view_CancelButtonClicked(object sender, EventArgs e)
-        {
-            //_view.Close();
-        }
+        //private void _view_CancelButtonClicked(object sender, EventArgs e)
+        //{
+        //    //_view.Close();
+        //}
     }
 }

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
@@ -85,7 +85,6 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             if (item.Command != null)
             {
                 child.Click += child_Click;
-                ((CommandBarButton)child).HandleEvents();                
             }
             return child;
         }

--- a/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
@@ -159,7 +159,6 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
                 : string.Empty;
 
             child.Click += child_Click;
-            ((CommandBarButton)child).HandleEvents();
             return child;
         }
 

--- a/RetailCoder.VBE/UI/Command/RegexSearchReplaceCommand.cs
+++ b/RetailCoder.VBE/UI/Command/RegexSearchReplaceCommand.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.UI.Command
 
         protected override void ExecuteImpl(object parameter)
         {
-            _presenter.Show();
+            //_presenter.Show();
         }
     }
 }

--- a/Rubberduck.Parsing/ComHelper.cs
+++ b/Rubberduck.Parsing/ComHelper.cs
@@ -37,10 +37,10 @@ namespace Rubberduck.Parsing
                     // obtain the ITypeInfo interface from the object
                     dispatch.GetTypeInfo(0, 0, out typeInfo);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     //Cannot get the ITypeInfo interface for the specified COM object
-                    return String.Empty;
+                    return string.Empty;
                 }
 
                 string typeName = "";
@@ -53,17 +53,17 @@ namespace Rubberduck.Parsing
                     typeInfo.GetDocumentation(-1, out typeName, out documentation,
                         out helpContext, out helpFile);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     // Cannot extract ITypeInfo information
-                    return String.Empty;
+                    return string.Empty;
                 }
                 return typeName;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // Unexpected error
-                return String.Empty;
+                return string.Empty;
             }
             finally
             {

--- a/Rubberduck.Parsing/Properties/AssemblyInfo.cs
+++ b/Rubberduck.Parsing/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("dd619c0b-6a3a-4aee-941d-ed940d8d142b")]

--- a/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
@@ -165,6 +165,8 @@ namespace Rubberduck.Parsing.Symbols
         /// </remarks>
         private void DeclareControlsAsMembers(IVBComponent form)
         {
+            if (form.Controls == null) { return; }
+
             foreach (var control in form.Controls)
             {
                 // The as type declaration should be TextBox, CheckBox, etc. depending on the type.

--- a/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
+++ b/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
@@ -112,7 +112,7 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IVBComponents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IVBComponents.cs
@@ -5,7 +5,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
 {
     public interface IVBComponents : ISafeComWrapper, IComCollection<IVBComponent>, IEquatable<IVBComponents>
     {
-        IVBComponent this[object index] { get; }
+        new IVBComponent this[object index] { get; }
 
         IVBE VBE { get; }
         IVBProject Parent { get; }

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarButton.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarButton.cs
@@ -15,16 +15,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         {
         }
 
-        public void HandleEvents()
-        {
-            ((Microsoft.Office.Core.CommandBarButton)Target).Click += Target_Click;
-        }
-
-        public void StopEvents()
-        {
-            ((Microsoft.Office.Core.CommandBarButton)Target).Click -= Target_Click;
-        }
-
         private Microsoft.Office.Core.CommandBarButton Button
         {
             get { return (Microsoft.Office.Core.CommandBarButton)Target; }
@@ -35,10 +25,24 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
             return new CommandBarButton((Microsoft.Office.Core.CommandBarButton)control.Target);
         }
 
-        public event EventHandler<CommandBarButtonClickEventArgs> Click;
+        private EventHandler<CommandBarButtonClickEventArgs> _clickHandler; 
+        public event EventHandler<CommandBarButtonClickEventArgs> Click
+        {
+            add
+            {
+                ((Microsoft.Office.Core.CommandBarButton)Target).Click += Target_Click;
+                _clickHandler += value;
+            }
+            remove
+            {
+                ((Microsoft.Office.Core.CommandBarButton)Target).Click -= Target_Click;
+                _clickHandler -= value;
+            }
+        }
+
         private void Target_Click(Microsoft.Office.Core.CommandBarButton ctrl, ref bool cancelDefault)
         {
-            var handler = Click;
+            var handler = _clickHandler;
             if (handler == null)
             {
                 return;

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
@@ -60,7 +60,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 {
                     return new Window(IsWrappingNullReference ? null : Target.MainWindow);
                 }
-                catch (InvalidComObjectException ex)
+                catch (InvalidComObjectException)
                 {
                     return null;
                 }

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -2124,8 +2124,6 @@ End Sub
             Assert.AreEqual(1, declaration.References.Count());
         }
 
-        // Ignored because handling forms/hierarchies is an open issue.
-        [Ignore]
         [TestMethod]
         public void GivenControlDeclaration_ResolvesUsageInCodeBehind()
         {

--- a/RubberduckTests/Mocks/MockUserFormBuilder.cs
+++ b/RubberduckTests/Mocks/MockUserFormBuilder.cs
@@ -68,6 +68,7 @@ namespace RubberduckTests.Mocks
 
             var window = new Mock<IWindow>();
             window.SetupProperty(w => w.IsVisible, false);
+            _component.Setup(m => m.Controls).Returns(_vbControls.Object);
             _component.Setup(m => m.DesignerWindow()).Returns(window.Object);
 
             return _component;

--- a/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodParameterClassificationTests.cs
+++ b/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodParameterClassificationTests.cs
@@ -46,13 +46,12 @@ End Sub
                 var qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
                 var emRule = new Mock<IExtractMethodRule>();
-                var theByte = new Byte();
                 emRule.Setup(emr => emr.setValidFlag(It.IsAny<IdentifierReference>(), It.IsAny<Selection>())).Returns(2);
                 var emRules = new List<IExtractMethodRule>() { emRule.Object, emRule.Object };
-                var SUT = new ExtractMethodParameterClassification(emRules);
+                var sut = new ExtractMethodParameterClassification(emRules);
 
                 //Act
-                SUT.classifyDeclarations(qSelection, declaration);
+                sut.classifyDeclarations(qSelection, declaration);
 
                 //Assert
                 // 2 rules on 1 referencdes = 2 validation checks

--- a/RubberduckTests/SourceControl/ChangesViewModelTests.cs
+++ b/RubberduckTests/SourceControl/ChangesViewModelTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +13,7 @@ namespace RubberduckTests.SourceControl
     public class ChangesViewModelTests
     {
         private Mock<ISourceControlProvider> _provider;
+        private readonly object _locker = new object();
 
         [TestInitialize]
         public void SetupMocks()
@@ -80,10 +82,9 @@ namespace RubberduckTests.SourceControl
             };
 
             var errorThrown = bool.FalseString; // need a reference type
-
             vm.ErrorThrown += (sender, e) =>
             {
-                lock (errorThrown)
+                lock (_locker)
                 {
                     MultiAssert.Aggregate(
                         () => Assert.AreEqual(e.Title, Rubberduck.UI.RubberduckUI.SourceControl_CommitStatus),
@@ -100,7 +101,7 @@ namespace RubberduckTests.SourceControl
             vm.CommitCommand.Execute(null);
 
             //assert
-            lock (errorThrown)
+            lock (_locker)
             {
                 Assert.IsTrue(bool.Parse(errorThrown));
             }


### PR DESCRIPTION
- no more skipped tests (okay, except one, but it's tied to a specific documented issue#)
- cleaned up CommandBarButton wrapper event handling
- cleaned up compiler warnings (only `ExtractMethod` warnings remain)