### PR TITLE
Various indenter fixes, partial fix for PassParameterByValueQuickFix

### DIFF
--- a/RetailCoder.VBE/Inspections/PassParameterByValueQuickFix.cs
+++ b/RetailCoder.VBE/Inspections/PassParameterByValueQuickFix.cs
@@ -74,12 +74,13 @@ namespace Rubberduck.Inspections
         private void FixMethod(VBAParser.ArgContext context, QualifiedSelection qualifiedSelection)
         {
             var selectionLength = context.BYREF() == null ? 0 : 6;
+            var replacementStart = context.Start.Column + (context.OPTIONAL() == null ? 0 : 9);
 
             var module = qualifiedSelection.QualifiedName.Component.CodeModule;
             {
                 var lines = module.GetLines(context.Start.Line, 1);
 
-                var result = lines.Remove(context.Start.Column, selectionLength).Insert(context.Start.Column, Tokens.ByVal + ' ');
+                var result = lines.Remove(replacementStart, selectionLength).Insert(replacementStart, Tokens.ByVal + ' ');
                 module.ReplaceLine(context.Start.Line, result);
             }
         }

--- a/Rubberduck.SmartIndenter/LogicalCodeLine.cs
+++ b/Rubberduck.SmartIndenter/LogicalCodeLine.cs
@@ -132,7 +132,7 @@ namespace Rubberduck.SmartIndenter
             var current = _lines.First().Indent(IndentationLevel, AtProcedureStart);
             var commentPos = string.IsNullOrEmpty(_lines.First().EndOfLineComment) ? 0 : current.Length - _lines.First().EndOfLineComment.Length;
             output.Add(current);
-            var alignment = FunctionAlign(current, _lines[1].Original.Trim().StartsWith(":="));
+            var alignment = FunctionAlign(current, _lines[1].Escaped.Trim().StartsWith(":="));
 
             //foreach (var line in _lines.Skip(1))
             for (var i = 1; i < _lines.Count; i++)
@@ -156,7 +156,7 @@ namespace Rubberduck.SmartIndenter
                 var operatorAdjust = _settings.IgnoreOperatorsInContinuations && OperatorIgnoreRegex.IsMatch(line.Original) ? 2 : 0;              
                 current = line.Indent(Math.Max(alignment - operatorAdjust, 0), AtProcedureStart, true);
                 output.Add(current);
-                alignment = FunctionAlign(current, i + 1 < _lines.Count && _lines[i + 1].Original.Trim().StartsWith(":="));
+                alignment = FunctionAlign(current, i + 1 < _lines.Count && _lines[i + 1].Escaped.Trim().StartsWith(":="));
                 commentPos = string.IsNullOrEmpty(line.EndOfLineComment) ? 0 : current.Length - line.EndOfLineComment.Length;
             }
 
@@ -181,9 +181,11 @@ namespace Rubberduck.SmartIndenter
                 var character = line.Substring(index - 1, 1);
                 switch (character)
                 {
-                    case "\"":
-                        //A String => jump to the end of it
-                        while (!line.Substring(index++, 1).Equals("\"")) { }
+                    case "\a":
+                        while (!line.Substring(index++, 1).Equals("\a")) { }
+                        break;
+                    case "\x2":
+                        while (!line.Substring(index++, 1).Equals("\x2")) { }
                         break;
                     case "(":
                         //Start of another function => remember this position

--- a/RubberduckTests/Inspections/ImplicitByRefParameterInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitByRefParameterInspectionTests.cs
@@ -295,6 +295,158 @@ End Sub";
             Assert.AreEqual(expectedCode, module.Content());
         }
 
+        //http://chat.stackexchange.com/transcript/message/34001991#34001991
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ImplicitByRefParameter_QuickFixWorks_OptionalParameter()
+        {
+            const string inputCode =
+@"Sub Foo(Optional arg1 As Integer)
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo(Optional ByRef arg1 As Integer)
+End Sub";
+
+            //Arrange
+            var builder = new MockVbeBuilder();
+            IVBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var project = vbe.Object.VBProjects[0];
+            var module = project.VBComponents[0].CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ImplicitByRefParameterInspection(parser.State);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            inspectionResults.First().QuickFixes.First().Fix();
+
+            Assert.AreEqual(expectedCode, module.Content());
+        }
+
+        //http://chat.stackexchange.com/transcript/message/34001991#34001991
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ImplicitByRefParameter_QuickFixWorks_Optional_LineContinuations()
+        {
+            const string inputCode =
+@"Sub Foo(Optional _
+        bar _
+        As Byte)
+    bar = 1
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo(Optional _
+        ByRef bar _
+        As Byte)
+    bar = 1
+End Sub";
+
+            //Arrange
+            var builder = new MockVbeBuilder();
+            IVBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var project = vbe.Object.VBProjects[0];
+            var module = project.VBComponents[0].CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ImplicitByRefParameterInspection(parser.State);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            inspectionResults.First().QuickFixes.First().Fix();
+
+            Assert.AreEqual(expectedCode, module.Content());
+        }
+
+        //http://chat.stackexchange.com/transcript/message/34001991#34001991
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ImplicitByRefParameter_QuickFixWorks_LineContinuation()
+        {
+            const string inputCode =
+@"Sub Foo( bar _
+        As Byte)
+    bar = 1
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo( ByRef bar _
+        As Byte)
+    bar = 1
+End Sub";
+
+            //Arrange
+            var builder = new MockVbeBuilder();
+            IVBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var project = vbe.Object.VBProjects[0];
+            var module = project.VBComponents[0].CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ImplicitByRefParameterInspection(parser.State);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            inspectionResults.First().QuickFixes.First().Fix();
+
+            Assert.AreEqual(expectedCode, module.Content());
+        }
+
+        //http://chat.stackexchange.com/transcript/message/34001991#34001991
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ImplicitByRefParameter_QuickFixWorks_LineContinuation_FirstLine()
+        {
+            const string inputCode =
+@"Sub Foo( _
+        bar _
+        As Byte)
+    bar = 1
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo( _
+        bar _
+        As Byte)
+    bar = 1
+End Sub";
+
+            //Arrange
+            var builder = new MockVbeBuilder();
+            IVBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var project = vbe.Object.VBProjects[0];
+            var module = project.VBComponents[0].CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ImplicitByRefParameterInspection(parser.State);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            inspectionResults.First().QuickFixes.First().Fix();
+
+            Assert.AreEqual(expectedCode, module.Content());
+        }
+
         [TestMethod]
         [TestCategory("Inspections")]
         public void InspectionType()

--- a/RubberduckTests/Inspections/ImplicitByRefParameterInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitByRefParameterInspectionTests.cs
@@ -342,8 +342,8 @@ End Sub";
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(Optional _
-        ByRef bar _
+@"Sub Foo(Optional ByRef _
+        bar _
         As Byte)
     bar = 1
 End Sub";
@@ -421,7 +421,7 @@ End Sub";
 
             const string expectedCode =
 @"Sub Foo( _
-        bar _
+        ByRef bar _
         As Byte)
     bar = 1
 End Sub";

--- a/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
@@ -955,6 +955,72 @@ End Sub";
 
         [TestMethod]
         [TestCategory("Inspections")]
+        public void ParameterCanBeByVal_QuickFixWithOptionalWorks()
+        {
+            const string inputCode =
+@"Sub Test(Optional foo As String = ""bar"")
+    Debug.Print foo
+End Sub";
+
+            const string expectedCode =
+@"Sub Test(Optional ByVal foo As String = ""bar"")
+    Debug.Print foo
+End Sub";
+
+            //Arrange
+            var builder = new MockVbeBuilder();
+            IVBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var project = vbe.Object.VBProjects[0];
+            var module = project.VBComponents[0].CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ParameterCanBeByValInspection(parser.State);
+            inspection.GetInspectionResults().First().QuickFixes.Single(s => s is PassParameterByValueQuickFix).Fix();
+
+            Assert.AreEqual(expectedCode, module.Content());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ParameterCanBeByVal_QuickFixWithOptionalByRefWorks()
+        {
+            const string inputCode =
+@"Sub Test(Optional ByRef foo As String = ""bar"")
+    Debug.Print foo
+End Sub";
+
+            const string expectedCode =
+@"Sub Test(Optional ByVal foo As String = ""bar"")
+    Debug.Print foo
+End Sub";
+
+            //Arrange
+            var builder = new MockVbeBuilder();
+            IVBComponent component;
+            var vbe = builder.BuildFromSingleStandardModule(inputCode, out component);
+            var project = vbe.Object.VBProjects[0];
+            var module = project.VBComponents[0].CodeModule;
+            var mockHost = new Mock<IHostApplication>();
+            mockHost.SetupAllProperties();
+            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(new Mock<ISinks>().Object));
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+
+            var inspection = new ParameterCanBeByValInspection(parser.State);
+            inspection.GetInspectionResults().First().QuickFixes.Single(s => s is PassParameterByValueQuickFix).Fix();
+
+            Assert.AreEqual(expectedCode, module.Content());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
         public void InspectionType()
         {
             var inspection = new ParameterCanBeByValInspection(null);

--- a/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
@@ -1026,7 +1026,6 @@ End Sub";
         [TestCategory("Inspections")]
         public void ParameterCanBeByVal_QuickFixWithOptional_LineContinuationsWorks()
         {
-            Assert.Inconclusive("Pending more comprehensive fix.");
             const string inputCode =
 @"Sub foo(Optional _
   ByRef _

--- a/RubberduckTests/SmartIndenter/LineContinuationTests.cs
+++ b/RubberduckTests/SmartIndenter/LineContinuationTests.cs
@@ -542,7 +542,90 @@ namespace RubberduckTests.SmartIndenter
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
 
+        //https://github.com/rubberduck-vba/Rubberduck/issues/2407
+        [TestMethod] 
+        [TestCategory("Indenter")]
+        public void ContinuationsInProcedureDeclarationsWithAlignWorks()
+        {
+            var code = new[]
+            {
+                "Sub MySub()",
+                "Dim x1 As Integer, x2 _",
+                "As Integer",
+                "End Sub"
+            };
+
+            var expected = new[]
+            {
+                "Sub MySub()",
+                "    Dim x1    As Integer, x2 _",
+                "              As Integer",
+                "End Sub"
+            };
+
+            var indenter = new Indenter(null, () =>
+            {
+                var s = IndenterSettingsTests.GetMockIndenterSettings();
+                s.IndentFirstDeclarationBlock = true;
+                s.AlignDims = true;
+                s.AlignDimColumn = 15;
+                return s;
+            });
+            var actual = indenter.Indent(code, string.Empty);
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
+        //https://github.com/rubberduck-vba/Rubberduck/issues/2407
+        [TestMethod] 
+        [TestCategory("Indenter")]
+        public void ContinuationsInProcedureDeclarationsWithAlignWorksBareType()
+        {
+            var code = new[]
+            {
+                "Sub MySub()",
+                "Dim x1 As Integer",
+                "Dim x2 As _",
+                "Integer",
+                "Dim x3 As Integer: _",
+                "Dim x4 As _",
+                "Integer",
+                "Dim x5 As Integer _",
+                "'Comment _",
+                "as _",
+                "integer",
+                "End Sub"
+            };
+
+            var expected = new[]
+            {
+                "Sub MySub()",
+                "    Dim x1    As Integer",
+                "    Dim x2    As _",
+                "    Integer",
+                "    Dim x3    As Integer: _",
+                "    Dim x4    As _",
+                "    Integer",
+                "    Dim x5    As Integer _",
+                "        'Comment _",
+                "        as _",
+                "        integer",
+                "End Sub"
+            };
+
+            var indenter = new Indenter(null, () =>
+            {
+                var s = IndenterSettingsTests.GetMockIndenterSettings();
+                s.IndentFirstDeclarationBlock = true;
+                s.AlignDims = true;
+                s.AlignDimColumn = 15;
+                return s;
+            });
+            var actual = indenter.Indent(code, string.Empty);
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
         [TestMethod]
+        [TestCategory("Indenter")]
         public void ContinuationWithOnlyCommentWorks()
         {
             var code = new[]

--- a/RubberduckTests/SmartIndenter/MiscAndCornerCaseTests.cs
+++ b/RubberduckTests/SmartIndenter/MiscAndCornerCaseTests.cs
@@ -589,5 +589,108 @@ namespace RubberduckTests.SmartIndenter
             var actual = indenter.Indent(code, string.Empty);
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
+
+        [TestMethod]       
+        [TestCategory("Indenter")]
+        public void QuotesInsideStringLiteralsWork()
+        {
+            var code = new[]
+            {
+                "Public Sub Test()",
+                "Debug.Print \"This is a \"\" in the middle of a string.\"",
+                "End Sub"
+            };
+
+            var expected = new[]
+            {
+                "Public Sub Test()",
+                "    Debug.Print \"This is a \"\" in the middle of a string.\"",
+                "End Sub"
+            };
+
+            var indenter = new Indenter(null, () => IndenterSettingsTests.GetMockIndenterSettings());
+            var actual = indenter.Indent(code, string.Empty);
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
+        [TestMethod]
+        [TestCategory("Indenter")]
+        public void SingleQuoteInEndOfLineCommentWorks()
+        {
+            var code = new[]
+            {
+                "Public Sub Test()",
+                "Debug.Print Chr$(34) 'Prints a single '\"' character.",
+                "End Sub"
+            };
+
+            var expected = new[]
+            {
+                "Public Sub Test()",
+                "    Debug.Print Chr$(34)                         'Prints a single '\"' character.",
+                "End Sub"
+            };
+
+            var indenter = new Indenter(null, () => IndenterSettingsTests.GetMockIndenterSettings());
+            var actual = indenter.Indent(code, string.Empty);
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
+        //http://chat.stackexchange.com/transcript/message/33933348#33933348
+        [TestMethod]        // Broken in VB6 SmartIndenter. Also broken in the code's conception. Sheesh - keep the cat off the keyboard.
+        [TestCategory("Indenter")]
+        public void BracketedIdentifiersWork()
+        {
+            Assert.Inconclusive("Pending fix for line numbers on continuation lines, function aligning of declarations.");
+            var code = new[]
+            {
+                "Sub test()",
+                "Dim _",
+                "s _",
+                "( _",
+                "[Option _ Explicit] _",
+                "+ _",
+                "1 _",
+                "To _",
+                "( _",
+                "[Evil : \"\" Comment \" 'here] _",
+                ") _",
+                "+ _",
+                "[End _ Sub] _",
+                ") _",
+                "As _",
+                "String _",
+                "* _",
+                "25",
+                "End Sub"
+            };
+
+            var expected = new[]
+            {
+                "Sub test()",
+                "    Dim _",
+                "    s _",
+                "    ( _",
+                "    [Option _ Explicit] _",
+                "    + _",
+                "    1 _",
+                "    To _",
+                "    ( _",
+                "    [Evil : \"\" Comment \" 'here] _",
+                "    ) _",
+                "    + _",
+                "    [End _ Sub] _",
+                "    ) _",
+                "    As _",
+                "    String _",
+                "    * _",
+                "    25",
+                "End Sub"
+            };
+
+            var indenter = new Indenter(null, () => IndenterSettingsTests.GetMockIndenterSettings());
+            var actual = indenter.Indent(code, string.Empty);
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
     }
 }

--- a/RubberduckTests/SmartIndenter/SpecificSettingTests.cs
+++ b/RubberduckTests/SmartIndenter/SpecificSettingTests.cs
@@ -456,6 +456,7 @@ namespace RubberduckTests.SmartIndenter
             {
                 var s = IndenterSettingsTests.GetMockIndenterSettings();
                 s.AlignCommentsWithCode = false;
+                s.IndentFirstCommentBlock = false;
                 return s;
             });
             var actual = indenter.Indent(code, string.Empty);


### PR DESCRIPTION
2 tests are asserted as inconclusive pending more comprehensive (and probably easy) fixes.  Partially addresses  #2408 (cases without line continuations), closes #2407, handles numerous indenter issues that I was too lazy to open, probably some that I was never aware of.