### PR TITLE
Ignore line numbers in continuations when indenting. 

### DIFF
--- a/Rubberduck.SmartIndenter/Indenter.cs
+++ b/Rubberduck.SmartIndenter/Indenter.cs
@@ -107,10 +107,11 @@ namespace Rubberduck.SmartIndenter
             var settings = _settings.Invoke();
             var logical = new List<LogicalCodeLine>();
             LogicalCodeLine current = null;
+            AbsoluteCodeLine previous = null;
 
             foreach (var line in lines)
             {
-                var absolute = new AbsoluteCodeLine(line, settings);
+                var absolute = new AbsoluteCodeLine(line, settings, previous);
                 if (current == null)
                 {
                     current = new LogicalCodeLine(absolute, settings);
@@ -125,6 +126,7 @@ namespace Rubberduck.SmartIndenter
                 {
                     current = null;
                 }
+                previous = absolute;
             }
             return logical;
         }

--- a/RubberduckTests/SmartIndenter/MiscAndCornerCaseTests.cs
+++ b/RubberduckTests/SmartIndenter/MiscAndCornerCaseTests.cs
@@ -641,7 +641,6 @@ namespace RubberduckTests.SmartIndenter
         [TestCategory("Indenter")]
         public void BracketedIdentifiersWork()
         {
-            Assert.Inconclusive("Pending fix for line numbers on continuation lines, function aligning of declarations.");
             var code = new[]
             {
                 "Sub test()",


### PR DESCRIPTION
Finishes handling of @ThunderFrame's evil bracketed identifier. May be some additional refactoring stemming from this.