### PR TITLE
Unit tests for subtypes of Declaration and refactorings

### DIFF
--- a/Rubberduck.Parsing/Symbols/AliasDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/AliasDeclarations.cs
@@ -10,6 +10,12 @@ namespace Rubberduck.Parsing.Symbols
     {
         private readonly RubberduckParserState _state;
 
+        private Declaration _conversionModule;
+        private Declaration _fileSystemModule;
+        private Declaration _interactionModule;
+        private Declaration _stringsModule;
+
+
         public AliasDeclarations(RubberduckParserState state)
         {
             _state = state;
@@ -46,399 +52,489 @@ namespace Rubberduck.Parsing.Symbols
 
         private IReadOnlyList<Declaration> AddAliasDeclarations()
         {
-            var conversionModule = _state.AllDeclarations.SingleOrDefault(
-                    item => item.IdentifierName == "Conversion" && item.Scope == "VBE7.DLL;VBA.Conversion");
-
-            var fileSystemModule = _state.AllDeclarations.SingleOrDefault(
-                    item => item.IdentifierName == "FileSystem" && item.Scope == "VBE7.DLL;VBA.FileSystem");
-
-            var interactionModule = _state.AllDeclarations.SingleOrDefault(
-                    item => item.IdentifierName == "Interaction" && item.Scope == "VBE7.DLL;VBA.Interaction");
-
-            var stringsModule = _state.AllDeclarations.SingleOrDefault(
-                    item => item.IdentifierName == "Strings" && item.Scope == "VBE7.DLL;VBA.Strings");
-
-            // all these modules are all part of the same project--only need to check one
-            if (conversionModule == null)
+            UpdateAliasFunctionModulesFromReferencedProjects(_state);
+            
+            if (NoReferenceToProjectContainingTheFunctionAliases())
             {
                 return new List<Declaration>();
             }
+            
+            var possiblyAliasedFunctions = ReferencedBuiltInFunctionsThatMightHaveAnAlias(_state);
+            var functionAliases = FunctionAliasesWithoutParameters();
+            AddParametersToAliasesFromReferencedFunctions(functionAliases, possiblyAliasedFunctions);
+            
+            return functionAliases;
+        }
 
-            var functions = _state.AllDeclarations.Where(s => s.DeclarationType == DeclarationType.Function &&
-                                                              s.Scope.StartsWith("VBE") &&
-                                                              Tokens.Any(token => s.IdentifierName == "_B_var_" + token))
-                                                  .ToList();
-
-            var errorFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Error"),
-                    conversionModule,
-                    conversionModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var hexFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Hex"),
-                    conversionModule,
-                    conversionModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var octFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Oct"),
-                    conversionModule,
-                    conversionModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var strFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Str"),
-                    conversionModule,
-                    conversionModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var curDirFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "FileSystem"), "CurDir"),
-                    fileSystemModule,
-                    fileSystemModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var commandFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Interaction"), "Command"),
-                    interactionModule,
-                    interactionModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var environFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Interaction"), "Environ"),
-                    interactionModule,
-                    interactionModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var chrFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Chr"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var chrwFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "ChrW"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var formatFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Format"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var lcaseFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "LCase"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var leftFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Left"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var leftbFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "LeftB"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var ltrimFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "LTrim"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var midFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Mid"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var midbFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "MidB"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var trimFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Trim"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var rightFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Right"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var rightbFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "RightB"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var rtrimFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "RTrim"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var ucaseFunction = new FunctionDeclaration(
-                    new QualifiedMemberName(
-                        new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "UCase"),
-                    stringsModule,
-                    stringsModule,
-                    "Variant",
-                    null,
-                    string.Empty,
-                    Accessibility.Global,
-                    null,
-                    new Selection(),
-                    false,
-                    true,
-                    new List<IAnnotation>(),
-                    new Attributes());
-
-            var functionAliases = new List<Declaration> {
-                errorFunction,
-                hexFunction,
-                octFunction,
-                strFunction,
-                curDirFunction,
-                commandFunction,
-                environFunction,
-                chrFunction,
-                chrwFunction,
-                formatFunction,
-                lcaseFunction,
-                leftFunction,
-                leftbFunction,
-                ltrimFunction,
-                midFunction,
-                midbFunction,
-                trimFunction,
-                rightFunction,
-                rightbFunction,
-                rtrimFunction,
-                ucaseFunction
-            };
-
-            // ReSharper disable once PossibleInvalidCastExceptionInForeachLoop
-            foreach (FunctionDeclaration alias in functionAliases)
+            private void UpdateAliasFunctionModulesFromReferencedProjects(RubberduckParserState state)
             {
-                foreach (var parameter in ((FunctionDeclaration)functions.Single(s => s.IdentifierName == "_B_var_" + alias.IdentifierName)).Parameters)
+                _conversionModule = state.AllDeclarations.SingleOrDefault(
+                        item => item.IdentifierName == "Conversion" && item.Scope == "VBE7.DLL;VBA.Conversion");
+
+                _fileSystemModule = state.AllDeclarations.SingleOrDefault(
+                        item => item.IdentifierName == "FileSystem" && item.Scope == "VBE7.DLL;VBA.FileSystem");
+
+                _interactionModule = state.AllDeclarations.SingleOrDefault(
+                        item => item.IdentifierName == "Interaction" && item.Scope == "VBE7.DLL;VBA.Interaction");
+
+                _stringsModule = state.AllDeclarations.SingleOrDefault(
+                        item => item.IdentifierName == "Strings" && item.Scope == "VBE7.DLL;VBA.Strings");
+            }
+
+
+            private bool NoReferenceToProjectContainingTheFunctionAliases()
+            {
+                return _conversionModule == null;   // All the modules containing function aliases are part of the same project. --> Only need to check one.
+            }
+
+
+            private List<Declaration> ReferencedBuiltInFunctionsThatMightHaveAnAlias(RubberduckParserState state)
+            {
+                var functions = state.AllDeclarations.Where(s => s.DeclarationType == DeclarationType.Function
+                                                                  && s.Scope.StartsWith("VBE")
+                                                                  && Tokens.Any(token => s.IdentifierName == "_B_var_" + token));
+                return functions.ToList();
+            }
+
+
+            private List<FunctionDeclaration> FunctionAliasesWithoutParameters()
+            {
+                return new List<FunctionDeclaration> {
+                    ErrorFunction(),
+                    HexFunction(),
+                    OctFunction(),
+                    StrFunction(),
+                    CurDirFunction(),
+                    CommandFunction(),
+                    EnvironFunction(),
+                    ChrFunction(),
+                    ChrwFunction(),
+                    FormatFunction(),
+                    LCaseFunction(),
+                    LeftFunction(),
+                    LeftBFunction(),
+                    LTrimFunction(),
+                    MidFunction(),
+                    MidBFunction(),
+                    TrimFunction(),
+                    RightFunction(),
+                    RightBFunction(),
+                    RTrimFunction(),
+                    UCaseFunction()
+                };
+            }
+
+                private FunctionDeclaration ErrorFunction()
                 {
-                    alias.AddParameter(parameter);
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Error"),
+                            _conversionModule,
+                            _conversionModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration HexFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Hex"),
+                            _conversionModule,
+                            _conversionModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration OctFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Oct"),
+                            _conversionModule,
+                            _conversionModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration StrFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Conversion"), "Str"),
+                            _conversionModule,
+                            _conversionModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration CurDirFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "FileSystem"), "CurDir"),
+                            _fileSystemModule,
+                            _fileSystemModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration CommandFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Interaction"), "Command"),
+                            _interactionModule,
+                            _interactionModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration EnvironFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Interaction"), "Environ"),
+                            _interactionModule,
+                            _interactionModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration ChrFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Chr"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration ChrwFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "ChrW"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration FormatFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Format"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration LCaseFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "LCase"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration LeftFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Left"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration LeftBFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "LeftB"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration LTrimFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "LTrim"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration MidFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Mid"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration MidBFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "MidB"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration TrimFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Trim"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration RightFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Right"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration RightBFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "RightB"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration RTrimFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "RTrim"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+                private FunctionDeclaration UCaseFunction()
+                {
+                    return new FunctionDeclaration(
+                            new QualifiedMemberName(
+                                new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "UCase"),
+                            _stringsModule,
+                            _stringsModule,
+                            "Variant",
+                            null,
+                            string.Empty,
+                            Accessibility.Global,
+                            null,
+                            new Selection(),
+                            false,
+                            true,
+                            new List<IAnnotation>(),
+                            new Attributes());
+                }
+
+
+            private static void AddParametersToAliasesFromReferencedFunctions(List<FunctionDeclaration> functionAliases, List<Declaration> referencedFunctions)
+            {
+                // ReSharper disable once PossibleInvalidCastExceptionInForeachLoop
+                foreach (var alias in functionAliases)
+                {
+                    foreach (var parameter in ((FunctionDeclaration)referencedFunctions.Single(s => s.IdentifierName == "_B_var_" + alias.IdentifierName)).Parameters)
+                    {
+                        alias.AddParameter(parameter);
+                    }
                 }
             }
 
-            return functionAliases;
-        }
     }
 }

--- a/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
@@ -53,7 +53,8 @@ namespace Rubberduck.Parsing.Symbols
             {
                 return new List<Declaration>();
             }
-            return ((ClassModuleDeclaration)type).Supertypes;
+            var classType = type as ClassModuleDeclaration;
+            return classType != null ? classType.Supertypes : new List<Declaration>();
         }
 
 
@@ -115,16 +116,7 @@ namespace Rubberduck.Parsing.Symbols
 
             private bool IsGlobalFromSubtypes()
             {
-                var isGlobal = false;
-                foreach (var type in Subtypes)
-                {
-                    if (type is ClassModuleDeclaration && ((ClassModuleDeclaration)type).IsGlobalClassModule)
-                    {
-                        isGlobal = true;
-                        break;
-                    }
-                }
-                return isGlobal;
+                return Subtypes.Any(subtype => (subtype is ClassModuleDeclaration && ((ClassModuleDeclaration)subtype).IsGlobalClassModule));
             }
 
 

--- a/Rubberduck.Parsing/Symbols/FormEventDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/FormEventDeclarations.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor;
 
@@ -15,15 +16,7 @@ namespace Rubberduck.Parsing.Symbols
 
         public IReadOnlyList<Declaration> Load()
         {
-            Declaration formsClassModule = null;
-            foreach (var declaration in _state.AllDeclarations)
-            {
-                if (declaration.DeclarationType == DeclarationType.ClassModule &&
-                    declaration.Scope == "FM20.DLL;MSForms.FormEvents")
-                {
-                    formsClassModule = declaration;
-                }
-            }
+            var formsClassModule = FormsClassModuleFromParserState(_state);
 
             if (formsClassModule == null)
             {
@@ -33,127 +26,169 @@ namespace Rubberduck.Parsing.Symbols
             return AddHiddenMSFormDeclarations(formsClassModule);
         }
 
-        private IReadOnlyList<Declaration> AddHiddenMSFormDeclarations(Declaration parentModule)
-        {
-            var userFormActivateEvent = new Declaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Activate"),
-                parentModule,
-                "FM20.DLL;MSForms.FormEvents",
-                string.Empty,
-                string.Empty,
-                false,
-                false,
-                Accessibility.Global,
-                DeclarationType.Event,
-                false,
-                null);
-
-            var userFormDeactivateEvent = new Declaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Deactivate"),
-                parentModule,
-                "FM20.DLL;MSForms.FormEvents",
-                string.Empty,
-                string.Empty,
-                false,
-                false,
-                Accessibility.Global,
-                DeclarationType.Event,
-                false,
-                null);
-
-            var userFormInitializeEvent = new Declaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Initialize"),
-                parentModule,
-                "FM20.DLL;MSForms.FormEvents",
-                string.Empty,
-                string.Empty,
-                false,
-                false,
-                Accessibility.Global,
-                DeclarationType.Event,
-                false,
-                null);
-
-            var userFormQueryCloseEvent = new Declaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "QueryClose"),
-                parentModule,
-                "FM20.DLL;MSForms.FormEvents",
-                string.Empty,
-                string.Empty,
-                false,
-                false,
-                Accessibility.Global,
-                DeclarationType.Event,
-                false,
-                null);
-
-            var userFormQueryCloseEventCancelParameter = new ParameterDeclaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Cancel"),
-                userFormQueryCloseEvent,
-                null,
-                new Selection(),
-                "Integer",
-                null,
-                string.Empty,
-                false,
-                true);
-
-            var userFormQueryCloseEventCloseModeParameter = new ParameterDeclaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "CloseMode"),
-                userFormQueryCloseEvent,
-                null,
-                new Selection(),
-                "Integer",
-                null,
-                string.Empty,
-                false,
-                true);
-
-            var userFormResizeEvent = new Declaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Resize"),
-                parentModule,
-                "FM20.DLL;MSForms.FormEvents",
-                string.Empty,
-                string.Empty,
-                false,
-                false,
-                Accessibility.Global,
-                DeclarationType.Event,
-                false,
-                null);
-
-            var userFormTerminateEvent = new Declaration(
-                new QualifiedMemberName(
-                    new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Terminate"),
-                parentModule,
-                "FM20.DLL;MSForms.FormEvents",
-                string.Empty,
-                string.Empty,
-                false,
-                false,
-                Accessibility.Global,
-                DeclarationType.Event,
-                false,
-                null);
-
-            return new List<Declaration>
+            private static Declaration FormsClassModuleFromParserState(RubberduckParserState state)
             {
-                userFormActivateEvent,
-                userFormDeactivateEvent,
-                userFormInitializeEvent,
-                userFormQueryCloseEvent,
-                userFormQueryCloseEventCancelParameter,
-                userFormQueryCloseEventCloseModeParameter,
-                userFormResizeEvent,
-                userFormTerminateEvent
-            };
-        }
+                return state.AllDeclarations.LastOrDefault(declaration => declaration.DeclarationType == DeclarationType.ClassModule
+                                                                            && declaration.Scope == "FM20.DLL;MSForms.FormEvents");
+            }
+
+
+            private IReadOnlyList<Declaration> AddHiddenMSFormDeclarations(Declaration formsClassModule)
+            {
+
+                var userFormActivateEvent = UserFormActivateEvent(formsClassModule);
+                var userFormDeactivateEvent = UserFormDeactivateEvent(formsClassModule);
+                var userFormInitializeEvent = UserFormInitializeEvent(formsClassModule);
+                var userFormQueryCloseEvent = UserFormQueryCloseEvent(formsClassModule);
+                var userFormQueryCloseEventCancelParameter = UserFormQueryCloseEventCancelParameter(userFormQueryCloseEvent);
+                var userFormQueryCloseEventCloseModeParameter = UserFormQueryCloseEventCloseModeParameter(userFormQueryCloseEvent);
+                var userFormResizeEvent = UserFormResizeEvent(formsClassModule);
+                var userFormTerminateEvent = UserFormTerminateEvent(formsClassModule);
+
+                return new List<Declaration>
+                {
+                    userFormActivateEvent,
+                    userFormDeactivateEvent,
+                    userFormInitializeEvent,
+                    userFormQueryCloseEvent,
+                    userFormQueryCloseEventCancelParameter,
+                    userFormQueryCloseEventCloseModeParameter,
+                    userFormResizeEvent,
+                    userFormTerminateEvent
+                };
+            }
+
+                private static Declaration UserFormActivateEvent(Declaration formsClassModule)
+                {
+                    return new Declaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Activate"),
+                        formsClassModule,
+                        "FM20.DLL;MSForms.FormEvents",
+                        string.Empty,
+                        string.Empty,
+                        false,
+                        false,
+                        Accessibility.Global,
+                        DeclarationType.Event,
+                        false,
+                        null);
+                }
+
+                private static Declaration UserFormDeactivateEvent(Declaration formsClassModule)
+                {
+                    return new Declaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Deactivate"),
+                        formsClassModule,
+                        "FM20.DLL;MSForms.FormEvents",
+                        string.Empty,
+                        string.Empty,
+                        false,
+                        false,
+                        Accessibility.Global,
+                        DeclarationType.Event,
+                        false,
+                        null);
+                }
+
+                private static Declaration UserFormInitializeEvent(Declaration formsClassModule)
+                {
+                    return new Declaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Initialize"),
+                        formsClassModule,
+                        "FM20.DLL;MSForms.FormEvents",
+                        string.Empty,
+                        string.Empty,
+                        false,
+                        false,
+                        Accessibility.Global,
+                        DeclarationType.Event,
+                        false,
+                        null);
+                }
+
+                private static Declaration UserFormQueryCloseEvent(Declaration formsClassModule)
+                {
+                    return new Declaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "QueryClose"),
+                        formsClassModule,
+                        "FM20.DLL;MSForms.FormEvents",
+                        string.Empty,
+                        string.Empty,
+                        false,
+                        false,
+                        Accessibility.Global,
+                        DeclarationType.Event,
+                        false,
+                        null);
+                }
+
+                private static ParameterDeclaration UserFormQueryCloseEventCancelParameter(Declaration userFormQueryCloseEvent)
+                {
+                    return new ParameterDeclaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Cancel"),
+                        userFormQueryCloseEvent,
+                        null,
+                        new Selection(),
+                        "Integer",
+                        null,
+                        string.Empty,
+                        false,
+                        true);
+                }
+
+                private static ParameterDeclaration UserFormQueryCloseEventCloseModeParameter(Declaration userFormQueryCloseEvent)
+                {
+                    return new ParameterDeclaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "CloseMode"),
+                        userFormQueryCloseEvent,
+                        null,
+                        new Selection(),
+                        "Integer",
+                        null,
+                        string.Empty,
+                        false,
+                        true);
+                }
+
+                private static Declaration UserFormResizeEvent(Declaration formsClassModule)
+                {
+                    return new Declaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Resize"),
+                        formsClassModule,
+                        "FM20.DLL;MSForms.FormEvents",
+                        string.Empty,
+                        string.Empty,
+                        false,
+                        false,
+                        Accessibility.Global,
+                        DeclarationType.Event,
+                        false,
+                        null);
+                }
+
+                private static Declaration UserFormTerminateEvent(Declaration formsClassModule)
+                {
+                    return new Declaration(
+                        new QualifiedMemberName(
+                            new QualifiedModuleName("MSForms", "C:\\WINDOWS\\system32\\FM20.DLL", "FormEvents"), "Terminate"),
+                        formsClassModule,
+                        "FM20.DLL;MSForms.FormEvents",
+                        string.Empty,
+                        string.Empty,
+                        false,
+                        false,
+                        Accessibility.Global,
+                        DeclarationType.Event,
+                        false,
+                        null);
+                }
+
     }
 }

--- a/RubberduckTests/Symbols/AccessibilityCheckTests.cs
+++ b/RubberduckTests/Symbols/AccessibilityCheckTests.cs
@@ -636,6 +636,19 @@ namespace RubberduckTests.Symbols
         }
 
 
+        [TestMethod]
+        public void AccessibilityCheckDoesNotTakeIntoAccountThatAMemberMightNotBeAccessibleBecauseItIsCoveredByAnotherMemberInNarrowerScope()
+        {
+            var projectDeclatation = GetTestProject("test_project");
+            var moduleDeclatation = GetTestClassModule(projectDeclatation, "test_Module");
+            var privateInstanceVariable = GetTestVariable(moduleDeclatation, "x", Accessibility.Private);
+            var privateFunctionDeclaration = GetTestFunction(moduleDeclatation, "foo", Accessibility.Private);
+            var localVariable = GetTestVariable(privateFunctionDeclaration, "x", Accessibility.Implicit);   //This variable makes the instance variable of the same name inaccessible inside the function.
+
+            Assert.IsTrue(AccessibilityCheck.IsAccessible(projectDeclatation, moduleDeclatation, privateFunctionDeclaration, privateInstanceVariable));
+        }
+
+
 
         //null reference handling tests
         

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -11,7 +11,7 @@ namespace RubberduckTests.Symbols
     public class ClassModuleDeclarationTests
     {
         [TestMethod]
-        public void HasDeclarationTypeClassModule()
+        public void ClassModulesHaveDeclarationTypeClassModule()
         {
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -1,0 +1,367 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+using Rubberduck.Parsing.VBA;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class ClassModuleDeclarationTests
+    {
+        [TestMethod]
+        public void HasDeclarationTypeClassModule()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsTrue(classModule.DeclarationType.HasFlag(DeclarationType.ClassModule));
+        }
+
+            private static ProjectDeclaration GetTestProject(string name)
+            {
+                var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ProjectDeclaration(qualifiedProjectName, name, false);
+            }
+
+                private static QualifiedModuleName StubQualifiedModuleName()
+                {
+                    return new QualifiedModuleName("dummy", "dummy", "dummy");
+                }
+
+            private static ClassModuleDeclaration GetTestClassModule(Declaration projectDeclatation, string name, bool isBuiltIn, Attributes attributes, bool hasDefaultInstanceVariable = false)
+            {
+                var qualifiedClassModuleMemberName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ClassModuleDeclaration(qualifiedClassModuleMemberName, projectDeclatation, name, isBuiltIn, null, attributes, hasDefaultInstanceVariable);
+            }
+
+
+        [TestMethod]
+        public void ByDefaultSubtypesIsEmpty()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsFalse(classModule.Subtypes.Any());
+        }
+
+
+        [TestMethod]
+        public void AddSubtypeAddsClassToSubtypes()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", false, null);
+            classModule.AddSubtype(subtype);
+
+            Assert.IsTrue(classModule.Subtypes.First().Equals(subtype));
+        }
+
+
+        [TestMethod]
+        public void ByDefaultSupertypesIsEmpty()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsFalse(classModule.Supertypes.Any());
+        }
+
+
+        [TestMethod]
+        public void AddSupertypeForDeclarationsAddsClassToSupertypes()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            var supertype = GetTestClassModule(projectDeclaration, "testSupertype", false, null);
+            classModule.AddSupertype(supertype);
+
+            Assert.IsTrue(classModule.Supertypes.First().Equals(supertype));
+        }
+
+
+        [TestMethod]
+        public void ByDefaultSupertypeNamesIsEmpty()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsFalse(classModule.SupertypeNames.Any());
+        }
+
+
+        [TestMethod]
+        public void AddSupertypeForStringsAddsTypenameToSupertypeNames()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            var supertypeName = "testSupertypeName";
+            classModule.AddSupertype(supertypeName);
+
+            Assert.IsTrue(classModule.SupertypeNames.First().Equals(supertypeName));
+        }
+
+
+        [TestMethod]
+        public void AddSupertypeForDeclarationsHasNoEffectOnSupertypeNames()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            var supertype = GetTestClassModule(projectDeclaration, "testSupertype", false, null);
+            classModule.AddSupertype(supertype);
+
+            Assert.IsFalse(classModule.SupertypeNames.Any());
+        }
+
+
+        [TestMethod]
+        public void AddSupertypeForStringsHasNoEffectsOnSupertypes()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            var supertypeName = "testSupertypeName";
+            classModule.AddSupertype(supertypeName);
+
+            Assert.IsFalse(classModule.Supertypes.Any());
+        }
+
+
+        [TestMethod]
+        public void GetSupertypesReturnsAnEmptyEnumerableForProceduralModules()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var proceduralModule = GetTestProceduralModule(projectDeclaration, "testModule");
+
+            Assert.IsFalse(ClassModuleDeclaration.GetSupertypes(proceduralModule).Any());
+        }
+
+            private static ProceduralModuleDeclaration GetTestProceduralModule(Declaration projectDeclatation, string name)
+            {
+                var qualifiedClassModuleMemberName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ProceduralModuleDeclaration(qualifiedClassModuleMemberName, projectDeclatation, name, false, null, null);
+            }
+
+
+        [TestMethod]
+        public void GetSupertypesReturnsTheSupertypesOfAClassModule()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var supertype = GetTestClassModule(projectDeclaration, "testSupertype", false, null);
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            classModule.AddSupertype(supertype);
+
+            Assert.AreEqual(supertype, ClassModuleDeclaration.GetSupertypes(classModule).First());
+        }
+        
+
+        [TestMethod]
+        public void GetSupertypesReturnsAnEmptyEnumerableForDeclarationsWithDeclarationTypeClassModuleWhichAreNoClassModuleDeclarations()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var fakeClassModule = GetTestFakeClassModule(projectDeclaration, "testFakeClass");
+
+            Assert.IsFalse(ClassModuleDeclaration.GetSupertypes(fakeClassModule).Any());
+        }
+
+            private static Declaration GetTestFakeClassModule(Declaration parentDeclatation, string name)
+            {
+                var qualifiedVariableMemberName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new Declaration(qualifiedVariableMemberName, parentDeclatation, "dummy", "test", "test", false, false, Accessibility.Public, DeclarationType.ClassModule, null, Selection.Home, false, null);
+            }
+
+
+
+        [TestMethod]
+        public void ByDefaultDefaultMemberIsNull()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsNull(classModule.DefaultMember);
+        }
+
+
+        [TestMethod]
+        public void ByDefaultClassModulesNotBuiltInAreNotExposed()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsFalse(classModule.IsExposed);
+        }
+
+
+        // TODO: Find out if there's info about "being exposed" in type libraries.
+        // We take the conservative approach of treating all type library modules as exposed.
+        [TestMethod]
+        public void BuiltInClassesAreExposed()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
+
+            Assert.IsTrue(classModule.IsExposed);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesWithTheExposedAttributeAreExposed()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddExposedClassAttribute();
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, classAttributes);
+
+            Assert.IsTrue(classModule.IsExposed);
+        }
+
+
+        [TestMethod]
+        public void ByDefaultClassModulesAreNotGlobalClasses()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsFalse(classModule.IsGlobalClassModule);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesWithTheGlobalNamespaceAttributeAreGlobalClasses()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddGlobalClassAttribute();
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, classAttributes);
+
+            Assert.IsTrue(classModule.IsGlobalClassModule);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesWithASubtypeBelowInTheHiearchyThatIsAGlobalClassAndThatHasBeenAddedBeforeCallingIsGlobalClassTheFirstTimeIsAGlobalClass()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddGlobalClassAttribute();
+            var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", false, classAttributes);
+            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", false, null);
+            subtype.AddSubtype(subsubtype);
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            classModule.AddSubtype(subtype);
+
+            Assert.IsTrue(classModule.IsGlobalClassModule);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesDoNotBecomeAGlobalClassIfASubtypeBelowInTheHiearchyIsAddedThatIsAGlobalClassAfterIsAGlobalClassHasAlreadyBeenCalled()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddGlobalClassAttribute();
+            var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", false, classAttributes);
+            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", false, null);
+            subtype.AddSubtype(subsubtype);
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            var dummy = classModule.IsGlobalClassModule;
+            classModule.AddSubtype(subtype);
+
+            Assert.IsFalse(classModule.IsGlobalClassModule);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesDoNotBecomeAGlobalClassIfBelowInTheHierarchyASubtypeIsAddedThatIsAGlobalClassAfterIsAGlobalClassHasAlreadyBeenCalled()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddGlobalClassAttribute();
+            var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", false, classAttributes);
+            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", false, null);
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+            classModule.AddSubtype(subtype);
+            var dummy = classModule.IsGlobalClassModule;
+            subtype.AddSubtype(subsubtype);
+
+            Assert.IsFalse(classModule.IsGlobalClassModule);
+        }
+
+
+        [TestMethod]
+        public void ByDefaultClassModulesDoNotHaveAPredeclaredID()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsFalse(classModule.HasPredeclaredId);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesHaveAPredeclaredIDIfStatedInTheConstructorThatTheyHaveADefaultInstanceVariable()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null, true);
+
+            Assert.IsTrue(classModule.HasPredeclaredId);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesWithThePredeclaredIDAttributeHaveAPredeclaredID()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddPredeclaredIdTypeAttribute();
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, classAttributes);
+
+            Assert.IsTrue(classModule.HasPredeclaredId);
+        }
+
+
+        [TestMethod]
+        public void ByDefaultClassModulesDoNotHaveADefaultInstanceVariable()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null);
+
+            Assert.IsFalse(classModule.HasDefaultInstanceVariable);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesThatAreGlobalClassesHaveADefaultInstanceVariable()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddGlobalClassAttribute();
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, classAttributes);
+
+            Assert.IsTrue(classModule.HasDefaultInstanceVariable);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesWithThePredeclaredIDAttributeHaveADefaultInstanceVariable()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddPredeclaredIdTypeAttribute();
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, classAttributes);
+
+            Assert.IsTrue(classModule.HasDefaultInstanceVariable);
+        }
+
+
+        [TestMethod]
+        public void ClassModulesHaveADefaultInstanceVariableIfThisIsStated()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", false, null, true);
+
+            Assert.IsTrue(classModule.HasDefaultInstanceVariable);
+        }
+
+    }
+}

--- a/RubberduckTests/Symbols/ConstantDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ConstantDeclarationTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class ConstantDeclarationTests
+    {
+        [TestMethod]
+        public void ExpressionReturnsTheContructorInjectedValue()
+        {
+            var value = "testtest";
+            var constantName =  new QualifiedMemberName(StubQualifiedModuleName(),"testConstant");
+            var constantDeclaration = new ConstantDeclaration(constantName, null, "test", "test", null, "test", null, Accessibility.Implicit, DeclarationType.Constant, value, null, Selection.Home, false);
+
+            Assert.AreEqual<string>(value, constantDeclaration.Expression);
+        }
+            
+            private static QualifiedModuleName StubQualifiedModuleName()
+            {
+                return new QualifiedModuleName("dummy", "dummy", "dummy");
+            }
+    }
+}

--- a/RubberduckTests/Symbols/ExternalProcedureDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ExternalProcedureDeclarationTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class ExternalProcedureDeclarationTests
+    {
+        [TestMethod]
+        public void ByDefaultExternalProceduresDoNotHaveParameters()
+        {
+            var externalProcedure = GetTestExternalProcedure("testProcedure");
+
+            Assert.IsFalse(externalProcedure.Parameters.Any());
+        }
+
+            private static ExternalProcedureDeclaration GetTestExternalProcedure(string name)
+            {
+                var qualifiedProcedureName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ExternalProcedureDeclaration(qualifiedProcedureName, null, null, DeclarationType.Procedure, "test", null, Accessibility.Public, null, Selection.Home, false, null);
+            }
+
+                private static QualifiedModuleName StubQualifiedModuleName()
+                {
+                    return new QualifiedModuleName("dummy", "dummy", "dummy");
+                }
+
+
+        [TestMethod]
+        public void ParametersReturnsTheParametersAddedViaAddParameters()
+        {
+            var externalProcedure = GetTestExternalProcedure("testProcedure");
+            var inputParameter = GetTestParameter("testParameter", false, false, false);
+            externalProcedure.AddParameter(inputParameter);
+            var returnedParameter = externalProcedure.Parameters.SingleOrDefault();
+
+            Assert.AreEqual(returnedParameter, inputParameter);
+        }
+
+            private static ParameterDeclaration GetTestParameter(string name, bool isOptional, bool isByRef, bool isParamArray)
+            {
+                var qualifiedParameterName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ParameterDeclaration(qualifiedParameterName, null, "test", null, "test", isOptional, isByRef, false, isParamArray);
+            }
+
+    }
+}

--- a/RubberduckTests/Symbols/FunctionDeclarationTests.cs
+++ b/RubberduckTests/Symbols/FunctionDeclarationTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+using Rubberduck.Parsing.VBA;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class FunctionDeclarationTests
+    {
+        [TestMethod]
+        public void FunctionsHaveDeclarationTypeFunction()
+        {
+            var function = GetTestFunction("testFoo", null);
+
+            Assert.IsTrue(function.DeclarationType.HasFlag(DeclarationType.Function));
+        }
+
+            private static FunctionDeclaration GetTestFunction(string name, Attributes attributes)
+            {
+                var qualifiedName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new FunctionDeclaration(qualifiedName, null, null, "test", null, "test", Accessibility.Implicit, null, Selection.Home, false, false, null, attributes);
+            }
+
+                private static QualifiedModuleName StubQualifiedModuleName()
+                {
+                    return new QualifiedModuleName("dummy", "dummy", "dummy");
+                }
+
+
+        [TestMethod]
+        public void ByDefaultFunctionsDoNotHaveParameters()
+        {
+            var function = GetTestFunction("testFoo", null);
+
+            Assert.IsFalse(function.Parameters.Any());
+        }
+
+
+        [TestMethod]
+        public void ParametersReturnsTheParametersAddedViaAddParameters()
+        {
+            var function = GetTestFunction("testFoo", null);
+            var inputParameter = GetTestParameter("testParameter", false, false, false);
+            function.AddParameter(inputParameter);
+            var returnedParameter = function.Parameters.SingleOrDefault();
+
+            Assert.AreEqual(returnedParameter, inputParameter);
+        }
+
+            private static ParameterDeclaration GetTestParameter(string name, bool isOptional, bool isByRef, bool isParamArray)
+            {
+                var qualifiedParameterName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ParameterDeclaration(qualifiedParameterName, null, "test", null, "test", isOptional, isByRef, false, isParamArray);
+            }
+
+
+        [TestMethod]
+        public void ByDefaultFunctionsAreNotDefaultMembers()
+        {
+            var function = GetTestFunction("testFoo", null);
+
+            Assert.IsFalse(function.IsDefaultMember);
+        }
+
+
+        [TestMethod]
+        public void FunctionsAreDefaultMembersIfTheyHaveTheDefaultMemberAttribute()
+        {
+            var attributes = new Attributes();
+            attributes.AddDefaultMemberAttribute("testFoo");
+            var function = GetTestFunction("testFoo", attributes);
+
+            Assert.IsTrue(function.IsDefaultMember);
+        }
+    }
+}

--- a/RubberduckTests/Symbols/ParameterDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ParameterDeclarationTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class ParameterDeclarationTests
+    {
+        [TestMethod]
+        public void ParametersHaveDeclarationTypeParameter()
+        {
+            var paramter = GetTestParameter("testParam", false, false, false);
+
+            Assert.IsTrue(paramter.DeclarationType.HasFlag(DeclarationType.Parameter));
+        }
+
+            private static ParameterDeclaration GetTestParameter(string name, bool isOptional, bool isByRef, bool isParamArray)
+            {
+                var qualifiedParameterName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ParameterDeclaration(qualifiedParameterName, null, "test", null,"test", isOptional,isByRef, false, isParamArray);
+            }
+
+                private static QualifiedModuleName StubQualifiedModuleName()
+                {
+                    return new QualifiedModuleName("dummy", "dummy", "dummy");
+                }
+
+
+        [TestMethod]
+        public void ParametersHaveImpliciteAccessibility()
+        {
+            var paramter = GetTestParameter("testParam", false, false, false);
+
+            Assert.IsTrue(paramter.Accessibility.HasFlag(Accessibility.Implicit));
+        }
+
+
+        [TestMethod]
+        public void IsParamArrayCanBeSetPublicly()
+        {
+            var paramter = GetTestParameter("testParam", false, false, false);
+            paramter.IsParamArray = true;
+
+            Assert.IsTrue(paramter.IsParamArray);
+        }
+
+    }
+}

--- a/RubberduckTests/Symbols/ProceduralModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ProceduralModuleDeclarationTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+using Rubberduck.Parsing.VBA;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class ProceduralModuleDeclarationTests
+    {
+        [TestMethod]
+        public void ProceduralModulesHaveDeclarationTypeProceduralModule()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var proceduralModule = GetTestProceduralModule(projectDeclaration, "testModule", false, null);
+
+            Assert.IsTrue(proceduralModule.DeclarationType.HasFlag(DeclarationType.ProceduralModule));
+        }
+
+            private static ProjectDeclaration GetTestProject(string name)
+            {
+                var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ProjectDeclaration(qualifiedProjectName, name, false);
+            }
+
+                private static QualifiedModuleName StubQualifiedModuleName()
+                {
+                    return new QualifiedModuleName("dummy", "dummy", "dummy");
+                }
+
+            private static ProceduralModuleDeclaration GetTestProceduralModule(Declaration projectDeclatation, string name, bool isBuiltIn, Attributes attributes)
+            {
+                var qualifiedProceduralModuleMemberName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ProceduralModuleDeclaration(qualifiedProceduralModuleMemberName, projectDeclatation, name, isBuiltIn, null, attributes);
+            }
+
+
+        [TestMethod]
+        public void ByDefaultProceduralModulesAreNotPrivate()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var proceduralModule = GetTestProceduralModule(projectDeclaration, "testModule", false, null);
+
+            Assert.IsFalse(proceduralModule.IsPrivateModule);
+        }
+
+    }
+}

--- a/RubberduckTests/Symbols/ProjectDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ProjectDeclarationTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class ProjectDeclarationTests
+    {
+        [TestMethod]
+        public void ProjectsHaveDeclarationTypeProject()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+
+            Assert.IsTrue(projectDeclaration.DeclarationType.HasFlag(DeclarationType.Project));
+        }
+
+            private static ProjectDeclaration GetTestProject(string name)
+            {
+                var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ProjectDeclaration(qualifiedProjectName, name, false);
+            }
+
+                private static QualifiedModuleName StubQualifiedModuleName()
+                {
+                    return new QualifiedModuleName("dummy", "dummy", "dummy");
+                }
+
+
+        [TestMethod]
+        public void ByDefaultProjectsReferenceNoOtherProjects()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+
+            Assert.IsFalse(projectDeclaration.ProjectReferences.Any());
+        }
+
+
+        [TestMethod]
+        public void ProjectsReferencesReturnsTheReferencesAddedViaAddProjectReference()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var projectId = "test";
+            var priority = 12;
+            projectDeclaration.AddProjectReference(projectId, priority);
+            var projectReference = projectDeclaration.ProjectReferences.Single();
+
+            Assert.IsTrue(projectReference.ReferencedProjectId == projectId && projectReference.Priority == priority);
+        }
+
+
+        [TestMethod]
+        public void ProjectsReferencesIgnoresReferencesWithTheSameIDAsOneAlreadyPresent()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var projectId = "test";
+            var priority = 12;
+            var otherPriority = 1;
+            projectDeclaration.AddProjectReference(projectId, priority);
+            projectDeclaration.AddProjectReference(projectId, otherPriority);
+            var projectReference = projectDeclaration.ProjectReferences.Single();
+
+            Assert.IsTrue(projectReference.ReferencedProjectId == projectId && projectReference.Priority == priority);
+        }
+
+
+        [TestMethod]
+        public void ProjectsReferencesReturnsTheReferencesInOrderOfAscendingPriority()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var projectId = "test";
+            var priority = 12;
+            var otherProjectId = "testtest";
+            var otherPriority = 1;
+            var yetAnotherProjectId = "testtesttest";
+            var yetAnotherPriority = 5;
+            projectDeclaration.AddProjectReference(projectId, priority);
+            projectDeclaration.AddProjectReference(otherProjectId, otherPriority);
+            projectDeclaration.AddProjectReference(yetAnotherProjectId, yetAnotherPriority);
+            var lowerPriorityProjectReference = projectDeclaration.ProjectReferences.First();
+
+            Assert.IsTrue(lowerPriorityProjectReference.ReferencedProjectId == otherProjectId && lowerPriorityProjectReference.Priority == otherPriority);
+        }
+
+    }
+}

--- a/RubberduckTests/Symbols/SubroutineDeclarationTests.cs
+++ b/RubberduckTests/Symbols/SubroutineDeclarationTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+using Rubberduck.Parsing.VBA;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class SubroutineDeclarationTests
+    {
+        [TestMethod]
+        public void SubroutinesHaveDeclarationTypeProcedure()
+        {
+            var subroutine = GetTestSub("testSub", null);
+
+            Assert.IsTrue(subroutine.DeclarationType.HasFlag(DeclarationType.Procedure));
+        }
+
+            private static SubroutineDeclaration GetTestSub(string name, Attributes attributes)
+            {
+                var qualifiedName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new SubroutineDeclaration(qualifiedName, null, null, "test", Accessibility.Implicit, null, Selection.Home, false, null, attributes);
+            }
+
+                private static QualifiedModuleName StubQualifiedModuleName()
+                {
+                    return new QualifiedModuleName("dummy", "dummy", "dummy");
+                }
+
+
+        [TestMethod]
+        public void ByDefaultSubroutinesDoNotHaveParameters()
+        {
+            var subroutine = GetTestSub("testSub", null);
+
+            Assert.IsFalse(subroutine.Parameters.Any());
+        }
+
+
+        [TestMethod]
+        public void ParametersReturnsTheParametersAddedViaAddParameters()
+        {
+            var subroutine = GetTestSub("testSub", null);
+            var inputParameter = GetTestParameter("testParameter", false, false, false);
+            subroutine.AddParameter(inputParameter);
+            var returnedParameter = subroutine.Parameters.SingleOrDefault();
+
+            Assert.AreEqual(returnedParameter, inputParameter);
+        }
+
+            private static ParameterDeclaration GetTestParameter(string name, bool isOptional, bool isByRef, bool isParamArray)
+            {
+                var qualifiedParameterName = new QualifiedMemberName(StubQualifiedModuleName(), name);
+                return new ParameterDeclaration(qualifiedParameterName, null, "test", null, "test", isOptional, isByRef, false, isParamArray);
+            }
+
+
+        [TestMethod]
+        public void ByDefaultSubroutinesAreNotDefaultMembers()
+        {
+            var subroutine = GetTestSub("testSub", null);
+
+            Assert.IsFalse(subroutine.IsDefaultMember);
+        }
+
+
+        [TestMethod]
+        public void SubroutinesAreDefaultMembersIfTheyHaveTheDefaultMemberAttribute()
+        {
+            var attributes = new Attributes();
+            attributes.AddDefaultMemberAttribute("testSub");
+            var subroutine = GetTestSub("testSub", attributes);
+
+            Assert.IsTrue(subroutine.IsDefaultMember);
+        }
+
+    }
+}


### PR DESCRIPTION
I added unit tests for the various subtypes of Declaration and refactored the three inventories for built-in declarations: `AliasDeclarations`, `DebugDeclarations`, and `FormEventDeclarations`.
Moreover, I added another test to those for `AccessibilityCheck` to document its limitations.

Doing this, several questions came to my mind, which you can read in the comments to my commits.