### PR TITLE
Prefer parent procedure name for variable declarations with same name.

### DIFF
--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -263,6 +263,10 @@ namespace Rubberduck.Parsing.Symbols
 
         public Declaration FindMemberEnclosingProcedure(Declaration enclosingProcedure, string memberName, DeclarationType memberType, ParserRuleContext onSiteContext = null)
         {
+            if (memberType == DeclarationType.Variable && enclosingProcedure.IdentifierName.Equals(memberName))
+            {
+                return enclosingProcedure;
+            }
             var allMatches = MatchName(memberName);
             var memberMatches = allMatches.Where(m =>
                 m.DeclarationType.HasFlag(memberType)


### PR DESCRIPTION
This passes the enum with the same name as the function test, but it's probably more generalizable to a more comprehensive solution to how enums are treated in the resolver.  Call it a shim ATM.