### PR TITLE
Custom declaration loading and some fixes from retailcoder

### DIFF
--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
@@ -45,11 +45,15 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
             typeName = "(" + declarationType + (string.IsNullOrEmpty(typeName) ? string.Empty : ":" + typeName) + ")";
 
-            if (declaration.DeclarationType.HasFlag(DeclarationType.Module))
+            if (declaration.DeclarationType.HasFlag(DeclarationType.Project))
+            {
+                formattedDeclaration = System.IO.Path.GetFileName(declaration.QualifiedName.QualifiedModuleName.ProjectPath) + ";" + declaration.IdentifierName;
+            }
+            else if (declaration.DeclarationType.HasFlag(DeclarationType.Module))
             {
                 formattedDeclaration = moduleName.ToString();
             }
-
+            
             if (declaration.DeclarationType.HasFlag(DeclarationType.Member))
             {
                 formattedDeclaration = declaration.QualifiedName.ToString();
@@ -59,7 +63,7 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                     formattedDeclaration += typeName;
                 }
             }
-
+            
             if (declaration.DeclarationType == DeclarationType.Enumeration
                 || declaration.DeclarationType == DeclarationType.UserDefinedType)
             {
@@ -68,8 +72,7 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                     ? System.IO.Path.GetFileName(moduleName.ProjectPath) + ";" + moduleName.ProjectName + "." + declaration.IdentifierName
                     : moduleName.ToString();
             }
-
-            if (declaration.DeclarationType == DeclarationType.EnumerationMember
+            else if (declaration.DeclarationType == DeclarationType.EnumerationMember
                 || declaration.DeclarationType == DeclarationType.UserDefinedTypeMember)
             {
                 formattedDeclaration = string.Format("{0}.{1}.{2}",
@@ -81,13 +84,13 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             }
 
             var subscripts = declaration.IsArray ? "()" : string.Empty;
-            if (declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Member))
+            if (declaration.ParentDeclaration != null && declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Member))
             {
                 // locals, parameters
                 formattedDeclaration = string.Format("{0}:{1}{2} {3}", declaration.ParentDeclaration.QualifiedName, declaration.IdentifierName, subscripts, typeName);
             }
 
-            if (declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Module))
+            if (declaration.ParentDeclaration != null && declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Module))
             {
                 // fields
                 var withEvents = declaration.IsWithEvents ? "(WithEvents) " : string.Empty;

--- a/Rubberduck.Parsing/Symbols/AliasDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/AliasDeclarations.cs
@@ -14,6 +14,7 @@ namespace Rubberduck.Parsing.Symbols
         private Declaration _fileSystemModule;
         private Declaration _interactionModule;
         private Declaration _stringsModule;
+        private Declaration _dateTimeModule;
 
         public AliasDeclarations(RubberduckParserState state)
         {
@@ -48,7 +49,9 @@ namespace Rubberduck.Parsing.Symbols
             Grammar.Tokens.RightB,
             Grammar.Tokens.RTrim,
             Grammar.Tokens.String,
-            Grammar.Tokens.UCase
+            Grammar.Tokens.UCase,
+            Grammar.Tokens.Date,
+            Grammar.Tokens.Time,
         };
 
         private IReadOnlyList<Declaration> AddAliasDeclarations()
@@ -71,7 +74,7 @@ namespace Rubberduck.Parsing.Symbols
             var functionAliases = FunctionAliasesWithoutParameters();
             AddParametersToAliasesFromReferencedFunctions(functionAliases, possiblyAliasedFunctions);
 
-            return functionAliases;
+            return functionAliases.Concat<Declaration>(PropertyGetDeclarations()).ToList();
         }
 
         private void UpdateAliasFunctionModulesFromReferencedProjects(DeclarationFinder finder)
@@ -88,6 +91,7 @@ namespace Rubberduck.Parsing.Symbols
             _fileSystemModule = finder.FindStdModule("FileSystem", vba, true);
             _interactionModule = finder.FindStdModule("Interaction", vba, true);
             _stringsModule = finder.FindStdModule("Strings", vba, true);
+            _dateTimeModule = finder.FindStdModule("DateTime", vba, true);
         }
 
 
@@ -120,6 +124,50 @@ namespace Rubberduck.Parsing.Symbols
             return functions.ToList();
         }
 
+        private List<PropertyGetDeclaration> PropertyGetDeclarations()
+        {
+            return new List<PropertyGetDeclaration>
+            {
+                DatePropertyGet(),
+                TimePropertyGet(),
+            };
+        }
+
+        private PropertyGetDeclaration DatePropertyGet()
+        {
+            return new PropertyGetDeclaration(
+                new QualifiedMemberName(_dateTimeModule.QualifiedName.QualifiedModuleName, "Date"),
+                _dateTimeModule,
+                _dateTimeModule,
+                "Variant",
+                null,
+                string.Empty,
+                Accessibility.Global,
+                null,
+                new Selection(),
+                false,
+                true,
+                new List<IAnnotation>(),
+                new Attributes());
+        }
+
+        private PropertyGetDeclaration TimePropertyGet()
+        {
+            return new PropertyGetDeclaration(
+                new QualifiedMemberName(_dateTimeModule.QualifiedName.QualifiedModuleName, "Time"),
+                _dateTimeModule,
+                _dateTimeModule,
+                "Variant",
+                null,
+                string.Empty,
+                Accessibility.Global,
+                null,
+                new Selection(),
+                false,
+                true,
+                new List<IAnnotation>(),
+                new Attributes());
+        }
 
         private List<FunctionDeclaration> FunctionAliasesWithoutParameters()
         {
@@ -146,7 +194,7 @@ namespace Rubberduck.Parsing.Symbols
                 RightBFunction(),
                 RTrimFunction(),
                 StringFunction(),
-                UCaseFunction()
+                UCaseFunction(),
             };
         }
 

--- a/Rubberduck.Parsing/Symbols/DebugDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DebugDeclarations.cs
@@ -21,7 +21,7 @@ namespace Rubberduck.Parsing.Symbols
         {
             var finder = new DeclarationFinder(_state.AllDeclarations, new CommentNode[] { }, new IAnnotation[] { });
 
-            if (ThereIsAGlobalBuiltInErrVariableDeclaration(finder))
+            if (WeHaveAlreadyLoadedTheDeclarationsBefore(finder))
             {
                 return new List<Declaration>();
             }
@@ -37,9 +37,14 @@ namespace Rubberduck.Parsing.Symbols
             return LoadDebugDeclarations(vba);
         }
 
+        private static bool WeHaveAlreadyLoadedTheDeclarationsBefore(DeclarationFinder finder)
+        {
+            return ThereIsAGlobalBuiltInErrVariableDeclaration(finder);
+        }
+
             private static bool ThereIsAGlobalBuiltInErrVariableDeclaration(DeclarationFinder finder) 
             {
-                return finder.MatchName(Tokens.Err).Any(declaration => declaration.IsBuiltIn
+                return finder.MatchName(Grammar.Tokens.Err).Any(declaration => declaration.IsBuiltIn
                                                                         && declaration.DeclarationType == DeclarationType.Variable
                                                                         && declaration.Accessibility == Accessibility.Global);
             }

--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -140,6 +140,24 @@ namespace Rubberduck.Parsing.Symbols
             return result;
         }
 
+        public Declaration FindClassModule(string name, Declaration parent = null, bool includeBuiltIn = false)
+        {
+            Declaration result = null;
+            try
+            {
+                var matches = MatchName(name);
+                result = matches.SingleOrDefault(declaration => declaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
+                    && (parent == null || parent.Equals(declaration.ParentDeclaration))
+                    && (includeBuiltIn || !declaration.IsBuiltIn));
+            }
+            catch (InvalidOperationException exception)
+            {
+                Logger.Error(exception, "Multiple matches found for class module '{0}'.", name);
+            }
+
+            return result;
+        }
+
         public Declaration FindReferencedProject(Declaration callingProject, string referencedProjectName)
         {
             return FindInReferencedProjectByPriority(callingProject, referencedProjectName, p => p.DeclarationType.HasFlag(DeclarationType.Project));

--- a/Rubberduck.Parsing/Symbols/FormEventDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/FormEventDeclarations.cs
@@ -33,12 +33,11 @@ namespace Rubberduck.Parsing.Symbols
             var msForms = finder.FindProject("MSForms");
             if (msForms == null)
             {
-                // If the VBA project is null, we haven't loaded any COM references;
-                // we're in a unit test and the mock project didn't setup any references.
+                //The corresponding COM reference has not been loaded.
                 return null;
             }
 
-            return finder.FindStdModule("FormEvents", msForms, true);
+            return finder.FindClassModule("FormEvents", msForms, true);
         }
 
 

--- a/RubberduckTests/Inspections/UntypedFunctionUsageInspectionTests.cs
+++ b/RubberduckTests/Inspections/UntypedFunctionUsageInspectionTests.cs
@@ -262,8 +262,16 @@ End Sub";
                 new List<IAnnotation>(),
                 new Attributes());
 
+            var dateTimeModule = new ProceduralModuleDeclaration(
+                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "DateTime"), "DateTime"),
+                vbaDeclaration,
+                "Strings",
+                true,
+                new List<IAnnotation>(),
+                new Attributes());
+
             var commandFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Interaction"), "_B_var_Command"),
+                new QualifiedMemberName(interactionModule.QualifiedName.QualifiedModuleName, "_B_var_Command"),
                 interactionModule,
                 interactionModule,
                 "Variant",
@@ -278,7 +286,7 @@ End Sub";
                 new Attributes());
 
             var environFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Interaction"), "_B_var_Environ"),
+                new QualifiedMemberName(interactionModule.QualifiedName.QualifiedModuleName, "_B_var_Environ"),
                 interactionModule,
                 interactionModule,
                 "Variant",
@@ -293,7 +301,7 @@ End Sub";
                 new Attributes());
 
             var rtrimFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_RTrim"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_RTrim"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -308,7 +316,7 @@ End Sub";
                 new Attributes());
 
             var chrFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Chr"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_Chr"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -323,7 +331,7 @@ End Sub";
                 new Attributes());
 
             var formatFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Format"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_Format"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -338,7 +346,7 @@ End Sub";
                 new Attributes());
 
             var firstFormatParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Expression"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "Expression"),
                 formatFunction,
                 "Variant",
                 null,
@@ -347,7 +355,7 @@ End Sub";
                 true);
 
             var secondFormatParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Format"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "Format"),
                 formatFunction,
                 "Variant",
                 null,
@@ -356,7 +364,7 @@ End Sub";
                 true);
 
             var thirdFormatParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "FirstDayOfWeek"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "FirstDayOfWeek"),
                 formatFunction,
                 "VbDayOfWeek",
                 null,
@@ -369,7 +377,7 @@ End Sub";
             formatFunction.AddParameter(thirdFormatParam);
 
             var rightFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Right"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_Right"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -384,7 +392,7 @@ End Sub";
                 new Attributes());
 
             var firstRightParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "String"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "String"),
                 rightFunction,
                 "Variant",
                 null,
@@ -395,7 +403,7 @@ End Sub";
             rightFunction.AddParameter(firstRightParam);
 
             var lcaseFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_LCase"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_LCase"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -410,7 +418,7 @@ End Sub";
                 new Attributes());
 
             var leftbFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_LeftB"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_LeftB"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -425,7 +433,7 @@ End Sub";
                 new Attributes());
 
             var firstLeftBParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "String"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "String"),
                 leftbFunction,
                 "Variant",
                 null,
@@ -436,7 +444,7 @@ End Sub";
             leftbFunction.AddParameter(firstLeftBParam);
 
             var chrwFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_ChrW"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_ChrW"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -451,7 +459,7 @@ End Sub";
                 new Attributes());
 
             var leftFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Left"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_Left"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -466,7 +474,7 @@ End Sub";
                 new Attributes());
 
             var firstLeftParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "String"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "String"),
                 leftFunction,
                 "Variant",
                 null,
@@ -477,7 +485,7 @@ End Sub";
             leftFunction.AddParameter(firstLeftParam);
 
             var rightbFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_RightB"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_RightB"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -492,7 +500,7 @@ End Sub";
                 new Attributes());
 
             var firstRightBParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "String"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "String"),
                 rightbFunction,
                 "Variant",
                 null,
@@ -503,7 +511,7 @@ End Sub";
             rightbFunction.AddParameter(firstRightBParam);
 
             var midbFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_MidB"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_MidB"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -518,7 +526,7 @@ End Sub";
                 new Attributes());
 
             var firstMidBParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "String"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "String"),
                 midbFunction,
                 "Variant",
                 null,
@@ -527,7 +535,7 @@ End Sub";
                 true);
 
             var secondMidBParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Start"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "Start"),
                 midbFunction,
                 "Long",
                 null,
@@ -539,7 +547,7 @@ End Sub";
             midbFunction.AddParameter(secondMidBParam);
 
             var ucaseFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_UCase"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_UCase"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -554,7 +562,7 @@ End Sub";
                 new Attributes());
 
             var trimFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Trim"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_Trim"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -569,7 +577,7 @@ End Sub";
                 new Attributes());
 
             var ltrimFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_LTrim"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_LTrim"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -584,7 +592,7 @@ End Sub";
                 new Attributes());
 
             var midFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Mid"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "_B_var_Mid"),
                 stringsModule,
                 stringsModule,
                 "Variant",
@@ -599,7 +607,7 @@ End Sub";
                 new Attributes());
 
             var firstMidParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "String"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "String"),
                 midbFunction,
                 "Variant",
                 null,
@@ -608,7 +616,7 @@ End Sub";
                 true);
 
             var secondMidParam = new ParameterDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "Start"),
+                new QualifiedMemberName(stringsModule.QualifiedName.QualifiedModuleName, "Start"),
                 midbFunction,
                 "Long",
                 null,
@@ -620,7 +628,7 @@ End Sub";
             midFunction.AddParameter(secondMidParam);
 
             var hexFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Hex"),
+                new QualifiedMemberName(conversionModule.QualifiedName.QualifiedModuleName, "_B_var_Hex"),
                 conversionModule,
                 conversionModule,
                 "Variant",
@@ -635,7 +643,7 @@ End Sub";
                 new Attributes());
 
             var octFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Oct"),
+                new QualifiedMemberName(conversionModule.QualifiedName.QualifiedModuleName, "_B_var_Oct"),
                 conversionModule,
                 conversionModule,
                 "Variant",
@@ -650,7 +658,7 @@ End Sub";
                 new Attributes());
 
             var errorFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Error"),
+                new QualifiedMemberName(conversionModule.QualifiedName.QualifiedModuleName, "_B_var_Error"),
                 conversionModule,
                 conversionModule,
                 "Variant",
@@ -665,7 +673,7 @@ End Sub";
                 new Attributes());
 
             var strFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_Str"),
+                new QualifiedMemberName(conversionModule.QualifiedName.QualifiedModuleName, "_B_var_Str"),
                 conversionModule,
                 conversionModule,
                 "Variant",
@@ -680,7 +688,7 @@ End Sub";
                 new Attributes());
 
             var curDirFunction = new FunctionDeclaration(
-                new QualifiedMemberName(new QualifiedModuleName("VBA", "C:\\Program Files\\Common Files\\Microsoft Shared\\VBA\\VBA7.1\\VBE7.DLL", "Strings"), "_B_var_CurDir"),
+                new QualifiedMemberName(fileSystemModule.QualifiedName.QualifiedModuleName, "_B_var_CurDir"),
                 fileSystemModule,
                 fileSystemModule,
                 "Variant",
@@ -694,6 +702,37 @@ End Sub";
                 new List<IAnnotation>(),
                 new Attributes());
 
+            var datePropertyGet = new PropertyGetDeclaration(
+                new QualifiedMemberName(dateTimeModule.QualifiedName.QualifiedModuleName, "Date"),
+                dateTimeModule,
+                dateTimeModule,
+                "Variant",
+                null,
+                string.Empty,
+                Accessibility.Global,
+                null,
+                new Selection(),
+                false,
+                true,
+                new List<IAnnotation>(),
+                new Attributes());
+        
+
+            var timePropertyGet = new PropertyGetDeclaration(
+                new QualifiedMemberName(dateTimeModule.QualifiedName.QualifiedModuleName, "Time"),
+                dateTimeModule,
+                dateTimeModule,
+                "Variant",
+                null,
+                string.Empty,
+                Accessibility.Global,
+                null,
+                new Selection(),
+                false,
+                true,
+                new List<IAnnotation>(),
+                new Attributes());
+
             return new List<Declaration>
             {
                 vbaDeclaration,
@@ -701,6 +740,7 @@ End Sub";
                 fileSystemModule,
                 interactionModule,
                 stringsModule,
+                dateTimeModule,
                 commandFunction,
                 environFunction,
                 rtrimFunction,
@@ -732,7 +772,9 @@ End Sub";
                 octFunction,
                 errorFunction,
                 strFunction,
-                curDirFunction
+                curDirFunction,
+                datePropertyGet,
+                timePropertyGet
             };
         }
     }


### PR DESCRIPTION
Aligned the load behaviour of the implementations of ICustomdeclarationLoader: now, they use the declarations at the time of the actual load of the declarations. Moreover, the declarations for the VBA project are only loaded once. (Also there is no hard fail anymore in the SpacialFormDeclarations in the situation that the VBA project is there, but not the information module.)

Furthermore, fixed a bug in FormsEventDeclarations I introduced yesterday.

Also includes the changes from PR #2487 of @retailcoder and the fixes of the failing tests. 