### PR TITLE
Allow special characters in Access Forms and Reports

### DIFF
--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -58,6 +58,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         private string SafeName
         {
+            get { return Path.GetInvalidFileNameChars().Aggregate(Name, (current, c) => current.Replace(c.ToString(), "_")); }
         }
 
         public IControls Controls

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -56,6 +56,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             set { Target.Name = value; }
         }
 
+        private string SafeName
+        {
+        }
+
         public IControls Controls
         {
             get
@@ -107,7 +111,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         /// <param name="folder">Destination folder for the resulting source file.</param>
         public string ExportAsSourceFile(string folder)
         {
-            var fullPath = Path.Combine(folder, Name + Type.FileExtension());
+            var fullPath = Path.Combine(folder, SafeName + Type.FileExtension());
             switch (Type)
             {
                 case ComponentType.UserForm:
@@ -165,7 +169,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         private string ExportToTempFile()
         {
-            var path = Path.Combine(Path.GetTempPath(), Name + Type.FileExtension());
+            var path = Path.Combine(Path.GetTempPath(), SafeName + Type.FileExtension());
             Export(path);
             return path;
         }


### PR DESCRIPTION
Substitutes illegal characters with underscores.

There could be naming collisions using this approach - These 2 names would rename to the *same* name.
- `Report_Foo_Bar\Fizz`
- `Report_Foo\Bar_Fizz`

It might be safer to use a hash when choosing a name.