### PR TITLE
Add IsWrappingNullReference tests on setters and methods of SafeComWrappers.

### DIFF
--- a/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
@@ -232,7 +232,7 @@ namespace Rubberduck.UI.Command
         {
             if (_state != null)
             {
-                _state.StateChanged += _state_StateChanged;
+                _state.StateChanged -= _state_StateChanged;
             }
         }
     }

--- a/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
@@ -167,7 +167,7 @@ namespace Rubberduck.UI.Command
         {
             if (_state != null)
             {
-                _state.StateChanged += _state_StateChanged;
+                _state.StateChanged -= _state_StateChanged;
             }
         }
     }

--- a/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
@@ -129,7 +129,7 @@ namespace Rubberduck.UI.Command
         {
             if (_state != null)
             {
-                _state.StateChanged += _state_StateChanged;
+                _state.StateChanged -= _state_StateChanged;
             }
         }
     }

--- a/RetailCoder.VBE/UI/UnitTesting/TestExplorerModel.cs
+++ b/RetailCoder.VBE/UI/UnitTesting/TestExplorerModel.cs
@@ -10,7 +10,7 @@ using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.UnitTesting
 {
-    public class TestExplorerModel : ViewModelBase
+    public class TestExplorerModel : ViewModelBase, IDisposable
     {
         private readonly IVBE _vbe;
         private readonly RubberduckParserState _state;
@@ -166,6 +166,14 @@ namespace Rubberduck.UI.UnitTesting
             if (handler != null)
             {
                 handler.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_state != null)
+            {
+                _state.StateChanged -= State_StateChanged;
             }
         }
     }

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBar.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBar.cs
@@ -29,13 +29,13 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public bool IsEnabled
         {
             get { return !IsWrappingNullReference && Target.Enabled; }
-            set { Target.Enabled = value; }
+            set { if (!IsWrappingNullReference) Target.Enabled = value; }
         }
 
         public int Height
         {
             get { return IsWrappingNullReference ? 0 : Target.Height; }
-            set { Target.Height = value; }
+            set { if (!IsWrappingNullReference) Target.Height = value; }
         }
 
         public int Index
@@ -46,25 +46,25 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public int Left
         {
             get { return IsWrappingNullReference ? 0 : Target.Left; }
-            set { Target.Left = value; }
+            set { if (!IsWrappingNullReference) Target.Left = value; }
         }
 
         public string Name
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Name; }
-            set { Target.Name = value; }
+            set { if (!IsWrappingNullReference) Target.Name = value; }
         }
 
         public CommandBarPosition Position
         {
             get { return IsWrappingNullReference ? 0 : (CommandBarPosition)Target.Position; }
-            set { Target.Position = (Microsoft.Office.Core.MsoBarPosition)value; }
+            set { if (!IsWrappingNullReference) Target.Position = (Microsoft.Office.Core.MsoBarPosition)value; }
         }
 
         public int Top
         {
             get { return IsWrappingNullReference ? 0 : Target.Top; }
-            set { Target.Top = value; }
+            set { if (!IsWrappingNullReference) Target.Top = value; }
         }
 
         public CommandBarType Type
@@ -75,28 +75,28 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public bool IsVisible
         {
             get { return !IsWrappingNullReference && Target.Visible; }
-            set { Target.Visible = value; }
+            set { if (!IsWrappingNullReference) Target.Visible = value; }
         }
 
         public int Width
         {
             get { return IsWrappingNullReference ? 0 : Target.Width; }
-            set { Target.Width = value; }
+            set { if (!IsWrappingNullReference) Target.Width = value; }
         }
 
         public ICommandBarControl FindControl(int id)
         {
-            return new CommandBarControl(Target.FindControl(Id: id));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.FindControl(Id: id));
         }
 
         public ICommandBarControl FindControl(ControlType type, int id)
         {
-            return new CommandBarControl(Target.FindControl(type, id));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.FindControl(type, id));
         }
         
         public void Delete()
         {
-            Target.Delete();
+            if (!IsWrappingNullReference) Target.Delete();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarButton.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarButton.cs
@@ -52,7 +52,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         private void Target_Click(Microsoft.Office.Core.CommandBarButton ctrl, ref bool cancelDefault)
         {
             var handler = _clickHandler;
-            if (handler == null)
+            if (handler == null || IsWrappingNullReference)
             {
                 return;
             }
@@ -72,31 +72,31 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public bool IsBuiltInFace
         {
             get { return !IsWrappingNullReference && Button.BuiltInFace; }
-            set { Button.BuiltInFace = value; }
+            set { if (!IsWrappingNullReference) Button.BuiltInFace = value; }
         }
 
         public int FaceId 
         {
             get { return IsWrappingNullReference ? 0 : Button.FaceId; }
-            set { Button.FaceId = value; }
+            set { if (!IsWrappingNullReference) Button.FaceId = value; }
         }
 
         public string ShortcutText
         {
             get { return IsWrappingNullReference ? string.Empty : Button.ShortcutText; }
-            set { Button.ShortcutText = value; }
+            set { if (!IsWrappingNullReference) Button.ShortcutText = value; }
         }
 
         public ButtonState State
         {
             get { return IsWrappingNullReference ? 0 : (ButtonState)Button.State; }
-            set { Button.State = (Microsoft.Office.Core.MsoButtonState)value; }
+            set { if (!IsWrappingNullReference) Button.State = (Microsoft.Office.Core.MsoButtonState)value; }
         }
 
         public ButtonStyle Style
         {
             get { return IsWrappingNullReference ? 0 : (ButtonStyle)Button.Style; }
-            set { Button.Style = (Microsoft.Office.Core.MsoButtonStyle)value; }
+            set { if (!IsWrappingNullReference) Button.Style = (Microsoft.Office.Core.MsoButtonStyle)value; }
         }
 
         public Image Picture { get; set; }
@@ -104,6 +104,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         public void ApplyIcon()
         {
+            if (IsWrappingNullReference) return;
+            
             Button.FaceId = 0;
             if (Picture == null || Mask == null)
             {

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControl.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControl.cs
@@ -14,7 +14,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public bool BeginsGroup
         {
             get { return !IsWrappingNullReference && Target.BeginGroup; }
-            set { Target.BeginGroup = value; }
+            set { if (!IsWrappingNullReference) Target.BeginGroup = value; }
         }
 
         public bool IsBuiltIn
@@ -25,25 +25,25 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public string Caption
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Caption; }
-            set { Target.Caption = value; }
+            set { if (!IsWrappingNullReference) Target.Caption = value; }
         }
 
         public string DescriptionText
         {
             get { return IsWrappingNullReference ? string.Empty : Target.DescriptionText; }
-            set { Target.DescriptionText = value; }
+            set { if (!IsWrappingNullReference) Target.DescriptionText = value; }
         }
 
         public bool IsEnabled
         {
             get { return !IsWrappingNullReference && Target.Enabled; }
-            set { Target.Enabled = value; }
+            set { if (!IsWrappingNullReference) Target.Enabled = value; }
         }
 
         public int Height
         {
             get { return Target.Height; }
-            set { Target.Height = value; }
+            set { if (!IsWrappingNullReference) Target.Height = value; }
         }
 
         public int Id
@@ -64,7 +64,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public string OnAction
         {
             get { return IsWrappingNullReference ? string.Empty : Target.OnAction; }
-            set { Target.OnAction = value; }
+            set { if (!IsWrappingNullReference) Target.OnAction = value; }
         }
 
         public ICommandBar Parent
@@ -75,25 +75,25 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public string Parameter
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Parameter; }
-            set { Target.Parameter = value; }
+            set { if (!IsWrappingNullReference) Target.Parameter = value; }
         }
 
         public int Priority
         {
             get { return IsWrappingNullReference ? 0 : Target.Priority; }
-            set { Target.Priority = value; }
+            set { if (!IsWrappingNullReference) Target.Priority = value; }
         }
 
         public string Tag 
         {
             get { return Target.Tag; }
-            set { Target.Tag = value; }
+            set { if (!IsWrappingNullReference) Target.Tag = value; }
         }
 
         public string TooltipText
         {
             get { return IsWrappingNullReference ? string.Empty : Target.TooltipText; }
-            set { Target.TooltipText = value; }
+            set { if (!IsWrappingNullReference) Target.TooltipText = value; }
         }
 
         public int Top
@@ -109,28 +109,28 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public bool IsVisible
         {
             get { return !IsWrappingNullReference && Target.Visible; }
-            set { Target.Visible = value; }
+            set { if (!IsWrappingNullReference) Target.Visible = value; }
         }
 
         public int Width
         {
             get { return IsWrappingNullReference ? 0 : Target.Width; }
-            set { Target.Width = value; }
+            set { if (!IsWrappingNullReference) Target.Width = value; }
         }
 
         public bool IsPriorityDropped
         {
-            get { return Target.IsPriorityDropped; }
+            get { return (!IsWrappingNullReference) && Target.IsPriorityDropped; }
         }
 
         public void Delete()
         {
-            Target.Delete(true);
+            if (!IsWrappingNullReference) Target.Delete(true);
         }
 
         public void Execute()
         {
-            Target.Execute();
+            if (!IsWrappingNullReference) Target.Execute();
         }
 
         public override bool Equals(ISafeComWrapper<Microsoft.Office.Core.CommandBarControl> other)

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControls.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControls.cs
@@ -25,27 +25,32 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         public ICommandBarControl this[object index]
         {
-            get { return new CommandBarControl(Target[index]); }
+            get { return new CommandBarControl(!IsWrappingNullReference ? Target[index] : null); }
         }
 
         public ICommandBarControl Add(ControlType type)
         {
-            return new CommandBarControl(Target.Add(type, Temporary:true));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.Add(type, Temporary:true));
         }
 
         public ICommandBarControl Add(ControlType type, int before)
         {
-            return new CommandBarControl(Target.Add(type, Before:before, Temporary:true));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.Add(type, Before: before, Temporary: true));
         }
 
         IEnumerator<ICommandBarControl> IEnumerable<ICommandBarControl>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<ICommandBarControl>(Target, o => new CommandBarControl((Microsoft.Office.Core.CommandBarControl)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<ICommandBarControl>(null, o => new CommandBarControl(null))
+                : new ComWrapperEnumerator<ICommandBarControl>(Target,
+                    o => new CommandBarControl((Microsoft.Office.Core.CommandBarControl) o));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<ICommandBarControl>)this).GetEnumerator();
+            return IsWrappingNullReference
+                ? new List<ICommandBarControl>().GetEnumerator()
+                : ((IEnumerable<ICommandBarControl>) this).GetEnumerator();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarPopup.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarPopup.cs
@@ -11,12 +11,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         public static ICommandBarPopup FromCommandBarControl(ICommandBarControl control)
         {
-            return new CommandBarPopup((Microsoft.Office.Core.CommandBarPopup)control.Target);
+            return new CommandBarPopup(control.Target as Microsoft.Office.Core.CommandBarPopup);
         }
 
         private Microsoft.Office.Core.CommandBarPopup Popup
         {
-            get { return (Microsoft.Office.Core.CommandBarPopup)Target; }
+            get { return Target as Microsoft.Office.Core.CommandBarPopup; }
         }
 
         public ICommandBar CommandBar

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBars.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBars.cs
@@ -18,13 +18,13 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public ICommandBar Add(string name)
         {
             DeleteExistingCommandBar(name);
-            return new CommandBar(Target.Add(name, Temporary:true));
+            return new CommandBar(IsWrappingNullReference ? null : Target.Add(name, Temporary: true));
         }
 
         public ICommandBar Add(string name, CommandBarPosition position)
         {
             DeleteExistingCommandBar(name);
-            return new CommandBar(Target.Add(name, position, Temporary: true));
+            return new CommandBar(IsWrappingNullReference ? null : Target.Add(name, position, Temporary: true));
         }
 
         private void DeleteExistingCommandBar(string name)
@@ -46,17 +46,20 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         public ICommandBarControl FindControl(int id)
         {
-            return new CommandBarControl(Target.FindControl(Id:id));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.FindControl(Id: id));
         }
 
         public ICommandBarControl FindControl(ControlType type, int id)
         {
-            return new CommandBarControl(Target.FindControl(type, id));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.FindControl(type, id));
         }
 
         IEnumerator<ICommandBar> IEnumerable<ICommandBar>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<ICommandBar>(Target, o => new CommandBar((Microsoft.Office.Core.CommandBar)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<ICommandBar>(null, o => new CommandBar(null))
+                : new ComWrapperEnumerator<ICommandBar>(Target,
+                    o => new CommandBar((Microsoft.Office.Core.CommandBar) o));
         }
 
         public IEnumerator GetEnumerator()
@@ -71,7 +74,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         public ICommandBar this[object index]
         {
-            get { return new CommandBar(Target[index]); }
+            get { return new CommandBar(IsWrappingNullReference ? null : Target[index]); }
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/AddIn.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/AddIn.cs
@@ -32,20 +32,20 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public string Description
         {
-            get { return IsWrappingNullReference ? string.Empty : Target.Description; } 
-            set { Target.Description = value; }
+            get { return IsWrappingNullReference ? string.Empty : Target.Description; }
+            set { if (!IsWrappingNullReference) Target.Description = value; }
         }
 
         public bool Connect
         {
             get { return !IsWrappingNullReference && Target.Connect; }
-            set { Target.Connect = value; }
+            set { if (!IsWrappingNullReference) Target.Connect = value; }
         }
 
         public object Object // definitely leaks a COM object
         {
             get { return IsWrappingNullReference ? null : Target.Object; }
-            set { Target.Object = value; }
+            set { if (!IsWrappingNullReference) Target.Object = value; }
         }
 
         public override bool Equals(ISafeComWrapper<VB.AddIn> other)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/AddIns.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/AddIns.cs
@@ -66,12 +66,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return Target.GetEnumerator();
+            return IsWrappingNullReference ? new List<IEnumerable>().GetEnumerator() : Target.GetEnumerator();
         }
 
         IEnumerator<IAddIn> IEnumerable<IAddIn>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<IAddIn>(Target, o => new AddIn((VB.AddIn)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IAddIn>(null, o => new AddIn(null))
+                : new ComWrapperEnumerator<IAddIn>(Target, o => new AddIn((VB.AddIn) o));
         }
     }
 }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodeModule.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodeModule.cs
@@ -44,12 +44,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public string Name
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Name; }
-            set { Target.Name = value; }
+            set { if (!IsWrappingNullReference) Target.Name = value; }
         }
 
         public string GetLines(int startLine, int count)
         {
-            return Target.get_Lines(startLine, count);
+            return IsWrappingNullReference ? string.Empty : Target.get_Lines(startLine, count);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         /// <returns></returns>
         public string GetLines(Selection selection)
         {
-            return GetLines(selection.StartLine, selection.LineCount);
+            return IsWrappingNullReference ? string.Empty : GetLines(selection.StartLine, selection.LineCount);
         }
 
         /// <summary>
@@ -68,6 +68,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         /// <param name="selection"></param>
         public void DeleteLines(Selection selection)
         {
+            if (IsWrappingNullReference) return; 
             DeleteLines(selection.StartLine, selection.LineCount);
         }
 
@@ -82,11 +83,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public string Content()
         {
-            return Target.CountOfLines == 0 ? string.Empty : GetLines(1, CountOfLines);
+            return IsWrappingNullReference || Target.CountOfLines == 0 ? string.Empty : GetLines(1, CountOfLines);
         }
 
         public void Clear()
         {
+            if (IsWrappingNullReference) return; 
             if (Target.CountOfLines > 0)
             {
                 Target.DeleteLines(1, CountOfLines);
@@ -107,31 +109,38 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public void AddFromString(string content)
         {
+            if (IsWrappingNullReference) return; 
             Target.AddFromString(content);
         }
 
         public void AddFromFile(string path)
         {
+            if (IsWrappingNullReference) return; 
             Target.AddFromFile(path);
         }
 
         public void InsertLines(int line, string content)
         {
+            if (IsWrappingNullReference) return; 
             Target.InsertLines(line, content);
         }
 
         public void DeleteLines(int startLine, int count = 1)
         {
+            if (IsWrappingNullReference) return; 
             Target.DeleteLines(startLine, count);
         }
 
         public void ReplaceLine(int line, string content)
         {
+            if (IsWrappingNullReference) return;           
             Target.ReplaceLine(line, content);
         }
 
         public Selection? Find(string target, bool wholeWord = false, bool matchCase = false, bool patternSearch = false)
         {
+            if (IsWrappingNullReference) return null;
+
             var startLine = 0;
             var startColumn = 0;
             var endLine = 0;
@@ -144,27 +153,29 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public int GetProcStartLine(string procName, ProcKind procKind)
         {
-            return Target.get_ProcStartLine(procName, (vbext_ProcKind)procKind);
+            return IsWrappingNullReference ? 0 : Target.get_ProcStartLine(procName, (vbext_ProcKind)procKind);
         }
 
         public int GetProcBodyStartLine(string procName, ProcKind procKind)
         {
-            return Target.get_ProcBodyLine(procName, (vbext_ProcKind)procKind);
+            return IsWrappingNullReference ? 0 : Target.get_ProcBodyLine(procName, (vbext_ProcKind)procKind);
         }
 
         public int GetProcCountLines(string procName, ProcKind procKind)
         {
-            return Target.get_ProcCountLines(procName, (vbext_ProcKind)procKind);
+            return IsWrappingNullReference ? 0 : Target.get_ProcCountLines(procName, (vbext_ProcKind)procKind);
         }
 
         public string GetProcOfLine(int line)
         {
+            if (IsWrappingNullReference) return string.Empty;
             vbext_ProcKind procKind;
             return Target.get_ProcOfLine(line, out procKind);
         }
 
         public ProcKind GetProcKindOfLine(int line)
         {
+            if (IsWrappingNullReference) return 0;
             vbext_ProcKind procKind;
             Target.get_ProcOfLine(line, out procKind);
             return (ProcKind)procKind;

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePane.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePane.cs
@@ -29,7 +29,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public int TopLine
         {
             get { return IsWrappingNullReference ? 0 : Target.TopLine; }
-            set { Target.TopLine = value; }
+            set { if (!IsWrappingNullReference) Target.TopLine = value; }
         }
 
         public int CountOfVisibleLines
@@ -50,11 +50,13 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public Selection Selection
         {
             get { return GetSelection(); }
-            set { SetSelection(value.StartLine, value.StartColumn, value.EndLine, value.EndColumn); }
+            set { if (!IsWrappingNullReference) SetSelection(value.StartLine, value.StartColumn, value.EndLine, value.EndColumn); }
         }
 
         private Selection GetSelection()
         {
+            if (IsWrappingNullReference) return new Selection(0, 0, 0, 0);
+
             int startLine;
             int startColumn;
             int endLine;
@@ -90,12 +92,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         private void SetSelection(int startLine, int startColumn, int endLine, int endColumn)
         {
+            if (IsWrappingNullReference) return;
             Target.SetSelection(startLine, startColumn, endLine, endColumn);
             ForceFocus();
         }
 
         private void ForceFocus()
         {
+            if (IsWrappingNullReference) return;
             Show();
 
             var window = VBE.MainWindow;
@@ -118,6 +122,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public void Show()
         {
+            if (IsWrappingNullReference) return;
             Target.Show();
         }
 

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePanes.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePanes.cs
@@ -30,22 +30,26 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public ICodePane Current 
         { 
             get { return new CodePane(IsWrappingNullReference ? null : Target.Current); }
-            set { Target.Current = (VB.CodePane)value.Target;}
+            set { if (!IsWrappingNullReference) Target.Current = (VB.CodePane)value.Target; }
         }
 
         public ICodePane this[object index]
         {
-            get { return new CodePane(Target.Item(index)); }
+            get { return new CodePane(IsWrappingNullReference ? null : Target.Item(index)); }
         }
 
         IEnumerator<ICodePane> IEnumerable<ICodePane>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<ICodePane>(Target, o => new CodePane((VB.CodePane)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<ICodePane>(null, o => new CodePane(null))
+                : new ComWrapperEnumerator<ICodePane>(Target, o => new CodePane((VB.CodePane) o));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<ICodePane>)this).GetEnumerator();
+            return IsWrappingNullReference
+                ? (IEnumerator) new List<IEnumerable>().GetEnumerator()
+                : ((IEnumerable<ICodePane>) this).GetEnumerator();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Control.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Control.cs
@@ -14,7 +14,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public string Name
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Name; }
-            set { Target.Name = value; }
+            set { if (!IsWrappingNullReference) Target.Name = value; }
         }
 
         public override bool Equals(ISafeComWrapper<VB.Forms.Control> other)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Controls.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Controls.cs
@@ -20,18 +20,22 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public IControl this[object index]
         {
-            get { return new Control((VB.Forms.Control) Target.Item(index)); }
+            get { return IsWrappingNullReference ? new Control(null) : new Control((VB.Forms.Control) Target.Item(index)); }
         }
 
         IEnumerator<IControl> IEnumerable<IControl>.GetEnumerator()
         {
             // soft-casting because ImageClass doesn't implement IControl
-            return new ComWrapperEnumerator<IControl>(Target, o => new Control(o as VB.Forms.Control));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IControl>(null, o => new Control(null))
+                : new ComWrapperEnumerator<IControl>(Target, o => new Control(o as VB.Forms.Control));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<IControl>)this).GetEnumerator();
+            return IsWrappingNullReference
+                ? (IEnumerator) new List<IEnumerable>().GetEnumerator()
+                : ((IEnumerable<IControl>) this).GetEnumerator();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/LinkedWindows.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/LinkedWindows.cs
@@ -29,27 +29,31 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public IWindow this[object index]
         {
-            get { return new Window(Target.Item(index)); }
+            get { return new Window(IsWrappingNullReference ? null : Target.Item(index)); }
         }
 
         public void Remove(IWindow window)
         {
+            if (IsWrappingNullReference) return;
             Target.Remove(((Window)window).Target);
         }
 
         public void Add(IWindow window)
         {
+            if (IsWrappingNullReference) return;
             Target.Add(((Window)window).Target);
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return Target.GetEnumerator();
+            return IsWrappingNullReference ? new List<IEnumerable>().GetEnumerator() : Target.GetEnumerator();
         }
 
         IEnumerator<IWindow> IEnumerable<IWindow>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<IWindow>(Target, o => new Window((VB.Window)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IWindow>(null, o => new Window(null))
+                : new ComWrapperEnumerator<IWindow>(Target, o => new Window((VB.Window) o));
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Properties.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Properties.cs
@@ -34,17 +34,21 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public IProperty this[object index]
         {
-            get { return new Property(Target.Item(index)); }
+            get { return new Property(IsWrappingNullReference ? null : Target.Item(index)); }
         }
 
         IEnumerator<IProperty> IEnumerable<IProperty>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<IProperty>(Target, o => new Property((VB.Property)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IProperty>(null, o => new Property(null))
+                : new ComWrapperEnumerator<IProperty>(Target, o => new Property((VB.Property) o));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<IProperty>)this).GetEnumerator();
+            return IsWrappingNullReference
+                ? (IEnumerator) new List<IEnumerable>().GetEnumerator()
+                : ((IEnumerable<IProperty>) this).GetEnumerator();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Property.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Property.cs
@@ -45,7 +45,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public object Value
         {
             get { return IsWrappingNullReference ? null : Target.Value; }
-            set { Target.Value = value; }
+            set { if (!IsWrappingNullReference) Target.Value = value; }
         }
 
         /// <summary>
@@ -53,12 +53,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         /// </summary>
         public object GetIndexedValue(object index1, object index2 = null, object index3 = null, object index4 = null)
         {
-            return Target.get_IndexedValue(index1, index2, index3, index4);
+            return IsWrappingNullReference ? null : Target.get_IndexedValue(index1, index2, index3, index4);
         }
 
         public void SetIndexedValue(object value, object index1, object index2 = null, object index3 = null, object index4 = null)
         {
-            Target.set_IndexedValue(index1, index2, index3, index4, value);
+            if (!IsWrappingNullReference) Target.set_IndexedValue(index1, index2, index3, index4, value);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public object Object
         {
             get { return IsWrappingNullReference ? null : Target.Object; }
-            set { Target.Object = value; }
+            set { if (!IsWrappingNullReference) Target.Object = value; }
         }
 
         public override bool Equals(ISafeComWrapper<VB.Property> other)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/References.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/References.cs
@@ -77,32 +77,37 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public IReference this[object index]
         {
-            get { return new Reference(Target.Item(index)); }
+            get { return new Reference(IsWrappingNullReference ? null : Target.Item(index)); }
         }
 
         public IReference AddFromGuid(string guid, int major, int minor)
         {
-            return new Reference(Target.AddFromGuid(guid, major, minor));
+            return new Reference(IsWrappingNullReference ? null : Target.AddFromGuid(guid, major, minor));
         }
 
         public IReference AddFromFile(string path)
         {
-            return new Reference(Target.AddFromFile(path));
+            return new Reference(IsWrappingNullReference ? null : Target.AddFromFile(path));
         }
 
         public void Remove(IReference reference)
         {
+            if (IsWrappingNullReference) return;
             Target.Remove(((ISafeComWrapper<VB.Reference>)reference).Target);
         }
 
         IEnumerator<IReference> IEnumerable<IReference>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<IReference>(Target, o => new Reference((VB.Reference)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IReference>(null, o => new Reference(null))
+                : new ComWrapperEnumerator<IReference>(Target, o => new Reference((VB.Reference) o));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<IReference>)this).GetEnumerator();
+            return IsWrappingNullReference
+                ? (IEnumerator) new List<IEnumerable>().GetEnumerator()
+                : ((IEnumerable<IReference>) this).GetEnumerator();
         }
 
         private bool _isReleased;

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -53,7 +53,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public string Name
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Name; }
-            set { Target.Name = value; }
+            set { if (!IsWrappingNullReference) Target.Name = value; }
         }
 
         private string SafeName

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
@@ -42,37 +42,41 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public void Remove(IVBComponent item)
         {
-            Target.Remove((VB.VBComponent) item.Target);
+            if (!IsWrappingNullReference) Target.Remove((VB.VBComponent)item.Target);
         }
 
         public IVBComponent Add(ComponentType type)
         {
-            return new VBComponent(Target.Add((VB.vbext_ComponentType) type));
+            return new VBComponent(IsWrappingNullReference ? null : Target.Add((VB.vbext_ComponentType)type));
         }
 
         public IVBComponent Import(string path)
         {
-            return new VBComponent(Target.Import(path));
+            return new VBComponent(IsWrappingNullReference ? null : Target.Import(path));
         }
 
         public IVBComponent AddCustom(string progId)
         {
-            return new VBComponent(Target.AddCustom(progId));
+            return new VBComponent(IsWrappingNullReference ? null : Target.AddCustom(progId));
         }
 
         public IVBComponent AddMTDesigner(int index = 0)
         {
-            return new VBComponent(Target.AddMTDesigner(index));
+            return new VBComponent(IsWrappingNullReference ? null : Target.AddMTDesigner(index));
         }
 
         IEnumerator<IVBComponent> IEnumerable<IVBComponent>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<IVBComponent>(Target, o => new VBComponent((VB.VBComponent)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IVBComponent>(null, o => new VBComponent(null))
+                : new ComWrapperEnumerator<IVBComponent>(Target, o => new VBComponent((VB.VBComponent) o));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<IVBComponent>)this).GetEnumerator();
+            return IsWrappingNullReference
+                ? (IEnumerator) new List<IEnumerable>().GetEnumerator()
+                : ((IEnumerable<IVBComponent>) this).GetEnumerator();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
@@ -23,13 +23,13 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public ICodePane ActiveCodePane
         {
             get { return new CodePane(IsWrappingNullReference ? null : Target.ActiveCodePane); }
-            set { Target.ActiveCodePane = (VB.CodePane)value.Target; }
+            set { if (!IsWrappingNullReference) Target.ActiveCodePane = (VB.CodePane)value.Target; }
         }
 
         public IVBProject ActiveVBProject
         {
             get { return new VBProject(IsWrappingNullReference ? null : Target.ActiveVBProject); }
-            set { Target.ActiveVBProject = (VB.VBProject)value.Target; }
+            set { if (!IsWrappingNullReference) Target.ActiveVBProject = (VB.VBProject)value.Target; }
         }
 
         public IWindow ActiveWindow

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProject.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProject.cs
@@ -27,19 +27,19 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public string HelpFile
         {
             get { return IsWrappingNullReference ? string.Empty : Target.HelpFile; }
-            set { Target.HelpFile = value; }
+            set { if (!IsWrappingNullReference) Target.HelpFile = value; }
         }
 
         public string Description 
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Description; }
-            set { Target.Description = value; } 
+            set { if (!IsWrappingNullReference) Target.Description = value; } 
         }
 
         public string Name
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Name; }
-            set { Target.Name = value; }
+            set { if (!IsWrappingNullReference) Target.Name = value; }
         }
 
         public EnvironmentMode Mode
@@ -105,12 +105,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public void SaveAs(string fileName)
         {
-            Target.SaveAs(fileName);
+            if (!IsWrappingNullReference) Target.SaveAs(fileName);
         }
 
         public void MakeCompiledFile()
         {
-            Target.MakeCompiledFile();
+            if (!IsWrappingNullReference) Target.MakeCompiledFile();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProjects.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProjects.cs
@@ -34,11 +34,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public IVBProject Add(ProjectType type)
         {
-            return new VBProject(Target.Add((VB.vbext_ProjectType)type));
+            return new VBProject(IsWrappingNullReference ? null : Target.Add((VB.vbext_ProjectType)type));
         }
 
         public void Remove(IVBProject project)
         {
+            if (IsWrappingNullReference) return;
             Target.Remove((VB.VBProject) project.Target);
         }
 
@@ -65,22 +66,26 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public IVBProject Open(string path)
         {
-            return new VBProject(Target.Open(path));
+            return new VBProject(IsWrappingNullReference ? null : Target.Open(path));
         }
 
         public IVBProject this[object index]
         {
-            get { return new VBProject(Target.Item(index)); }
+            get { return new VBProject(IsWrappingNullReference ? null : Target.Item(index)); }
         }
 
         IEnumerator<IVBProject> IEnumerable<IVBProject>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<IVBProject>(Target, o => new VBProject((VB.VBProject)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IVBProject>(null, o => new VBProject(null))
+                : new ComWrapperEnumerator<IVBProject>(Target, o => new VBProject((VB.VBProject) o));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<IVBProject>)this).GetEnumerator();
+            return IsWrappingNullReference
+                ? (IEnumerator) new List<IEnumerable>().GetEnumerator()
+                : ((IEnumerable<IVBProject>) this).GetEnumerator();
         }
 
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Window.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Window.cs
@@ -41,31 +41,31 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public bool IsVisible
         {
             get { return !IsWrappingNullReference && Target.Visible; }
-            set { Target.Visible = value; }
+            set { if (!IsWrappingNullReference) Target.Visible = value; }
         }
 
         public int Left
         {
             get { return IsWrappingNullReference ? 0 : Target.Left; }
-            set { Target.Left = value; }
+            set { if (!IsWrappingNullReference) Target.Left = value; }
         }
 
         public int Top
         {
             get { return IsWrappingNullReference ? 0 : Target.Top; }
-            set { Target.Top = value; }
+            set { if (!IsWrappingNullReference) Target.Top = value; }
         }
 
         public int Width
         {
             get { return IsWrappingNullReference ? 0 : Target.Width; }
-            set { Target.Width = value; }
+            set { if (!IsWrappingNullReference) Target.Width = value; }
         }
 
         public int Height
         {
             get { return IsWrappingNullReference ? 0 : Target.Height; }
-            set { Target.Height = value; }
+            set { if (!IsWrappingNullReference) Target.Height = value; }
         }
 
         public WindowState WindowState
@@ -90,27 +90,27 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public void Close()
         {
-            Target.Close();
+            if (!IsWrappingNullReference) Target.Close();
         }
 
         public void SetFocus()
         {
-            Target.SetFocus();
+            if (!IsWrappingNullReference) Target.SetFocus();
         }
 
         public void SetKind(WindowKind eKind)
         {
-            Target.SetKind((vbext_WindowType)eKind);
+            if (!IsWrappingNullReference) Target.SetKind((vbext_WindowType)eKind);
         }
 
         public void Detach()
         {
-            Target.Detach();
+            if (!IsWrappingNullReference) Target.Detach();
         }
 
         public void Attach(int lWindowHandle)
         {
-            Target.Attach(lWindowHandle);
+            if (!IsWrappingNullReference) Target.Attach(lWindowHandle);
         }
         
         public override void Release(bool final = false)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Windows.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Windows.cs
@@ -14,7 +14,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public int Count
         {
-            get { return Target.Count; }
+            get { return IsWrappingNullReference ? 0 : Target.Count; }
         }
 
         public IVBE VBE
@@ -29,11 +29,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public IWindow this[object index]
         {
-            get { return new Window(Target.Item(index)); }
+            get { return new Window(IsWrappingNullReference ? null : Target.Item(index)); }
         }
 
         public ToolWindowInfo CreateToolWindow(IAddIn addInInst, string progId, string caption, string guidPosition)
         {
+            if (IsWrappingNullReference) return new ToolWindowInfo(null, null);
             object control = null;
             var window = new Window(Target.CreateToolWindow((VB.AddIn)addInInst.Target, progId, caption, guidPosition, ref control));
             return new ToolWindowInfo(window, control);
@@ -41,12 +42,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return Target.GetEnumerator();
+            return IsWrappingNullReference ? new List<IEnumerable>().GetEnumerator() : Target.GetEnumerator();
         }
 
         IEnumerator<IWindow> IEnumerable<IWindow>.GetEnumerator()
         {
-            return new ComWrapperEnumerator<IWindow>(Target, o => new Window((VB.Window)o));
+            return IsWrappingNullReference
+                ? new ComWrapperEnumerator<IWindow>(null, o => new Window(null))
+                : new ComWrapperEnumerator<IWindow>(Target, o => new Window((VB.Window) o));
         }
 
         public override void Release(bool final = false)


### PR DESCRIPTION
Unfortunately it still crashes the host, but _much_ less dramatically.  All the WER logs now include clr information, so this is probably a step in the right direction at least.