### PR TITLE
CustomDeclarationLoaders now use finder on parser state 

### DIFF
--- a/Rubberduck.Parsing/Symbols/DeclarationLoaders/AliasDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationLoaders/AliasDeclarations.cs
@@ -56,7 +56,7 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
 
         private IReadOnlyList<Declaration> AddAliasDeclarations()
         {
-            var finder = new DeclarationFinder(_state.AllDeclarations, new IAnnotation[] { });
+            var finder = _state.DeclarationFinder;;
 
             if (WeHaveAlreadyLoadedTheDeclarationsBefore(finder))
             {

--- a/Rubberduck.Parsing/Symbols/DeclarationLoaders/DebugDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationLoaders/DebugDeclarations.cs
@@ -18,7 +18,7 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
 
         public IReadOnlyList<Declaration> Load()
         {
-            var finder = new DeclarationFinder(_state.AllDeclarations, new IAnnotation[] { });
+            var finder = _state.DeclarationFinder;;
 
             if (WeHaveAlreadyLoadedTheDeclarationsBefore(finder))
             {

--- a/Rubberduck.Parsing/Symbols/DeclarationLoaders/FormEventDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationLoaders/FormEventDeclarations.cs
@@ -28,7 +28,7 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
 
         private static Declaration FormsClassModuleFromParserState(RubberduckParserState state)
         {
-            var finder = new DeclarationFinder(state.AllDeclarations, new IAnnotation[] { });
+            var finder = state.DeclarationFinder;
 
             var msForms = finder.FindProject("MSForms");
             if (msForms == null)

--- a/Rubberduck.Parsing/Symbols/DeclarationLoaders/SpecialFormDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationLoaders/SpecialFormDeclarations.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
 
         public IReadOnlyList<Declaration> Load()
         {
-            var finder = new DeclarationFinder(_state.AllDeclarations, new IAnnotation[] { });
+            var finder = _state.DeclarationFinder;
 
             if (WeHaveAlreadyLoadedTheDeclarationsBefore(finder))
             {

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -107,7 +107,10 @@ namespace Rubberduck.Parsing.VBA
             }
 
             SyncComReferences(State.Projects);
+            State.RefreshFinder(_hostApp);
+
             AddBuiltInDeclarations();
+            State.RefreshFinder(_hostApp);
 
             foreach (var component in components)
             {
@@ -229,7 +232,10 @@ namespace Rubberduck.Parsing.VBA
             }
 
             SyncComReferences(State.Projects);
+            State.RefreshFinder(_hostApp);
+
             AddBuiltInDeclarations();
+            State.RefreshFinder(_hostApp);
 
             // invalidation cleanup should go into ParseAsync?
             foreach (var key in _componentAttributes.Keys)


### PR DESCRIPTION
Made CustomDeclarationLoaders use the DeclarationFinder on the RubberduckParserState.