### PR TITLE
Fix MarkAsDead so it doesn't eat too extra NewLines. Closes #2022

### DIFF
--- a/Rubberduck.Parsing/Preprocessing/LivelinessExpression.cs
+++ b/Rubberduck.Parsing/Preprocessing/LivelinessExpression.cs
@@ -16,40 +16,19 @@ namespace Rubberduck.Parsing.Preprocessing
 
         public override IValue Evaluate()
         {
-            bool isAlive = _isAlive.Evaluate().AsBool;
+            var isAlive = _isAlive.Evaluate().AsBool;
             var code = _code.Evaluate().AsString;
-            if (isAlive)
-            {
-                return new StringValue(code);
-            }
-            else
-            {
-                return new StringValue(MarkAsDead(code));
-            }
+            return isAlive ? new StringValue(code) : new StringValue(MarkAsDead(code));
         }
 
         private string MarkAsDead(string code)
         {
-            bool hasNewLine = false;
-            if (code.EndsWith(Environment.NewLine))
-            {
-                hasNewLine = true;
-            }
+            var hasNewLine = code.EndsWith(Environment.NewLine);
             // Remove parsed new line.
-            code = code.TrimEnd('\r', '\n');
-            var lines = code.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+            code = code.Substring(0, code.Length - Environment.NewLine.Length);
+            var lines = code.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
             var result = string.Join(Environment.NewLine, lines.Select(_ => string.Empty));
             if (hasNewLine)
-            {
-                result += Environment.NewLine;
-            }
-            return result;
-        }
-
-        private string MarkLineAsDead(string line)
-        {
-            var result = string.Empty;
-            if (line.EndsWith(Environment.NewLine))
             {
                 result += Environment.NewLine;
             }


### PR DESCRIPTION
It _might_ have been possible to fix this in the `VBAConditionalCompilationParser` grammar, but I was never able to track down what expression was responsible for the extra newline.  Regardless, this ensures that the selections aren't compressed when code is marked as dead.