### PR TITLE
Rework parse coordinator part1 bugfix

### DIFF
--- a/Rubberduck.Parsing/VBA/ComponentParseTask.cs
+++ b/Rubberduck.Parsing/VBA/ComponentParseTask.cs
@@ -101,9 +101,15 @@ namespace Rubberduck.Parsing.VBA
                         Cause = exception
                     });
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException exception)
             {
-                // no results to be used, so no results "returned"
+                //We return this, so that the calling code knows that the operation actually has been cancelled.
+                var failedHandler = ParseFailure;
+                if (failedHandler != null)
+                    failedHandler.Invoke(this, new ParseFailureArgs
+                    {
+                        Cause = exception
+                    });
             }
         }
 

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -239,7 +239,6 @@ namespace Rubberduck.Parsing.VBA
         {
             if (finishedParseTask.IsFaulted)
             {
-                var exception = finishedParseTask.Exception.InnerException;
                 State.SetModuleState(component, ParserState.Error, finishedParseTask.Exception.InnerException as SyntaxErrorException);
             }
             else if (finishedParseTask.IsCompleted)

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -215,7 +215,14 @@ namespace Rubberduck.Parsing.VBA
 
             parser.ParseFailure += (sender, e) =>
             {
-                tcs.SetException(e.Cause);
+                if (e.Cause is OperationCanceledException)
+                {
+                    tcs.SetCanceled();
+                }
+                else
+                {
+                    tcs.SetException(e.Cause);
+                }
             };
             parser.ParseCompleted += (sender, e) =>
             {
@@ -230,9 +237,9 @@ namespace Rubberduck.Parsing.VBA
 
         private void ProcessComponentParseResults(IVBComponent component, Task<ComponentParseTask.ParseCompletionArgs> finishedParseTask)
         {
-            finishedParseTask.Wait();
             if (finishedParseTask.IsFaulted)
             {
+                var exception = finishedParseTask.Exception.InnerException;
                 State.SetModuleState(component, ParserState.Error, finishedParseTask.Exception.InnerException as SyntaxErrorException);
             }
             else if (finishedParseTask.IsCompleted)


### PR DESCRIPTION
This fixes the wrong behaviour on parser errors and parser cancellation I introduced previously.