### PR TITLE
Rework parse coordinator part2

### DIFF
--- a/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
@@ -122,7 +122,7 @@ namespace Rubberduck.Refactorings.ExtractInterface
         private int _insertionLine;
         private void _state_StateChanged(object sender, EventArgs e)
         {
-            if (_state.Status != ParserState.ResolvedDeclarations)
+            if (_state.Status != ParserState.Ready)
             {
                 return;
             }

--- a/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
@@ -65,8 +65,6 @@ namespace Rubberduck.Refactorings.ExtractInterface
                     pane.Selection = oldSelection.Value.Selection;
                 }
             }
-
-            _state.OnParseRequested(this);
         }
 
         public void Refactor(QualifiedSelection target)
@@ -124,7 +122,7 @@ namespace Rubberduck.Refactorings.ExtractInterface
         private int _insertionLine;
         private void _state_StateChanged(object sender, EventArgs e)
         {
-            if (_state.Status != ParserState.Ready)
+            if (_state.Status != ParserState.ResolvedDeclarations)
             {
                 return;
             }

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -80,7 +80,8 @@ namespace Rubberduck.Parsing.VBA
             }
             else
             {
-                Parse(_cancellationTokens[0]);
+                Cancel();
+                ParseInternal(_cancellationTokens[0]);
             }
         }
 
@@ -101,7 +102,28 @@ namespace Rubberduck.Parsing.VBA
         /// <summary>
         /// For the use of tests only
         /// </summary>
+        /// 
         public void Parse(CancellationTokenSource token)
+        {
+            SetSavedCancellationTokenSource(token);
+            ParseInternal(token);
+        }
+
+        private void SetSavedCancellationTokenSource(CancellationTokenSource token)
+        {
+            if (_cancellationTokens.Any())
+            {
+                _cancellationTokens[0].Cancel();
+                _cancellationTokens[0].Dispose();
+                _cancellationTokens[0] = token;
+            }
+            else
+            {
+                _cancellationTokens.Add(token);
+            }
+        }
+
+        private void ParseInternal(CancellationTokenSource token)
         {
             State.RefreshProjects(_vbe);
 


### PR DESCRIPTION
This PR introduces a possibility to opt out of evaluating the overall parser state when setting module states and a method to trigger the evaluation manually.
This then gets used to set the module states for all components concurrently.

Furthermore, cancelation on reparse is introduced for the tests and `OperationCanceledExceptions`  in the `ParseCoordinator` are now handled (by swallowing them).

Moreover, the module states are now set before parsing or resolving the declarations, removing the flickering parser state.