### PR TITLE
Fix naming collision for built in enums and types. Ref #2620

### DIFF
--- a/RetailCoder.VBE/Inspections/ProcedureNotUsedInspection.cs
+++ b/RetailCoder.VBE/Inspections/ProcedureNotUsedInspection.cs
@@ -60,8 +60,6 @@ namespace Rubberduck.Inspections
                 handlers.AddRange(forms.SelectMany(form => State.FindFormEventHandlers(form)));
             }
 
-            //handlers.AddRange(builtInHandlers);
-
             var interfaceMembers = State.DeclarationFinder.FindAllInterfaceMembers().ToList();
             var implementingMembers = State.DeclarationFinder.FindAllInterfaceImplementingMembers().ToList();
 
@@ -78,7 +76,10 @@ namespace Rubberduck.Inspections
         private static readonly DeclarationType[] ProcedureTypes =
         {
             DeclarationType.Procedure,
-            DeclarationType.Function
+            DeclarationType.Function,
+            DeclarationType.LibraryProcedure,
+            DeclarationType.LibraryFunction,
+            DeclarationType.Event
         };
 
         private bool IsIgnoredDeclaration(Declaration declaration, IEnumerable<Declaration> interfaceMembers, IEnumerable<Declaration> interfaceImplementingMembers , IEnumerable<Declaration> handlers, IEnumerable<Declaration> classes, IEnumerable<Declaration> modules)

--- a/Rubberduck.Parsing/Symbols/ProceduralModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ProceduralModuleDeclaration.cs
@@ -49,18 +49,18 @@ namespace Rubberduck.Parsing.Symbols
         //These are the pseudo-module ctor for COM enumerations and types.
         public ProceduralModuleDeclaration(ComEnumeration pseudo, Declaration parent, QualifiedModuleName module)
             : this(
-                module.QualifyMemberName(pseudo.Name),
+                module.QualifyMemberName(string.Format("_{0}", pseudo.Name)),
                 parent,
-                pseudo.Name,
+                string.Format("_{0}", pseudo.Name),
                 true,
                 new List<IAnnotation>(),
                 new Attributes()) { }
 
         public ProceduralModuleDeclaration(ComStruct pseudo, Declaration parent, QualifiedModuleName module)
             : this(
-                module.QualifyMemberName(pseudo.Name),
+                module.QualifyMemberName(string.Format("_{0}", pseudo.Name)),
                 parent,
-                pseudo.Name,
+                string.Format("_{0}", pseudo.Name),
                 true,
                 new List<IAnnotation>(),
                 new Attributes()) { }


### PR DESCRIPTION
Still need to catch the default member/indexer thing.