### PR TITLE
Rework parse coordinator part4

### DIFF
--- a/Rubberduck.Parsing/VBA/ComponentParseTask.cs
+++ b/Rubberduck.Parsing/VBA/ComponentParseTask.cs
@@ -62,7 +62,7 @@ namespace Rubberduck.Parsing.VBA
 
                 var stopwatch = Stopwatch.StartNew();
                 ITokenStream stream;
-                var tree = ParseInternal(_component.Name, code, new IParseTreeListener[] { commentListener, annotationListener }, out stream);
+                var tree = ParseInternal(_component.Name, code, new IParseTreeListener[]{ commentListener, annotationListener }, out stream);
                 stopwatch.Stop();
                 token.ThrowIfCancellationRequested();
 

--- a/Rubberduck.Parsing/VBA/ComponentParseTask.cs
+++ b/Rubberduck.Parsing/VBA/ComponentParseTask.cs
@@ -62,7 +62,7 @@ namespace Rubberduck.Parsing.VBA
 
                 var stopwatch = Stopwatch.StartNew();
                 ITokenStream stream;
-                var tree = ParseInternal(_component.Name, code, new IParseTreeListener[]{ commentListener, annotationListener }, out stream);
+                var tree = ParseInternal(_component.Name, code, new IParseTreeListener[] { commentListener, annotationListener }, out stream);
                 stopwatch.Stop();
                 token.ThrowIfCancellationRequested();
 
@@ -104,6 +104,16 @@ namespace Rubberduck.Parsing.VBA
             catch (OperationCanceledException exception)
             {
                 //We return this, so that the calling code knows that the operation actually has been cancelled.
+                var failedHandler = ParseFailure;
+                if (failedHandler != null)
+                    failedHandler.Invoke(this, new ParseFailureArgs
+                    {
+                        Cause = exception
+                    });
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, "Exception thrown in thread {0}, ParseTaskID {1}.", Thread.CurrentThread.ManagedThreadId, _taskId);
                 var failedHandler = ParseFailure;
                 if (failedHandler != null)
                     failedHandler.Invoke(this, new ParseFailureArgs

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -78,19 +78,20 @@ namespace Rubberduck.Parsing.VBA
 
         private void ReparseRequested(object sender, EventArgs e)
         {
+            CancellationToken token;
             lock (_cancellationSyncObject)
             {
                 Cancel();
-                var token = _cancellationTokens[0].Token;
+                token = _cancellationTokens[0].Token;
             }
 
             if (!_isTestScope)
             {
-                Task.Run(() => ParseAll(sender, _cancellationTokens[0].Token));
+                Task.Run(() => ParseAll(sender, token));
             }
             else
             {
-                ParseInternal(_cancellationTokens[0].Token);
+                ParseInternal(token);
             }
         }
 
@@ -676,7 +677,7 @@ namespace Rubberduck.Parsing.VBA
                 }
                 catch (Exception exception)
                 {
-                    Logger.Error(exception);
+                    Logger.Error(exception, "Exception thrown adding built-in declarations. (thread {0}).", Thread.CurrentThread.ManagedThreadId);
                 }
             }
         }

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -152,25 +152,25 @@ namespace Rubberduck.Parsing.VBA
 
         private void ParseInternalInternal(CancellationToken token)
         {
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
             
             State.RefreshProjects(_vbe);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             var components = State.Projects.SelectMany(project => project.VBComponents).ToList();
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             // tests do not fire events when components are removed--clear components
             ClearComponentStateCacheForTests();
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             // invalidation cleanup should go into ParseAsync?
             CleanUpComponentAttributes(components);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             ExecuteCommonParseActivities(components, token);
         }
@@ -196,53 +196,53 @@ namespace Rubberduck.Parsing.VBA
 
         private void ExecuteCommonParseActivities(List<IVBComponent> toParse, CancellationToken token)
         {
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
             
             SetModuleStates(toParse, ParserState.Pending, token);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             SyncComReferences(State.Projects, token);
             RefreshDeclarationFinder();
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             AddBuiltInDeclarations();
             RefreshDeclarationFinder();
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             _projectDeclarations.Clear();
             State.ClearBuiltInReferences();
 
             ParseComponents(toParse, token);
 
-            if (token.IsCancellationRequested || State.Status >= ParserState.Error)
-            {
-                throw new OperationCanceledException(token);
-            }
+                if (token.IsCancellationRequested || State.Status >= ParserState.Error)
+                {
+                    throw new OperationCanceledException(token);
+                }
 
             ResolveAllDeclarations(toParse, token);
             RefreshDeclarationFinder();
 
-            if (token.IsCancellationRequested || State.Status >= ParserState.Error)
-            {
-                throw new OperationCanceledException(token);
-            }
+                if (token.IsCancellationRequested || State.Status >= ParserState.Error)
+                {
+                    throw new OperationCanceledException(token);
+                }
 
             State.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            if (token.IsCancellationRequested || State.Status >= ParserState.Error)
-            {
-                throw new OperationCanceledException(token);
-            }
+                if (token.IsCancellationRequested || State.Status >= ParserState.Error)
+                {
+                    throw new OperationCanceledException(token);
+                }
 
             ResolveAllReferences(token);
 
-            if (token.IsCancellationRequested || State.Status >= ParserState.Error)
-            {
-                throw new OperationCanceledException(token);
-            }
+                if (token.IsCancellationRequested || State.Status >= ParserState.Error)
+                {
+                    throw new OperationCanceledException(token);
+                }
 
             State.RebuildSelectionCache();
         }
@@ -260,19 +260,19 @@ namespace Rubberduck.Parsing.VBA
 
             Parallel.ForEach(components, options, component => State.SetModuleState(component, parserState, token, null, false));
 
-            if (!token.IsCancellationRequested)
-            {
-                State.EvaluateParserState();
-            }
+                if (!token.IsCancellationRequested)
+                {
+                    State.EvaluateParserState();
+                }
         }
 
         private void ParseComponents(List<IVBComponent> components, CancellationToken token)
         {
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
             
             SetModuleStates(components, ParserState.Parsing, token);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             var options = new ParallelOptions();
             options.CancellationToken = token;
@@ -363,11 +363,11 @@ namespace Rubberduck.Parsing.VBA
 
         private void ResolveAllDeclarations(List<IVBComponent> components, CancellationToken token)
         {
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
             
             SetModuleStates(components, ParserState.ResolvingDeclarations, token);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             var options = new ParallelOptions();
             options.CancellationToken = token;
@@ -459,19 +459,19 @@ namespace Rubberduck.Parsing.VBA
 
         private void ResolveAllReferences(CancellationToken token)
         {
-            token.ThrowIfCancellationRequested();
-
+                token.ThrowIfCancellationRequested();
+    
             var components = State.ParseTrees.Select(kvp => kvp.Key.Component).ToList();
-
-            token.ThrowIfCancellationRequested();
-
+            
+                token.ThrowIfCancellationRequested();
+            
             SetModuleStates(components, ParserState.ResolvingReferences, token);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             ExecuteCompilationPasses();
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             var options = new ParallelOptions();
             options.CancellationToken = token;
@@ -492,14 +492,14 @@ namespace Rubberduck.Parsing.VBA
                 throw;
             }
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             AddUndeclaredVariablesToDeclarations();
 
             //This is here and not in the calling method because it has to happen before the ready state is reached.
             //RefreshDeclarationFinder(); //Commented out because it breaks the unresolved and undeclared collections.
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             State.EvaluateParserState();
         }
@@ -520,7 +520,7 @@ namespace Rubberduck.Parsing.VBA
         {
             Debug.Assert(State.GetModuleState(qualifiedName.Component) == ParserState.ResolvingReferences || token.IsCancellationRequested);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             Logger.Debug("Resolving identifier references in '{0}'... (thread {1})", qualifiedName.Name, Thread.CurrentThread.ManagedThreadId);
 

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -601,28 +601,28 @@ namespace Rubberduck.Parsing.VBA
 
         private void ParseAllInternal(object requestor, CancellationToken token)
         {
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             State.RefreshProjects(_vbe);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             var components = State.Projects.SelectMany(project => project.VBComponents).ToList();
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             var componentsRemoved = ClearStateCashForRemovedComponents(components);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             // invalidation cleanup should go into ParseAsync?
             CleanUpComponentAttributes(components);
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             var toParse = components.Where(component => State.IsNewOrModified(component)).ToList();
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             if (toParse.Count == 0)
             {
@@ -635,7 +635,7 @@ namespace Rubberduck.Parsing.VBA
                 //return; // returning here leaves state in 'ResolvedDeclarations' when a module is removed, which disables refresh
             }
 
-            token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
             ExecuteCommonParseActivities(toParse, token);
         }

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -317,26 +317,15 @@ namespace Rubberduck.Parsing.VBA
         }
 
 
-        public void SetModuleState(IVBComponent component, ParserState state, SyntaxErrorException parserError = null, bool evaluateOverallState = true)
-        {
-            lock (component)
-            {
-                SetModuleStateInternal(component, state, parserError, evaluateOverallState);
-            }
-        }
-
         public void SetModuleState(IVBComponent component, ParserState state, CancellationToken token, SyntaxErrorException parserError = null, bool evaluateOverallState = true)
         {
-            lock (component)
+            if (!token.IsCancellationRequested)
             {
-                if (!token.IsCancellationRequested)
-                {
-                    SetModuleStateInternal(component, state, parserError, evaluateOverallState);
-                }
+                SetModuleState(component, state, parserError, evaluateOverallState);
             }
         }
         
-        public void SetModuleStateInternal(IVBComponent component, ParserState state, SyntaxErrorException parserError = null, bool evaluateOverallState = true)
+        public void SetModuleState(IVBComponent component, ParserState state, SyntaxErrorException parserError = null, bool evaluateOverallState = true)
         {
             if (AllUserDeclarations.Count > 0)
             {


### PR DESCRIPTION
I changed the locking in the `ParseCoordinator` on the parser runs such that we should have only one parsing run running a time  (except maybe in the tests where reparses run on the thread requesting them.)

Moreover, I introduced locking on setting the cancellation and exchanging the `CancellationTokenSources` in the `ParseCoordinator` to guarantee that each parsing run has a unique `CancellationTokenSource` that gets set to cancelled before the next parse is requested.

Furthermore, I changed the cancellation handling in the `ParseCoordinator` to `ThrowIfCancellationRequested` from just returning. That guarantees that we always return to the handler where we want the cancellations to stop.

Finally, I made the `ComponentParseTask` report all exceptions during the parse to its `ParseFailure` handler, so that the parser state is now set to error in case an unexpected exception was thrown in the parser. 