### PR TITLE
Add event source to track selection changes originating in Project Window.

### DIFF
--- a/RetailCoder.VBE/App.cs
+++ b/RetailCoder.VBE/App.cs
@@ -63,8 +63,8 @@ namespace Rubberduck
             _version = version;
             _checkVersionCommand = checkVersionCommand;
 
-            VBEEvents.SelectionChanged += _vbe_SelectionChanged;
-            VBEEvents.WindowFocusChange += _vbe_FocusChanged;
+            VBENativeServices.SelectionChanged += _vbe_SelectionChanged;
+            VBENativeServices.WindowFocusChange += _vbe_FocusChanged;
 
             _configService.SettingsChanged += _configService_SettingsChanged;
             _parser.State.StateChanged += Parser_StateChanged;
@@ -72,6 +72,9 @@ namespace Rubberduck
 
             UiDispatcher.Initialize();
         }
+
+        //TODO - This should be able to move to the appropriate handling classes now.
+        #region Statusbar 
 
         private void State_StatusMessageUpdate(object sender, RubberduckStatusMessageEventArgs e)
         {
@@ -92,90 +95,79 @@ namespace Rubberduck
 
         private void _vbe_FocusChanged(object sender, WindowChangedEventArgs e)
         {
-            if (e.EventType == WindowChangedEventArgs.FocusType.GotFocus)
+            if (e.EventType == FocusType.GotFocus)
             {
                 switch (e.Window.Type)
                 {
                     case WindowKind.Designer:
+                        //Designer or control on designer form selected.
                         RefreshSelection(e.Window);
                         break;
                     case WindowKind.CodeWindow:
+                        //Caret changed in a code pane.
                         RefreshSelection(e.CodePane);
                         break;
                 }              
-            }          
+            }
+            else if (e.EventType == FocusType.ChildFocus)
+            {
+                //Treeview selection changed in project window.
+                RefreshSelection();
+            }
         }
 
         private ParserState _lastStatus;
         private Declaration _lastSelectedDeclaration;
         private void RefreshSelection(ICodePane pane)
         {
-            Declaration selectedDeclaration = null;
-            if (!pane.IsWrappingNullReference)
+            if (pane == null || pane.IsWrappingNullReference)
             {
-                selectedDeclaration = _parser.State.FindSelectedDeclaration(pane);
-                var refCount = selectedDeclaration == null ? 0 : selectedDeclaration.References.Count();
-                var caption = _stateBar.GetContextSelectionCaption(_vbe.ActiveCodePane, selectedDeclaration);
-                _stateBar.SetContextSelectionCaption(caption, refCount);
+                return;
             }
 
-            var currentStatus = _parser.State.Status;
-            if (ShouldEvaluateCanExecute(selectedDeclaration, currentStatus))
-            {
-                _appMenus.EvaluateCanExecute(_parser.State);
-                _stateBar.EvaluateCanExecute(_parser.State);
-            }
-
-            _lastStatus = currentStatus;
-            _lastSelectedDeclaration = selectedDeclaration;
+            var selectedDeclaration = _parser.State.FindSelectedDeclaration(pane);
+            var caption = _stateBar.GetContextSelectionCaption(_vbe.ActiveCodePane, selectedDeclaration);
+            UpdateStatusbarAndCommandState(caption, selectedDeclaration);
         }
 
         private void RefreshSelection(IWindow window)
         {
-            if (window.IsWrappingNullReference || window.Type != WindowKind.Designer)
+            if (window == null || window.IsWrappingNullReference || window.Type != WindowKind.Designer)
             {
                 return;
             }
-            var caption = String.Empty;
-            var refCount = 0;
 
-            WindowKind windowKind = _vbe.ActiveWindow.Type;
-            var pane = _vbe.ActiveCodePane;
             var component = _vbe.SelectedVBComponent;
+            var caption = GetComponentControlsCaption(component);
+            //TODO: Need to find the selected declaration for the Form\Control.
+            UpdateStatusbarAndCommandState(caption, null);
+        }
 
-            Declaration selectedDeclaration = null;
-
-            //TODO - I doubt this is the best way to check if the SelectedVBComponent and the ActiveCodePane are the same component.
-            if (windowKind == WindowKind.CodeWindow || (!_vbe.SelectedVBComponent.IsWrappingNullReference
-                                                        && component.ParentProject.ProjectId == pane.CodeModule.Parent.ParentProject.ProjectId
-                                                        && component.Name == pane.CodeModule.Parent.Name))
+        private void RefreshSelection()
+        {
+            var caption = string.Empty;
+            var component = _vbe.SelectedVBComponent;
+            if (component == null || component.IsWrappingNullReference)
             {
-                selectedDeclaration = _parser.State.FindSelectedDeclaration(pane);
-                refCount = selectedDeclaration == null ? 0 : selectedDeclaration.References.Count();
-                caption = _stateBar.GetContextSelectionCaption(_vbe.ActiveCodePane, selectedDeclaration);
-            }
-            else if (windowKind == WindowKind.Designer)
-            {
-                caption = GetComponentControlsCaption(component);
+                //The user might have selected the project node in Project Explorer
+                //If they've chosen a folder, we'll return the project anyway
+                caption = !_vbe.ActiveVBProject.IsWrappingNullReference
+                    ? _vbe.ActiveVBProject.Name
+                    : null;
             }
             else
             {
-                if (_vbe.SelectedVBComponent.IsWrappingNullReference)
-                {
-                    //The user might have selected the project node in Project Explorer
-                    //If they've chosen a folder, we'll return the project anyway
-                    caption = !_vbe.ActiveVBProject.IsWrappingNullReference
-                        ? _vbe.ActiveVBProject.Name
-                        : null;
-                }
-                else
-                {
-                    caption = component.Type == ComponentType.UserForm && component.HasOpenDesigner
-                        ? GetComponentControlsCaption(component)
-                        : String.Format("{0}.{1} ({2})", component.ParentProject.Name, component.Name, component.Type);
-                }
+                caption = component.Type == ComponentType.UserForm && component.HasOpenDesigner
+                    ? GetComponentControlsCaption(component)
+                    : string.Format("{0}.{1} ({2})", component.ParentProject.Name, component.Name, component.Type);
             }
+            //TODO: Need to find the selected declaration for the selected treeview item.
+            UpdateStatusbarAndCommandState(caption, null);
+        }
 
+        private void UpdateStatusbarAndCommandState(string caption, Declaration selectedDeclaration)
+        {
+            var refCount = selectedDeclaration == null ? 0 : selectedDeclaration.References.Count();
             _stateBar.SetContextSelectionCaption(caption, refCount);
 
             var currentStatus = _parser.State.Status;
@@ -186,7 +178,7 @@ namespace Rubberduck
             }
 
             _lastStatus = currentStatus;
-            _lastSelectedDeclaration = selectedDeclaration;
+            _lastSelectedDeclaration = selectedDeclaration;            
         }
 
         private string GetComponentControlsCaption(IVBComponent component)
@@ -214,6 +206,8 @@ namespace Rubberduck
                    (selectedDeclaration != null && !selectedDeclaration.Equals(_lastSelectedDeclaration)) ||
                    (selectedDeclaration == null && _lastSelectedDeclaration != null);
         }
+
+        #endregion
 
         private void _configService_SettingsChanged(object sender, ConfigurationChangedEventArgs e)
         {
@@ -366,8 +360,8 @@ namespace Rubberduck
                 _parser.State.StatusMessageUpdate -= State_StatusMessageUpdate;
             }
 
-            VBEEvents.SelectionChanged += _vbe_SelectionChanged;
-            VBEEvents.WindowFocusChange += _vbe_FocusChanged;
+            VBENativeServices.SelectionChanged += _vbe_SelectionChanged;
+            VBENativeServices.WindowFocusChange += _vbe_FocusChanged;
 
             if (_configService != null)
             {

--- a/RetailCoder.VBE/Extension.cs
+++ b/RetailCoder.VBE/Extension.cs
@@ -56,7 +56,7 @@ namespace Rubberduck
                 {
                     var vbe = (Microsoft.Vbe.Interop.VBE) Application;                  
                     _ide = new VBEditor.SafeComWrappers.VBA.VBE(vbe);
-                    VBEEvents.HookEvents(_ide);
+                    VBENativeServices.HookEvents(_ide);
                     
                     var addin = (Microsoft.Vbe.Interop.AddIn)AddInInst;
                     _addin = new VBEditor.SafeComWrappers.VBA.AddIn(addin) { Object = this };
@@ -221,7 +221,7 @@ namespace Rubberduck
 
         private void ShutdownAddIn()
         {
-            VBEEvents.UnhookEvents();
+            VBENativeServices.UnhookEvents();
 
             var currentDomain = AppDomain.CurrentDomain;
             currentDomain.AssemblyResolve -= LoadFromSameFolder;

--- a/Rubberduck.VBEEditor/Events/WindowChangedEventArgs.cs
+++ b/Rubberduck.VBEEditor/Events/WindowChangedEventArgs.cs
@@ -3,14 +3,15 @@ using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.VBEditor.Events
 {
+    public enum FocusType
+    {
+        GotFocus,
+        LostFocus,
+        ChildFocus
+    }
+
     public class WindowChangedEventArgs : EventArgs
     {
-        public enum FocusType
-        {
-            GotFocus,
-            LostFocus
-        }
-
         public IntPtr Hwnd { get; private set; }
         public IWindow Window { get; private set; }
         public ICodePane CodePane { get; private set; }

--- a/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
+++ b/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
@@ -125,7 +125,7 @@
     <Compile Include="Events\ProjectEventArgs.cs" />
     <Compile Include="Events\ProjectRenamedEventArgs.cs" />
     <Compile Include="Events\SelectionChangedEventArgs.cs" />
-    <Compile Include="Events\VBEEvents.cs" />
+    <Compile Include="Events\VBENativeServices.cs" />
     <Compile Include="Events\WindowChangedEventArgs.cs" />
     <Compile Include="Extensions\MSAccessComponentTypeExtensions.cs" />
     <Compile Include="SafeComWrappers\Abstract\ISafeComWrapper.cs" />

--- a/Rubberduck.VBEEditor/WindowsApi/CodePaneSubclass.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/CodePaneSubclass.cs
@@ -16,9 +16,9 @@ namespace Rubberduck.VBEditor.WindowsApi
             _pane = pane;
         }
 
-        protected override void DispatchFocusEvent(WindowChangedEventArgs.FocusType type)
+        protected override void DispatchFocusEvent(FocusType type)
         {
-            var window = VBEEvents.GetWindowInfoFromHwnd(Hwnd);
+            var window = VBENativeServices.GetWindowInfoFromHwnd(Hwnd);
             if (window == null)
             {
                 return;

--- a/Rubberduck.VBEEditor/WindowsApi/DesignerWindowSubclass.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/DesignerWindowSubclass.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
+using Rubberduck.Common.WinAPI;
+using Rubberduck.VBEditor.Events;
 
 namespace Rubberduck.VBEditor.WindowsApi
 {
@@ -6,5 +9,18 @@ namespace Rubberduck.VBEditor.WindowsApi
     {
         //Stub for designer window replacement.  :-)
         internal DesignerWindowSubclass(IntPtr hwnd) : base(hwnd) { }
+
+        public override int SubClassProc(IntPtr hWnd, IntPtr msg, IntPtr wParam, IntPtr lParam, IntPtr uIdSubclass, IntPtr dwRefData)
+        {
+            //Any time the selected control changes in the hosted userform, the F3 Overlay has to be redrawn.  This is a good proxy
+            //for child control selections, so raise a focus event.
+            if ((int) msg == (int)WM.ERASEBKGND)
+            {
+                DispatchFocusEvent(FocusType.GotFocus);
+            }
+            //This is an output window firehose, leave this here, but comment it out when done.
+            //Debug.WriteLine("WM: {0:X4}, wParam {1}, lParam {2}", msg, wParam, lParam);
+            return base.SubClassProc(hWnd, msg, wParam, lParam, uIdSubclass, dwRefData);
+        }
     }
 }

--- a/Rubberduck.VBEEditor/WindowsApi/FocusSource.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/FocusSource.cs
@@ -17,9 +17,9 @@ namespace Rubberduck.VBEditor.WindowsApi
             }
         }
 
-        protected virtual void DispatchFocusEvent(WindowChangedEventArgs.FocusType type)
+        protected virtual void DispatchFocusEvent(FocusType type)
         {
-            var window = VBEEvents.GetWindowInfoFromHwnd(Hwnd);
+            var window = VBENativeServices.GetWindowInfoFromHwnd(Hwnd);
             if (window == null)
             {
                 return;
@@ -33,10 +33,10 @@ namespace Rubberduck.VBEditor.WindowsApi
             {
                 case (uint)WM.SETFOCUS:
 
-                    DispatchFocusEvent(WindowChangedEventArgs.FocusType.GotFocus);
+                    DispatchFocusEvent(FocusType.GotFocus);
                     break;
                 case (uint)WM.KILLFOCUS:
-                    DispatchFocusEvent(WindowChangedEventArgs.FocusType.LostFocus);
+                    DispatchFocusEvent(FocusType.LostFocus);
                     break;
             }
             return base.SubClassProc(hWnd, msg, wParam, lParam, uIdSubclass, dwRefData);

--- a/Rubberduck.VBEEditor/WindowsApi/NativeMethods.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/NativeMethods.cs
@@ -69,15 +69,6 @@ namespace Rubberduck.VBEditor.WindowsApi
             return result;
         }
 
-        /// <summary>   Gets the parent window of this item. </summary>
-        ///
-        /// <param name="hWnd"> The window handle. </param>
-        /// <returns>   The parent window IntPtr handle. </returns>
-        [DllImport("User32.dll")]
-        internal static extern IntPtr GetParent(IntPtr hWnd);
-
-
-
         /// <summary>Activates the window by simulating a click.</summary>
         ///
         /// <param name="windowHandle">         Handle of the window to be activated. </param>

--- a/Rubberduck.VBEEditor/WindowsApi/User32.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/User32.cs
@@ -66,5 +66,12 @@ namespace Rubberduck.VBEditor.WindowsApi
         /// <returns>The length of the returned class name (without the null terminator), zero on error.</returns>
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+        /// <summary>   Gets the parent window of this item. </summary>
+        ///
+        /// <param name="hWnd"> The window handle. </param>
+        /// <returns>   The parent window IntPtr handle. </returns>
+        [DllImport("User32.dll")]
+        internal static extern IntPtr GetParent(IntPtr hWnd);
     }
 }


### PR DESCRIPTION
This should get @ThunderFrame's missing functionality back. It's still a bit tweaky though (updates the status bar twice) - I need to add code to discriminate between clicks **_in_** the Project Window and selection changes in the tree-view due to switching panes via their MDI windows.