### PR TITLE
Remove references of not reparsed components.

### DIFF
--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -215,7 +215,7 @@ namespace Rubberduck.Parsing.VBA
                 token.ThrowIfCancellationRequested();
 
             _projectDeclarations.Clear();
-            State.ClearBuiltInReferences();
+            State.ClearAllReferences();
 
             ParseComponents(toParse, token);
 
@@ -612,7 +612,7 @@ namespace Rubberduck.Parsing.VBA
 
                 token.ThrowIfCancellationRequested();
 
-            var componentsRemoved = ClearStateCashForRemovedComponents(components);
+            var componentsRemoved = CleanUpRemovedComponents(components);
 
                 token.ThrowIfCancellationRequested();
 
@@ -642,10 +642,10 @@ namespace Rubberduck.Parsing.VBA
         }
 
         /// <summary>
-        /// Clears state cach for removed components.
+        /// Clears state cache of removed components.
         /// Returns whether components have been removed.
         /// </summary>
-        private bool ClearStateCashForRemovedComponents(List<IVBComponent> components)
+        private bool CleanUpRemovedComponents(List<IVBComponent> components)
         {
             var removedModuledecalrations = RemovedModuleDeclarations(components);
             var componentRemoved = removedModuledecalrations.Any();

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -742,6 +742,14 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
+        public void ClearAllReferences()
+        {
+            foreach (var declaration in AllDeclarations)
+            {
+                declaration.ClearReferences();
+            }
+        }
+
         public bool ClearStateCache(IVBComponent component, bool notifyStateChanged = false)
         {
             return component != null && ClearStateCache(new QualifiedModuleName(component), notifyStateChanged);


### PR DESCRIPTION
Made the `ParseCoordinator` remove all references upon reparse and not only those to the built-in declarations and the modules that have been modified.

This will have to change again, when I implement selective reference resolving.

This PR will make issue #2737 more obscure since there will never be a `DeclarationFinder` at whose time of construction any references are are resolved.