### PR TITLE
Saving module to module references

### DIFF
--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -141,7 +141,12 @@ namespace Rubberduck.Parsing.Symbols
 
         public IEnumerable<Declaration> Members(Declaration module)
         {
-            return _declarations[module.QualifiedName.QualifiedModuleName];
+            return Members(module.QualifiedName.QualifiedModuleName);
+        }
+
+        public IEnumerable<Declaration> Members(QualifiedModuleName module)
+        {
+            return _declarations[module];
         }
 
         private IEnumerable<Declaration> _nonBaseAsType;

--- a/Rubberduck.Parsing/VBA/ModuleState.cs
+++ b/Rubberduck.Parsing/VBA/ModuleState.cs
@@ -21,8 +21,8 @@ namespace Rubberduck.Parsing.VBA
         public List<IAnnotation> Annotations { get; private set; }
         public SyntaxErrorException ModuleException { get; private set; }
         public IDictionary<Tuple<string, DeclarationType>, Attributes> ModuleAttributes { get; private set; }
-        public HashSet<QualifiedModuleName> HasReferenceToModule { get; private set;}
-        public ConcurrentDictionary<QualifiedModuleName, byte> IsReferencedByModule { get; private set; }
+        public ConcurrentDictionary<QualifiedModuleName, byte> HasReferenceToModule { get; private set; }
+        public HashSet<QualifiedModuleName> IsReferencedByModule { get; private set; }
 
         public bool IsNew { get; private set; }
 
@@ -46,8 +46,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = null;
             ModuleAttributes = new Dictionary<Tuple<string, DeclarationType>, Attributes>();
-            HasReferenceToModule = new HashSet<QualifiedModuleName>();
-            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            HasReferenceToModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            IsReferencedByModule = new HashSet<QualifiedModuleName>();
 
             IsNew = true;
         }
@@ -63,8 +63,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = null;
             ModuleAttributes = new Dictionary<Tuple<string, DeclarationType>, Attributes>();
-            HasReferenceToModule = new HashSet<QualifiedModuleName>();
-            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            HasReferenceToModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            IsReferencedByModule = new HashSet<QualifiedModuleName>();
 
             IsNew = true;
         }
@@ -80,8 +80,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = moduleException;
             ModuleAttributes = new Dictionary<Tuple<string, DeclarationType>, Attributes>();
-            HasReferenceToModule = new HashSet<QualifiedModuleName>();
-            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            HasReferenceToModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            IsReferencedByModule = new HashSet<QualifiedModuleName>();
 
             IsNew = true;
         }
@@ -97,8 +97,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = null;
             ModuleAttributes = moduleAttributes;
-            HasReferenceToModule = new HashSet<QualifiedModuleName>();
-            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            HasReferenceToModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            IsReferencedByModule = new HashSet<QualifiedModuleName>();
 
             IsNew = true;
         }
@@ -154,12 +154,12 @@ namespace Rubberduck.Parsing.VBA
 
         public void RefreshHasReferenceToModule()
         {
-            HasReferenceToModule = new HashSet<QualifiedModuleName>();
+            HasReferenceToModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
         }
 
         public void RefreshIsReferencedByModule()
         {
-            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+            IsReferencedByModule = new HashSet<QualifiedModuleName>();
         }
 
 

--- a/Rubberduck.Parsing/VBA/ModuleState.cs
+++ b/Rubberduck.Parsing/VBA/ModuleState.cs
@@ -6,6 +6,7 @@ using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.VBA
 {
@@ -20,6 +21,8 @@ namespace Rubberduck.Parsing.VBA
         public List<IAnnotation> Annotations { get; private set; }
         public SyntaxErrorException ModuleException { get; private set; }
         public IDictionary<Tuple<string, DeclarationType>, Attributes> ModuleAttributes { get; private set; }
+        public HashSet<QualifiedModuleName> HasReferenceToModule { get; private set;}
+        public ConcurrentDictionary<QualifiedModuleName, byte> IsReferencedByModule { get; private set; }
 
         public bool IsNew { get; private set; }
 
@@ -43,6 +46,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = null;
             ModuleAttributes = new Dictionary<Tuple<string, DeclarationType>, Attributes>();
+            HasReferenceToModule = new HashSet<QualifiedModuleName>();
+            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
 
             IsNew = true;
         }
@@ -58,6 +63,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = null;
             ModuleAttributes = new Dictionary<Tuple<string, DeclarationType>, Attributes>();
+            HasReferenceToModule = new HashSet<QualifiedModuleName>();
+            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
 
             IsNew = true;
         }
@@ -73,6 +80,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = moduleException;
             ModuleAttributes = new Dictionary<Tuple<string, DeclarationType>, Attributes>();
+            HasReferenceToModule = new HashSet<QualifiedModuleName>();
+            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
 
             IsNew = true;
         }
@@ -88,6 +97,8 @@ namespace Rubberduck.Parsing.VBA
             Annotations = new List<IAnnotation>();
             ModuleException = null;
             ModuleAttributes = moduleAttributes;
+            HasReferenceToModule = new HashSet<QualifiedModuleName>();
+            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
 
             IsNew = true;
         }
@@ -140,6 +151,17 @@ namespace Rubberduck.Parsing.VBA
             ModuleAttributes = moduleAttributes;
             return this;
         }
+
+        public void RefreshHasReferenceToModule()
+        {
+            HasReferenceToModule = new HashSet<QualifiedModuleName>();
+        }
+
+        public void RefreshIsReferencedByModule()
+        {
+            IsReferencedByModule = new ConcurrentDictionary<QualifiedModuleName, byte>();
+        }
+
 
         private bool _isDisposed;
         public void Dispose()

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -217,6 +217,8 @@ namespace Rubberduck.Parsing.VBA
             _projectDeclarations.Clear();
             State.ClearAllReferences();
 
+            ClearModuleToModuleReferences(toParse);
+
             ParseComponents(toParse, token);
 
                 if (token.IsCancellationRequested || State.Status >= ParserState.Error)
@@ -266,6 +268,14 @@ namespace Rubberduck.Parsing.VBA
                 {
                     State.EvaluateParserState();
                 }
+        }
+
+        private void ClearModuleToModuleReferences(List<IVBComponent> toClear)
+        {
+            foreach (var component in toClear)
+            {
+                State.ClearModuleToModuleReferencesFromModule(new QualifiedModuleName(component));       
+            }
         }
 
         private void ParseComponents(List<IVBComponent> components, CancellationToken token)
@@ -496,6 +506,10 @@ namespace Rubberduck.Parsing.VBA
 
                 token.ThrowIfCancellationRequested();
 
+            AddModuleToModuleReferences(State.DeclarationFinder, token);
+
+                token.ThrowIfCancellationRequested();
+            
             AddUndeclaredVariablesToDeclarations();
 
             //This is here and not in the calling method because it has to happen before the ready state is reached.
@@ -552,6 +566,41 @@ namespace Rubberduck.Parsing.VBA
                     Logger.Error(exception, "Exception thrown resolving '{0}' (thread {1}).", qualifiedName.Name, Thread.CurrentThread.ManagedThreadId);
                     State.SetModuleState(qualifiedName.Component, ParserState.ResolverError, token);
                 }
+            }
+        }
+
+        private void AddModuleToModuleReferences(DeclarationFinder finder, CancellationToken token)
+        {
+            var options = new ParallelOptions();
+            options.CancellationToken = token;
+            options.MaxDegreeOfParallelism = _maxDegreeOfReferenceResolverParallelism;
+            try
+            {
+                Parallel.For(0, State.ParseTrees.Count, options,
+                    (index) => AddModuleToModuleReferences(finder, State.ParseTrees[index].Key)
+                );
+            }
+            catch (AggregateException exception)
+            {
+                if (exception.Flatten().InnerExceptions.All(ex => ex is OperationCanceledException))
+                {
+                    throw exception.InnerException; //This eliminates the stack trace, but for the cancellation, this is irrelevant.
+                }
+                State.SetStatusAndFireStateChanged(this, ParserState.ResolverError);
+                throw;
+            }
+        }
+
+        private void AddModuleToModuleReferences(DeclarationFinder finder, QualifiedModuleName referencedModule)
+        {
+            var referencingModules = finder.Members(referencedModule)
+                                        .SelectMany(declaration => declaration.References)
+                                        .Select(reference => reference.QualifiedModuleName)
+                                        .Distinct()
+                                        .Where(referencingModule => !referencedModule.Equals(referencingModule));
+            foreach (var referencingModule in referencingModules)
+            {
+                State.AddModuleToModuleReference(referencedModule, referencingModule);
             }
         }
 
@@ -651,6 +700,7 @@ namespace Rubberduck.Parsing.VBA
             var componentRemoved = removedModuledecalrations.Any();
             foreach (var declaration in removedModuledecalrations)
             {
+                State.ClearModuleToModuleReferencesFromModule(declaration.QualifiedName.QualifiedModuleName);
                 State.ClearStateCache(declaration.QualifiedName.QualifiedModuleName);
             }
             return componentRemoved;

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -1098,12 +1098,12 @@ namespace Rubberduck.Parsing.VBA
             {
                 return;
             }
-            if (referencingModuleState.HasReferenceToModule.Contains(referencedModule))
+            if (referencedModuleState.IsReferencedByModule.Contains(referencingModule))
             {
                 return;
             }
-            referencedModuleState.IsReferencedByModule.AddOrUpdate(referencingModule, 1, (key,value) => value);
-            referencingModuleState.HasReferenceToModule.Add(referencedModule);
+            referencedModuleState.IsReferencedByModule.Add(referencingModule);
+            referencingModuleState.HasReferenceToModule.AddOrUpdate(referencedModule, 1, (key, value) => value);
         }
 
         public void ClearModuleToModuleReferencesFromModule(QualifiedModuleName referencingModule)
@@ -1115,14 +1115,13 @@ namespace Rubberduck.Parsing.VBA
             }
 
             ModuleState referencedModuleState;
-            byte dummyOutValue;
-            foreach (var referencedModule in referencingModuleState.HasReferenceToModule)
-            { 
+            foreach (var referencedModule in referencingModuleState.HasReferenceToModule.Keys)
+            {
                 if (!_moduleStates.TryGetValue(referencedModule,out referencedModuleState))
                 {
                     continue;
                 }
-                referencedModuleState.IsReferencedByModule.TryRemove(referencingModule,out dummyOutValue);
+                referencedModuleState.IsReferencedByModule.Remove(referencingModule);
             }
             referencingModuleState.RefreshHasReferenceToModule();
         }
@@ -1134,7 +1133,7 @@ namespace Rubberduck.Parsing.VBA
             {
                 return new HashSet<QualifiedModuleName>();
             }
-            return new HashSet<QualifiedModuleName>(referencingModuleState.HasReferenceToModule);
+            return new HashSet<QualifiedModuleName>(referencingModuleState.HasReferenceToModule.Keys);
         }
 
         public HashSet<QualifiedModuleName> ModulesReferencing(QualifiedModuleName referencedModule)
@@ -1144,7 +1143,7 @@ namespace Rubberduck.Parsing.VBA
             {
                 return new HashSet<QualifiedModuleName>();
             }
-            return new HashSet<QualifiedModuleName>(referencedModuleState.IsReferencedByModule.Keys);
+            return new HashSet<QualifiedModuleName>(referencedModuleState.IsReferencedByModule);
         }
 
         private bool _isDisposed;


### PR DESCRIPTION
I set up the infrastructure for saving module to module references on the `ModuleStates` and added the handling to the `ParseCoodinator`.  This will be used later on to enable selective reference resolving only for those modules for which the references might have changed.

I would appreciate any featback on this PR before I go on and implement the selective resolving.

In the implementation I opted to add the module to module references after all references have been resolved. I did this simply because it is much simpler than doing it while resolving the references. (One would have to get a reference to the correct `ModuleState` or the `RubberduckParserState` at the point where the references are added, the `BoundExpressionVisitor` if I see it correctly.) 
Although the path I have taken should yield inferior performace, it took only 38ms out of a total parsing run of 29s in my test project to get the module to module references from the references. So, performance should not be the problem here.

BTW, that the `IsReferencedBy` collection is not concurrent but the `HasReferenceTo` collection is is coupled to how the references get added.
