### PR TITLE
Make retrieval of TypeName safe with 64 bit typelibs. 

### DIFF
--- a/Rubberduck.Parsing/ComReflection/ComAlias.cs
+++ b/Rubberduck.Parsing/ComReflection/ComAlias.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices.ComTypes;
 using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
 using TYPEFLAGS = System.Runtime.InteropServices.ComTypes.TYPEFLAGS;
@@ -10,7 +8,6 @@ namespace Rubberduck.Parsing.ComReflection
     [DebuggerDisplay("{Name} As {TypeName}")]
     public class ComAlias : ComBase
     {
-        public VarEnum VarType { get; private set; }
         public string TypeName { get; private set; }
         public bool IsHidden { get; private set; }
         public bool IsRestricted { get; private set; }
@@ -20,7 +17,6 @@ namespace Rubberduck.Parsing.ComReflection
             Index = index;
             Documentation = new ComDocumentation(typeLib, index);
             Guid = attributes.guid;
-            VarType = (VarEnum)attributes.tdescAlias.vt;
             IsHidden = attributes.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN);
             IsRestricted = attributes.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED);
             
@@ -29,22 +25,9 @@ namespace Rubberduck.Parsing.ComReflection
                 TypeName = "LongPtr";
                 return;                
             }
-          
-            if (ComVariant.TypeNames.ContainsKey(VarType))
-            {
-                TypeName = ComVariant.TypeNames[VarType];
-            }
-            else if (VarType == VarEnum.VT_USERDEFINED)
-            {
-                ITypeInfo refType;
-                info.GetRefTypeInfo((int)attributes.tdescAlias.lpValue, out refType);
-                var doc = new ComDocumentation(refType, -1);
-                TypeName = doc.Name;
-            }
-            else
-            {
-                throw new NotImplementedException(string.Format("Didn't expect an alias with a type of {0}.", VarType));
-            }
+
+            var aliased = new ComParameter(attributes, info);
+            TypeName = aliased.TypeName;
         }
     }
 }

--- a/Rubberduck.Parsing/ComReflection/ComParameter.cs
+++ b/Rubberduck.Parsing/ComReflection/ComParameter.cs
@@ -37,7 +37,6 @@ namespace Rubberduck.Parsing.ComReflection
         public bool IsOptional { get; private set; }
         public bool IsParamArray { get; set; }
 
-
         private Guid _enumGuid = Guid.Empty;
         public bool IsEnumMember
         {
@@ -79,6 +78,12 @@ namespace Rubberduck.Parsing.ComReflection
             }
             var member = enumType.Members.FirstOrDefault(m => m.Value == (int)DefaultValue);
             DefaultAsEnum = member != null ? member.Name : string.Empty;
+        }
+
+        //This overload should only be used for retrieving the TypeName from a random TYPEATTR. TODO: Should be a base class of ComParameter instead.
+        public ComParameter(TYPEATTR attributes, ITypeInfo info)
+        {
+            GetParameterType(attributes.tdescAlias, info);
         }
 
         private void GetParameterType(TYPEDESC desc, ITypeInfo info)


### PR DESCRIPTION
Ref #2770.   This should close the issue, but I need someone with a 64 bit Office install to test it. 