### PR TITLE
Hide the grammar issue around `Mid$` from the user.

### DIFF
--- a/Rubberduck.Parsing/Binding/SimpleNameDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/SimpleNameDefaultBinding.cs
@@ -75,12 +75,14 @@ namespace Rubberduck.Parsing.Binding
                 var bracketedExpression = _declarationFinder.OnBracketedExpression(_context.GetText(), _context);
                 return new SimpleNameExpression(bracketedExpression, ExpressionClassification.Unbound, _context);
             }
-            else
+            //TODO - this is a complete and total hack to prevent `Mid` and `Mid$` from creating undeclared variables
+            //pending an actual fix to the grammar.  See #2618
+            else if (!_name.Equals("Mid") && !_name.Equals("Mid$"))
             {
                 var undeclaredLocal = _declarationFinder.OnUndeclaredVariable(_parent, _name, _context);
                 return new SimpleNameExpression(undeclaredLocal, ExpressionClassification.Variable, _context);
             }
-            //return new ResolutionFailedExpression();
+            return new ResolutionFailedExpression();
         }
 
         private IBoundExpression ResolveProcedureNamespace()


### PR DESCRIPTION
This PR basically prevents the creation of an undeclared variable Declaration with an identifier name of `Mid`.  This masks the underlying issue in #2618, which is that `Mid` is used in the grammar as both a statement (LHS) and a function (RHS). The only _visible_ side effect of this hack should be that it won't always show the function details on the command bar when the `Mid` is selected in a code pane.  This should be safe if the function is hidden by a user declaration - it would only effect an undeclared use, and that would result in a compile error.

Leaving #2618 open (even though this resolves the symptom) to track the need for a grammar fix.