### PR TITLE
Hack for 2773

### DIFF
--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -702,6 +702,10 @@ namespace Rubberduck.Parsing.VBA
         {
                 token.ThrowIfCancellationRequested();
 
+            Thread.Sleep(50); //Simplistic hack to give the VBE time to do its work in case the parsing run is requested from an event handler. 
+
+                token.ThrowIfCancellationRequested();
+
             State.RefreshProjects(_vbe);
 
                 token.ThrowIfCancellationRequested();


### PR DESCRIPTION
This introduces a hack to circumvent the cause of issue #2773.

In `ParseAllInternal`, which is only called in the live code, I added a delay of 50ms before refreshing the projects from the VBE so that the VBE has time to actually release components before we query it, in case the parse is requested from the handler for the component removed event. 