### PR TITLE
Validate handles and catch COM errors when matching code panes.

### DIFF
--- a/Rubberduck.VBEEditor/Events/VBENativeServices.cs
+++ b/Rubberduck.VBEEditor/Events/VBENativeServices.cs
@@ -170,12 +170,27 @@ namespace Rubberduck.VBEditor.Events
 
         private static ICodePane GetCodePaneFromHwnd(IntPtr hwnd)
         {
-            var caption = hwnd.GetWindowText();
-            return _vbe.CodePanes.FirstOrDefault(x => x.Window.Caption.Equals(caption));
+            try
+            {
+                var caption = hwnd.GetWindowText();
+                return _vbe.CodePanes.FirstOrDefault(x => x.Window.Caption.Equals(caption));
+            }
+            catch
+            {
+                // This *should* only happen when a code pane window is removed and RD responds faster than
+                // the VBE removes it from the windows collection. TODO: Find a better method to match code panes
+                // to windows than testing the captions.
+                return null;
+            }
         }
 
         private static IWindow GetWindowFromHwnd(IntPtr hwnd)
         {
+            if (!User32.IsWindow(hwnd))
+            {
+                return null;
+            }
+
             var caption = hwnd.GetWindowText();
             return _vbe.Windows.FirstOrDefault(x => x.Caption.Equals(caption));
         }

--- a/Rubberduck.VBEEditor/WindowsApi/User32.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/User32.cs
@@ -82,5 +82,14 @@ namespace Rubberduck.VBEditor.WindowsApi
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         internal static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string lclassName, string windowTitle);
+
+        /// <summary>
+        /// Validates a window handle.
+        /// </summary>
+        /// <param name="hWnd">The handle to validate.</param>
+        /// <returns></returns>
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool IsWindow(IntPtr hWnd);
     }
 }


### PR DESCRIPTION
Closes #2814

This is a temporary fix pending some better method of matching an `hWnd` to a `CodePane` than testing all of the captions in the CodePanes collection. Not sure if the VBE recycles all of the windows when it removes one, but if so we should be able to get a hook in there and manually track the window associations.