### PR TITLE
Exception handling for unit tests and more

### DIFF
--- a/RetailCoder.VBE/UnitTesting/TestEngine.cs
+++ b/RetailCoder.VBE/UnitTesting/TestEngine.cs
@@ -98,8 +98,6 @@ namespace Rubberduck.UnitTesting
                     {
                         Logger.Error("Unexpected COM exception while running tests.", ex);
                         test.UpdateResult(TestOutcome.Inconclusive, "Unexpected COM exception.");
-                        OnTestCompleted();
-                        continue;
                     }
 
                     stopwatch.Stop();

--- a/Rubberduck.VBEEditor/Application/ExcelApp.cs
+++ b/Rubberduck.VBEEditor/Application/ExcelApp.cs
@@ -6,6 +6,8 @@ namespace Rubberduck.VBEditor.Application
 {
     public class ExcelApp : HostApplicationBase<Microsoft.Office.Interop.Excel.Application>
     {
+        public const int MaxPossibleLengthOfProcedureName = 255;
+
         public ExcelApp() : base("Excel") { }
         public ExcelApp(IVBE vbe) : base(vbe, "Excel") { }
 
@@ -95,9 +97,13 @@ namespace Rubberduck.VBEditor.Application
                 ? declaration.ProjectDisplayName
                 : Path.GetFileName(module.ProjectPath);
 
-            return string.IsNullOrEmpty(documentName)
+            var candidateString = string.IsNullOrEmpty(documentName)
                 ? qualifiedMemberName.ToString()
                 : string.Format("'{0}'!{1}", documentName.Replace("'", "''"), qualifiedMemberName);
+
+            return candidateString.Length <= MaxPossibleLengthOfProcedureName
+                ? candidateString
+                : qualifiedMemberName.ToString();
         }
     }
 }


### PR DESCRIPTION
This and that:

1) Slightly more safety for long procedure names in Excel. (If > 255 chars, drop the filename.)

2) Catching and logging of COMExceptions thrown during running the unit tests. (`Application.Run` might not like what we are feeding it.) Exception gets logged and test gets set to `Inconclusive - Unexpected COM error`.

3) Small refactoring of `SyncCOMReferences` in the `ParseCoordinator`. Now, the setup for parallelism gets only performed if there is actually soemthing to load.  