### PR TITLE
Added safe value retrieval to Members function on the DeclarationFinder

### DIFF
--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -236,7 +236,10 @@ namespace Rubberduck.Parsing.Symbols
 
         public IEnumerable<Declaration> Members(QualifiedModuleName module)
         {
-            return _declarations[module];
+            ConcurrentBag<Declaration> members;
+            return _declarations.TryGetValue(module,out members)
+                    ? members.ToList()
+                    : Enumerable.Empty<Declaration>();
         }
 
         public IEnumerable<Declaration> FindDeclarationsWithNonBaseAsType()


### PR DESCRIPTION
This should fix the second batch of errors from the log posted in issue #2912.

Previously the `Members` function on the `DeclarationFinder` assumed that we only look for declarations belonging to QMNs that exist in the `_declarations` collection.