### PR TITLE
Extract class on parse coordinator - Fix of binding

### DIFF
--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -102,17 +102,17 @@ namespace Rubberduck.Root
             Bind<Func<IIndenterSettings>>().ToMethod(t => () => KernelInstance.Get<IGeneralConfigService>().LoadConfiguration().UserSettings.IndenterSettings);
 
             BindCustomDeclarationLoadersToParser();
+            Rebind<ICOMReferenceSynchronizer, IProjectReferencesProvider>().To<COMReferenceSynchronizer>().InSingletonScope().WithConstructorArgument("serializedDeclarationsPath", (string)null);
             Rebind<IBuiltInDeclarationLoader>().To<BuiltInDeclarationLoader>().InSingletonScope();
-            Rebind<ICOMReferenceSynchronizer>().To<COMReferenceSynchronizer>().InSingletonScope().WithConstructorArgument("serializedDeclarationsPath", (string)null);
             Rebind<IDeclarationResolveRunner>().To<DeclarationResolveRunner>().InSingletonScope();
             Rebind<IModuleToModuleReferenceManager>().To<ModuleToModuleReferenceManager>().InSingletonScope();
             Rebind<IParserStateManager>().To<ParserStateManager>().InSingletonScope();
             Rebind<IParseRunner>().To<ParseRunner>().InSingletonScope();
             Rebind<IParsingStageService>().To<ParsingStageService>().InSingletonScope();
             Rebind<IProjectManager>().To<ProjectManager>().InSingletonScope();
-            Bind<IProjectReferencesProvider>().To<COMReferenceSynchronizer>().InSingletonScope().WithConstructorArgument("serializedDeclarationsPath", (string)null);
             Rebind<IReferenceRemover>().To<ReferenceRemover>().InSingletonScope();
             Rebind<IReferenceResolveRunner>().To<ReferenceResolveRunner>().InSingletonScope();
+            Rebind<IParseCoordinator>().To<ParseCoordinator>().InSingletonScope();
 
             Bind<Func<IVBAPreprocessor>>().ToMethod(p => () => new VBAPreprocessor(double.Parse(_vbe.Version, CultureInfo.InvariantCulture)));
 

--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -66,7 +66,7 @@ namespace Rubberduck.Root
             Bind<IVBE>().ToConstant(_vbe);
             Bind<IAddIn>().ToConstant(_addin);
             Bind<App>().ToSelf().InSingletonScope();
-            Bind<RubberduckParserState>().ToSelf().InSingletonScope();
+            Bind<RubberduckParserState, IParseTreeProvider, IDeclarationFinderProvider>().To<RubberduckParserState>().InSingletonScope();
             Bind<ISelectionChangeService>().To<SelectionChangeService>().InSingletonScope();
             Bind<ISourceControlProvider>().To<GitProvider>();
             //Bind<GitProvider>().ToSelf().InSingletonScope();        

--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -102,8 +102,18 @@ namespace Rubberduck.Root
             Bind<Func<IIndenterSettings>>().ToMethod(t => () => KernelInstance.Get<IGeneralConfigService>().LoadConfiguration().UserSettings.IndenterSettings);
 
             BindCustomDeclarationLoadersToParser();
+            Rebind<IBuiltInDeclarationLoader>().To<BuiltInDeclarationLoader>().InSingletonScope();
             Rebind<ICOMReferenceSynchronizer>().To<COMReferenceSynchronizer>().InSingletonScope().WithConstructorArgument("serializedDeclarationsPath", (string)null);
+            Rebind<IDeclarationResolveRunner>().To<DeclarationResolveRunner>().InSingletonScope();
+            Rebind<IModuleToModuleReferenceManager>().To<ModuleToModuleReferenceManager>().InSingletonScope();
+            Rebind<IParserStateManager>().To<ParserStateManager>().InSingletonScope();
+            Rebind<IParseRunner>().To<ParseRunner>().InSingletonScope();
+            Rebind<IParsingStageService>().To<ParsingStageService>().InSingletonScope();
+            Rebind<IProjectManager>().To<ProjectManager>().InSingletonScope();
             Bind<IProjectReferencesProvider>().To<COMReferenceSynchronizer>().InSingletonScope().WithConstructorArgument("serializedDeclarationsPath", (string)null);
+            Rebind<IReferenceRemover>().To<ReferenceRemover>().InSingletonScope();
+            Rebind<IReferenceResolveRunner>().To<ReferenceResolveRunner>().InSingletonScope();
+
             Bind<Func<IVBAPreprocessor>>().ToMethod(p => () => new VBAPreprocessor(double.Parse(_vbe.Version, CultureInfo.InvariantCulture)));
 
             Rebind<ISearchResultsWindowViewModel>().To<SearchResultsWindowViewModel>().InSingletonScope();

--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -335,6 +335,8 @@
     <Compile Include="VBA\AttributeParser.cs" />
     <Compile Include="VBA\Attributes.cs" />
     <Compile Include="VBA\BuiltInDeclarationLoader.cs" />
+    <Compile Include="VBA\IDeclarationFinderProvider.cs" />
+    <Compile Include="VBA\IParseTreeProvider.cs" />
     <Compile Include="VBA\ParsingStageService.cs" />
     <Compile Include="VBA\CollectionExtensions.cs" />
     <Compile Include="VBA\IParsingStageService.cs" />

--- a/Rubberduck.Parsing/VBA/IDeclarationFinderProvider.cs
+++ b/Rubberduck.Parsing/VBA/IDeclarationFinderProvider.cs
@@ -1,0 +1,11 @@
+﻿using Rubberduck.Parsing.Symbols;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public interface IDeclarationFinderProvider
+    {
+        DeclarationFinder DeclarationFinder { get; }
+
+        void RefreshDeclarationFinder();
+    }
+}

--- a/Rubberduck.Parsing/VBA/IParseTreeProvider.cs
+++ b/Rubberduck.Parsing/VBA/IParseTreeProvider.cs
@@ -1,0 +1,11 @@
+﻿using Antlr4.Runtime.Tree;
+using Rubberduck.VBEditor;
+using System.Collections.Generic;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public interface IParseTreeProvider
+    {
+        List<KeyValuePair<QualifiedModuleName, IParseTree>> ParseTrees { get; }
+    }
+}

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -281,6 +281,7 @@ namespace Rubberduck.Parsing.VBA
         private void PerformPreParseCleanup(IReadOnlyCollection<QualifiedModuleName> modulesToParse, IReadOnlyCollection<QualifiedModuleName> toResolveReferences, CancellationToken token)
         {
             _moduleToModuleReferenceManager.ClearModuleToModuleReferencesFromModule(modulesToParse);
+            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesToModule(modulesToParse);
             _referenceRemover.RemoveReferencesBy(toResolveReferences, token); 
         }
 

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -42,7 +42,7 @@ namespace Rubberduck.Parsing.VBA
         public string Message { get; }
     }
 
-    public sealed class RubberduckParserState : IDisposable
+    public sealed class RubberduckParserState : IDisposable, IDeclarationFinderProvider, IParseTreeProvider
     {
         // circumvents VBIDE API's tendency to return a new instance at every parse, which breaks reference equality checks everywhere
         private readonly IDictionary<string, IVBProject> _projects = new Dictionary<string, IVBProject>();


### PR DESCRIPTION
In my previous PR, I assumed that our default interface binding was in singleton scope, which is not true.

This PR rebinds the runners and their likes in singleton scope.

The code in the previous PR only works because because everything uses the `RubberduckParserState` at the moment, which is bound in singleton scope.