### PR TITLE
Improvements on cleanup in ParseCoordinator

### DIFF
--- a/RetailCoder.VBE/API/ParserState.cs
+++ b/RetailCoder.VBE/API/ParserState.cs
@@ -95,7 +95,8 @@ namespace Rubberduck.API
             var referenceResolveRunner = new ReferenceResolveRunner(
                 _state,
                 parserStateManager,
-                moduleToModuleReferenceManager);
+                moduleToModuleReferenceManager,
+                referenceRemover);
             var parsingStageService = new ParsingStageService(
                 comSynchronizer,
                 builtInDeclarationLoader,

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -358,19 +358,6 @@ namespace Rubberduck.Parsing.VBA
             toParse.UnionWith(modules.Where(module => _parserStateManager.GetModuleState(module) != ParserState.Ready));
             token.ThrowIfCancellationRequested();           
 
-            if (toParse.Count == 0)
-            {
-                if (removedModules.Any())  // trigger UI updates
-                {
-                    _parserStateManager.SetStatusAndFireStateChanged(requestor, ParserState.ResolvedDeclarations, token);
-                }
-
-                _parserStateManager.SetStatusAndFireStateChanged(requestor, State.Status, token);
-                //return; // returning here leaves state in 'ResolvedDeclarations' when a module is removed, which disables refresh
-            }
-
-            token.ThrowIfCancellationRequested();
-
             ExecuteCommonParseActivities(toParse.AsReadOnly(), toReResolveReferences, token);
         }
 

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -215,7 +215,10 @@ namespace Rubberduck.Parsing.VBA
             else
             {
                 toResolveReferences = ModulesForWhichToResolveReferences(toParse, toReresolveReferences);
-                PerformPreParseCleanup(toParse, toResolveReferences, token);
+                token.ThrowIfCancellationRequested();
+
+                //This is purely a security measure. In the success path the reference resolver removes the old references. 
+                _referenceRemover.RemoveReferencesBy(toParse, token);   
                 token.ThrowIfCancellationRequested();
 
                 _parserStateManager.SetModuleStates(toParse, ParserState.Parsing, token);
@@ -286,13 +289,6 @@ namespace Rubberduck.Parsing.VBA
             toResolveReferences.UnionWith(_moduleToModuleReferenceManager.ModulesReferencingAny(modulesToParse));
             toResolveReferences.UnionWith(toReresolveReferences);
             return toResolveReferences.AsReadOnly();
-        }
-
-        private void PerformPreParseCleanup(IReadOnlyCollection<QualifiedModuleName> modulesToParse, IReadOnlyCollection<QualifiedModuleName> toResolveReferences, CancellationToken token)
-        {
-            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesFromModule(modulesToParse);
-            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesToModule(modulesToParse);
-            _referenceRemover.RemoveReferencesBy(toResolveReferences, token); 
         }
 
 

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -250,8 +250,8 @@ namespace Rubberduck.Parsing.VBA
                 throw new OperationCanceledException(token);
             }
 
-            //Explicitely setting the overall state here guerantees that the handlers attached 
-            //to the state change to ResolvedDeclarations always run in case there is no error.
+            //Explicitly setting the overall state here guarantees that the handlers attached 
+            //to the state change to ResolvedDeclarations always run, provided there is no error.
             State.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
             if (token.IsCancellationRequested || State.Status >= ParserState.Error)

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -336,9 +336,6 @@ namespace Rubberduck.Parsing.VBA
             _parserStateManager.SetStatusAndFireStateChanged(requestor, ParserState.ResolvedDeclarations, token);
             token.ThrowIfCancellationRequested();
 
-            Thread.Sleep(50); //Simplistic hack to give the VBE time to do its work in case the parsing run is requested from an event handler. 
-            token.ThrowIfCancellationRequested();
-
             _projectManager.RefreshProjects();
             token.ThrowIfCancellationRequested();
 

--- a/Rubberduck.Parsing/VBA/ReferenceResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceResolveRunner.cs
@@ -16,10 +16,12 @@ namespace Rubberduck.Parsing.VBA
         public ReferenceResolveRunner(
             RubberduckParserState state, 
             IParserStateManager parserStateManager, 
-            IModuleToModuleReferenceManager moduletToModuleReferenceManager) 
+            IModuleToModuleReferenceManager moduletToModuleReferenceManager,
+            IReferenceRemover referenceRemover) 
         :base(state, 
             parserStateManager, 
-            moduletToModuleReferenceManager)
+            moduletToModuleReferenceManager,
+            referenceRemover)
         { }
 
 

--- a/Rubberduck.Parsing/VBA/ReferenceResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceResolveRunnerBase.cs
@@ -57,6 +57,11 @@ namespace Rubberduck.Parsing.VBA
             _toResolve.UnionWith(toResolve);
             token.ThrowIfCancellationRequested();
 
+            if(!_toResolve.Any())
+            {
+                return;
+            }
+
             ExecuteCompilationPasses();
             token.ThrowIfCancellationRequested();
 

--- a/Rubberduck.Parsing/VBA/SynchronousReferenceResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/SynchronousReferenceResolveRunner.cs
@@ -13,10 +13,12 @@ namespace Rubberduck.Parsing.VBA
         public SynchronousReferenceResolveRunner(
             RubberduckParserState state,
             IParserStateManager parserStateManager,
-            IModuleToModuleReferenceManager moduletToModuleReferenceManager) 
-        :base(state, 
-            parserStateManager, 
-            moduletToModuleReferenceManager)
+            IModuleToModuleReferenceManager moduletToModuleReferenceManager,
+            IReferenceRemover referenceRemover)
+        : base(state,
+            parserStateManager,
+            moduletToModuleReferenceManager,
+            referenceRemover)
         { }
 
 

--- a/RubberduckTests/Mocks/MockParser.cs
+++ b/RubberduckTests/Mocks/MockParser.cs
@@ -75,7 +75,8 @@ namespace RubberduckTests.Mocks
             var referenceResolveRunner = new SynchronousReferenceResolveRunner(
                 state,
                 parserStateManager,
-                moduleToModuleReferenceManager);
+                moduleToModuleReferenceManager,
+                referenceRemover);
             var parsingStageService = new ParsingStageService(
                 comSynchronizer,
                 builtInDeclarationLoader,


### PR DESCRIPTION
This PR improves the cleanup in the ParseCoordinator.

1. Now, modules referencing removed modules will get reresolved no matter whether they have been modified or not.
2.  Module-to-module references get cleared correctly for removed modules.
3. The `ReferenceResolveRunner` now removes all references by the modules to resolve. This is safer than doing it in the `ParseCoordinator` because we have to cache the references to resolve for a potential cancellation. (The unresolved declarations would get loast otherwise.) 
4. The module-to-module references also get removed in the ReferenceResolveRunner` now. Again, this solves potential issues with cancelled parsing runs.

Moreover, superfluous state changes have been removed in the case that we do not parse anything. (These previously caused the inspections to run twice when no modules got parsed.)