### PR TITLE
Fix issue 3002

### DIFF
--- a/RetailCoder.VBE/API/ParserState.cs
+++ b/RetailCoder.VBE/API/ParserState.cs
@@ -70,7 +70,7 @@ namespace Rubberduck.API
             var projectManager = new ProjectManager(_state, _vbe);
             var moduleToModuleReferenceManager = new ModuleToModuleReferenceManager();
             var parserStateManager = new ParserStateManager(_state);
-            var referenceRemover = new ReferenceRemover(_state, moduleToModuleReferenceManager);
+            var referenceRemover = new ReferenceRemover(_state);
             var comSynchronizer = new COMReferenceSynchronizer(_state, parserStateManager);
             var builtInDeclarationLoader = new BuiltInDeclarationLoader(
                 _state,

--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -242,6 +242,11 @@ namespace Rubberduck.Parsing.Symbols
                     : Enumerable.Empty<Declaration>();
         }
 
+        public IReadOnlyCollection<QualifiedModuleName> AllModules()
+        {
+            return _declarations.Keys.ToList();
+        }
+
         public IEnumerable<Declaration> FindDeclarationsWithNonBaseAsType()
         {
             return _nonBaseAsType.Value;

--- a/Rubberduck.Parsing/VBA/ReferenceRemover.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceRemover.cs
@@ -11,11 +11,9 @@ namespace Rubberduck.Parsing.VBA
         private const int _maxDegreeOfReferenceRemovalParallelism = -1;
 
         public ReferenceRemover(
-            RubberduckParserState state, 
-            IModuleToModuleReferenceManager moduleToModuleReferenceManager) 
+            RubberduckParserState state) 
         :base(
-            state, 
-            moduleToModuleReferenceManager)
+            state)
         {}
 
 

--- a/Rubberduck.Parsing/VBA/ReferenceRemoverBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceRemoverBase.cs
@@ -9,23 +9,16 @@ namespace Rubberduck.Parsing.VBA
     public abstract class ReferenceRemoverBase : IReferenceRemover
     {
         private readonly RubberduckParserState _state;
-        private readonly IModuleToModuleReferenceManager _moduleToModuleReferenceManager;
 
         public ReferenceRemoverBase(
-            RubberduckParserState state,
-            IModuleToModuleReferenceManager moduleToModuleReferenceManager)
+            RubberduckParserState state)
         {
             if (state == null)
             {
                 throw new ArgumentNullException(nameof(state));
             }
-            if (moduleToModuleReferenceManager == null)
-            {
-                throw new ArgumentNullException(nameof(moduleToModuleReferenceManager));
-            }
 
             _state = state;
-            _moduleToModuleReferenceManager = moduleToModuleReferenceManager;
         }
 
 
@@ -39,8 +32,8 @@ namespace Rubberduck.Parsing.VBA
             {
                 return;
             }
-            var referencedModulesNeedingReferenceRemoval = _moduleToModuleReferenceManager.ModulesReferencedByAny(modules);
-            RemoveReferencesByFromTargetModules(modules, referencedModulesNeedingReferenceRemoval, token);
+            var modulesNeedingReferenceRemoval = _state.DeclarationFinder.AllModules();
+            RemoveReferencesByFromTargetModules(modules, modulesNeedingReferenceRemoval, token);
         }
 
         protected void RemoveReferencesByFromTargetModule(IReadOnlyCollection<QualifiedModuleName> referencingModules, QualifiedModuleName targetModule)

--- a/Rubberduck.Parsing/VBA/SynchronousReferenceRemover.cs
+++ b/Rubberduck.Parsing/VBA/SynchronousReferenceRemover.cs
@@ -10,8 +10,7 @@ namespace Rubberduck.Parsing.VBA
             RubberduckParserState state,
             IModuleToModuleReferenceManager moduleToModuleReferenceManager) 
         :base(
-            state, 
-            moduleToModuleReferenceManager)
+            state)
         { }
 
 


### PR DESCRIPTION
This removes a premature optimization in the `ReferenceRemoverBase` because of which eferences got only removed from user declarations. 

Closes #3002