### PR TITLE
Re-optimize reference removal

### DIFF
--- a/RetailCoder.VBE/API/ParserState.cs
+++ b/RetailCoder.VBE/API/ParserState.cs
@@ -70,7 +70,7 @@ namespace Rubberduck.API
             var projectManager = new ProjectManager(_state, _vbe);
             var moduleToModuleReferenceManager = new ModuleToModuleReferenceManager();
             var parserStateManager = new ParserStateManager(_state);
-            var referenceRemover = new ReferenceRemover(_state);
+            var referenceRemover = new ReferenceRemover(_state, moduleToModuleReferenceManager);
             var comSynchronizer = new COMReferenceSynchronizer(_state, parserStateManager);
             var builtInDeclarationLoader = new BuiltInDeclarationLoader(
                 _state,

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -281,7 +281,6 @@ namespace Rubberduck.Parsing.VBA
         private void PerformPreParseCleanup(IReadOnlyCollection<QualifiedModuleName> toParse, CancellationToken token)
         {
             _referenceRemover.RemoveReferencesBy(toParse, token);
-            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesFromModule(toParse);
         }
 
         private void RefreshDeclarationFinder()

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -218,7 +218,7 @@ namespace Rubberduck.Parsing.VBA
                 token.ThrowIfCancellationRequested();
 
                 //This is purely a security measure. In the success path the reference resolver removes the old references. 
-                _referenceRemover.RemoveReferencesBy(toParse, token);   
+                PerformPreParseCleanup(toParse, token);
                 token.ThrowIfCancellationRequested();
 
                 _parserStateManager.SetModuleStates(toParse, ParserState.Parsing, token);
@@ -276,6 +276,12 @@ namespace Rubberduck.Parsing.VBA
             //This is the point where the change of the overall state to Ready is triggered on the success path.
             _parserStateManager.EvaluateOverallParserState(token);
             token.ThrowIfCancellationRequested();
+        }
+
+        private void PerformPreParseCleanup(IReadOnlyCollection<QualifiedModuleName> toParse, CancellationToken token)
+        {
+            _referenceRemover.RemoveReferencesBy(toParse, token);
+            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesFromModule(toParse);
         }
 
         private void RefreshDeclarationFinder()

--- a/Rubberduck.Parsing/VBA/ReferenceRemover.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceRemover.cs
@@ -11,9 +11,11 @@ namespace Rubberduck.Parsing.VBA
         private const int _maxDegreeOfReferenceRemovalParallelism = -1;
 
         public ReferenceRemover(
-            RubberduckParserState state) 
+            RubberduckParserState state,
+            IModuleToModuleReferenceManager moduleToModuleReferenceManager) 
         :base(
-            state)
+            state,
+            moduleToModuleReferenceManager)
         {}
 
 

--- a/Rubberduck.Parsing/VBA/ReferenceRemoverBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceRemoverBase.cs
@@ -9,16 +9,23 @@ namespace Rubberduck.Parsing.VBA
     public abstract class ReferenceRemoverBase : IReferenceRemover
     {
         private readonly RubberduckParserState _state;
+        private readonly IModuleToModuleReferenceManager _moduleToModuleReferenceManager;
 
         public ReferenceRemoverBase(
-            RubberduckParserState state)
+            RubberduckParserState state,
+            IModuleToModuleReferenceManager moduleToModuleReferenceManager)
         {
             if (state == null)
             {
                 throw new ArgumentNullException(nameof(state));
             }
+            if (moduleToModuleReferenceManager == null)
+            {
+                throw new ArgumentNullException(nameof(moduleToModuleReferenceManager));
+            }
 
             _state = state;
+            _moduleToModuleReferenceManager = moduleToModuleReferenceManager;
         }
 
 
@@ -32,7 +39,7 @@ namespace Rubberduck.Parsing.VBA
             {
                 return;
             }
-            var modulesNeedingReferenceRemoval = _state.DeclarationFinder.AllModules();
+            var modulesNeedingReferenceRemoval = _moduleToModuleReferenceManager.ModulesReferencedByAny(modules);
             RemoveReferencesByFromTargetModules(modules, modulesNeedingReferenceRemoval, token);
         }
 

--- a/Rubberduck.Parsing/VBA/ReferenceResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceResolveRunner.cs
@@ -57,10 +57,12 @@ namespace Rubberduck.Parsing.VBA
                 MaxDegreeOfParallelism = _maxDegreeOfReferenceResolverParallelism
             };
 
+            var allModules = finder.AllModules();
+
             try
             {
-                Parallel.For(0, _state.ParseTrees.Count, options,
-                    (index) => AddModuleToModuleReferences(finder, _state.ParseTrees[index].Key)
+                Parallel.ForEach(allModules, options,
+                    referencedModule => AddModuleToModuleReferences(finder, referencedModule)
                 );
             }
             catch (AggregateException exception)

--- a/Rubberduck.Parsing/VBA/ReferenceResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceResolveRunnerBase.cs
@@ -92,9 +92,9 @@ namespace Rubberduck.Parsing.VBA
 
         private void PerformPreResolveCleanup(IReadOnlyCollection<QualifiedModuleName> toResolve, CancellationToken token)
         {
+            _referenceRemover.RemoveReferencesBy(toResolve, token);
             _moduleToModuleReferenceManager.ClearModuleToModuleReferencesFromModule(toResolve);
             _moduleToModuleReferenceManager.ClearModuleToModuleReferencesToModule(toResolve);
-            _referenceRemover.RemoveReferencesBy(toResolve, token);
         }
 
         private void ExecuteCompilationPasses()

--- a/Rubberduck.Parsing/VBA/SynchronousReferenceRemover.cs
+++ b/Rubberduck.Parsing/VBA/SynchronousReferenceRemover.cs
@@ -8,9 +8,10 @@ namespace Rubberduck.Parsing.VBA
     {
         public SynchronousReferenceRemover(
             RubberduckParserState state,
-            IModuleToModuleReferenceManager moduleToModuleReferenceManager) 
+            IModuleToModuleReferenceManager moduleToModuleReferenceManager)
         :base(
-            state)
+            state,
+            moduleToModuleReferenceManager)
         { }
 
 

--- a/Rubberduck.Parsing/VBA/SynchronousReferenceResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/SynchronousReferenceResolveRunner.cs
@@ -46,7 +46,7 @@ namespace Rubberduck.Parsing.VBA
         {
             try
             {
-                foreach(var module in _state.ParseTrees.Select(kvp => kvp.Key))
+                foreach(var module in finder.AllModules())
                 {
                     AddModuleToModuleReferences(finder, module);
                 }


### PR DESCRIPTION
The optimization removed in my last PR was not really premature.

This PR reintroduces the optimization. The bug fixed by removing the optimization is kept fixed by actually saving all module-to-module references, not just those to user-defined modules.

This saves about a second every parsing run in my test project. Here, the time saved does not scale with the number of modules to parse but with the total number of declarations, including those in referenced projects.  