### PR TITLE
Cleaning up Super- and Subtypes

### DIFF
--- a/RetailCoder.VBE/API/ParserState.cs
+++ b/RetailCoder.VBE/API/ParserState.cs
@@ -71,6 +71,7 @@ namespace Rubberduck.API
             var moduleToModuleReferenceManager = new ModuleToModuleReferenceManager();
             var parserStateManager = new ParserStateManager(_state);
             var referenceRemover = new ReferenceRemover(_state, moduleToModuleReferenceManager);
+            var supertypeClearer = new SupertypeClearer(_state);
             var comSynchronizer = new COMReferenceSynchronizer(_state, parserStateManager);
             var builtInDeclarationLoader = new BuiltInDeclarationLoader(
                 _state,
@@ -107,7 +108,8 @@ namespace Rubberduck.API
             var parsingCacheService = new ParsingCacheService(
                 _state,
                 moduleToModuleReferenceManager,
-                referenceRemover 
+                referenceRemover,
+                supertypeClearer
                 );
 
             _parser = new ParseCoordinator(

--- a/RetailCoder.VBE/API/ParserState.cs
+++ b/RetailCoder.VBE/API/ParserState.cs
@@ -104,14 +104,19 @@ namespace Rubberduck.API
                 declarationResolveRunner,
                 referenceResolveRunner  
                 );
+            var parsingCacheService = new ParsingCacheService(
+                _state,
+                moduleToModuleReferenceManager,
+                referenceRemover 
+                );
 
             _parser = new ParseCoordinator(
                 _state,
                 parsingStageService,
+                parsingCacheService,
                 projectManager,
-                moduleToModuleReferenceManager,
-                parserStateManager,
-                referenceRemover);
+                parserStateManager
+                );
         }
 
         /// <summary>

--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -109,6 +109,7 @@ namespace Rubberduck.Root
             Rebind<IParserStateManager>().To<ParserStateManager>().InSingletonScope();
             Rebind<IParseRunner>().To<ParseRunner>().InSingletonScope();
             Rebind<IParsingStageService>().To<ParsingStageService>().InSingletonScope();
+            Rebind<IParsingCacheService>().To<ParsingCacheService>().InSingletonScope();
             Rebind<IProjectManager>().To<ProjectManager>().InSingletonScope();
             Rebind<IReferenceRemover>().To<ReferenceRemover>().InSingletonScope();
             Rebind<IReferenceResolveRunner>().To<ReferenceResolveRunner>().InSingletonScope();

--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -106,6 +106,7 @@ namespace Rubberduck.Root
             Rebind<IBuiltInDeclarationLoader>().To<BuiltInDeclarationLoader>().InSingletonScope();
             Rebind<IDeclarationResolveRunner>().To<DeclarationResolveRunner>().InSingletonScope();
             Rebind<IModuleToModuleReferenceManager>().To<ModuleToModuleReferenceManager>().InSingletonScope();
+            Rebind<ISupertypeClearer>().To<SupertypeClearer>().InSingletonScope();
             Rebind<IParserStateManager>().To<ParserStateManager>().InSingletonScope();
             Rebind<IParseRunner>().To<ParseRunner>().InSingletonScope();
             Rebind<IParsingStageService>().To<ParsingStageService>().InSingletonScope();

--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -336,6 +336,8 @@
     <Compile Include="VBA\Attributes.cs" />
     <Compile Include="VBA\BuiltInDeclarationLoader.cs" />
     <Compile Include="PreProcessing\TokensValue.cs" />
+    <Compile Include="VBA\ParsingCacheService.cs" />
+    <Compile Include="VBA\IParsingCacheService.cs" />
     <Compile Include="VBA\SimpleVBAModuleTokenStreamProvider.cs" />
     <Compile Include="VBA\ICommonTokenStreamProvider.cs" />
     <Compile Include="VBA\ModuleToModuleReferenceManager.cs" />

--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -336,6 +336,10 @@
     <Compile Include="VBA\Attributes.cs" />
     <Compile Include="VBA\BuiltInDeclarationLoader.cs" />
     <Compile Include="PreProcessing\TokensValue.cs" />
+    <Compile Include="VBA\SupertypeClearer.cs" />
+    <Compile Include="VBA\SynchronousSupertypeClearer.cs" />
+    <Compile Include="VBA\SupertypeClearerBase.cs" />
+    <Compile Include="VBA\ISupertypeClearer.cs" />
     <Compile Include="VBA\ParsingCacheService.cs" />
     <Compile Include="VBA\IParsingCacheService.cs" />
     <Compile Include="VBA\SimpleVBAModuleTokenStreamProvider.cs" />

--- a/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
@@ -194,13 +194,15 @@ namespace Rubberduck.Parsing.Symbols
 
         public Declaration DefaultMember { get; internal set; }
 
-        public IReadOnlyList<string> SupertypeNames => _supertypeNames;
+        //This is just convenience for the resolver to split gathering the names of the supertypes and resolving them.
+        //todo: Find a cleaner solution for this.
+        public IEnumerable<string> SupertypeNames => _supertypeNames;
 
-        public IReadOnlyList<Declaration> Supertypes => _supertypes.ToList();
+        public IEnumerable<Declaration> Supertypes => _supertypes;
 
-        public IReadOnlyList<Declaration> Subtypes => _subtypes.ToList();
+        public IEnumerable<Declaration> Subtypes => _subtypes;
 
-        public void AddSupertype(string supertypeName)
+        public void AddSupertypeName(string supertypeName)
         {
             _supertypeNames.Add(supertypeName);
         }
@@ -212,7 +214,25 @@ namespace Rubberduck.Parsing.Symbols
 
         public void AddSubtype(Declaration subtype)
         {
+            InvalidateCachedIsGlobal();
             _subtypes.Add(subtype);
+        }
+
+        private void InvalidateCachedIsGlobal()
+        {
+            if (_isGlobal.HasValue)
+            {
+                InvalidateCachedIsGlobalForSupertypes();    //If it is not set, it has no influence on the state of the supertypes.
+                _isGlobal = null;
+            }
+        }
+
+        private void InvalidateCachedIsGlobalForSupertypes()
+        {
+            foreach(var supertype in Supertypes)
+            {
+                (supertype as ClassModuleDeclaration)?.InvalidateCachedIsGlobal();
+            }
         }
     }
 }

--- a/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
@@ -227,7 +227,6 @@ namespace Rubberduck.Parsing.Symbols
             {
                 (supertype as ClassModuleDeclaration)?.RemoveSubtype(this);
             }
-            _supertypeNames.Clear();
             _supertypes.Clear();
         }
 

--- a/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
@@ -209,10 +209,11 @@ namespace Rubberduck.Parsing.Symbols
 
         public void AddSupertype(Declaration supertype)
         {
+            (supertype as ClassModuleDeclaration)?.AddSubtype(this);
             _supertypes.Add(supertype);
         }
 
-        public void AddSubtype(Declaration subtype)
+        private void AddSubtype(Declaration subtype)
         {
             InvalidateCachedIsGlobal();
             _subtypes.Add(subtype);

--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -242,6 +242,11 @@ namespace Rubberduck.Parsing.Symbols
                     : Enumerable.Empty<Declaration>();
         }
 
+        public Declaration ModuleDeclaration(QualifiedModuleName module)
+        {
+            return Members(module).FirstOrDefault(member => member.DeclarationType.HasFlag(DeclarationType.Module));
+        }
+
         public IReadOnlyCollection<QualifiedModuleName> AllModules()
         {
             return _declarations.Keys.ToList();

--- a/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
@@ -390,7 +390,7 @@ namespace Rubberduck.Parsing.Symbols
         public override void EnterImplementsStmt(VBAParser.ImplementsStmtContext context)
         {
             // The expression will be later resolved to the actual declaration. Have to split the work up because we have to gather/create all declarations first.
-            ((ClassModuleDeclaration)_moduleDeclaration).AddSupertype(context.expression().GetText());
+            ((ClassModuleDeclaration)_moduleDeclaration).AddSupertypeName(context.expression().GetText());
         }
 
         public override void EnterOptionBaseStmt(VBAParser.OptionBaseStmtContext context)

--- a/Rubberduck.Parsing/Symbols/TypeHierarchyPass.cs
+++ b/Rubberduck.Parsing/Symbols/TypeHierarchyPass.cs
@@ -52,7 +52,6 @@ namespace Rubberduck.Parsing.Symbols
                 if (implementedInterface.Classification != ExpressionClassification.ResolutionFailed)
                 {
                     classModule.AddSupertype(implementedInterface.ReferencedDeclaration);
-                    ((ClassModuleDeclaration)implementedInterface.ReferencedDeclaration).AddSubtype(classModule);
                 }
                 else
                 {

--- a/Rubberduck.Parsing/VBA/IParsingCacheService.cs
+++ b/Rubberduck.Parsing/VBA/IParsingCacheService.cs
@@ -1,6 +1,6 @@
 ﻿namespace Rubberduck.Parsing.VBA
 {
-    public interface IParsingCacheService : IDeclarationFinderProvider, IModuleToModuleReferenceManager, IReferenceRemover
+    public interface IParsingCacheService : IDeclarationFinderProvider, IModuleToModuleReferenceManager, IReferenceRemover, ISupertypeClearer
     {
     }
 }

--- a/Rubberduck.Parsing/VBA/IParsingCacheService.cs
+++ b/Rubberduck.Parsing/VBA/IParsingCacheService.cs
@@ -1,0 +1,6 @@
+﻿namespace Rubberduck.Parsing.VBA
+{
+    public interface IParsingCacheService : IDeclarationFinderProvider, IModuleToModuleReferenceManager, IReferenceRemover
+    {
+    }
+}

--- a/Rubberduck.Parsing/VBA/ISupertypeClearer.cs
+++ b/Rubberduck.Parsing/VBA/ISupertypeClearer.cs
@@ -1,0 +1,11 @@
+﻿using Rubberduck.VBEditor;
+using System.Collections.Generic;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public interface ISupertypeClearer
+    {
+        void ClearSupertypes(QualifiedModuleName module);
+        void ClearSupertypes(IEnumerable<QualifiedModuleName> modules);
+    }
+}

--- a/Rubberduck.Parsing/VBA/ParsingCacheService.cs
+++ b/Rubberduck.Parsing/VBA/ParsingCacheService.cs
@@ -11,11 +11,13 @@ namespace Rubberduck.Parsing.VBA
         private readonly IDeclarationFinderProvider _declarationFinderProvider;
         private readonly IModuleToModuleReferenceManager _moduleToModuleReferenceManager;
         private readonly IReferenceRemover _referenceRemover;
+        private readonly ISupertypeClearer _supertypeClearer;
 
         public ParsingCacheService(
             IDeclarationFinderProvider declarationFinderProvider,
             IModuleToModuleReferenceManager moduleToModuleReferenceManager,
-            IReferenceRemover referenceRemover)
+            IReferenceRemover referenceRemover,
+            ISupertypeClearer supertypeClearer)
         {
             if(declarationFinderProvider == null)
             {
@@ -29,9 +31,14 @@ namespace Rubberduck.Parsing.VBA
             {
                 throw new ArgumentNullException(nameof(referenceRemover));
             }
+            if (supertypeClearer == null)
+            {
+                throw new ArgumentNullException(nameof(supertypeClearer));
+            }
             _declarationFinderProvider = declarationFinderProvider;
             _moduleToModuleReferenceManager = moduleToModuleReferenceManager;
             _referenceRemover = referenceRemover;
+            _supertypeClearer = supertypeClearer;
         }
 
         public DeclarationFinder DeclarationFinder => _declarationFinderProvider.DeclarationFinder;
@@ -59,6 +66,16 @@ namespace Rubberduck.Parsing.VBA
         public void ClearModuleToModuleReferencesToModule(QualifiedModuleName referencedModule)
         {
             _moduleToModuleReferenceManager.ClearModuleToModuleReferencesToModule(referencedModule);
+        }
+
+        public void ClearSupertypes(IEnumerable<QualifiedModuleName> modules)
+        {
+            _supertypeClearer.ClearSupertypes(modules);
+        }
+
+        public void ClearSupertypes(QualifiedModuleName module)
+        {
+            _supertypeClearer.ClearSupertypes(module);
         }
 
         public IReadOnlyCollection<QualifiedModuleName> ModulesReferencedBy(QualifiedModuleName referencingModule)

--- a/Rubberduck.Parsing/VBA/ParsingCacheService.cs
+++ b/Rubberduck.Parsing/VBA/ParsingCacheService.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public class ParsingCacheService : IParsingCacheService
+    {
+        private readonly IDeclarationFinderProvider _declarationFinderProvider;
+        private readonly IModuleToModuleReferenceManager _moduleToModuleReferenceManager;
+        private readonly IReferenceRemover _referenceRemover;
+
+        public ParsingCacheService(
+            IDeclarationFinderProvider declarationFinderProvider,
+            IModuleToModuleReferenceManager moduleToModuleReferenceManager,
+            IReferenceRemover referenceRemover)
+        {
+            if(declarationFinderProvider == null)
+            {
+                throw new ArgumentNullException(nameof(declarationFinderProvider));
+            }
+            if (moduleToModuleReferenceManager == null)
+            {
+                throw new ArgumentNullException(nameof(moduleToModuleReferenceManager));
+            }
+            if (referenceRemover == null)
+            {
+                throw new ArgumentNullException(nameof(referenceRemover));
+            }
+            _declarationFinderProvider = declarationFinderProvider;
+            _moduleToModuleReferenceManager = moduleToModuleReferenceManager;
+            _referenceRemover = referenceRemover;
+        }
+
+        public DeclarationFinder DeclarationFinder => _declarationFinderProvider.DeclarationFinder;
+
+        public void AddModuleToModuleReference(QualifiedModuleName referencingModule, QualifiedModuleName referencedModule)
+        {
+            _moduleToModuleReferenceManager.AddModuleToModuleReference(referencingModule, referencedModule);
+        }
+
+        public void ClearModuleToModuleReferencesFromModule(IEnumerable<QualifiedModuleName> referencingModules)
+        {
+            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesFromModule(referencingModules);
+        }
+
+        public void ClearModuleToModuleReferencesFromModule(QualifiedModuleName referencingModule)
+        {
+            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesFromModule(referencingModule);
+        }
+
+        public void ClearModuleToModuleReferencesToModule(IEnumerable<QualifiedModuleName> referencedModules)
+        {
+            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesToModule(referencedModules);
+        }
+
+        public void ClearModuleToModuleReferencesToModule(QualifiedModuleName referencedModule)
+        {
+            _moduleToModuleReferenceManager.ClearModuleToModuleReferencesToModule(referencedModule);
+        }
+
+        public IReadOnlyCollection<QualifiedModuleName> ModulesReferencedBy(QualifiedModuleName referencingModule)
+        {
+            return _moduleToModuleReferenceManager.ModulesReferencedBy(referencingModule);
+        }
+
+        public IReadOnlyCollection<QualifiedModuleName> ModulesReferencedByAny(IEnumerable<QualifiedModuleName> referencingModules)
+        {
+            return _moduleToModuleReferenceManager.ModulesReferencedByAny(referencingModules);
+        }
+
+        public IReadOnlyCollection<QualifiedModuleName> ModulesReferencing(QualifiedModuleName referencedModule)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IReadOnlyCollection<QualifiedModuleName> ModulesReferencingAny(IEnumerable<QualifiedModuleName> referencedModules)
+        {
+            return _moduleToModuleReferenceManager.ModulesReferencingAny(referencedModules);
+        }
+
+        public void RefreshDeclarationFinder()
+        {
+            _declarationFinderProvider.RefreshDeclarationFinder();
+        }
+
+        public void RemoveModuleToModuleReference(QualifiedModuleName referencedModule, QualifiedModuleName referencingModule)
+        {
+            _moduleToModuleReferenceManager.RemoveModuleToModuleReference(referencedModule, referencingModule);
+        }
+
+        public void RemoveReferencesBy(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token)
+        {
+            _referenceRemover.RemoveReferencesBy(modules, token);
+        }
+
+        public void RemoveReferencesBy(QualifiedModuleName module, CancellationToken token)
+        {
+            _referenceRemover.RemoveReferencesBy(module, token);
+        }
+
+        public void RemoveReferencesTo(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token)
+        {
+            _referenceRemover.RemoveReferencesTo(modules, token);
+        }
+
+        public void RemoveReferencesTo(QualifiedModuleName module, CancellationToken token)
+        {
+            _referenceRemover.RemoveReferencesTo(module, token);
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/SupertypeClearer.cs
+++ b/Rubberduck.Parsing/VBA/SupertypeClearer.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public class SupertypeClearer : SupertypeClearerBase
+    {
+        private const int _maxDegreeOfSupertypeClearingParallelism = -1;
+
+        public SupertypeClearer(IDeclarationFinderProvider declarationFinderProvider) 
+            :base(declarationFinderProvider)
+        {}
+
+        public override void ClearSupertypes(IEnumerable<QualifiedModuleName> modules)
+        {
+            var options = new ParallelOptions();
+            options.MaxDegreeOfParallelism = _maxDegreeOfSupertypeClearingParallelism;
+
+            Parallel.ForEach(
+                   modules, 
+                   options,
+                   module => ClearSupertypes(module)
+               );
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/SupertypeClearerBase.cs
+++ b/Rubberduck.Parsing/VBA/SupertypeClearerBase.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using Rubberduck.VBEditor;
+using Rubberduck.Parsing.Symbols;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public abstract class SupertypeClearerBase : ISupertypeClearer
+    {
+        private readonly IDeclarationFinderProvider _declarationFinderProvider;
+
+        public SupertypeClearerBase(IDeclarationFinderProvider declarationFinderProvider)
+        {
+            if(declarationFinderProvider == null)
+            {
+                throw new ArgumentNullException(nameof(declarationFinderProvider));
+            }
+            _declarationFinderProvider = declarationFinderProvider;
+        }
+
+        public abstract void ClearSupertypes(IEnumerable<QualifiedModuleName> modules);
+
+        public void ClearSupertypes(QualifiedModuleName module)
+        {
+            var finder = _declarationFinderProvider.DeclarationFinder;
+            var moduleDeclaration = finder.ModuleDeclaration(module);
+            (moduleDeclaration as ClassModuleDeclaration)?.ClearSupertypes();   
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/SynchronousSupertypeClearer.cs
+++ b/Rubberduck.Parsing/VBA/SynchronousSupertypeClearer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public class SynchronousSupertypeClearer : SupertypeClearerBase
+    {
+        public SynchronousSupertypeClearer(IDeclarationFinderProvider declarationFinderProvider) 
+            :base(declarationFinderProvider)
+        {}
+
+        public override void ClearSupertypes(IEnumerable<QualifiedModuleName> modules)
+        {
+            foreach(var module in modules)
+            {
+                ClearSupertypes(module);
+            }
+        }
+    }
+}

--- a/RubberduckTests/Mocks/MockParser.cs
+++ b/RubberduckTests/Mocks/MockParser.cs
@@ -48,6 +48,7 @@ namespace RubberduckTests.Mocks
             Func<IVBAPreprocessor> preprocessorFactory = () => new VBAPreprocessor(double.Parse(vbe.Version, CultureInfo.InvariantCulture));
             var projectManager = new SynchronousProjectManager(state, vbe);
             var moduleToModuleReferenceManager = new ModuleToModuleReferenceManager();
+            var supertypeClearer = new SynchronousSupertypeClearer(state); 
             var parserStateManager = new SynchronousParserStateManager(state);
             var referenceRemover = new SynchronousReferenceRemover(state, moduleToModuleReferenceManager);
             var comSynchronizer = new SynchronousCOMReferenceSynchronizer(
@@ -87,7 +88,8 @@ namespace RubberduckTests.Mocks
             var parsingCacheService = new ParsingCacheService(
                 state,
                 moduleToModuleReferenceManager,
-                referenceRemover 
+                referenceRemover,
+                supertypeClearer
                 );
 
             return new ParseCoordinator(

--- a/RubberduckTests/Mocks/MockParser.cs
+++ b/RubberduckTests/Mocks/MockParser.cs
@@ -84,14 +84,18 @@ namespace RubberduckTests.Mocks
                 declarationResolveRunner,
                 referenceResolveRunner
                 );
+            var parsingCacheService = new ParsingCacheService(
+                state,
+                moduleToModuleReferenceManager,
+                referenceRemover 
+                );
 
-            return new ParseCoordinator( 
+            return new ParseCoordinator(
                 state,
                 parsingStageService,
+                parsingCacheService,
                 projectManager,
-                moduleToModuleReferenceManager,
                 parserStateManager,
-                referenceRemover,
                 true);
         }
 

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -289,6 +289,24 @@ namespace RubberduckTests.Symbols
             Assert.IsFalse(classModule.IsGlobalClassModule);
         }
 
+        [TestCategory("Resolver")]
+        [TestMethod]
+        public void ClassModulesBecomeAGlobalClassIfASubtypeBelowInTheHiearchyIsAddedThatIsAGlobalClassAfterIsAGlobalClassHasAlreadyBeenCalled()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddGlobalClassAttribute();
+            var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", true, classAttributes);
+            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
+            subtype.AddSubtype(subsubtype);
+            subsubtype.AddSupertype(subtype);
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
+            var dummy = classModule.IsGlobalClassModule;
+            classModule.AddSubtype(subtype);
+            subtype.AddSupertype(classModule);
+
+            Assert.IsTrue(classModule.IsGlobalClassModule);
+        }
 
         [TestCategory("Resolver")]
         [TestMethod]
@@ -305,6 +323,26 @@ namespace RubberduckTests.Symbols
             subtype.AddSubtype(subsubtype);
 
             Assert.IsFalse(classModule.IsGlobalClassModule);
+        }
+
+
+        [TestCategory("Resolver")]
+        [TestMethod]
+        public void ClassModulesBecomeAGlobalClassIfBelowInTheHierarchyASubtypeIsAddedThatIsAGlobalClassAfterIsAGlobalClassHasAlreadyBeenCalled()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classAttributes = new Attributes();
+            classAttributes.AddGlobalClassAttribute();
+            var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", true, classAttributes);
+            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
+            classModule.AddSubtype(subtype);
+            subtype.AddSupertype(classModule);
+            var dummy = classModule.IsGlobalClassModule;
+            subtype.AddSubtype(subsubtype);
+            subsubtype.AddSupertype(subtype);
+
+            Assert.IsTrue(classModule.IsGlobalClassModule);
         }
 
 

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -99,17 +99,20 @@ namespace RubberduckTests.Symbols
             Assert.IsFalse(classModule.Supertypes.Any());
         }
 
+        //The reasoning behind this is that the names of the supertypes only depend on the module itself.
+        //So, the module itself has to be changed to change them. That in turn would mean a reparse and discarding the module declaration. 
         [TestCategory("Resolver")]
         [TestMethod]
-        public void ClearSupertypeRemovesAllSupertypesNames()
+        public void ClearSupertypeDoesNotRemoveSupertypesNames()
         {
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
             classModule.AddSupertypeName("testSupertype1");
             classModule.AddSupertypeName("testSupertype2");
             classModule.ClearSupertypes();
+            var supertypeNameCount = classModule.SupertypeNames.Count();
 
-            Assert.IsFalse(classModule.SupertypeNames.Any());
+            Assert.AreEqual(2, supertypeNameCount);
         }
 
         [TestCategory("Resolver")]

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -74,7 +74,7 @@ namespace RubberduckTests.Symbols
 
         [TestCategory("Resolver")]
         [TestMethod]
-        public void AddSupertypeForDeclarationsAddsClassToSupertypes()
+        public void AddSupertypeAddsClassToSupertypes()
         {
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
@@ -84,6 +84,71 @@ namespace RubberduckTests.Symbols
             Assert.IsTrue(classModule.Supertypes.First().Equals(supertype));
         }
 
+        [TestCategory("Resolver")]
+        [TestMethod]
+        public void ClearSupertypeRemovesAllSupertypes()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
+            var supertype1 = GetTestClassModule(projectDeclaration, "testSupertype1", true, null);
+            var supertype2 = GetTestClassModule(projectDeclaration, "testSupertype2", true, null);
+            classModule.AddSupertype(supertype1);
+            classModule.AddSupertype(supertype2);
+            classModule.ClearSupertypes();
+
+            Assert.IsFalse(classModule.Supertypes.Any());
+        }
+
+        [TestCategory("Resolver")]
+        [TestMethod]
+        public void ClearSupertypeRemovesAllSupertypesNames()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
+            classModule.AddSupertypeName("testSupertype1");
+            classModule.AddSupertypeName("testSupertype2");
+            classModule.ClearSupertypes();
+
+            Assert.IsFalse(classModule.SupertypeNames.Any());
+        }
+
+        [TestCategory("Resolver")]
+        [TestMethod]
+        public void ClearSupertypeRemovesAllSupertypesRemovesTheClassFromTheSubtypesOfTheSupertypes()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
+            var supertype1 = GetTestClassModule(projectDeclaration, "testSupertype1", true, null);
+            var supertype2 = GetTestClassModule(projectDeclaration, "testSupertype2", true, null);
+            var otherClass = GetTestClassModule(projectDeclaration, "otherTestClass", true, null);
+            classModule.AddSupertype(supertype1);
+            classModule.AddSupertype(supertype2);
+            otherClass.AddSupertype(supertype1);
+            otherClass.AddSupertype(supertype2);
+            classModule.ClearSupertypes();
+
+            Assert.IsFalse(supertype1.Subtypes.Any(subtype => subtype.Equals(classModule)));
+            Assert.IsFalse(supertype2.Subtypes.Any(subtype => subtype.Equals(classModule)));
+        }
+
+        [TestCategory("Resolver")]
+        [TestMethod]
+        public void ClearSupertypeRemovesAllSupertypesDoesNotRemoveOtherSubtypesFromTheSupertypes()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
+            var supertype1 = GetTestClassModule(projectDeclaration, "testSupertype1", true, null);
+            var supertype2 = GetTestClassModule(projectDeclaration, "testSupertype2", true, null);
+            var otherClass = GetTestClassModule(projectDeclaration, "otherTestClass", true, null);
+            classModule.AddSupertype(supertype1);
+            classModule.AddSupertype(supertype2);
+            otherClass.AddSupertype(supertype1);
+            otherClass.AddSupertype(supertype2);
+            classModule.ClearSupertypes();
+
+            Assert.IsTrue(supertype1.Subtypes.Any(subtype => subtype.Equals(otherClass)));
+            Assert.IsTrue(supertype2.Subtypes.Any(subtype => subtype.Equals(otherClass)));
+        }
 
         [TestCategory("Resolver")]
         [TestMethod]
@@ -98,7 +163,7 @@ namespace RubberduckTests.Symbols
 
         [TestCategory("Resolver")]
         [TestMethod]
-        public void AddSupertypeForStringsAddsTypenameToSupertypeNames()
+        public void AddSupertypeNameAddsTypenameToSupertypeNames()
         {
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
@@ -111,7 +176,7 @@ namespace RubberduckTests.Symbols
 
         [TestCategory("Resolver")]
         [TestMethod]
-        public void AddSupertypeForDeclarationsHasNoEffectOnSupertypeNames()
+        public void AddSupertypeHasNoEffectOnSupertypeNames()
         {
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
@@ -124,7 +189,7 @@ namespace RubberduckTests.Symbols
 
         [TestCategory("Resolver")]
         [TestMethod]
-        public void AddSupertypeForStringsHasNoEffectsOnSupertypes()
+        public void AddSupertypeNameHasNoEffectsOnSupertypes()
         {
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -103,7 +103,7 @@ namespace RubberduckTests.Symbols
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
             var supertypeName = "testSupertypeName";
-            classModule.AddSupertype(supertypeName);
+            classModule.AddSupertypeName(supertypeName);
 
             Assert.IsTrue(classModule.SupertypeNames.First().Equals(supertypeName));
         }
@@ -129,7 +129,7 @@ namespace RubberduckTests.Symbols
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
             var supertypeName = "testSupertypeName";
-            classModule.AddSupertype(supertypeName);
+            classModule.AddSupertypeName(supertypeName);
 
             Assert.IsFalse(classModule.Supertypes.Any());
         }
@@ -274,23 +274,6 @@ namespace RubberduckTests.Symbols
 
         [TestCategory("Resolver")]
         [TestMethod]
-        public void ClassModulesDoNotBecomeAGlobalClassIfASubtypeBelowInTheHiearchyIsAddedThatIsAGlobalClassAfterIsAGlobalClassHasAlreadyBeenCalled()
-        {
-            var projectDeclaration = GetTestProject("testProject");
-            var classAttributes = new Attributes();
-            classAttributes.AddGlobalClassAttribute();
-            var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", true, classAttributes);
-            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
-            subtype.AddSubtype(subsubtype);
-            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
-            var dummy = classModule.IsGlobalClassModule;
-            classModule.AddSubtype(subtype);
-
-            Assert.IsFalse(classModule.IsGlobalClassModule);
-        }
-
-        [TestCategory("Resolver")]
-        [TestMethod]
         public void ClassModulesBecomeAGlobalClassIfASubtypeBelowInTheHiearchyIsAddedThatIsAGlobalClassAfterIsAGlobalClassHasAlreadyBeenCalled()
         {
             var projectDeclaration = GetTestProject("testProject");
@@ -306,23 +289,6 @@ namespace RubberduckTests.Symbols
             subtype.AddSupertype(classModule);
 
             Assert.IsTrue(classModule.IsGlobalClassModule);
-        }
-
-        [TestCategory("Resolver")]
-        [TestMethod]
-        public void ClassModulesDoNotBecomeAGlobalClassIfBelowInTheHierarchyASubtypeIsAddedThatIsAGlobalClassAfterIsAGlobalClassHasAlreadyBeenCalled()
-        {
-            var projectDeclaration = GetTestProject("testProject");
-            var classAttributes = new Attributes();
-            classAttributes.AddGlobalClassAttribute();
-            var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", true, classAttributes);
-            var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
-            var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
-            classModule.AddSubtype(subtype);
-            var dummy = classModule.IsGlobalClassModule;
-            subtype.AddSubtype(subsubtype);
-
-            Assert.IsFalse(classModule.IsGlobalClassModule);
         }
 
 

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -50,12 +50,12 @@ namespace RubberduckTests.Symbols
 
         [TestCategory("Resolver")]
         [TestMethod]
-        public void AddSubtypeAddsClassToSubtypes()
+        public void AddSupertypeAddsClassToSubtypesOfSupertype()
         {
             var projectDeclaration = GetTestProject("testProject");
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
             var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
-            classModule.AddSubtype(subtype);
+            subtype.AddSupertype(classModule);
 
             Assert.IsTrue(classModule.Subtypes.First().Equals(subtype));
         }
@@ -264,9 +264,9 @@ namespace RubberduckTests.Symbols
             classAttributes.AddGlobalClassAttribute();
             var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", true, classAttributes);
             var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
-            subtype.AddSubtype(subsubtype);
+            subsubtype.AddSupertype(subtype);
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
-            classModule.AddSubtype(subtype);
+            subtype.AddSupertype(classModule);
 
             Assert.IsTrue(classModule.IsGlobalClassModule);
         }
@@ -281,11 +281,9 @@ namespace RubberduckTests.Symbols
             classAttributes.AddGlobalClassAttribute();
             var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", true, classAttributes);
             var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
-            subtype.AddSubtype(subsubtype);
             subsubtype.AddSupertype(subtype);
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
             var dummy = classModule.IsGlobalClassModule;
-            classModule.AddSubtype(subtype);
             subtype.AddSupertype(classModule);
 
             Assert.IsTrue(classModule.IsGlobalClassModule);
@@ -302,10 +300,8 @@ namespace RubberduckTests.Symbols
             var subsubtype = GetTestClassModule(projectDeclaration, "testSubSubtype", true, classAttributes);
             var subtype = GetTestClassModule(projectDeclaration, "testSubtype", true, null);
             var classModule = GetTestClassModule(projectDeclaration, "testClass", true, null);
-            classModule.AddSubtype(subtype);
             subtype.AddSupertype(classModule);
             var dummy = classModule.IsGlobalClassModule;
-            subtype.AddSubtype(subsubtype);
             subsubtype.AddSupertype(subtype);
 
             Assert.IsTrue(classModule.IsGlobalClassModule);


### PR DESCRIPTION
This PR introduces a mechanism to clean up the super- and subtypes for modules that do not get reparsed themselves but implement one that does or are implemented by one that does.
Previously, the modules were left with stale super- and subtypes, respectively.

This fixes issue #2987.