### PR TITLE
Restricting compilation passes

### DIFF
--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -255,7 +255,6 @@ namespace Rubberduck.Parsing.Symbols
         public IEnumerable<Declaration> FindDeclarationsWithNonBaseAsType()
         {
             return _nonBaseAsType.Value;
-
         }
  
         public IEnumerable<Declaration> FindEventHandlers()

--- a/Rubberduck.Parsing/Symbols/ICompilationPass.cs
+++ b/Rubberduck.Parsing/Symbols/ICompilationPass.cs
@@ -1,7 +1,10 @@
-﻿namespace Rubberduck.Parsing.Symbols
+﻿using Rubberduck.VBEditor;
+using System.Collections.Generic;
+
+namespace Rubberduck.Parsing.Symbols
 {
     public interface ICompilationPass
     {
-        void Execute();
+        void Execute(IReadOnlyCollection<QualifiedModuleName> modules);
     }
 }

--- a/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
@@ -71,6 +71,11 @@ namespace Rubberduck.Parsing.Symbols
             _projectReferences.Add(new ProjectReference(referencedProjectId, priority));
         }
 
+        public void ClearProjectReferences()
+        {
+            _projectReferences.Clear();
+        }
+
         private string _displayName;
         /// <summary>
         /// WARNING: This property has side effects. It changes the ActiveVBProject, which causes a flicker in the VBE.

--- a/Rubberduck.Parsing/Symbols/ProjectReferencePass.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectReferencePass.cs
@@ -1,5 +1,3 @@
-using NLog;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Rubberduck.Parsing.Symbols
@@ -7,7 +5,6 @@ namespace Rubberduck.Parsing.Symbols
     public sealed class ProjectReferencePass : ICompilationPass
     {
         private readonly DeclarationFinder _declarationFinder;
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         public ProjectReferencePass(DeclarationFinder declarationFinder)
         {
@@ -16,19 +13,18 @@ namespace Rubberduck.Parsing.Symbols
 
         public void Execute()
         {
-            var stopwatch = Stopwatch.StartNew();
-            var projects = _declarationFinder.Projects.ToList();
-            var allReferences = projects.Where(p => p.IsUserDefined).SelectMany(p => ((ProjectDeclaration)p).ProjectReferences).ToList();
+            var projects = _declarationFinder.Projects.Cast<ProjectDeclaration>().ToList();
+            var allReferences = projects.Where(p => p.IsUserDefined).SelectMany(p => p.ProjectReferences).ToList();
             var builtInProjects = projects.Where(p => !p.IsUserDefined).ToList();
             // Give each built-in project access to all other projects so that e.g. CurrentDb in Access has access to the Database class defined in a different project.
             foreach (var builtInProject in builtInProjects)
             {
+                builtInProject.ClearProjectReferences();    //Built-in projects have no project references of their own.
                 foreach (var reference in allReferences)
                 {
-                    ((ProjectDeclaration)builtInProject).AddProjectReference(reference.ReferencedProjectId, reference.Priority);
+                    builtInProject.AddProjectReference(reference.ReferencedProjectId, reference.Priority);
                 }
             }
-            stopwatch.Stop();
         }
     }
 }

--- a/Rubberduck.Parsing/Symbols/ProjectReferencePass.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectReferencePass.cs
@@ -1,3 +1,5 @@
+using Rubberduck.VBEditor;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Rubberduck.Parsing.Symbols
@@ -11,7 +13,7 @@ namespace Rubberduck.Parsing.Symbols
             _declarationFinder = declarationFinder;
         }
 
-        public void Execute()
+        public void Execute(IReadOnlyCollection<QualifiedModuleName> modules)
         {
             var projects = _declarationFinder.Projects.Cast<ProjectDeclaration>().ToList();
             var allReferences = projects.Where(p => p.IsUserDefined).SelectMany(p => p.ProjectReferences).ToList();

--- a/Rubberduck.Parsing/Symbols/TypeAnnotationPass.cs
+++ b/Rubberduck.Parsing/Symbols/TypeAnnotationPass.cs
@@ -2,6 +2,8 @@ using NLog;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Binding;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
@@ -29,7 +31,7 @@ namespace Rubberduck.Parsing.Symbols
             _expressionParser = expressionParser;
         }
 
-        public void Execute()
+        public void Execute(IReadOnlyCollection<QualifiedModuleName> modules)
         {
             var stopwatch = Stopwatch.StartNew();
             foreach (var declaration in _declarationFinder.FindDeclarationsWithNonBaseAsType())

--- a/Rubberduck.Parsing/Symbols/TypeAnnotationPass.cs
+++ b/Rubberduck.Parsing/Symbols/TypeAnnotationPass.cs
@@ -33,12 +33,14 @@ namespace Rubberduck.Parsing.Symbols
 
         public void Execute(IReadOnlyCollection<QualifiedModuleName> modules)
         {
-            var stopwatch = Stopwatch.StartNew();
-            foreach (var declaration in _declarationFinder.FindDeclarationsWithNonBaseAsType())
+            var toDetermineAsTypeDeclaration = _declarationFinder
+                                                .FindDeclarationsWithNonBaseAsType()
+                                                .Where(decl => decl.AsTypeDeclaration == null 
+                                                        || modules.Contains(decl.QualifiedName.QualifiedModuleName));
+            foreach (var declaration in toDetermineAsTypeDeclaration)
             {
                 AnnotateType(declaration);
             }
-            stopwatch.Stop();
         }
 
         private void AnnotateType(Declaration declaration)

--- a/Rubberduck.Parsing/Symbols/TypeHierarchyPass.cs
+++ b/Rubberduck.Parsing/Symbols/TypeHierarchyPass.cs
@@ -2,7 +2,9 @@ using NLog;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Binding;
 using Rubberduck.Parsing.VBA;
-using System.Diagnostics;
+using Rubberduck.VBEditor;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -28,14 +30,15 @@ namespace Rubberduck.Parsing.Symbols
             _expressionParser = expressionParser;
         }
 
-        public void Execute()
+        public void Execute(IReadOnlyCollection<QualifiedModuleName> modules)
         {
-            var stopwatch = Stopwatch.StartNew();
-            foreach (var declaration in _declarationFinder.Classes)
+            var toRelsolveSupertypesFor = _declarationFinder.
+                                            UserDeclarations(DeclarationType.ClassModule).      //Built-in classes get their supertypes added directly.
+                                            Where(decl => modules.Contains(decl.QualifiedName.QualifiedModuleName));
+            foreach (var declaration in toRelsolveSupertypesFor)
             {
                 AddImplementedInterface(declaration);
             }
-            stopwatch.Stop();
         }
 
         private void AddImplementedInterface(Declaration potentialClassModule)

--- a/Rubberduck.Parsing/Symbols/TypeHierarchyPass.cs
+++ b/Rubberduck.Parsing/Symbols/TypeHierarchyPass.cs
@@ -32,9 +32,9 @@ namespace Rubberduck.Parsing.Symbols
 
         public void Execute(IReadOnlyCollection<QualifiedModuleName> modules)
         {
-            var toRelsolveSupertypesFor = _declarationFinder.
-                                            UserDeclarations(DeclarationType.ClassModule).      //Built-in classes get their supertypes added directly.
-                                            Where(decl => modules.Contains(decl.QualifiedName.QualifiedModuleName));
+            var toRelsolveSupertypesFor = _declarationFinder
+                                            .UserDeclarations(DeclarationType.ClassModule)      //Built-in classes get their supertypes added directly.
+                                            .Where(decl => modules.Contains(decl.QualifiedName.QualifiedModuleName));
             foreach (var declaration in toRelsolveSupertypesFor)
             {
                 AddImplementedInterface(declaration);

--- a/Rubberduck.Parsing/VBA/BuiltInDeclarationLoader.cs
+++ b/Rubberduck.Parsing/VBA/BuiltInDeclarationLoader.cs
@@ -44,7 +44,7 @@ namespace Rubberduck.Parsing.VBA
                     if (customDeclarations.Any())
                     {
                         LastLoadOfBuiltInDeclarationsLoadedDeclarations = true;
-                        foreach (var declaration in customDeclarationLoader.Load())
+                        foreach (var declaration in customDeclarations)
                         {
                             _state.AddDeclaration(declaration);
                         }

--- a/Rubberduck.Parsing/VBA/ICOMReferenceSynchronizer.cs
+++ b/Rubberduck.Parsing/VBA/ICOMReferenceSynchronizer.cs
@@ -1,4 +1,5 @@
-﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+﻿using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -7,7 +8,7 @@ namespace Rubberduck.Parsing.VBA
     public interface ICOMReferenceSynchronizer
     {
         bool LastSyncOfCOMReferencesLoadedReferences { get; }
-        bool LastSyncOfCOMReferencesUnloadedReferences { get; }
+        IEnumerable<QualifiedModuleName> COMReferencesUnloadedUnloadedInLastSync { get; }
 
         void SyncComReferences(IReadOnlyList<IVBProject> projects, CancellationToken token);
     }

--- a/Rubberduck.Parsing/VBA/ParsingStageService.cs
+++ b/Rubberduck.Parsing/VBA/ParsingStageService.cs
@@ -66,11 +66,11 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        public bool LastSyncOfCOMReferencesUnloadedReferences
+        public IEnumerable<QualifiedModuleName> COMReferencesUnloadedUnloadedInLastSync
         {
             get
             {
-                return _comSynchronizer.LastSyncOfCOMReferencesUnloadedReferences;
+                return _comSynchronizer.COMReferencesUnloadedUnloadedInLastSync;
             }
         }
 

--- a/Rubberduck.Parsing/VBA/ReferenceResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceResolveRunnerBase.cs
@@ -72,7 +72,7 @@ namespace Rubberduck.Parsing.VBA
             PerformPreResolveCleanup(_toResolve.AsReadOnly(), token);
             token.ThrowIfCancellationRequested();
 
-            ExecuteCompilationPasses();
+            ExecuteCompilationPasses(_toResolve.AsReadOnly());
             token.ThrowIfCancellationRequested();
 
             var parseTreesToResolve = _state.ParseTrees.Where(kvp => _toResolve.Contains(kvp.Key)).ToList();
@@ -97,7 +97,7 @@ namespace Rubberduck.Parsing.VBA
             _moduleToModuleReferenceManager.ClearModuleToModuleReferencesToModule(toResolve);
         }
 
-        private void ExecuteCompilationPasses()
+        private void ExecuteCompilationPasses(IReadOnlyCollection<QualifiedModuleName> modules)
         {
             var passes = new List<ICompilationPass>
                 {
@@ -106,7 +106,7 @@ namespace Rubberduck.Parsing.VBA
                     new TypeHierarchyPass(_state.DeclarationFinder, new VBAExpressionParser()),
                     new TypeAnnotationPass(_state.DeclarationFinder, new VBAExpressionParser())
                 };
-            passes.ForEach(p => p.Execute());
+            passes.ForEach(p => p.Execute(modules));
         }
 
         protected void ResolveReferences(DeclarationFinder finder, QualifiedModuleName module, IParseTree tree, CancellationToken token)

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -17,6 +17,7 @@ using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.SafeComWrappers.VBA;
+using System.Linq;
 
 // ReSharper disable LoopCanBeConvertedToQuery
 
@@ -1018,6 +1019,7 @@ namespace Rubberduck.Parsing.VBA
         {
             var projectName = reference.Name;
             var key = new QualifiedModuleName(projectName, reference.FullPath, projectName);
+            ClearAsTypeDeclarationPointingToReference(key);
             ModuleState moduleState;
             if (_moduleStates.TryRemove(key, out moduleState))
             {
@@ -1025,11 +1027,23 @@ namespace Rubberduck.Parsing.VBA
                 {
                     moduleState.Dispose();
                 }
-
+            }
+            else
+            {             
                 Logger.Warn("Could not remove declarations for removed reference '{0}' ({1}).", reference.Name, QualifiedModuleName.GetProjectId(reference));
             }
         }
-
+        
+        private void ClearAsTypeDeclarationPointingToReference(QualifiedModuleName referencedProject)
+        {
+            var toClearAsTypeDeclaration = DeclarationFinder
+                                            .FindDeclarationsWithNonBaseAsType()
+                                            .Where(decl => decl.QualifiedName.QualifiedModuleName == referencedProject);
+            foreach(var declaration in toClearAsTypeDeclaration)
+            {
+                declaration.AsTypeDeclaration = null;
+            }
+        }
 
         private bool _isDisposed;
 

--- a/RubberduckTests/Symbols/ProjectDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ProjectDeclarationTests.cs
@@ -51,6 +51,20 @@ namespace RubberduckTests.Symbols
 
 
         [TestMethod]
+        public void ClearProjectsReferencesClearsTheProjectReferences()
+        {
+            var projectDeclaration = GetTestProject("testProject");
+            var projectId = "test";
+            var priority = 12;
+            projectDeclaration.AddProjectReference(projectId, priority);
+            projectDeclaration.ClearProjectReferences();
+            var projectReferences = projectDeclaration.ProjectReferences;
+
+            Assert.IsFalse(projectReferences.Any());
+        }
+
+
+        [TestMethod]
         public void ProjectsReferencesIgnoresReferencesWithTheSameIDAsOneAlreadyPresent()
         {
             var projectDeclaration = GetTestProject("testProject");


### PR DESCRIPTION
Previously, the compilation passes always ran for all modules/declarations. This PR restricts them to those declarations for which they need to run. 
This should typically save about 1s on reparses since most of the time is spent in the `TypeAnnotationPass` for referenced projects, which typically do not change. (The performance measure is from my test project for performance tests where 90% of the declarations in that pass are built-in ones (of about 19000).)

This closes #2986. However, I forgot to put this into the appropriate commit message, which is not the last one. So I will close the issue manually after this PR got merged.

Moreover, this PR improves cache invalidation for module-to-module references in the case that project references get unloaded.