### PR TITLE
Remove HasAttribute Bug

### DIFF
--- a/Rubberduck.Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.Inspections/Concrete/MissingAttributeInspection.cs
@@ -42,7 +42,14 @@ namespace Rubberduck.Inspections.Concrete
 
             public override void ExitAnnotation(VBAParser.AnnotationContext context)
             {
-                var isMemberAnnotation = context.AnnotationType.HasFlag(AnnotationType.MemberAnnotation);
+                var annotationType = context.AnnotationType;
+
+                if (!annotationType.HasFlag(AnnotationType.Attribute))
+                {
+                    return;
+                }
+
+                var isMemberAnnotation = annotationType.HasFlag(AnnotationType.MemberAnnotation);
                 var isModuleScope = CurrentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Module);
 
                 if (isModuleScope && !isMemberAnnotation)

--- a/Rubberduck.Parsing/VBA/Attributes.cs
+++ b/Rubberduck.Parsing/VBA/Attributes.cs
@@ -80,7 +80,11 @@ namespace Rubberduck.Parsing.VBA
     {
         public bool HasAttributeFor(AnnotationType annotationType, string memberName = null)
         {
-            Debug.Assert(annotationType.HasFlag(AnnotationType.Attribute));
+            if (!annotationType.HasFlag(AnnotationType.Attribute))
+            {
+                return false;
+            }
+
             var name = "VB_" + annotationType;
 
             if (annotationType.HasFlag(AnnotationType.MemberAnnotation))

--- a/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
@@ -42,6 +42,39 @@ Option Explicit
 
         [TestCategory("Inspections")]
         [TestMethod]
+        public void NoResultGivenNonAttributeAnnotation()
+        {
+            const string testModuleName = "Test";
+            const string inputCode = @"
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = """ + testModuleName + @"""   ' (ignored)
+Attribute VB_GlobalNameSpace = False              ' (ignored)
+Attribute VB_Creatable = False                    ' (ignored)
+Attribute VB_PredeclaredId = False                ' Must be False
+Attribute VB_Exposed = False                      ' Must be False
+Option Explicit
+
+'@TestMethod
+Public Sub Test()
+End Sub
+";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out component);
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+            var inspection = new MissingAttributeInspection(state);
+            var inspector = InspectionsHelper.GetInspector(inspection);
+            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [TestCategory("Inspections")]
+        [TestMethod]
         public void HasResultGivenPredeclaredIdAnnotation_WithoutAttribute()
         {
             const string testModuleName = "Test";


### PR DESCRIPTION
The PR #3046 introduced a bug mentioned to us as a new issue in issue #3051:
Running the inspections failed with a false assertion whenever there have been annotations other than the attribute annotations.

This PR fixes this by removing the `Debug.Assert` and replacing it by returning `false`, if the annotation passed in does not have the `Attribute` flag.