### PR TITLE
Report Module in Exception Log Message for Exceptions Thrown Parsing a Module

### DIFF
--- a/Rubberduck.Parsing/VBA/ComponentParseTask.cs
+++ b/Rubberduck.Parsing/VBA/ComponentParseTask.cs
@@ -91,7 +91,7 @@ namespace Rubberduck.Parsing.VBA
             }
             catch (COMException exception)
             {
-                Logger.Error(exception, $"Exception thrown in thread {Thread.CurrentThread.ManagedThreadId}, ParseTaskID {_taskId}.");
+                Logger.Error(exception, $"Exception thrown in thread {Thread.CurrentThread.ManagedThreadId} while parsing module {_qualifiedName.Name}, ParseTaskID {_taskId}.");
                 var failedHandler = ParseFailure;
                 failedHandler?.Invoke(this, new ParseFailureArgs
                 {
@@ -119,7 +119,7 @@ namespace Rubberduck.Parsing.VBA
             }
             catch (Exception exception)
             {
-                Logger.Error(exception, $"Exception thrown in thread {Thread.CurrentThread.ManagedThreadId}, ParseTaskID {_taskId}.");
+                Logger.Error(exception, $"Exception thrown in thread {Thread.CurrentThread.ManagedThreadId} while parsing module {_qualifiedName.Name}, ParseTaskID {_taskId}.");
                 var failedHandler = ParseFailure;
                 failedHandler?.Invoke(this, new ParseFailureArgs
                 {


### PR DESCRIPTION
To be able to better pinpoint the location of non-syntax exceptions thrown while parsing I added the module name to the log message, as suggested in issue #3093.