### PR TITLE
Fixing Set Assignments

### DIFF
--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
@@ -150,7 +150,8 @@ namespace Rubberduck.Parsing.Symbols
             ParserRuleContext expression,
             StatementResolutionContext statementContext = StatementResolutionContext.Undefined,
             bool isAssignmentTarget = false,
-            bool hasExplicitLetStatement = false)
+            bool hasExplicitLetStatement = false,
+            bool isSetAssignment = false)
         {
             var withExpression = GetInnerMostWithExpression();
             var boundExpression = _bindingService.ResolveDefault(
@@ -186,7 +187,7 @@ namespace Rubberduck.Parsing.Symbols
                 var members = _declarationFinder.Members(module);
                 hasDefaultMember = members.Any(m => m.Attributes.Any(a => a.Name == $"{m.IdentifierName}.VB_UserMemId" && a.Values.SingleOrDefault() == "0"));
             }
-            _boundExpressionVisitor.AddIdentifierReferences(boundExpression, _qualifiedModuleName, _currentScope, _currentParent, !hasDefaultMember && isAssignmentTarget, hasExplicitLetStatement);
+            _boundExpressionVisitor.AddIdentifierReferences(boundExpression, _qualifiedModuleName, _currentScope, _currentParent, (!hasDefaultMember || isSetAssignment) && isAssignmentTarget, hasExplicitLetStatement);
         }
 
         private void ResolveType(ParserRuleContext expression)
@@ -356,7 +357,8 @@ namespace Rubberduck.Parsing.Symbols
                 context.lExpression(),
                 StatementResolutionContext.LetStatement,
                 true,
-                letStatement != null);
+                letStatement != null,
+                false);
             ResolveDefault(context.expression());
         }
 
@@ -366,7 +368,8 @@ namespace Rubberduck.Parsing.Symbols
                 context.lExpression(),
                 StatementResolutionContext.SetStatement,
                 true,
-                false);
+                false,
+                true);
             ResolveDefault(context.expression());
         }
 

--- a/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
@@ -71,11 +71,30 @@ End Function";
 
         [TestMethod]
         [TestCategory("Inspections")]
-        public void NonReturningFunction_DoesNotReturnResult()
+        public void NonReturningFunction_DoesNotReturnResult_Let()
         {
             const string inputCode =
 @"Function Foo() As Boolean
     Foo = True
+End Function";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new NonReturningFunctionInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void NonReturningFunction_DoesNotReturnResult_Set()
+        {
+            const string inputCode =
+@"Function Foo() As Collection
+    Set Foo = new Collection
 End Function";
 
             IVBComponent component;


### PR DESCRIPTION
This PR fixes both #2803 and #2868.

The common issue was that in the resolver an assignment was never treated as such if the target had a default member. For let statements, this is correct. However, this is not correct for set statements; these never assign to the default member.

This PR does not contain any tests covering the issues, simply because I currently do not know how to set up a test including a type with a default member.