### PR TITLE
Fixed AsTypeName for declarations with type hints

### DIFF
--- a/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
@@ -116,7 +116,7 @@ namespace Rubberduck.Parsing.Symbols
 
                 if (superType != null)
                 {
-                    ((ClassModuleDeclaration) _moduleDeclaration).AddSupertype(superType);
+                    ((ClassModuleDeclaration)_moduleDeclaration).AddSupertype(superType);
                 }
             }
             SetCurrentScope();
@@ -626,12 +626,14 @@ namespace Rubberduck.Parsing.Symbols
             var args = context.arg();
             foreach (var argContext in args)
             {
-                var asTypeClause = argContext.asTypeClause();
-                var asTypeName = asTypeClause == null
-                    ? Tokens.Variant
-                    : asTypeClause.type().GetText();
                 var identifier = argContext.unrestrictedIdentifier();
                 string typeHint = Identifier.GetTypeHintValue(identifier);
+                var asTypeClause = argContext.asTypeClause();
+                var asTypeName = typeHint == null
+                    ? asTypeClause == null
+                        ? Tokens.Variant
+                        : asTypeClause.type().GetText()
+                    : SymbolList.TypeHintToTypeName[typeHint];
                 bool isArray = argContext.LPAREN() != null;
                 AddDeclaration(
                     CreateDeclaration(
@@ -656,7 +658,7 @@ namespace Rubberduck.Parsing.Symbols
                 AddIdentifierStatementLabelDeclaration(combinedLabel.identifierStatementLabel());
                 AddLineNumberLabelDeclaration(combinedLabel.lineNumberLabel());
             }
-            else if (context.identifierStatementLabel() != null) 
+            else if (context.identifierStatementLabel() != null)
             {
                 AddIdentifierStatementLabelDeclaration(context.identifierStatementLabel());
             }
@@ -714,9 +716,11 @@ namespace Rubberduck.Parsing.Symbols
             var name = Identifier.GetName(identifier);
             var typeHint = Identifier.GetTypeHintValue(identifier);
             var asTypeClause = context.asTypeClause();
-            var asTypeName = asTypeClause == null
-                ? Tokens.Variant
-                : asTypeClause.type().GetText();
+            var asTypeName = typeHint == null
+                ? asTypeClause == null
+                    ? Tokens.Variant
+                    : asTypeClause.type().GetText()
+                : SymbolList.TypeHintToTypeName[typeHint];
             var withEvents = parent.WITHEVENTS() != null;
             var isAutoObject = asTypeClause != null && asTypeClause.NEW() != null;
             bool isArray = context.LPAREN() != null;
@@ -740,15 +744,17 @@ namespace Rubberduck.Parsing.Symbols
             var parent = (VBAParser.ConstStmtContext)context.Parent;
             var accessibility = GetMemberAccessibility(parent.visibility());
 
-            var asTypeClause = context.asTypeClause();
-            var asTypeName = asTypeClause == null
-                ? Tokens.Variant
-                : asTypeClause.type().GetText();
             var identifier = context.identifier();
             var typeHint = Identifier.GetTypeHintValue(identifier);
+            var asTypeClause = context.asTypeClause();
+            var asTypeName = typeHint == null
+                ? asTypeClause == null
+                    ? Tokens.Variant
+                    : asTypeClause.type().GetText()
+                : SymbolList.TypeHintToTypeName[typeHint];
             var name = Identifier.GetName(identifier);
             var value = context.expression().GetText();
-            var constStmt = (VBAParser.ConstStmtContext) context.Parent;
+            var constStmt = (VBAParser.ConstStmtContext)context.Parent;
 
             var declaration = new ConstantDeclaration(
                 new QualifiedMemberName(_qualifiedName, name),


### PR DESCRIPTION
As discussed in #3084, declarations which contain type hints should not be treated as `"Variant"`. The fix assigns proper `AsTypeName` property value for such declarations.