### PR TITLE
Cache Invalidation for Projects Outside of the Sinks

### DIFF
--- a/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -254,7 +254,7 @@ namespace Rubberduck.Navigation.CodeExplorer
                 return;
             }
 
-            var userDeclarations = _state.AllUserDeclarations
+            var userDeclarations = _state.DeclarationFinder.AllUserDeclarations
                 .GroupBy(declaration => declaration.ProjectId)
                 .ToList();
 

--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -376,6 +376,8 @@ namespace Rubberduck.Parsing.Symbols
                     .SelectMany(item => item.Value);
         }
 
+        public IEnumerable<Declaration> AllUserDeclarations => _userDeclarationsByType.AllValues();
+
         public IEnumerable<Declaration> BuiltInDeclarations(DeclarationType type)
         {
             List<Declaration> result;
@@ -385,6 +387,8 @@ namespace Rubberduck.Parsing.Symbols
                     .Where(item => item.Key.HasFlag(type))
                     .SelectMany(item => item.Value);
         }
+
+        public IEnumerable<Declaration> AllBuiltInDeclarations => _builtInDeclarationsByType.Value.AllValues();
 
         public IEnumerable<Declaration> DeclarationsWithType(DeclarationType type)
         {

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -7,6 +7,7 @@ using Rubberduck.VBEditor;
 using System.Diagnostics;
 using System.Linq;
 using NLog;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.VBA
 {
@@ -366,10 +367,17 @@ namespace Rubberduck.Parsing.VBA
             var removedModules = RemovedModules(modules);
             token.ThrowIfCancellationRequested();
 
+            var removedProjects = RemovedProjects(_projectManager.Projects);
+            token.ThrowIfCancellationRequested();
+
             var toReResolveReferences = _parsingCacheService.ModulesReferencingAny(removedModules);
             token.ThrowIfCancellationRequested();
 
             CleanUpRemovedComponents(removedModules, token);
+            token.ThrowIfCancellationRequested();
+
+            //This must come after the component cleanup because of cache invalidation.
+            CleanUpRemovedProjects(removedProjects);
             token.ThrowIfCancellationRequested();
 
             var toParse = modules.Where(module => State.IsNewOrModified(module)).ToHashSet();
@@ -400,12 +408,34 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
+        private void CleanUpRemovedProjects(IReadOnlyCollection<Tuple<string,string>> removedProjects)
+        {
+            var removedProjectIds = removedProjects.Select(removedProject => removedProject.Item1);
+            ClearStateCache(removedProjectIds);
+        }
+
+        private void ClearStateCache(IEnumerable<string> projectIds)
+        {
+            foreach (var projectId in projectIds)
+            {
+                State.ClearStateCache(projectId);
+            }
+        }
+
         private IReadOnlyCollection<QualifiedModuleName> RemovedModules(IReadOnlyCollection<QualifiedModuleName> modules)
         {
             var modulesWithModuleDeclarations = State.DeclarationFinder.UserDeclarations(DeclarationType.Module).Select(declaration => declaration.QualifiedName.QualifiedModuleName);
             var currentlyExistingModules = modules.ToHashSet();
             var removedModuledecalrations = modulesWithModuleDeclarations.Where(module => !currentlyExistingModules.Contains(module));
             return removedModuledecalrations.ToHashSet().AsReadOnly();
+        }
+
+        private IReadOnlyCollection<Tuple<string,string>> RemovedProjects(IReadOnlyCollection<IVBProject> projects)
+        {
+            var projectsWithProjectDeclarations = State.DeclarationFinder.UserDeclarations(DeclarationType.Project).Select(declaration => new Tuple<string,string>(declaration.ProjectId, declaration.ProjectName));
+            var currentlyExistingProjects = projects.Select(project => new Tuple<string, string>(project.ProjectId, project.Name)).ToHashSet();
+            var removedProjects = projectsWithProjectDeclarations.Where(project => !currentlyExistingProjects.Contains(project));
+            return removedProjects.ToHashSet().AsReadOnly();
         }
 
 

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -241,13 +241,18 @@ namespace Rubberduck.Parsing.VBA
                 token.ThrowIfCancellationRequested();
 
                 _parsingStageService.ResolveDeclarations(toParse, token);
-                RefreshDeclarationFinder();
             }
 
             if (token.IsCancellationRequested || State.Status >= ParserState.Error)
             {
                 throw new OperationCanceledException(token);
             }
+
+            //We need to refresh the DeclarationFinder before the handlers for ResolvedDeclarations run no matter 
+            //whether we parsed or resolved something because modules not referenced by any remeining module might
+            //have been removed. E.g. the CodeExplorer needs this update. 
+            RefreshDeclarationFinder();
+            token.ThrowIfCancellationRequested();
 
             //Explicitly setting the overall state here guarantees that the handlers attached 
             //to the state change to ResolvedDeclarations always run, provided there is no error. 

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -765,20 +765,20 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        private void ClearStateCache(string projectId, bool notifyStateChanged = false)
+        public void ClearStateCache(string projectId, bool notifyStateChanged = false)
         {
             try
             {
-                foreach (var moduleState in _moduleStates)
+                foreach (var moduleState in _moduleStates.Where(moduleState => moduleState.Key.ProjectId == projectId))
                 {
-                    if (moduleState.Key.ProjectId == projectId && moduleState.Key.Component != null)
+                    if (moduleState.Key.Component != null)
                     {
                         while (!ClearStateCache(moduleState.Key.Component))
                         {
                             // until Hell freezes over?
                         }
                     }
-                    else if (moduleState.Key.ProjectId == projectId && moduleState.Key.Component == null)
+                    else if (moduleState.Key.Component == null)
                     {
                         // store project module name
                         var qualifiedModuleName = moduleState.Key;
@@ -790,8 +790,9 @@ namespace Rubberduck.Parsing.VBA
                     }
                 }
             }
-            catch (COMException)
+            catch (COMException exception)
             {
+                Logger.Error(exception, $"Unexpected COMException while clearing the project with projectId {projectId}. Clearing all modules.");
                 _moduleStates.Clear();
             }
 

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -140,7 +140,6 @@ namespace Rubberduck.Parsing.VBA
             if (!e.Project.VBE.IsInDesignMode) { return; }
 
             Logger.Debug("Project '{0}' was added.", e.ProjectId);
-            RefreshProjects(_vbe); // note side-effect: assigns ProjectId/HelpFile
             OnParseRequested(sender);
         }
 
@@ -149,7 +148,6 @@ namespace Rubberduck.Parsing.VBA
             if (!e.Project.VBE.IsInDesignMode) { return; }
             
             Debug.Assert(e.ProjectId != null);
-            RemoveProject(e.ProjectId, true);
             OnParseRequested(sender);
         }
 
@@ -163,9 +161,6 @@ namespace Rubberduck.Parsing.VBA
             }
 
             Logger.Debug("Project {0} was renamed.", e.ProjectId);
-
-            RemoveProject(e.ProjectId);
-            RefreshProjects(e.Project.VBE);
 
             OnParseRequested(sender);
         }
@@ -207,6 +202,18 @@ namespace Rubberduck.Parsing.VBA
 
             Logger.Debug("Component '{0}' was renamed to '{1}'.", e.OldName, e.Component.Name);
 
+            //todo: Find out for which situation this drastic (and problematic) cache invalidation has been introduced.
+            if (ComponentIsWorksheet(e))
+            {
+                RemoveProject(e.ProjectId);
+                Logger.Debug("Project '{0}' was removed.", e.Component.Name);
+            }
+
+            OnParseRequested(sender);
+        }
+
+        private bool ComponentIsWorksheet(ComponentRenamedEventArgs e)
+        {
             var componentIsWorksheet = false;
             foreach (var declaration in AllUserDeclarations)
             {
@@ -214,7 +221,7 @@ namespace Rubberduck.Parsing.VBA
                     declaration.DeclarationType == DeclarationType.ClassModule &&
                     declaration.IdentifierName == e.OldName)
                 {
-                    foreach (var superType in ((ClassModuleDeclaration) declaration).Supertypes)
+                    foreach (var superType in ((ClassModuleDeclaration)declaration).Supertypes)
                     {
                         if (superType.IdentifierName == "Worksheet")
                         {
@@ -227,19 +234,7 @@ namespace Rubberduck.Parsing.VBA
                 }
             }
 
-            if (componentIsWorksheet)
-            {
-                RemoveProject(e.ProjectId);
-                Logger.Debug("Project '{0}' was removed.", e.Component.Name);
-
-                RefreshProjects(e.Project.VBE);
-            }
-            else
-            {
-                RemoveRenamedComponent(e.ProjectId, e.OldName);
-            }
-
-            OnParseRequested(sender);
+            return componentIsWorksheet;
         }
 
         public void OnStatusMessageUpdate(string message)
@@ -842,28 +837,6 @@ namespace Rubberduck.Parsing.VBA
             var success = RemoveKeysFromCollections(keys);
 
             if (notifyStateChanged)
-            {
-                OnStateChanged(this, ParserState.ResolvedDeclarations);   // trigger test explorer and code explorer updates
-                OnStateChanged(this, ParserState.Ready);   // trigger find all references &c. updates
-            }
-
-            return success;
-        }
-
-        private bool RemoveRenamedComponent(string projectId, string oldComponentName)
-        {
-            var keys = new List<QualifiedModuleName>();
-            foreach (var key in _moduleStates.Keys)
-            {
-                if (key.ComponentName == oldComponentName && key.ProjectId == projectId)
-                {
-                    keys.Add(key);
-                }
-            }
-
-            var success = keys.Count != 0 && RemoveKeysFromCollections(keys);
-
-            if (success)
             {
                 OnStateChanged(this, ParserState.ResolvedDeclarations);   // trigger test explorer and code explorer updates
                 OnStateChanged(this, ParserState.Ready);   // trigger find all references &c. updates


### PR DESCRIPTION
So far, the module states of a project got removed in the event sinks, which is problematic for several reasons. First, they simply do not get removed in case the events are deactivated, e.g. because code is running. Second, for its own cache invalidation the `ParseCoordinator` needs to know which components got removed. That is not possible if they got removed already in the sinks.  

I added the cache invalidation for projects to the `ParseCoordinator` and removed the cache invalidation in the sinks. (They always initiate a parse.) There is only one exception. Currently, the entire project gets cleared if a component is renamed that has the supertype `Worksheet`. Since I could not find out the reasoning behind it, I left the code there and added a corresponding _todo_ remark. 

Fixes #3115 