### PR TITLE
Unify Parse Running

### DIFF
--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -135,7 +135,7 @@ namespace Rubberduck.Parsing.VBA
             try
             {
                 Monitor.Enter(_parsingRunSyncObject, ref lockTaken);
-                ParseInternalInternal(token);
+                ParseAllInternal(this, token);
             }
             catch (OperationCanceledException)
             {
@@ -147,35 +147,6 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        private void ParseInternalInternal(CancellationToken token)
-        {
-            token.ThrowIfCancellationRequested();
-
-            _parserStateManager.SetStatusAndFireStateChanged(this, ParserState.Pending, token);
-            token.ThrowIfCancellationRequested();
-
-            _projectManager.RefreshProjects();
-            token.ThrowIfCancellationRequested();
-
-            var modules = _projectManager.AllModules();
-            token.ThrowIfCancellationRequested();
-
-            // tests do not fire events when components are removed--clear components
-            ClearComponentsForTests();
-            token.ThrowIfCancellationRequested();
-
-            ExecuteCommonParseActivities(modules, new List<QualifiedModuleName>(), token);
-        }
-
-        private void ClearComponentsForTests()
-        {
-            foreach (var tree in State.ParseTrees)
-            {
-                State.ClearStateCache(tree.Key);    // handle potentially removed components without crashing
-                _parsingCacheService.ClearModuleToModuleReferencesFromModule(tree.Key);
-                _parsingCacheService.ClearModuleToModuleReferencesToModule(tree.Key);
-            }
-        }
 
         private void ExecuteCommonParseActivities(IReadOnlyCollection<QualifiedModuleName> toParse, IReadOnlyCollection<QualifiedModuleName> toReresolveReferencesInput, CancellationToken token)
         {


### PR DESCRIPTION
So far, there have been two different cache invalidation strategies in the `ParseCoordinator`. The production version took care to invalidate just as much cache as necessary given which modules had been added, removed or modified. In contrast, the test version cleared all declarations every time.

The reasoning to remove all declarations on every reparse while running tests was that the cache invalidation for removed and renamed projects happened in the sinks, which do not run in tests. (The mock VBE does not raise events.) Now that all the cache invalidation moved to the start of the production version, there is no need anymore to throw away everything in the tests.

So, in addition to a few tweaks to the cache invalidation, I went in and removed the special treatment of tests. Now, the only real difference is that the parser does not run on a backgroud task in tests, and that everything is synchronous. This change allows to actually write tests covering caching related bugs.