### PR TITLE
Created IntegerDataTypeInspection

### DIFF
--- a/Rubberduck.Inspections/Concrete/IntegerDataTypeInspection.cs
+++ b/Rubberduck.Inspections/Concrete/IntegerDataTypeInspection.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Rubberduck.Common;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Inspections.Resources;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.UI;
+
+namespace Rubberduck.Inspections.Concrete
+{
+    public sealed class IntegerDataTypeInspection : InspectionBase
+    {
+        public IntegerDataTypeInspection(RubberduckParserState state) : base(state, CodeInspectionSeverity.Hint)
+        {
+        }
+
+        public override CodeInspectionType InspectionType { get; } = CodeInspectionType.CodeQualityIssues;
+
+        public override IEnumerable<IInspectionResult> GetInspectionResults()
+        {
+            var interfaceImplementationMembers = UserDeclarations.FindInterfaceImplementationMembers().ToHashSet();
+
+            var excludeParameterMembers = State.DeclarationFinder.FindEventHandlers().ToHashSet();
+            excludeParameterMembers.UnionWith(interfaceImplementationMembers);
+
+            var result = UserDeclarations
+                .Where(declaration =>
+                    declaration.AsTypeName == Tokens.Integer &&
+                    !interfaceImplementationMembers.Contains(declaration) &&
+                    declaration.DeclarationType != DeclarationType.LibraryFunction &&
+                    (declaration.DeclarationType != DeclarationType.Parameter || IncludeParameterDeclaration(declaration, excludeParameterMembers)))
+                .Select(issue =>
+                    new DeclarationInspectionResult(this,
+                        string.Format(InspectionsUI.IntegerDataTypeInspectionResultFormat,
+                            RubberduckUI.ResourceManager.GetString("DeclarationType_" + issue.DeclarationType,
+                                CultureInfo.CurrentUICulture),
+                            issue.IdentifierName),
+                        issue));
+
+            return result;
+        }
+
+        private static bool IncludeParameterDeclaration(Declaration parameterDeclaration, ICollection<Declaration> parentDeclarationsToExclude)
+        {
+            var parentDeclaration = parameterDeclaration.ParentDeclaration;
+
+            return parentDeclaration.DeclarationType != DeclarationType.LibraryFunction &&
+                   parentDeclaration.DeclarationType != DeclarationType.LibraryProcedure &&
+                   !parentDeclarationsToExclude.Contains(parentDeclaration);
+        }
+    }
+}

--- a/Rubberduck.Inspections/QuickFixes/ChangeIntegerToLongQuickFix.cs
+++ b/Rubberduck.Inspections/QuickFixes/ChangeIntegerToLongQuickFix.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using Rubberduck.Parsing.Grammar;
+using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
+using Rubberduck.Common;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Inspections.Resources;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+
+namespace Rubberduck.Inspections.QuickFixes
+{
+    public class ChangeIntegerToLongQuickFix : IQuickFix
+    {
+        private readonly RubberduckParserState _state;
+
+        private static readonly HashSet<Type> _supportedInspections = new HashSet<Type>
+        {
+            typeof(IntegerDataTypeInspection)
+        };
+
+        public ChangeIntegerToLongQuickFix(RubberduckParserState state)
+        {
+            _state = state;
+        }
+
+        public IReadOnlyCollection<Type> SupportedInspections { get; } = _supportedInspections.ToList();
+
+        public void Fix(IInspectionResult result)
+        {
+            var rewriter = _state.GetRewriter(result.Target);
+
+            if (result.Target.HasTypeHint)
+            {
+                ReplaceTypeHint(result.Context, rewriter);
+            }
+            else
+            {
+                switch (result.Target.DeclarationType)
+                {
+                    case DeclarationType.Variable:
+                        var variableContext = (VBAParser.VariableSubStmtContext)result.Context;
+                        rewriter.Replace(variableContext.asTypeClause().type(), Tokens.Long);
+                        break;
+                    case DeclarationType.Constant:
+                        var constantContext = (VBAParser.ConstSubStmtContext)result.Context;
+                        rewriter.Replace(constantContext.asTypeClause().type(), Tokens.Long);
+                        break;
+                    case DeclarationType.Parameter:
+                        var parameterContext = (VBAParser.ArgContext)result.Context;
+                        rewriter.Replace(parameterContext.asTypeClause().type(), Tokens.Long);
+                        break;
+                    case DeclarationType.Function:
+                        var functionContext = (VBAParser.FunctionStmtContext)result.Context;
+                        rewriter.Replace(functionContext.asTypeClause().type(), Tokens.Long);
+                        break;
+                    case DeclarationType.PropertyGet:
+                        var propertyContext = (VBAParser.PropertyGetStmtContext)result.Context;
+                        rewriter.Replace(propertyContext.asTypeClause().type(), Tokens.Long);
+                        break;
+                    case DeclarationType.UserDefinedTypeMember:
+                        var userDefinedTypeMemberContext = (VBAParser.UdtMemberContext)result.Context;
+                        if (userDefinedTypeMemberContext.reservedNameMemberDeclaration() != null)
+                        {
+                            rewriter.Replace(
+                                userDefinedTypeMemberContext.reservedNameMemberDeclaration().asTypeClause().type(),
+                                Tokens.Long);
+
+                        }
+                        else
+                        {
+                            rewriter.Replace(
+                                userDefinedTypeMemberContext.untypedNameMemberDeclaration().optionalArrayClause().asTypeClause().type(),
+                                Tokens.Long);
+                        }
+                        break;
+                }
+            }
+
+            var interfaceMembers = _state.DeclarationFinder.FindAllInterfaceMembers().ToArray();
+
+            ParserRuleContext matchingInterfaceMemberContext;
+
+            switch (result.Target.DeclarationType)
+            {
+                case DeclarationType.Parameter:
+                    matchingInterfaceMemberContext =
+                        interfaceMembers.Select(member => member.Context)
+                            .FirstOrDefault(c => c == result.Context.Parent.Parent);
+
+                    if (matchingInterfaceMemberContext != null)
+                    {
+                        var interfaceParameterIndex = GetParameterIndex((VBAParser.ArgContext)result.Context);
+
+                        var implementationMembers =
+                            _state.AllUserDeclarations.FindInterfaceImplementationMembers(interfaceMembers.First(
+                                member => member.Context == matchingInterfaceMemberContext)).ToHashSet();
+
+                        var parameterDeclarations =
+                            _state.DeclarationFinder.UserDeclarations(DeclarationType.Parameter)
+                                .Where(p => implementationMembers.Contains(p.ParentDeclaration))
+                                .Cast<ParameterDeclaration>()
+                                .ToArray();
+
+                        foreach (var parameter in parameterDeclarations)
+                        {
+                            var parameterContext = (VBAParser.ArgContext)parameter.Context;
+                            var parameterIndex = GetParameterIndex(parameterContext);
+
+                            if (parameterIndex == interfaceParameterIndex)
+                            {
+                                var parameterRewriter = _state.GetRewriter(parameter);
+
+                                if (parameter.HasTypeHint)
+                                {
+                                    ReplaceTypeHint(parameterContext, parameterRewriter);
+                                }
+                                else
+                                {
+                                    parameterRewriter.Replace(parameterContext.asTypeClause().type(), Tokens.Long);
+                                }
+                            }
+                        }
+                    }
+                    break;
+                case DeclarationType.Function:
+                    matchingInterfaceMemberContext =
+                        interfaceMembers.Select(member => member.Context)
+                            .FirstOrDefault(c => c == result.Context);
+
+                    if (matchingInterfaceMemberContext != null)
+                    {
+                        var functionDeclarations =
+                            _state.AllUserDeclarations.FindInterfaceImplementationMembers(
+                                    interfaceMembers.First(member => member.Context == matchingInterfaceMemberContext))
+                                .Cast<FunctionDeclaration>()
+                                .ToHashSet();
+
+                        foreach (var function in functionDeclarations)
+                        {
+                            var functionRewriter = _state.GetRewriter(function);
+
+                            if (function.HasTypeHint)
+                            {
+                                ReplaceTypeHint(function.Context, functionRewriter);
+                            }
+                            else
+                            {
+                                var functionContext = (VBAParser.FunctionStmtContext)function.Context;
+                                functionRewriter.Replace(functionContext.asTypeClause().type(), Tokens.Long);
+                            }
+                        }
+                    }
+                    break;
+                case DeclarationType.PropertyGet:
+                    matchingInterfaceMemberContext =
+                        interfaceMembers.Select(member => member.Context)
+                            .FirstOrDefault(c => c == result.Context);
+
+                    if (matchingInterfaceMemberContext != null)
+                    {
+                        var propertyGetDeclarations =
+                            _state.AllUserDeclarations.FindInterfaceImplementationMembers(
+                                    interfaceMembers.First(member => member.Context == matchingInterfaceMemberContext))
+                                .Cast<PropertyGetDeclaration>()
+                                .ToHashSet();
+
+                        foreach (var propertyGet in propertyGetDeclarations)
+                        {
+                            var propertyGetRewriter = _state.GetRewriter(propertyGet);
+
+                            if (propertyGet.HasTypeHint)
+                            {
+                                ReplaceTypeHint(propertyGet.Context, propertyGetRewriter);
+                            }
+                            else
+                            {
+                                var propertyGetContext = (VBAParser.PropertyGetStmtContext)propertyGet.Context;
+                                propertyGetRewriter.Replace(propertyGetContext.asTypeClause().type(), Tokens.Long);
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+        public string Description(IInspectionResult result)
+        {
+            return InspectionsUI.IntegerDataTypeQuickFix;
+        }
+
+        public bool CanFixInProcedure => true;
+        public bool CanFixInModule => true;
+        public bool CanFixInProject => true;
+
+        private static int GetParameterIndex(VBAParser.ArgContext context)
+        {
+            return Array.IndexOf(((VBAParser.ArgListContext)context.Parent).arg().ToArray(), context);
+        }
+
+        private static void ReplaceTypeHint(RuleContext context, IModuleRewriter rewriter)
+        {
+            var typeHintContext = ParserRuleContextHelper.GetDescendent<VBAParser.TypeHintContext>(context);
+            rewriter.Replace(typeHintContext, "&");
+        }
+    }
+}

--- a/Rubberduck.Inspections/Rubberduck.Inspections.csproj
+++ b/Rubberduck.Inspections/Rubberduck.Inspections.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Concrete\ApplicationWorksheetFunctionInspection.cs" />
     <Compile Include="Concrete\AssignedByValParameterInspection.cs" />
     <Compile Include="Concrete\LineLabelNotUsedInspection.cs" />
+    <Compile Include="Concrete\IntegerDataTypeInspection.cs" />
     <Compile Include="ParseTreeListeners\AttributeAnnotationListener.cs" />
     <Compile Include="Concrete\ConstantNotUsedInspection.cs" />
     <Compile Include="Concrete\DefaultProjectNameInspection.cs" />
@@ -104,6 +105,7 @@
     <Compile Include="QuickFixes\ApplicationWorksheetFunctionQuickFix.cs" />
     <Compile Include="QuickFixes\AssignedByValParameterMakeLocalCopyQuickFix.cs" />
     <Compile Include="QuickFixes\ChangeDimToPrivateQuickFix.cs" />
+    <Compile Include="QuickFixes\ChangeIntegerToLongQuickFix.cs" />
     <Compile Include="QuickFixes\SpecifyExplicitByRefModifierQuickFix.cs" />
     <Compile Include="QuickFixes\ChangeProcedureToFunctionQuickFix.cs" />
     <Compile Include="QuickFixes\ConvertToProcedureQuickFix.cs" />

--- a/Rubberduck.Parsing/Inspections/Resources/InspectionsUI.resx
+++ b/Rubberduck.Parsing/Inspections/Resources/InspectionsUI.resx
@@ -739,4 +739,16 @@ If the parameter can be null, ignore this inspection result; passing a null valu
     <value>Line label '{0}' is not used</value>
     <comment>{0} line label name</comment>
   </data>
+  <data name="IntegerDataTypeInspectionMeta" xml:space="preserve">
+    <value>The maximum value of a 16-bit signed integer is 32,767 - using a 32-bit (Long) integer data type where possible can help prevent 'Overflow' run-time errors, and is better handled by modern CPUs.</value>
+  </data>
+  <data name="IntegerDataTypeInspectionName" xml:space="preserve">
+    <value>Use of 16-bit integer type</value>
+  </data>
+  <data name="IntegerDataTypeInspectionResultFormat" xml:space="preserve">
+    <value>{0} '{1}' is declared as Integer</value>
+  </data>
+  <data name="IntegerDataTypeQuickFix" xml:space="preserve">
+    <value>Change declaration type to Long</value>
+  </data>
 </root>

--- a/Rubberduck.Parsing/Inspections/Resources/InspectionsUI1.Designer.cs
+++ b/Rubberduck.Parsing/Inspections/Resources/InspectionsUI1.Designer.cs
@@ -673,6 +673,42 @@ namespace Rubberduck.Parsing.Inspections.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The maximum value of a 16-bit signed integer is 32,767 - using a 32-bit (Long) integer data type where possible can help prevent &apos;Overflow&apos; run-time errors, and is better handled by modern CPUs..
+        /// </summary>
+        public static string IntegerDataTypeInspectionMeta {
+            get {
+                return ResourceManager.GetString("IntegerDataTypeInspectionMeta", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use of 16-bit integer type.
+        /// </summary>
+        public static string IntegerDataTypeInspectionName {
+            get {
+                return ResourceManager.GetString("IntegerDataTypeInspectionName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} &apos;{1}&apos; is declared as Integer.
+        /// </summary>
+        public static string IntegerDataTypeInspectionResultFormat {
+            get {
+                return ResourceManager.GetString("IntegerDataTypeInspectionResultFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change declaration type to Long.
+        /// </summary>
+        public static string IntegerDataTypeQuickFix {
+            get {
+                return ResourceManager.GetString("IntegerDataTypeQuickFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Introduce local variable.
         /// </summary>
         public static string IntroduceLocalVariableQuickFix {

--- a/RubberduckTests/Inspections/IntegerDataTypeInspectionTests.cs
+++ b/RubberduckTests/Inspections/IntegerDataTypeInspectionTests.cs
@@ -1,0 +1,1289 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Inspections.QuickFixes;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Resources;
+using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestClass]
+    public class IntegerDataTypeInspectionTests
+    {
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_Function()
+        {
+            const string inputCode =
+@"Function Foo() As Integer
+End Function";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_PropertyGet()
+        {
+            const string inputCode =
+@"Property Get Foo() As Integer
+End Property";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_Parameter()
+        {
+            const string inputCode =
+@"Sub Foo(arg as Integer)
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_Variable()
+        {
+            const string inputCode =
+@"Sub Foo()
+    Dim v as Integer
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_Constant()
+        {
+            const string inputCode =
+@"Sub Foo()
+    Const c as Integer = 0
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_UserDefinedTypeMember()
+        {
+            const string inputCode =
+@"Type T
+    i as Integer
+End Type";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_FunctionInterfaceImplementation()
+        {
+            const string inputCode1 =
+@"Function Foo() As Integer
+End Function";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo() As Integer
+End Function";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_PropertyGetInterfaceImplementation()
+        {
+            const string inputCode1 =
+@"Property Get Foo() As Integer
+End Property";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo() As Integer
+End Property";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_ParameterInterfaceImplementation()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg as Integer)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_ReturnsResult_MultipleInterfaceImplementations()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg As Integer)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg As Integer)
+End Sub";
+
+            const string inputCode3 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode3)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_DoesNotReturnResult_LibraryFunction()
+        {
+            const string inputCode =
+@"Declare Function Foo Lib ""lib.dll"" () As Integer";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_DoesNotReturnResult_LibraryFunctionParameter()
+        {
+            const string inputCode =
+@"Declare Function Foo Lib ""lib.dll"" (arg As Integer) As String";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_DoesNotReturnResult_LibraryProcedureParameter()
+        {
+            const string inputCode =
+@"Declare Sub Foo Lib ""lib.dll"" (arg As Integer)";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_Ignored_DoesNotReturnResult()
+        {
+            const string inputCode =
+@"'@Ignore IntegerDataType
+Sub Foo(arg1 As Integer)
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_Function()
+        {
+            const string inputCode =
+@"Function Foo() As Integer
+End Function";
+
+            const string expectedCode =
+@"Function Foo() As Long
+End Function";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_FunctionWithTypeHint()
+        {
+            const string inputCode =
+@"Function Foo%()
+End Function";
+
+            const string expectedCode =
+@"Function Foo&()
+End Function";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_PropertyGet()
+        {
+            const string inputCode =
+@"Property Get Foo() As Integer
+End Property";
+
+            const string expectedCode =
+@"Property Get Foo() As Long
+End Property";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_PropertyGetWithTypeHint()
+        {
+            const string inputCode =
+@"Property Get Foo%()
+End Property";
+
+            const string expectedCode =
+@"Property Get Foo&()
+End Property";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_Parameter()
+        {
+            const string inputCode =
+@"Sub Foo(arg As Integer)
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo(arg As Long)
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_ParameterWithTypeHint()
+        {
+            const string inputCode =
+@"Sub Foo(arg%)
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo(arg&)
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_Variable()
+        {
+            const string inputCode =
+@"Sub Foo()
+    Dim v As Integer
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo()
+    Dim v As Long
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_VariableWithTypeHint()
+        {
+            const string inputCode =
+@"Sub Foo()
+    Dim v%
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo()
+    Dim v&
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_Constant()
+        {
+            const string inputCode =
+@"Sub Foo()
+    Const c As Integer = 0
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo()
+    Const c As Long = 0
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_ConstantWithTypeHint()
+        {
+            const string inputCode =
+@"Sub Foo()
+    Const c% = 0
+End Sub";
+
+            const string expectedCode =
+@"Sub Foo()
+    Const c& = 0
+End Sub";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_UserDefinedTypeReservedNameMember()
+        {
+            const string inputCode =
+@"Type T
+    i as Integer
+End Type";
+
+            const string expectedCode =
+@"Type T
+    i as Long
+End Type";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_UserDefinedTypeUntypedNameMember()
+        {
+            const string inputCode =
+@"Type T
+    i() as Integer
+End Type";
+
+            const string expectedCode =
+@"Type T
+    i() as Long
+End Type";
+
+            IVBComponent component;
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementation()
+        {
+            const string inputCode1 =
+@"Function Foo() As Integer
+End Function";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo() As Integer
+End Function";
+
+            const string expectedCode1 =
+@"Function Foo() As Long
+End Function";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo() As Long
+End Function";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementationWithTypeHints()
+        {
+            const string inputCode1 =
+@"Function Foo%()
+End Function";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo%()
+End Function";
+
+            const string expectedCode1 =
+@"Function Foo&()
+End Function";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo&()
+End Function";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementationWithInterfaceTypeHint()
+        {
+            const string inputCode1 =
+@"Function Foo%()
+End Function";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo() As Integer
+End Function";
+
+            const string expectedCode1 =
+@"Function Foo&()
+End Function";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo() As Long
+End Function";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementationWithImplementationTypeHint()
+        {
+            const string inputCode1 =
+@"Function Foo() As Integer
+End Function";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo%()
+End Function";
+
+            const string expectedCode1 =
+@"Function Foo() As Long
+End Function";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Function IClass1_Foo&()
+End Function";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementation()
+        {
+            const string inputCode1 =
+@"Property Get Foo() As Integer
+End Property";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo() As Integer
+End Property";
+
+            const string expectedCode1 =
+@"Property Get Foo() As Long
+End Property";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo() As Long
+End Property";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementationWithTypeHints()
+        {
+            const string inputCode1 =
+@"Property Get Foo%()
+End Property";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo%()
+End Property";
+
+            const string expectedCode1 =
+@"Property Get Foo&()
+End Property";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo&()
+End Property";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementationWithInterfaceTypeHint()
+        {
+            const string inputCode1 =
+@"Property Get Foo%()
+End Property";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo() As Integer
+End Property";
+
+            const string expectedCode1 =
+@"Property Get Foo&()
+End Property";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo() As Long
+End Property";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementationWithImplementationTypeHint()
+        {
+            const string inputCode1 =
+@"Property Get Foo() As Integer
+End Property";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo%()
+End Property";
+
+            const string expectedCode1 =
+@"Property Get Foo() As Long
+End Property";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Property Get IClass1_Foo&()
+End Property";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithTypeHints()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg1%)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1%)
+End Sub";
+
+            const string expectedCode1 =
+@"Sub Foo(arg1&)
+End Sub";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1&)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithInterfaceTypeHint()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg1%)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1 As Integer)
+End Sub";
+
+            const string expectedCode1 =
+@"Sub Foo(arg1&)
+End Sub";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1 As Long)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithImplementationTypeHint()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg1 As Integer)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1%)
+End Sub";
+
+            const string expectedCode1 =
+@"Sub Foo(arg1 As Long)
+End Sub";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1&)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementation()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg1 As Integer)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1 As Integer)
+End Sub";
+
+            const string expectedCode1 =
+@"Sub Foo(arg1 As Long)
+End Sub";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1 As Long)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithDifferentName()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg1 As Integer)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg2 As Integer)
+End Sub";
+
+            const string expectedCode1 =
+@"Sub Foo(arg1 As Long)
+End Sub";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg2 As Long)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void IntegerDataType_QuickFixWorks_MultipleParameterInterfaceImplementation()
+        {
+            const string inputCode1 =
+@"Sub Foo(arg1 As Integer, arg2 as Integer)
+End Sub";
+
+            const string inputCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1 As Integer, arg2 as Integer)
+End Sub";
+
+            const string expectedCode1 =
+@"Sub Foo(arg1 As Long, arg2 as Integer)
+End Sub";
+
+            const string expectedCode2 =
+@"Implements IClass1
+
+Sub IClass1_Foo(arg1 As Long, arg2 as Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .MockVbeBuilder()
+                .Build();
+
+            var state = MockParser.CreateAndParse(vbe.Object);
+
+            var inspection = new IntegerDataTypeInspection(state);
+            var inspectionResults = inspection.GetInspectionResults();
+
+            new ChangeIntegerToLongQuickFix(state).Fix(
+                inspectionResults.First(
+                    result =>
+                        ((VBAParser.ArgContext)result.Context).unrestrictedIdentifier()
+                        .identifier()
+                        .untypedIdentifier()
+                        .identifierValue()
+                        .GetText() == "arg1"));
+
+            var project = vbe.Object.VBProjects[0];
+            var interfaceComponent = project.VBComponents[0];
+            var implementationComponent = project.VBComponents[1];
+
+            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void InspectionType()
+        {
+            var inspection = new IntegerDataTypeInspection(null);
+            Assert.AreEqual(CodeInspectionType.CodeQualityIssues, inspection.InspectionType);
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void InspectionName()
+        {
+            const string inspectionName = "IntegerDataTypeInspection";
+            var inspection = new IntegerDataTypeInspection(null);
+
+            Assert.AreEqual(inspectionName, inspection.Name);
+        }
+    }
+}

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Inspections\AssignedByValParameterMakeLocalCopyQuickFixTests.cs" />
     <Compile Include="Inspections\EmptyIfBlockInspectionTests.cs" />
     <Compile Include="Inspections\InspectionsHelper.cs" />
+    <Compile Include="Inspections\IntegerDataTypeInspectionTests.cs" />
     <Compile Include="Inspections\MissingAnnotationInspectionTests.cs" />
     <Compile Include="Inspections\MissingAttributeInspectionTests.cs" />
     <Compile Include="Inspections\ModuleScopeDimKeywordInspectionTests.cs" />


### PR DESCRIPTION
Closes #3084 

I challenge anyone to find a bug :-)

I believe this inspection accounts for all possibilities, including type hint/no type hint combinations in interface and its implementation.

@retailcoder I have changed the proposed 

> {0} '{1}' is declared 'As Integer'

to

> {0} '{1}' is declared as Integer

because in case of type hints the literal 'As Integer' quote does not apply.