### PR TITLE
Implement checkbox in Settings to enable Source Control.  SC disabled by default.

### DIFF
--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -600,7 +600,20 @@ namespace Rubberduck.Root
                 KernelInstance.Get<ToDoExplorerCommandMenuItem>()
             };
 
-            return new ToolsParentMenu(items);
+            var itemsSCDisabled = new IMenuItem[]
+            {
+                KernelInstance.Get<RegexAssistantCommandMenuItem>(),
+                KernelInstance.Get<ToDoExplorerCommandMenuItem>()
+            };
+
+            if (KernelInstance.Get<IGeneralConfigService>().LoadConfiguration().UserSettings.GeneralSettings.SourceControlEnabled == false)
+            {
+                return new ToolsParentMenu(itemsSCDisabled);
+            }
+            else
+            {
+                return new ToolsParentMenu(items);
+            }
         }
 
         private IEnumerable<IMenuItem> GetFormDesignerContextMenuItems()

--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -593,27 +593,19 @@ namespace Rubberduck.Root
 
         private IMenuItem GetToolsParentMenu()
         {
-            var items = new IMenuItem[]
-            {
-                KernelInstance.Get<SourceControlCommandMenuItem>(),
-                KernelInstance.Get<RegexAssistantCommandMenuItem>(),
-                KernelInstance.Get<ToDoExplorerCommandMenuItem>()
-            };
-
-            var itemsSCDisabled = new IMenuItem[]
+            var items = new List<IMenuItem> ()
             {
                 KernelInstance.Get<RegexAssistantCommandMenuItem>(),
                 KernelInstance.Get<ToDoExplorerCommandMenuItem>()
             };
 
-            if (KernelInstance.Get<IGeneralConfigService>().LoadConfiguration().UserSettings.GeneralSettings.SourceControlEnabled == false)
+
+            if (KernelInstance.Get<IGeneralConfigService>().LoadConfiguration().UserSettings.GeneralSettings.SourceControlEnabled == true)
             {
-                return new ToolsParentMenu(itemsSCDisabled);
+                items.Add(KernelInstance.Get<SourceControlCommandMenuItem>());
             }
-            else
-            {
-                return new ToolsParentMenu(items);
-            }
+            
+            return new ToolsParentMenu(items.ToArray());
         }
 
         private IEnumerable<IMenuItem> GetFormDesignerContextMenuItems()

--- a/RetailCoder.VBE/Settings/GeneralConfigProvider.cs
+++ b/RetailCoder.VBE/Settings/GeneralConfigProvider.cs
@@ -53,30 +53,21 @@ namespace Rubberduck.Settings
         protected virtual void OnLanguageChanged(EventArgs e)
         {
             var handler = LanguageChanged;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            LanguageChanged?.Invoke(this, e);
         }
 
         public event EventHandler AutoSaveSettingsChanged;
         protected virtual void OnAutoSaveSettingsChanged(EventArgs e)
         {
             var handler = AutoSaveSettingsChanged;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            AutoSaveSettingsChanged?.Invoke(this, e);
         }
 
         public event EventHandler SourceControlEnabledChanged;
         protected virtual void OnSourceControlEnabledChanged(EventArgs e)
         {
             var handler = SourceControlEnabledChanged;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            SourceControlEnabledChanged?.Invoke(this, e);
         }
     }
 }

--- a/RetailCoder.VBE/Settings/GeneralConfigProvider.cs
+++ b/RetailCoder.VBE/Settings/GeneralConfigProvider.cs
@@ -68,5 +68,15 @@ namespace Rubberduck.Settings
                 handler(this, e);
             }
         }
+
+        public event EventHandler SourceControlEnabledChanged;
+        protected virtual void OnSourceControlEnabledChanged(EventArgs e)
+        {
+            var handler = SourceControlEnabledChanged;
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
     }
 }

--- a/RetailCoder.VBE/Settings/GeneralSettings.cs
+++ b/RetailCoder.VBE/Settings/GeneralSettings.cs
@@ -13,7 +13,6 @@ namespace Rubberduck.Settings
         bool SmartIndenterPrompted { get; set; }
         bool AutoSaveEnabled { get; set; }
         int AutoSavePeriod { get; set; }
-        //char Delimiter { get; set; }
         int MinimumLogLevel { get; set; }
         bool SourceControlEnabled { get; set; }
     }
@@ -27,7 +26,6 @@ namespace Rubberduck.Settings
         public bool SmartIndenterPrompted { get; set; }
         public bool AutoSaveEnabled { get; set; }
         public int AutoSavePeriod { get; set; }
-        //public char Delimiter { get; set; }
 
         private int _logLevel;
         public int MinimumLogLevel
@@ -60,7 +58,6 @@ namespace Rubberduck.Settings
             SmartIndenterPrompted = false;
             AutoSaveEnabled = false;
             AutoSavePeriod = 10;
-            //Delimiter = '.';
             MinimumLogLevel = LogLevel.Off.Ordinal;
             SourceControlEnabled = false;
         }
@@ -74,7 +71,6 @@ namespace Rubberduck.Settings
                    SmartIndenterPrompted == other.SmartIndenterPrompted &&
                    AutoSaveEnabled == other.AutoSaveEnabled &&
                    AutoSavePeriod == other.AutoSavePeriod &&
-                   //Delimiter.Equals(other.Delimiter) &&
                    MinimumLogLevel == other.MinimumLogLevel &&
                    SourceControlEnabled == other.SourceControlEnabled;
         }

--- a/RetailCoder.VBE/Settings/GeneralSettings.cs
+++ b/RetailCoder.VBE/Settings/GeneralSettings.cs
@@ -15,6 +15,7 @@ namespace Rubberduck.Settings
         int AutoSavePeriod { get; set; }
         //char Delimiter { get; set; }
         int MinimumLogLevel { get; set; }
+        bool SourceControlEnabled { get; set; }
     }
 
     [XmlType(AnonymousType = true)]
@@ -49,6 +50,8 @@ namespace Rubberduck.Settings
             }
         }
 
+        public bool SourceControlEnabled { get; set; }
+
         public GeneralSettings()
         {
             Language = new DisplayLanguageSetting("en-US");
@@ -59,6 +62,7 @@ namespace Rubberduck.Settings
             AutoSavePeriod = 10;
             //Delimiter = '.';
             MinimumLogLevel = LogLevel.Off.Ordinal;
+            SourceControlEnabled = false;
         }
 
         public bool Equals(GeneralSettings other)
@@ -71,7 +75,8 @@ namespace Rubberduck.Settings
                    AutoSaveEnabled == other.AutoSaveEnabled &&
                    AutoSavePeriod == other.AutoSavePeriod &&
                    //Delimiter.Equals(other.Delimiter) &&
-                   MinimumLogLevel == other.MinimumLogLevel;
+                   MinimumLogLevel == other.MinimumLogLevel &&
+                   SourceControlEnabled == other.SourceControlEnabled;
         }
     }
 }

--- a/RetailCoder.VBE/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/RetailCoder.VBE/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -436,13 +436,13 @@
                                 <Image Source="{StaticResource PrintImage}" />
                             </MenuItem.Icon>
                         </MenuItem>
-                        <MenuItem Header="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=SourceControlPanel_Caption}">
+                        <MenuItem Header="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=SourceControlPanel_Caption}" Visibility="{Binding SourceControlEnabled, Converter={StaticResource BoolToVisibility}}" >
                             <MenuItem Header="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=CodeExplorer_Commit}"
-                                  Command="{Binding CommitCommand}"
-                                  CommandParameter="{Binding SelectedItem}" />
+                                      Command="{Binding CommitCommand}"
+                                      CommandParameter="{Binding SelectedItem}" />
                             <MenuItem Header="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=CodeExplorer_Undo}"
-                                  Command="{Binding UndoCommand}"
-                                  CommandParameter="{Binding SelectedItem}">
+                                      Command="{Binding UndoCommand}"
+                                      CommandParameter="{Binding SelectedItem}">
                                 <MenuItem.Icon>
                                     <Image Source="{StaticResource UndoImage}" />
                                 </MenuItem.Icon>

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -139,7 +139,7 @@ namespace Rubberduck.UI {
                 return ResourceManager.GetString("AboutWindow_GeneralThanks", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Special Thanks.
         /// </summary>
@@ -148,7 +148,7 @@ namespace Rubberduck.UI {
                 return ResourceManager.GetString("AboutWindow_SpecialThanksLabel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add.
         /// </summary>
@@ -402,7 +402,7 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter {0} was not a numeric value on invocatoin {1}. {2}.
+        ///   Looks up a localized string similar to Parameter {0} was not a numeric value on invocation {1}. {2}.
         /// </summary>
         public static string Assert_VerifyParameterNonNumeric {
             get {
@@ -1727,11 +1727,38 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable Source Control.  (Restart Rubberduck to take effect.).
+        /// </summary>
+        public static string GeneralSettings_EnableSourceControl {
+            get {
+                return ResourceManager.GetString("GeneralSettings_EnableSourceControl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source Control is Experimental and is known to be troublesome.  Use at your own risk!.
+        /// </summary>
+        public static string GeneralSettings_EnableSourceControlWarning {
+            get {
+                return ResourceManager.GetString("GeneralSettings_EnableSourceControlWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>
         public static string GeneralSettings_ErrorLogLevel {
             get {
                 return ResourceManager.GetString("GeneralSettings_ErrorLogLevel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Experimental Features:.
+        /// </summary>
+        public static string GeneralSettings_ExperimentalFeatures {
+            get {
+                return ResourceManager.GetString("GeneralSettings_ExperimentalFeatures", resourceCulture);
             }
         }
         

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -1727,20 +1727,11 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable Source Control.  (Restart Rubberduck to take effect.).
+        ///   Looks up a localized string similar to Enable Source Control. Requires a restart to take effect..
         /// </summary>
         public static string GeneralSettings_EnableSourceControl {
             get {
                 return ResourceManager.GetString("GeneralSettings_EnableSourceControl", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Source Control is Experimental and is known to be troublesome.  Use at your own risk!.
-        /// </summary>
-        public static string GeneralSettings_EnableSourceControlWarning {
-            get {
-                return ResourceManager.GetString("GeneralSettings_EnableSourceControlWarning", resourceCulture);
             }
         }
         
@@ -1759,6 +1750,15 @@ namespace Rubberduck.UI {
         public static string GeneralSettings_ExperimentalFeatures {
             get {
                 return ResourceManager.GetString("GeneralSettings_ExperimentalFeatures", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only enable these if you know what you&apos;re doing. Enabling and/or using features from this section may result in things breaking unexpectedly and irrevocable data loss..
+        /// </summary>
+        public static string GeneralSettings_ExperimentalFeaturesWarning {
+            get {
+                return ResourceManager.GetString("GeneralSettings_ExperimentalFeaturesWarning", resourceCulture);
             }
         }
         

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -2053,10 +2053,10 @@ Would you like to import them to Rubberduck?</value>
     <comment>0: Selected target Identifier; 1: Event Parent; 2: Event name</comment>
   </data>
   <data name="GeneralSettings_EnableSourceControl" xml:space="preserve">
-    <value>Enable Source Control.  (Restart Rubberduck to take effect.)</value>
+    <value>Enable Source Control. Requires a restart to take effect.</value>
   </data>
-  <data name="GeneralSettings_EnableSourceControlWarning" xml:space="preserve">
-    <value>Source Control is Experimental and is known to be troublesome.  Use at your own risk!</value>
+  <data name="GeneralSettings_ExperimentalFeaturesWarning" xml:space="preserve">
+    <value>Only enable these if you know what you're doing. Enabling and/or using features from this section may result in things breaking unexpectedly and irrevocable data loss.</value>
   </data>
   <data name="GeneralSettings_ExperimentalFeatures" xml:space="preserve">
     <value>Experimental Features:</value>

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -2052,4 +2052,13 @@ Would you like to import them to Rubberduck?</value>
     <value>Method '{0}' is an implementation of event '{1}.{2}'.  Rename event '{2}'?</value>
     <comment>0: Selected target Identifier; 1: Event Parent; 2: Event name</comment>
   </data>
+  <data name="GeneralSettings_EnableSourceControl" xml:space="preserve">
+    <value>Enable Source Control.  (Restart Rubberduck to take effect.)</value>
+  </data>
+  <data name="GeneralSettings_EnableSourceControlWarning" xml:space="preserve">
+    <value>Source Control is Experimental and is known to be troublesome.  Use at your own risk!</value>
+  </data>
+  <data name="GeneralSettings_ExperimentalFeatures" xml:space="preserve">
+    <value>Experimental Features:</value>
+  </data>
 </root>

--- a/RetailCoder.VBE/UI/Settings/GeneralSettings.xaml
+++ b/RetailCoder.VBE/UI/Settings/GeneralSettings.xaml
@@ -14,6 +14,7 @@
         <converters:DelimiterValueToTextConverter x:Key="DelimiterValueToText" />
         <converters:DelimiterToTextConverter x:Key="DelimiterToText" />
         <converters:HotkeyDisplayConverter x:Key="HotkeyDisplay" />
+        <BooleanToVisibilityConverter x:Key="boolToVis" />
 
         <LinearGradientBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" EndPoint="0,1" StartPoint="0,0">
             <GradientStop Color="#FFD9F4FF" Offset="0"/>
@@ -215,6 +216,13 @@
                             </DataGridTemplateColumn>
                         </DataGrid.Columns>
                     </DataGrid>
+
+                    <Label Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_ExperimentalFeatures}" FontWeight="SemiBold" />
+                    <Label x:Name="SC_Warning" Margin="20,-5,0,0" Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_EnableSourceControlWarning}"
+                           FontWeight="Bold" Foreground="Red" Visibility="{Binding SourceControlEnabled, Converter={StaticResource boolToVis}}" />
+                    <CheckBox x:Name="SC_Checkbox" Margin="5,0,0,5" Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_EnableSourceControl}"
+                           IsChecked="{Binding SourceControlEnabled}" />
+
                 </StackPanel>
             </Grid>
         </ScrollViewer>

--- a/RetailCoder.VBE/UI/Settings/GeneralSettings.xaml
+++ b/RetailCoder.VBE/UI/Settings/GeneralSettings.xaml
@@ -14,7 +14,6 @@
         <converters:DelimiterValueToTextConverter x:Key="DelimiterValueToText" />
         <converters:DelimiterToTextConverter x:Key="DelimiterToText" />
         <converters:HotkeyDisplayConverter x:Key="HotkeyDisplay" />
-        <BooleanToVisibilityConverter x:Key="boolToVis" />
 
         <LinearGradientBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" EndPoint="0,1" StartPoint="0,0">
             <GradientStop Color="#FFD9F4FF" Offset="0"/>
@@ -124,14 +123,6 @@
                               IsChecked="{Binding CheckVersionAtStartup}" />
                     <StackPanel Orientation="Horizontal"/>
 
-                    <!--<Label Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_FolderDelimiterLabel}" FontWeight="SemiBold" />
-                    <ComboBox Width="210"
-                      HorizontalAlignment="Left"
-                      Margin="5"
-                      SelectedIndex="0"
-                      ItemsSource="{Binding Source={StaticResource Delimiters}, Converter={StaticResource DelimiterToText}, UpdateSourceTrigger=PropertyChanged}"
-                      SelectedItem="{Binding Delimiter, Mode=TwoWay, Converter={StaticResource DelimiterValueToText}}" />-->
-
                     <Label Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_MinimumLogLevelLabel}" FontWeight="SemiBold" />
                     <StackPanel Orientation="Horizontal">
                         <ComboBox Width="210"
@@ -218,9 +209,12 @@
                     </DataGrid>
 
                     <Label Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_ExperimentalFeatures}" FontWeight="SemiBold" />
-                    <Label x:Name="SC_Warning" Margin="20,-5,0,0" Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_EnableSourceControlWarning}"
-                           FontWeight="Bold" Foreground="Red" Visibility="{Binding SourceControlEnabled, Converter={StaticResource boolToVis}}" />
-                    <CheckBox x:Name="SC_Checkbox" Margin="5,0,0,5" Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_EnableSourceControl}"
+                    <Label Margin="5,0,0,5" FontWeight="Bold" Foreground="Red">
+                        <Label.Content>
+                            <AccessText TextWrapping="Wrap" Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_ExperimentalFeaturesWarning}"/>
+                        </Label.Content>
+                    </Label>
+                    <CheckBox Margin="5,0,0,5" Content="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=GeneralSettings_EnableSourceControl}"
                            IsChecked="{Binding SourceControlEnabled}" />
 
                 </StackPanel>

--- a/RetailCoder.VBE/UI/Settings/GeneralSettingsViewModel.cs
+++ b/RetailCoder.VBE/UI/Settings/GeneralSettingsViewModel.cs
@@ -153,6 +153,20 @@ namespace Rubberduck.UI.Settings
             }
         }
 
+        private bool _sourceControlEnabled;
+        public bool SourceControlEnabled
+        {
+            get { return _sourceControlEnabled; }
+            set
+            {
+                if (_sourceControlEnabled != value)
+                {
+                    _sourceControlEnabled = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         private readonly CommandBase _showLogFolderCommand;
         public CommandBase ShowLogFolderCommand
         {
@@ -186,7 +200,8 @@ namespace Rubberduck.UI.Settings
                 AutoSaveEnabled = AutoSaveEnabled,
                 AutoSavePeriod = AutoSavePeriod,
                 //Delimiter = (char)Delimiter,
-                MinimumLogLevel = SelectedLogLevel.Ordinal
+                MinimumLogLevel = SelectedLogLevel.Ordinal,
+                SourceControlEnabled = SourceControlEnabled
             };
         }
 
@@ -201,6 +216,7 @@ namespace Rubberduck.UI.Settings
             AutoSavePeriod = general.AutoSavePeriod;
             //Delimiter = (DelimiterOptions)general.Delimiter;
             SelectedLogLevel = LogLevels.First(l => l.Ordinal == general.MinimumLogLevel);
+            SourceControlEnabled = general.SourceControlEnabled;
         }
 
         private void ImportSettings()

--- a/RubberduckTests/Settings/GeneralSettingsTests.cs
+++ b/RubberduckTests/Settings/GeneralSettingsTests.cs
@@ -135,6 +135,16 @@ namespace RubberduckTests.Settings
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.AutoSavePeriod, viewModel.AutoSavePeriod);
         }
 
+        [TestCategory("Settings")]
+        [TestMethod]
+        public void SourceControlEnabledIsSetInCtor()
+        {
+            var defaultConfig = GetDefaultConfig();
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object);
+
+            Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.SourceControlEnabled, viewModel.SourceControlEnabled);
+        }
+
         //[TestCategory("Settings")]
         //[TestMethod]
         //public void DelimiterIsSetInCtor()


### PR DESCRIPTION
This PR adds a "Experimental Features:" section to the bottom of the General Settings window, and a checkbox to "Enable Source Control".

The text box changes a Boolean value in the Settings store, which is read during the launch of RD to enable (or not) the presence of the Source Control item in the `Rubberduck` --> `Tools` menu.  It requires a restart to take effect, but since most users who will use SC will toggle it on once and leave it, I figure that requiring a restart should be fine.

When the checkbox is checked, a "Warning: this feature is Experimental! Use at your own risk!" message in red color appears above the checkbox.  I wanted to change the caption for the checkbox, but that would have involved some sort of event-handling which I didn't quite understand how to do yet, nor was is worth the effort for a temporary feature.