### PR TITLE
All Declarations belong to the DeclarationFinder

### DIFF
--- a/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationFinder.cs
@@ -353,6 +353,8 @@ namespace Rubberduck.Parsing.Symbols
 
         public IReadOnlyCollection<QualifiedModuleName> AllModules => _declarations.Keys.AsReadOnly();
 
+        public IEnumerable<Declaration> AllDeclarations => _declarations.AllValues();
+
         public IEnumerable<Declaration> FindDeclarationsWithNonBaseAsType()
         {
             return _nonBaseAsType.Value;

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -637,7 +637,7 @@ End Sub
             var parser = MockParser.Create(vbe.Object);
             parser.Parse(new CancellationTokenSource());
 
-            var expected = parser.State.AllDeclarations.Single(item => item.DeclarationType == DeclarationType.Variable);
+            var expected = parser.State.DeclarationFinder.DeclarationsWithType(DeclarationType.Variable).Single();
             var actual = parser.State.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
 
             Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);
@@ -667,7 +667,7 @@ End Sub
             var parser = MockParser.Create(vbe.Object);
             parser.Parse(new CancellationTokenSource());
 
-            var expected = parser.State.AllDeclarations.Single(item => item.DeclarationType == DeclarationType.Variable);
+            var expected = parser.State.DeclarationFinder.DeclarationsWithType(DeclarationType.Variable).Single();
             var actual = parser.State.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
 
             Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);


### PR DESCRIPTION
So far, declarations can be accessed via the `DeclarationFinder` and directly via `AllDeclarations` and `AllUserDeclarations` on the `RubberduckParserState`. 

This PR rewires how the access on the `RubberduckParserState` works. Now, the public properties just refer to the corresponding properties on the `DeclarationFinder`. In addition, there is a new private property working like the old `AllDeclarations`, which is used to provide the declarations for constructing the `DeclarationFinder`.

Moreover, a new function got introduced returning whether there are declarations at all. This is used in the sinks instead of the old method of using `AllDeclarations.Count`. (This actually queried all all declarations every time.)

 