### PR TITLE
Fix log levels greater than Info not appearing in logs

### DIFF
--- a/RetailCoder.VBE/Common/LogLevelHelper.cs
+++ b/RetailCoder.VBE/Common/LogLevelHelper.cs
@@ -51,7 +51,7 @@ namespace Rubberduck.Common
 
         public static void SetMinimumLogLevel(LogLevel minimumLogLevel)
         {
-            if (LogManager.GlobalThreshold == minimumLogLevel) 
+            if (LogManager.GlobalThreshold == minimumLogLevel && LogHeaderWritten == true)
             {
                 return;
             }
@@ -69,7 +69,7 @@ namespace Rubberduck.Common
             if (minimumLogLevel == LogLevel.Off)
             {
                 LogManager.DisableLogging();
-                LogManager.GlobalThreshold = minimumLogLevel;
+                LogManager.GlobalThreshold = LogLevel.Off;
                 LogManager.ReconfigExistingLoggers();
                 return;
             }


### PR DESCRIPTION
This fixes the regression introduced in PR #3106.

At the beginning of `setMinimumLogLevel` a check was added to see if the new `minimumLogLevel` was same as the current log level.  That check also needed to see if this was the first time setting a minimum log level, as told by the `LogHeaderWritten` bool. 