### PR TITLE
Tweaks to the ObjectVariableNotSetInspection

### DIFF
--- a/Rubberduck.Inspections/Concrete/ObjectVariableNotSetInspection.cs
+++ b/Rubberduck.Inspections/Concrete/ObjectVariableNotSetInspection.cs
@@ -23,8 +23,9 @@ namespace Rubberduck.Inspections.Concrete
                 VariableRequiresSetAssignmentEvaluator.GetDeclarationsPotentiallyRequiringSetAssignment(State.AllUserDeclarations);
 
             var candidateReferencesRequiringSetAssignment = 
-                allInterestingDeclarations.SelectMany(dec => dec.References)
-                    .Where(dec => !IsIgnoringInspectionResultFor(dec, AnnotationName))
+                allInterestingDeclarations
+                    .SelectMany(dec => dec.References)
+                    .Where(reference => !IsIgnoringInspectionResultFor(reference, AnnotationName))                    
                     .Where(reference => reference.IsAssignment);
 
             var referencesRequiringSetAssignment = candidateReferencesRequiringSetAssignment                  

--- a/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
+++ b/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
@@ -124,8 +124,7 @@ namespace Rubberduck.Inspections
             //If the RHS is the identifierName of one of the 'interesting' declarations, we need to use 'Set'
             //unless the 'interesting' declaration is also a Variant
             var rhsIdentifier = GetRHSIdentifierExpressionText(letStmtContext);
-            return variantAndObjectDeclarations
-                   .Where(dec => dec.IdentifierName == rhsIdentifier && dec.AsTypeName != Tokens.Variant).Any();
+            return variantAndObjectDeclarations.Any(dec => dec.IdentifierName == rhsIdentifier && dec.AsTypeName != Tokens.Variant);
         }
 
         private static bool IsLetAssignment(IdentifierReference reference)

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -588,7 +588,7 @@ visibility : PRIVATE | PUBLIC | FRIEND | GLOBAL;
 expression :
     // Literal Expression has to come before lExpression, otherwise it'll be classified as simple name expression instead.	
 	whiteSpace? LPAREN whiteSpace? expression whiteSpace? RPAREN                                    # parenthesizedExpr
-	|literalExpression                                                                              # literalExpr
+	| literalExpression                                                                             # literalExpr
 	| lExpression                                                                                   # lExpr
 	| builtInType                                                                                   # builtInTypeExpr
 	| TYPEOF whiteSpace expression                                                                  # typeofexpr        // To make the grammar SLL, the type-of-is-expression is actually the child of an IS relational op.

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -13,9 +13,8 @@ namespace Rubberduck.Parsing.VBA
 {
     public class ParseCoordinator : IParseCoordinator
     {
-        public RubberduckParserState State { get { return _state; } }
+        public RubberduckParserState State { get; }
 
-        private readonly RubberduckParserState _state;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         private readonly IParsingStageService _parsingStageService;
@@ -54,7 +53,7 @@ namespace Rubberduck.Parsing.VBA
                 throw new ArgumentNullException(nameof(parserStateManager));
             }
 
-            _state = state;
+            State = state;
             _parsingStageService = parsingStageService;
             _projectManager = projectManager;
             _parsingCacheService = parsingCacheService;

--- a/Rubberduck.Parsing/VBA/ParsingCacheService.cs
+++ b/Rubberduck.Parsing/VBA/ParsingCacheService.cs
@@ -90,7 +90,7 @@ namespace Rubberduck.Parsing.VBA
 
         public IReadOnlyCollection<QualifiedModuleName> ModulesReferencing(QualifiedModuleName referencedModule)
         {
-            throw new NotImplementedException();
+            return _moduleToModuleReferenceManager.ModulesReferencing(referencedModule);
         }
 
         public IReadOnlyCollection<QualifiedModuleName> ModulesReferencingAny(IEnumerable<QualifiedModuleName> referencedModules)

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -636,7 +636,7 @@ namespace Rubberduck.Parsing.VBA
 
         private bool ThereAreDeclarations()
         {
-            return _moduleStates.Values.Where(state => state.Declarations != null && state.Declarations.Keys.Any()).Any();
+            return _moduleStates.Values.Any(state => state.Declarations != null && state.Declarations.Keys.Any());
         }
 
         /// <summary>

--- a/Rubberduck.Parsing/VBA/SynchronousReferenceResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/SynchronousReferenceResolveRunner.cs
@@ -3,7 +3,6 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.VBEditor;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 namespace Rubberduck.Parsing.VBA

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -514,6 +514,34 @@ End Sub";
             AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
         }
 
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_LSetOnUDT_ReturnsNoResult()
+        {
+
+            var expectResultCount = 0;
+            var input =
+                @"
+Type TFoo
+  CountryCode As String * 2
+  SecurityNumber As String * 8
+End Type
+
+Type TBar
+  ISIN As String * 10
+End Type
+
+Sub Test()
+
+  Dim foo As TFoo
+  Dim bar As TBar
+
+  bar.ISIN = ""DE12345678""
+  LSet foo = bar
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
+
         private void AssertInputCodeYieldsExpectedInspectionResultCount(string inputCode, int expected)
         {
             IVBComponent component;

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -424,18 +424,92 @@ End Sub";
         public void ObjectVariableNotSet_FunctionReturnNotSet_ReturnsResult()
         {
 
-            var expectResultCount = 0;
+            var expectResultCount = 1;
             var input =
 @"
-Enum TestEnum
-    EnumOne
-    EnumTwo
-    EnumThree
-End Enum
+Private Function Test() As Collection
+    Test = new Collection
+End Function";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
 
-Private Sub TestEnum()
-    Dim enumVariable As TestEnum
-    enumVariable = EnumThree
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_ObjectLiteral_ReturnsResult()
+        {
+
+            var expectResultCount = 1;
+            var input =
+    @"
+Private Sub Test()
+    Dim bar As Variant
+    bar = Nothing
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_NonObjectLiteral_ReturnsNoResult()
+        {
+
+            var expectResultCount = 0;
+            var input =
+    @"
+Private Sub Test()
+    Dim bar As Variant
+    bar = Null
+    bar = Empty
+    bar = ""aaa""
+    bar = 5
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_ForEach_ReturnsNoResult()
+        {
+
+            var expectResultCount = 0;
+            var input =
+    @"
+Private Sub Test()
+    Dim bar As Variant
+    For Each foo In bar
+    Next
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_RSet_ReturnsNoResult()
+        {
+
+            var expectResultCount = 0;
+            var input =
+    @"
+Private Sub Test()
+    Dim foo As Variant
+    Dim bar As Variant
+    RSet foo = bar
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ObjectVariableNotSet_LSet_ReturnsNoResult()
+        {
+
+            var expectResultCount = 0;
+            var input =
+    @"
+Private Sub Test()
+    Dim foo As Variant
+    Dim bar As Variant
+    LSet foo = bar
 End Sub";
             AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
         }


### PR DESCRIPTION
This Pr includes some tweaks to the `ObjectVariableNotSetInspection`. Now, it will fire for a let assignment of `Nothing` to a `Variant` and never for any other literal. Moreover, it no longer crashes for assignments other than set and let assignments.

Fixes #3181  