### PR TITLE
3082 long procedure names

### DIFF
--- a/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
+++ b/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
@@ -151,6 +151,7 @@
     <Compile Include="SafeComWrappers\Office.Core\CommandBarButton.cs" />
     <Compile Include="SafeComWrappers\Office.Core\CommandBarButtonClickEventArgs.cs" />
     <Compile Include="SafeComWrappers\Office.Core\CommandBarControl.cs" />
+    <Compile Include="SafeComWrappers\Office.Core\CommandBarControlCaptionGuard.cs" />
     <Compile Include="SafeComWrappers\Office.Core\CommandBarControls.cs" />
     <Compile Include="SafeComWrappers\Office.Core\CommandBarPopup.cs" />
     <Compile Include="SafeComWrappers\Office.Core\CommandBarPosition.cs" />

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControl.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControl.cs
@@ -25,7 +25,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         public string Caption
         {
             get { return IsWrappingNullReference ? string.Empty : Target.Caption; }
-            set { if (!IsWrappingNullReference) Target.Caption = value; }
+            set { if (!IsWrappingNullReference) Target.Caption = CommandBarControlCaptionGuard.ApplyGuard(value); }
         }
 
         public string DescriptionText

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControlCaptionGuard.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControlCaptionGuard.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
+{
+    public static class CommandBarControlCaptionGuard
+    {
+        private static int MAX_CAPTION_LENGTH = 255;
+        private static int MODIFIED_PRE_POST_ELLIPSIS_LENGTH = 30;
+        private static string ELLIPSIS = "...";
+
+
+        public static string ApplyGuard(string proposedCaption)
+        {
+            if (proposedCaption == null || proposedCaption.Length < MAX_CAPTION_LENGTH)
+            {
+                return proposedCaption;
+            }
+
+            if (IsMethodFormat(proposedCaption))
+            {
+                var splitCaption = proposedCaption.Split(new[] { "." }, System.StringSplitOptions.None);
+                Debug.Assert(splitCaption.Length == 3);
+                //splitCaption[0] = Coordinates plus filename (allowed to be nearly 200 characters)
+                //splitCaption[1] = Module Name (limited to 31 characters by VBE)
+                //splitCaption[2] = Sub or Function name plus a type string at the end (e.g. "(procedure)")
+
+                //Reduce the filename first if it is too 'long'
+                splitCaption[0] = MinimizeCaptionPortionName(splitCaption[0]);
+
+                if ( splitCaption[0].Length + splitCaption[1].Length + splitCaption[2].Length > MAX_CAPTION_LENGTH)
+                {
+                    //still too long, truncate the method name
+                    splitCaption[2] = MinimizeCaptionPortionName(splitCaption[2]);
+                }
+
+                return $"{splitCaption[0]}.{splitCaption[1]}.{splitCaption[2]}";
+            }
+
+            //Don't recognize the format, so bluntly truncate and avoid the exception
+            return proposedCaption.Substring(0, MAX_CAPTION_LENGTH - (ELLIPSIS.Length * 2)) + ELLIPSIS;
+        }
+
+        public static bool IsMethodFormat(string proposedCaption)
+        {
+            //Example of a caption input when a method is selected: 
+            //"L23C13 | TheFilename.TheModuleName.TheMethodName (procedure)"
+            var pattern = @"^[L][0-9]+[C][0-9]+\s[|]\s[a-zA-Z0-9]+[.][a-zA-Z0-9]+[.][a-zA-Z0-9]+\s[(][a-z]+[)]\z";
+            return Regex.IsMatch(proposedCaption, pattern);
+        }
+
+        private static string MinimizeCaptionPortionName(string methodNamePlusTypeIdentifier)
+        {
+            if (methodNamePlusTypeIdentifier.Length > MODIFIED_PRE_POST_ELLIPSIS_LENGTH * 2 + ELLIPSIS.Length)
+            {
+                var preEllipsis = methodNamePlusTypeIdentifier.Substring(0, MODIFIED_PRE_POST_ELLIPSIS_LENGTH);
+                var postEllipsis = methodNamePlusTypeIdentifier.Substring(methodNamePlusTypeIdentifier.Length - MODIFIED_PRE_POST_ELLIPSIS_LENGTH);
+                return $"{preEllipsis}{ELLIPSIS}{postEllipsis}";
+            }
+            return methodNamePlusTypeIdentifier;
+        }
+    }
+}

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="SourceControl\SynchrounouslyConstructedDeclarationFinderFactory.cs" />
     <Compile Include="Symbols\AccessibilityCheckTests.cs" />
     <Compile Include="Symbols\ClassModuleDeclarationTests.cs" />
+    <Compile Include="Symbols\CommandBarControlCaptionGuardTests.cs" />
     <Compile Include="Symbols\DeclarationFinderTests.cs" />
     <Compile Include="Symbols\ProjectDeclarationTests.cs" />
     <Compile Include="Symbols\ConstantDeclarationTests.cs" />

--- a/RubberduckTests/Symbols/CommandBarControlCaptionGuardTests.cs
+++ b/RubberduckTests/Symbols/CommandBarControlCaptionGuardTests.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rubberduck.VBEditor.SafeComWrappers.Office.Core;
+using System;
+
+namespace RubberduckTests.Symbols
+{
+    [TestClass]
+    public class CommandBarControlCaptionGuardTests
+    {
+        private const int MAX_CAPTION_LENGTH = 256;
+        private const string COORDINATE = "L5C27";
+        private const string MODULENAME = "TheContainingModule";
+        private const string FILENAME = "TheFilename";
+        private const string TYPEIDENTIFIER = "(procedure)";
+
+        [TestMethod]
+        [TestCategory("Guard")]
+        public void CommandBarControlCaptionGuard_Regex_MeetsPattern()
+        {
+            string proposedCaption = GetFormattedMethodIdentifierOfLength(60);
+            Assert.IsTrue(CommandBarControlCaptionGuard.IsMethodFormat(proposedCaption));
+        }
+
+        [TestMethod]
+        [TestCategory("Guard")]
+        public void CommandBarControlCaptionGuard_Regex_TooShort()
+        {
+            string proposedCaption = GetFormattedMethodIdentifierOfLength(60);
+            Assert.IsFalse(CommandBarControlCaptionGuard.IsMethodFormat(proposedCaption.Substring(0, 5)));
+        }
+
+        [TestMethod]
+        [TestCategory("Guard")]
+        public void CommandBarControlCaptionGuard_Regex_ExtraChars()
+        {
+            string proposedCaption = GetFormattedMethodIdentifierOfLength(60);
+            Assert.IsFalse(CommandBarControlCaptionGuard.IsMethodFormat(proposedCaption + "Yo!!"));
+        }
+
+    [TestMethod]
+        [TestCategory("GuardFunction")]
+        public void CommandBarControlCaptionGuard_ShortName()
+        {
+            string proposedCaption = GetFormattedMethodIdentifierOfLength(60);
+            var result = CommandBarControlCaptionGuard.ApplyGuard(proposedCaption);
+
+            Assert.IsTrue(result.Equals(proposedCaption, StringComparison.InvariantCulture));
+            Assert.IsFalse(result.Contains("..."));
+        }
+
+        [TestMethod]
+        [TestCategory("GuardFunction")]
+        public void CommandBarControlCaptionGuard_TooLongSubName()
+        {
+            string proposedCaption = GetFormattedMethodIdentifierOfLength(260);
+            var result = CommandBarControlCaptionGuard.ApplyGuard(proposedCaption);
+
+            Assert.IsTrue(result.Length <= MAX_CAPTION_LENGTH);
+            Assert.IsTrue(result.Contains("..."));
+        }
+
+        [TestMethod]
+        [TestCategory("GuardFunction")]
+        public void CommandBarControlCaptionGuard_TooLongFileName()
+        {
+            string reallyLongFilename = GetIdentifierOfLength(200);
+            string proposedCaption = GetFormattedMethodIdentifierOfLength(300, reallyLongFilename);
+            var result = CommandBarControlCaptionGuard.ApplyGuard(proposedCaption);
+
+            Assert.IsTrue(result.Length <= MAX_CAPTION_LENGTH);
+            Assert.IsTrue(result.Contains("..."));
+        }
+
+        private string GetFormattedMethodIdentifierOfLength(int targetLength, string fileName = FILENAME)
+        {
+            var preamble = $"{COORDINATE} | {fileName}.{MODULENAME}.";
+            var proposedCaption = preamble + GetIdentifierOfLength(targetLength - preamble.Length);
+            proposedCaption = proposedCaption.Substring(0, targetLength - (TYPEIDENTIFIER.Length + 1)) + " " + TYPEIDENTIFIER;
+            if (proposedCaption.Length != targetLength)
+            {
+                Assert.Inconclusive("Test Generated Format String has incorrect length");
+            }
+            return proposedCaption;
+        }
+
+        private string GetIdentifierOfLength(int targetLength)
+        {
+            int maxLoopIterations = 100;
+            string proposedCaption = "Abcdefghij";
+            for (int idx = 0; idx <= maxLoopIterations; idx++)
+            {
+                proposedCaption = proposedCaption + proposedCaption;
+                if (proposedCaption.Length > targetLength)
+                {
+                    idx = maxLoopIterations + 1;
+                    proposedCaption = proposedCaption.Substring(0, targetLength);
+                }
+            }
+            if (proposedCaption.Length != targetLength)
+            {
+                Assert.Inconclusive("Test Generated String has incorrect length");
+            }
+            return proposedCaption;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #3082 by introducing a guard clause when the CommandBarControlCaption property is set.  When there is an attempt to set the Caption property to a string with more than 255 characters, the clause checks for a pattern match to apply specific reduction logic.  If the input string length exceeds 255 and the pattern match fails, the clause simply truncates the string and appends an ellipsis to prevent an exception/crash.  
