### PR TITLE
First step towards clean exit

### DIFF
--- a/RetailCoder.VBE/AppMenu.cs
+++ b/RetailCoder.VBE/AppMenu.cs
@@ -70,12 +70,16 @@ namespace Rubberduck
             _parser.State.StateChanged -= OnParserStateChanged;
             _selectionService.SelectedDeclarationChanged -= OnSelectedDeclarationChange;
 
-            // note: doing this wrecks the teardown process. counter-intuitive? sure. but hey it works.
-            //foreach (var menu in _menus.Where(menu => menu.Item != null))
-            //{
-            //    menu.RemoveChildren();
-            //    menu.Item.Delete();
-            //}
+            RemoveMenus();
+        }
+
+        private void RemoveMenus()
+        {
+            foreach (var menu in _menus.Where(menu => menu.Item != null))
+            {
+                menu.RemoveChildren();
+                menu.Item.Delete();
+            }
         }
     }
 }

--- a/RetailCoder.VBE/AppMenu.cs
+++ b/RetailCoder.VBE/AppMenu.cs
@@ -77,8 +77,7 @@ namespace Rubberduck
         {
             foreach (var menu in _menus.Where(menu => menu.Item != null))
             {
-                menu.RemoveChildren();
-                menu.Item.Delete();
+                menu.RemoveMenu();
             }
         }
     }

--- a/RetailCoder.VBE/Extension.cs
+++ b/RetailCoder.VBE/Extension.cs
@@ -243,6 +243,16 @@ namespace Rubberduck
                 _kernel = null;
             }
 
+            Debug.WriteLine("Extension: Initiating garbage collection.");
+
+            GC.Collect();
+
+            Debug.WriteLine("Extension: Initiated garbage collection.");
+
+            GC.WaitForPendingFinalizers();
+
+            Debug.WriteLine("Extension: Finalizers have run.");
+
             _isInitialized = false;
         }
 

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
@@ -119,29 +119,17 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
             try
             {
-                foreach (var child in _items.Values.Select(item => item as CommandBarButton).Where(child => child != null))
+                foreach (var button in _items.Values.Select(item => item as ICommandBarButton).Where(child => child != null))
                 {
-                    var button = Parent.FindControl(child.Id);
-                    if (button is ICommandBarButton && !button.IsWrappingNullReference)
+                    if (!button.IsWrappingNullReference)
                     {
-                        (button as ICommandBarButton).Click -= child_Click;
+                        button.Click -= child_Click;
                     }
                     button.Delete();
                 }
             }
             catch (COMException exception)
             {
-                /*
-Application: EXCEL.EXE
-Framework Version: v4.0.30319
-Description: The process was terminated due to an unhandled exception.
-Exception Info: System.Runtime.InteropServices.COMException
-   at Microsoft.Office.Core.CommandBarControl.get_Parent()
-   at Rubberduck.VBEditor.SafeComWrappers.Office.Core.CommandBarControl.get_Parent()
-   at Rubberduck.VBEditor.SafeComWrappers.Office.Core.CommandBarButton.remove_Click(System.EventHandler`1<Rubberduck.VBEditor.SafeComWrappers.Office.Core.CommandBarButtonClickEventArgs>)
-   at Rubberduck.UI.Command.MenuItems.CommandBars.AppCommandBarBase.RemoveChildren()
-   at Rubberduck.UI.Command.MenuItems.CommandBars.RubberduckCommandBar.Dispose()
-                */
                 Logger.Error(exception, "Error removing child controls from commandbar.");
             }
         }

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
@@ -109,9 +109,18 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
         public ICommandBars Parent { get; set; }
         public ICommandBar Item { get; private set; }
-        public void RemoveChildren()
+
+        public void RemoveCommandBar()
         {
-            Logger.Debug("Removing child controls from commandbar.");
+            Logger.Debug("Removing commandbar.");
+            RemoveChildren();
+            Item?.Delete();
+            Item = null;
+            Parent = null;
+        }
+
+        private void RemoveChildren()
+        {
             if (Parent == null || Parent.IsWrappingNullReference)
             {
                 return;
@@ -132,6 +141,7 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             {
                 Logger.Error(exception, "Error removing child controls from commandbar.");
             }
+            _items.Clear();
         }
 
         // note: HAAAAACK!!!

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/IAppCommandBar.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/IAppCommandBar.cs
@@ -6,6 +6,6 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
     {
         ICommandBars Parent { get; set; }
         ICommandBar Item { get; }
-        void RemoveChildren();
+        void RemoveCommandBar();
     }
 }

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -138,10 +138,13 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             _parser.State.StateChanged -= OnParserStateChanged;
             _parser.State.StatusMessageUpdate -= OnParserStatusMessageUpdate;
 
-            //note: doing this wrecks the teardown process. counter-intuitive? sure. but hey it works.
-            //RemoveChildren();
-            //Item.Delete();
-            //Item.Release(true);
+            RemoveCommandBar();
+        }
+
+        private void RemoveCommandBar()
+        {
+            RemoveChildren();
+            Item.Delete();
         }
     }
 

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -140,12 +140,6 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
             RemoveCommandBar();
         }
-
-        private void RemoveCommandBar()
-        {
-            RemoveChildren();
-            Item.Delete();
-        }
     }
 
     public enum RubberduckCommandBarItemDisplayOrder

--- a/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/IParentMenuItem.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/IParentMenuItem.cs
@@ -6,6 +6,6 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
     {
         ICommandBarControls Parent { get; set; }
         ICommandBarPopup Item { get; }
-        void RemoveChildren();
+        void RemoveMenu();
     }
 }

--- a/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using Rubberduck.Parsing.VBA;
@@ -93,14 +94,14 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
             foreach (var child in _items.Keys.Select(item => item as IParentMenuItem).Where(child => child != null))
             {
                 child.RemoveChildren();
-                //var item = _items[child];
-                //Debug.Assert(item is CommandBarPopup);
-                //(item as CommandBarPopup).Delete();
+                var item = _items[child];
+                Debug.Assert(item is CommandBarPopup);
+                (item as CommandBarPopup).Delete();
             }
             foreach (var child in _items.Values.Select(item => item as CommandBarButton).Where(child => child != null))
             {
                 child.Click -= child_Click;
-                //child.Delete();
+                child.Delete();
             }
         }
 

--- a/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using Rubberduck.Parsing.VBA;
@@ -88,13 +89,19 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
             EvaluateCanExecute(null);
         }
 
-        public void RemoveChildren()
+        public void RemoveMenu()
+        {
+            Logger.Debug($"Removing menu {_key}.");
+            RemoveChildren();
+            Item?.Delete();
+            Item = null;
+        }
+
+        private void RemoveChildren()
         {
             foreach (var child in _items.Keys.Select(item => item as IParentMenuItem).Where(child => child != null))
             {
-                child.RemoveChildren();
-                var item = _items[child] as ICommandBarPopup;
-                item?.Delete();
+                child.RemoveMenu();
             }
             foreach (var child in _items.Values.Select(item => item as ICommandBarButton).Where(child => child != null))
             {

--- a/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using Rubberduck.Parsing.VBA;
@@ -94,11 +93,10 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
             foreach (var child in _items.Keys.Select(item => item as IParentMenuItem).Where(child => child != null))
             {
                 child.RemoveChildren();
-                var item = _items[child];
-                Debug.Assert(item is CommandBarPopup);
-                (item as CommandBarPopup).Delete();
+                var item = _items[child] as ICommandBarPopup;
+                item?.Delete();
             }
-            foreach (var child in _items.Values.Select(item => item as CommandBarButton).Where(child => child != null))
+            foreach (var child in _items.Values.Select(item => item as ICommandBarButton).Where(child => child != null))
             {
                 child.Click -= child_Click;
                 child.Delete();

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -320,7 +320,7 @@ namespace Rubberduck.Parsing.VBA
                 if (watch != null && watch.IsRunning) watch.Stop();
                 if (lockTaken) Monitor.Exit(_parsingRunSyncObject);
             }
-            if (watch != null) Logger.Debug("Parsing run finished after {0}s. (thread {1}).", watch.Elapsed.Seconds, Thread.CurrentThread.ManagedThreadId);
+            if (watch != null) Logger.Debug("Parsing run finished after {0}s. (thread {1}).", watch.Elapsed.TotalSeconds, Thread.CurrentThread.ManagedThreadId);
         }
 
         private void ParseAllInternal(object requestor, CancellationToken token)

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarButton.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarButton.cs
@@ -31,21 +31,27 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
         {
             add
             {
-                ((Microsoft.Office.Core.CommandBarButton)Target).Click += Target_Click;
+                if (_clickHandler == null)
+                {
+                    ((Microsoft.Office.Core.CommandBarButton)Target).Click += Target_Click;
+                }
                 _clickHandler += value;
                 System.Diagnostics.Debug.WriteLine("Added handler for: {0} '{1}' (tag: {2}, hashcode:{3})", Parent.Name, Target.Caption, Tag, Target.GetHashCode());
             }
             remove
             {
+                _clickHandler -= value;
                 try
                 {
-                    ((Microsoft.Office.Core.CommandBarButton)Target).Click -= Target_Click;
+                    if (_clickHandler == null)
+                    {
+                        ((Microsoft.Office.Core.CommandBarButton)Target).Click -= Target_Click;
+                    }
                 }
                 catch
                 {
                     // he's gone, dave.
                 }
-                _clickHandler -= value;
                 System.Diagnostics.Debug.WriteLine("Removed handler for: {0} '{1}' (tag: {2}, hashcode:{3})", Parent.GetType().Name, Target.Caption, Tag, Target.GetHashCode());
             }
         }

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControl.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControl.cs
@@ -6,6 +6,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 {
     public class CommandBarControl : SafeComWrapper<Microsoft.Office.Core.CommandBarControl>, ICommandBarControl
     {
+        public const bool AddCommandBarControlsTemporarily = false;
+
         public CommandBarControl(Microsoft.Office.Core.CommandBarControl target) 
             : base(target)
         {
@@ -125,7 +127,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         public void Delete()
         {
-            if (!IsWrappingNullReference) Target.Delete(true);
+            if (!IsWrappingNullReference) Target.Delete(AddCommandBarControlsTemporarily);
         }
 
         public void Execute()

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControls.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControls.cs
@@ -30,12 +30,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         public ICommandBarControl Add(ControlType type)
         {
-            return new CommandBarControl(IsWrappingNullReference ? null : Target.Add(type, Temporary:true));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.Add(type, Temporary: CommandBarControl.AddCommandBarControlsTemporarily));
         }
 
         public ICommandBarControl Add(ControlType type, int before)
         {
-            return new CommandBarControl(IsWrappingNullReference ? null : Target.Add(type, Before: before, Temporary: true));
+            return new CommandBarControl(IsWrappingNullReference ? null : Target.Add(type, Before: before, Temporary: CommandBarControl.AddCommandBarControlsTemporarily));
         }
 
         IEnumerator<ICommandBarControl> IEnumerable<ICommandBarControl>.GetEnumerator()

--- a/Rubberduck.VBEEditor/WindowsApi/SubclassingWindow.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/SubclassingWindow.cs
@@ -39,10 +39,18 @@ namespace Rubberduck.VBEditor.WindowsApi
             AssignHandle();
         }
 
+        private bool _disposed = false;
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             ReleaseHandle();
             _thisHandle.Free();
+
+            _disposed = true;
         }
 
         private void AssignHandle()

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -36,7 +36,7 @@ End Sub
             var expectResultCount = 0;
             var input =
                 @"
-Public Property Let Foo() As String
+Public Property Let Foo(rhs As String)
 End Property
 
 Private Sub DoSomething()
@@ -48,12 +48,12 @@ End Sub
 
         [TestMethod]
         [TestCategory("Inspections")]
-        public void ObjectVariableNotSet_GivenPropertySet_ReturnsResult()
+        public void ObjectVariableNotSet_GivenPropertySet_WithoutSet_ReturnsResult()
         {
             var expectResultCount = 1;
             var input =
                 @"
-Public Property Set Foo() As Object
+Public Property Set Foo(rhs As Object)
 End Property
 
 Private Sub DoSomething()
@@ -65,12 +65,12 @@ End Sub
 
         [TestMethod]
         [TestCategory("Inspections")]
-        public void ObjectVariableNotSet_GivenPropertySet_ReturnsNoResult()
+        public void ObjectVariableNotSet_GivenPropertySet_WithSet_ReturnsNoResult()
         {
             var expectResultCount = 0;
             var input =
                 @"
-Public Property Set Foo() As Object
+Public Property Set Foo(rhs As Object)
 End Property
 
 Private Sub DoSomething()


### PR DESCRIPTION
This PR is a first step towards a clean exist; it fixes one reason of the crash on exit: we have not been unregistering the `Click` events from the `CommandBarButton`s, neither in the command bar nor in the menus.  This leads to a fatal error on shutdown.

This PR changes the `CommandBarControl`s to be added permanently and to be removed explicitly on shutdown, removing the `Click` handlers as well. Moreover, as a safety measure, the GC gets invoked at the end of the shutdown.

There are more problematic sections I have identified and I am looking into. However, although there are still plenty of COM access violations on shutdown, I get a clean exit in Excel in production now, but not when debugging.

ref issue #3213