### PR TITLE
Apply Refresh Message to Code Inspections window

### DIFF
--- a/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/RetailCoder.VBE/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -214,7 +214,7 @@ namespace Rubberduck.Navigation.CodeExplorer
                 _isBusy = value;
                 OnPropertyChanged();
                 // If the window is "busy" then hide the Refresh message
-                OnPropertyChanged("EmptyTreeMessageVisibility");
+                OnPropertyChanged("EmptyUIRefreshMessageVisibility");
             }
         }
 
@@ -566,7 +566,7 @@ namespace Rubberduck.Navigation.CodeExplorer
             }
         }
 
-        public Visibility EmptyTreeMessageVisibility
+        public Visibility EmptyUIRefreshMessageVisibility
         {
             get
             {

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -416,6 +416,9 @@
     <Compile Include="UI\Command\MenuItems\CommandBars\ContextDescriptionLabelMenuItem.cs" />
     <Compile Include="UI\Command\MenuItems\IndentCurrentProjectCommandMenuItem.cs" />
     <Compile Include="UI\Command\MenuItems\ExportAllCommandMenuItem.cs" />
+    <Compile Include="UI\Controls\EmptyUIRefresh.xaml.cs">
+      <DependentUpon>EmptyUIRefresh.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\EnvironmentProvider.cs" />
     <Compile Include="UI\Inspections\AggregateInspectionResult.cs" />
     <Compile Include="UI\ModernFolderBrowser.cs" />
@@ -1375,6 +1378,10 @@
     <Page Include="UI\CodeExplorer\CodeExplorerControl.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\Controls\EmptyUIRefresh.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UI\Inspections\InspectionResultsControl.xaml">
       <SubType>Designer</SubType>

--- a/RetailCoder.VBE/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/RetailCoder.VBE/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -708,22 +708,6 @@
             <RowDefinition Height="Auto" MinHeight="48"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Grid.RowSpan="3" Background="#FFEEF5FD">
-            <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="WrapWithOverflow" TextAlignment="Center"
-                       Visibility="{Binding EmptyTreeMessageVisibility}" MinWidth="200">
-                <Run FontWeight="Bold" Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=CodeExplorer_EmptyViewMessage_Title}"/><LineBreak/><Run/>
-                <LineBreak/>
-                <Button Command="{Binding RefreshCommand}" BorderThickness="0" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
-                    <Image Height="16" Source="../../Resources/arrow-circle-double.png" ClipToBounds="True" />
-                    <Button.ToolTip>
-                        <TextBlock Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=Refresh}" />
-                    </Button.ToolTip>
-                </Button>
-                <Hyperlink Command="{Binding RefreshCommand}"><Run Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=Refresh}"/></Hyperlink>
-                <Run Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=CodeExplorer_EmptyViewMessage}"/>
-            </TextBlock>
-        </Border>
-
         <ToolBarTray Grid.Row="0" IsLocked="True">
             <ToolBar Style="{DynamicResource ToolBarWithOverflowOnlyShowingWhenNeededStyle}">
 
@@ -859,6 +843,8 @@
 
             </ToolBar>
         </ToolBarTray>
+
+        <controls:EmptyUIRefresh Grid.Row="1" />
 
         <TreeView x:Name="ProjectTree"
                   Grid.Row="1"

--- a/RetailCoder.VBE/UI/Controls/EmptyUIRefresh.xaml
+++ b/RetailCoder.VBE/UI/Controls/EmptyUIRefresh.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="Rubberduck.UI.Controls.EmptyUIRefresh"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+
+    <Border Background="AliceBlue" DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext}">
+        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="WrapWithOverflow" TextAlignment="Center"
+                       MinWidth="200" Visibility="{Binding EmptyUIRefreshMessageVisibility}">
+            <Run FontWeight="Bold" Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=EmptyUIRefreshMessage_Title}"/><LineBreak/>
+            <LineBreak/>
+            <Button Command="{Binding RefreshCommand}" BorderThickness="0" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
+                <Image Height="16" Source="../../Resources/arrow-circle-double.png" ClipToBounds="True" />
+                <Button.ToolTip>
+                    <TextBlock Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=Refresh}" />
+                </Button.ToolTip>
+            </Button>
+            <Hyperlink Command="{Binding RefreshCommand}"><Run Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=Refresh}"/></Hyperlink>
+            <Run Text="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=EmptyUIRefreshMessage}"/>
+	    </TextBlock>
+    </Border>
+
+</UserControl>

--- a/RetailCoder.VBE/UI/Controls/EmptyUIRefresh.xaml.cs
+++ b/RetailCoder.VBE/UI/Controls/EmptyUIRefresh.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Rubberduck.UI.Controls
+{
+    /// <summary>
+    /// Interaction logic for Refresh.xaml
+    /// </summary>
+    public partial class EmptyUIRefresh : UserControl
+    {
+        public EmptyUIRefresh()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/RetailCoder.VBE/UI/Inspections/InspectionResultsControl.xaml
+++ b/RetailCoder.VBE/UI/Inspections/InspectionResultsControl.xaml
@@ -469,8 +469,6 @@
             <RowDefinition Height="Auto" MinHeight="48"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Grid.RowSpan="3" Background="White" />
-
         <ToolBarTray Grid.Row="0" IsLocked="True">
             <ToolBar Style="{StaticResource ToolBarWithOverflowOnlyShowingWhenNeededStyle}">
 
@@ -537,14 +535,15 @@
             </ToolBar>
         </ToolBarTray>
 
-        <controls:GroupingGrid Grid.Row="1"
+        <controls:GroupingGrid x:Name="InspectionResultsGrid"
+                               Grid.Row="1"
                                ShowGroupingItemCount="True"
                                SelectedItem="{Binding SelectedItem}"
                                ItemsSource="{Binding Source={StaticResource ResultsByInspectionType}, IsAsync=True}"
                                Visibility="{Binding IsChecked, ElementName=GroupByInspectionType, Converter={StaticResource BoolToVisibility}}"
                                VirtualizingPanel.IsVirtualizingWhenGrouping="True">
             <DataGrid.Columns>
-                <DataGridTemplateColumn Header="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=CodeInspectionResults_Type}" SortDirection="Descending">
+                <DataGridTemplateColumn Header="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=CodeInspectionResults_Type}" SortDirection="{Binding}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate DataType="abstract1:IInspectionResult">
                             <Image Source="{Binding Inspection, Converter={StaticResource InspectionIconConverter}}" Height="16" />
@@ -574,6 +573,8 @@
                 <DataGridTextColumn Header="{Resx ResxName=Rubberduck.UI.RubberduckUI, Key=CodeInspectionResults_Location}" Binding="{Binding QualifiedSelection.QualifiedName}" />
             </DataGrid.Columns>
         </controls:GroupingGrid>
+
+        <controls:EmptyUIRefresh Grid.Row="1" Visibility="{Binding EmptyUIRefreshVisibility}"/>
 
         <controls:BusyIndicator Grid.Row="1" Width="120" Height="120" Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibility}}" />
 

--- a/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
+++ b/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
@@ -255,7 +255,7 @@ namespace Rubberduck.UI.Inspections
         }
 
         private bool _isBusy;
-        public bool IsBusy { get { return _isBusy; } set { _isBusy = value; OnPropertyChanged(); } }
+        public bool IsBusy { get { return _isBusy; } set { _isBusy = value; OnPropertyChanged(); OnPropertyChanged("EmptyUIRefreshMessageVisibility"); } }
 
         private bool _runInspectionsOnReparse;
         private void HandleStateChanged(object sender, EventArgs e)
@@ -305,9 +305,8 @@ namespace Rubberduck.UI.Inspections
 
             UiDispatcher.Invoke(() =>
             {
-                //Results = new ObservableCollection<IInspectionResult>(results);
-
                 IsBusy = false;
+                OnPropertyChanged("EmptyUIRefreshVisibility");
                 IsRefreshing = false;
                 SelectedItem = null;
             });
@@ -476,6 +475,22 @@ namespace Rubberduck.UI.Inspections
         private bool CanExecuteCopyResultsCommand(object parameter)
         {
             return !IsBusy && _results != null && _results.Any();
+        }
+
+        public Visibility EmptyUIRefreshVisibility
+        {
+            get
+            {
+                return _state.Projects.Count > 0 ? Visibility.Hidden : Visibility.Visible;
+            }
+        }
+
+        public Visibility EmptyUIRefreshMessageVisibility
+        {
+            get
+            {
+                return _isBusy ? Visibility.Hidden : Visibility.Visible;
+            }
         }
 
         public void Dispose()

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -618,25 +618,6 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to to parse and process
-        ///the projects in the VBE..
-        /// </summary>
-        public static string CodeExplorer_EmptyViewMessage {
-            get {
-                return ResourceManager.GetString("CodeExplorer_EmptyViewMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Rubberduck doesn&apos;t see anything yet..
-        /// </summary>
-        public static string CodeExplorer_EmptyViewMessage_Title {
-            get {
-                return ResourceManager.GetString("CodeExplorer_EmptyViewMessage_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Expand node and all child nodes.
         /// </summary>
         public static string CodeExplorer_ExpandSubnodesToolTip {
@@ -1526,6 +1507,25 @@ namespace Rubberduck.UI {
         public static string EasterEgg_Continuator {
             get {
                 return ResourceManager.GetString("EasterEgg_Continuator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to to parse and process
+        ///the projects in the VBE..
+        /// </summary>
+        public static string EmptyUIRefreshMessage {
+            get {
+                return ResourceManager.GetString("EmptyUIRefreshMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rubberduck doesn&apos;t see anything yet..
+        /// </summary>
+        public static string EmptyUIRefreshMessage_Title {
+            get {
+                return ResourceManager.GetString("EmptyUIRefreshMessage_Title", resourceCulture);
             }
         }
         

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -2092,12 +2092,12 @@ Would you like to import them to Rubberduck?</value>
   <data name="CodeExplorer_AddModule" xml:space="preserve">
     <value>Add Module</value>
   </data>
-  <data name="CodeExplorer_EmptyViewMessage" xml:space="preserve">
+  <data name="EmptyUIRefreshMessage" xml:space="preserve">
     <value>to parse and process
 the projects in the VBE.</value>
     <comment>Follows the text for "Refresh"</comment>
   </data>
-  <data name="CodeExplorer_EmptyViewMessage_Title" xml:space="preserve">
+  <data name="EmptyUIRefreshMessage_Title" xml:space="preserve">
     <value>Rubberduck doesn't see anything yet.</value>
   </data>
 </root>


### PR DESCRIPTION
This PR refactors the "Rubberduck doesn't see anything, Refresh plz" message from the Code Explorer into a separate reusable element, and applies it to the Code Inspections window.