### PR TITLE
Using statements for tests

### DIFF
--- a/RubberduckTests/Binding/IndexDefaultBindingTests.cs
+++ b/RubberduckTests/Binding/IndexDefaultBindingTests.cs
@@ -50,11 +50,14 @@ End Property
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
+                var declaration =
+                    state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
+                                                          d.IdentifierName == "Test2");
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet && d.IdentifierName == "Test2");
-
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -79,11 +82,15 @@ End Property
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet && d.IdentifierName == "Test1");
+            using (var state = Parse(vbe))
+            {
+                var declaration =
+                    state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
+                                                          d.IdentifierName == "Test1");
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         private static RubberduckParserState Parse(Mock<IVBE> vbe)

--- a/RubberduckTests/Binding/MemberAccessDefaultBindingTests.cs
+++ b/RubberduckTests/Binding/MemberAccessDefaultBindingTests.cs
@@ -31,11 +31,13 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -51,11 +53,12 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
-
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -71,11 +74,12 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
-
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -91,11 +95,12 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.EnumerationMember && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.EnumerationMember && d.IdentifierName == BINDING_TARGET_UNRESTRICTEDNAME);
-
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         private static RubberduckParserState Parse(Mock<IVBE> vbe)
@@ -112,20 +117,20 @@ namespace RubberduckTests.Binding
 
         private string CreateFunction(string functionName)
         {
-            return string.Format(@"
-Public Function {0}() As Variant
+            return $@"
+Public Function {functionName}() As Variant
     TestEnumMember
 End Function
-", functionName);
+";
         }
 
         private string CreateEnumType(string typeName, string memberName)
         {
-            return string.Format(@"
-Public Enum {0}
-    {1}
+            return $@"
+Public Enum {typeName}
+    {memberName}
 End Enum
-", typeName, memberName);
+";
         }
     }
 }

--- a/RubberduckTests/Binding/MemberAccessProcedurePointerBindingTests.cs
+++ b/RubberduckTests/Binding/MemberAccessProcedurePointerBindingTests.cs
@@ -15,59 +15,58 @@ namespace RubberduckTests.Binding
     public class MemberAccessProcedurePointerBindingTests
     {
         private const string BINDING_TARGET_NAME = "BindingTarget";
-        private const string TEST_CLASS_NAME = "TestClass";       
+        private const string TEST_CLASS_NAME = "TestClass";
 
-            [TestCategory("Binding")]
-            [TestMethod]
-            public void ProceduralModuleWithAccessibleMember()
+        [TestCategory("Binding")]
+        [TestMethod]
+        public void ProceduralModuleWithAccessibleMember()
+        {
+            var builder = new MockVbeBuilder();
+            var enclosingProjectBuilder = builder.ProjectBuilder(BINDING_TARGET_NAME, ProjectProtection.Unprotected);
+            string code = CreateCaller(TEST_CLASS_NAME) + Environment.NewLine + CreateCallee();
+            enclosingProjectBuilder.AddComponent(TEST_CLASS_NAME, ComponentType.StandardModule, code);
+            var enclosingProject = enclosingProjectBuilder.Build();
+            builder.AddProject(enclosingProject);
+            var vbe = builder.Build();
+            using (var state = Parse(vbe))
             {
-                var builder = new MockVbeBuilder();
-                var enclosingProjectBuilder = builder.ProjectBuilder(BINDING_TARGET_NAME, ProjectProtection.Unprotected);
-                string code = CreateCaller(TEST_CLASS_NAME) + Environment.NewLine + CreateCallee();
-                enclosingProjectBuilder.AddComponent(TEST_CLASS_NAME, ComponentType.StandardModule, code);
-                var enclosingProject = enclosingProjectBuilder.Build();
-                builder.AddProject(enclosingProject);
-                var vbe = builder.Build();
-                var state = Parse(vbe);
-
-                Declaration declaration;
-
-                declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == TEST_CLASS_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == TEST_CLASS_NAME);
                 Assert.AreEqual(1, declaration.References.Count(), "Procedural Module should have reference");
 
                 declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_NAME);
                 Assert.AreEqual(1, declaration.References.Count(), "Function should have reference");
             }
+        }
 
-            private static RubberduckParserState Parse(Mock<IVBE> vbe)
+        private static RubberduckParserState Parse(Mock<IVBE> vbe)
+        {
+            var parser = MockParser.Create(vbe.Object);
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status != ParserState.Ready)
             {
-                var parser = MockParser.Create(vbe.Object);
-                parser.Parse(new CancellationTokenSource());
-                if (parser.State.Status != ParserState.Ready)
-                {
-                    Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
-                }
-                var state = parser.State;
-                return state;
+                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
             }
+            var state = parser.State;
+            return state;
+        }
 
-            private string CreateCaller(string moduleName)
-            {
-                return string.Format(@"
+        private string CreateCaller(string moduleName)
+        {
+            return $@"
 Declare PtrSafe Function EnumWindows Lib ""user32"" (ByVal lpEnumFunc As LongPtr, ByVal lParam As LongPtr) As Long
 
 Public Sub Caller()
-    EnumWindows AddressOf {0}.{1}, 1
+    EnumWindows AddressOf {moduleName}.{BINDING_TARGET_NAME}, 1
 End Sub
-", moduleName, BINDING_TARGET_NAME);
-            }
-
-            private string CreateCallee()
-            {
-                return string.Format(@"
-Public Function {0}() As LongPtr
-End Function
-", BINDING_TARGET_NAME);
-            }
+";
         }
+
+        private string CreateCallee()
+        {
+            return $@"
+Public Function {BINDING_TARGET_NAME}() As LongPtr
+End Function
+";
+        }
+    }
 }

--- a/RubberduckTests/Binding/MemberAccessTypeBindingTests.cs
+++ b/RubberduckTests/Binding/MemberAccessTypeBindingTests.cs
@@ -32,12 +32,14 @@ namespace RubberduckTests.Binding
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.ProjectName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.ProjectName == BindingTargetName);
 
-            // lExpression adds one reference, the MemberAcecssExpression adds another one.
-            Assert.AreEqual(2, declaration.References.Count());
+                // lExpression adds one reference, the MemberAcecssExpression adds another one.
+                Assert.AreEqual(2, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -45,7 +47,7 @@ namespace RubberduckTests.Binding
         public void LExpressionIsProjectAndUnrestrictedNameIsProceduralModule()
         {
             const string projectName = "AnyName";
-            var enclosingModuleCode = string.Format("Public WithEvents anything As {0}.{1}", projectName, BindingTargetName);
+            var enclosingModuleCode = $"Public WithEvents anything As {projectName}.{BindingTargetName}";
 
             var builder = new MockVbeBuilder();
             var enclosingProject = builder
@@ -55,11 +57,13 @@ namespace RubberduckTests.Binding
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -67,7 +71,7 @@ namespace RubberduckTests.Binding
         public void LExpressionIsProjectAndUnrestrictedNameIsClassModule()
         {
             const string projectName = "AnyName";
-            var enclosingModuleCode = string.Format("Public WithEvents anything As {0}.{1}", projectName, BindingTargetName);
+            var enclosingModuleCode = $"Public WithEvents anything As {projectName}.{BindingTargetName}";
 
             var builder = new MockVbeBuilder();
             var enclosingProject = builder
@@ -77,11 +81,13 @@ namespace RubberduckTests.Binding
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ClassModule && d.IdentifierName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ClassModule && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -90,7 +96,7 @@ namespace RubberduckTests.Binding
         {
             var builder = new MockVbeBuilder();
             const string referencedProjectName = "AnyReferencedProjectName";
-            var code = string.Format("Public WithEvents anything As {0}.{1}", referencedProjectName, BindingTargetName);
+            var code = $"Public WithEvents anything As {referencedProjectName}.{BindingTargetName}";
 
             var referencedProject = builder
                 .ProjectBuilder(referencedProjectName, ReferencedProjectFilepath, ProjectProtection.Unprotected)
@@ -106,11 +112,13 @@ namespace RubberduckTests.Binding
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -122,17 +130,20 @@ namespace RubberduckTests.Binding
 
             var enclosingProject = builder
                 .ProjectBuilder("AnyProjectName", ProjectProtection.Unprotected)
-                .AddComponent(TestClassName, ComponentType.ClassModule, string.Format("Public WithEvents anything As {0}.{1}", className, BindingTargetName))
+                .AddComponent(TestClassName, ComponentType.ClassModule,
+                    $"Public WithEvents anything As {className}.{BindingTargetName}")
                 .AddComponent(className, ComponentType.ClassModule, CreateUdt(BindingTargetName))
                 .Build();
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.UserDefinedType && d.IdentifierName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.UserDefinedType && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -145,24 +156,27 @@ namespace RubberduckTests.Binding
             var builder = new MockVbeBuilder();
             var enclosingProject = builder
                 .ProjectBuilder(projectName, ProjectProtection.Unprotected)
-                .AddComponent(TestClassName, ComponentType.ClassModule, string.Format("Public WithEvents anything As {0}.{1}.{2}", projectName, className, BindingTargetName))
+                .AddComponent(TestClassName, ComponentType.ClassModule,
+                    $"Public WithEvents anything As {projectName}.{className}.{BindingTargetName}")
                 .AddComponent(className, ComponentType.ClassModule, CreateUdt(BindingTargetName))
                 .Build();
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            Assert.AreEqual(state.Status, ParserState.Ready);
+                Assert.AreEqual(state.Status, ParserState.Ready);
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.ProjectName == projectName);
-            Assert.AreEqual(1, declaration.References.Count(), "Project reference expected");
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.ProjectName == projectName);
+                Assert.AreEqual(1, declaration.References.Count(), "Project reference expected");
 
-            declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ClassModule && d.IdentifierName == className);
-            Assert.AreEqual(1, declaration.References.Count(), "Module reference expected");
+                declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ClassModule && d.IdentifierName == className);
+                Assert.AreEqual(1, declaration.References.Count(), "Module reference expected");
 
-            declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.UserDefinedType && d.IdentifierName == BindingTargetName);
-            Assert.AreEqual(1, declaration.References.Count(), "Type reference expected");
+                declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.UserDefinedType && d.IdentifierName == BindingTargetName);
+                Assert.AreEqual(1, declaration.References.Count(), "Type reference expected");
+            }
         }
 
         private static RubberduckParserState Parse(Mock<IVBE> vbe)
@@ -179,20 +193,20 @@ namespace RubberduckTests.Binding
 
         private string CreateEnumType(string typeName)
         {
-            return string.Format(@"
-Public Enum {0}
+            return $@"
+Public Enum {typeName}
     TestEnumMember
 End Enum
-", typeName);
+";
         }
 
         private string CreateUdt(string typeName)
         {
-            return string.Format(@"
-Public Type {0}
+            return $@"
+Public Type {typeName}
     TestTypeMember As String
 End Type
-", typeName);
+";
         }
     }
 }

--- a/RubberduckTests/Binding/SimpleNameDefaultBindingTests.cs
+++ b/RubberduckTests/Binding/SimpleNameDefaultBindingTests.cs
@@ -34,9 +34,11 @@ End Sub", BindingTargetName);
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Variable && d.IdentifierName == BindingTargetName);
-            Assert.AreEqual(1, declaration.References.Count());
+            using (var state = Parse(vbe))
+            {
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Variable && d.IdentifierName == BindingTargetName);
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -50,9 +52,11 @@ End Sub", BindingTargetName);
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
-            Assert.AreEqual(1, declaration.References.Count());
+            using (var state = Parse(vbe))
+            {
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -66,11 +70,13 @@ End Sub", BindingTargetName);
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.IdentifierName == BindingTargetName);
+            using (var state = Parse(vbe))
+            {
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(state.Status, ParserState.Ready);
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(state.Status, ParserState.Ready);
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -93,11 +99,13 @@ End Sub", BindingTargetName);
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -121,11 +129,13 @@ End Sub", BindingTargetName);
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -147,11 +157,13 @@ End Sub", BindingTargetName);
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BindingTargetName);
 
-            Assert.AreEqual(0, declaration.References.Count());
+                Assert.AreEqual(0, declaration.References.Count());
+            }
         }
 
         private static RubberduckParserState Parse(Mock<IVBE> vbe)
@@ -168,20 +180,20 @@ End Sub", BindingTargetName);
 
         private string CreateTestProcedure(string bindingTarget)
         {
-            return string.Format(@"
+            return $@"
 Public Sub Test()
-    Dim a As String * {0}
+    Dim a As String * {bindingTarget}
 End Sub
-", bindingTarget);
+";
         }
 
         private string CreateEnumType(string typeName)
         {
-            return string.Format(@"
-Public Enum {0}
+            return $@"
+Public Enum {typeName}
     TestEnumMember
 End Enum
-", typeName);
+";
         }
     }
 }

--- a/RubberduckTests/Binding/SimpleNameProcedurePointerBindingTests.cs
+++ b/RubberduckTests/Binding/SimpleNameProcedurePointerBindingTests.cs
@@ -28,11 +28,13 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -46,12 +48,14 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(state.Status, ParserState.Ready);
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(state.Status, ParserState.Ready);
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -65,11 +69,13 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Function && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         private static RubberduckParserState Parse(Mock<IVBE> vbe)
@@ -86,21 +92,21 @@ namespace RubberduckTests.Binding
 
         private string CreateCaller()
         {
-            return string.Format(@"
+            return $@"
 Declare PtrSafe Function EnumWindows Lib ""user32"" (ByVal lpEnumFunc As LongPtr, ByVal lParam As LongPtr) As Long
 
 Public Sub Caller()
-    EnumWindows AddressOf {0}, 1
+    EnumWindows AddressOf {BINDING_TARGET_NAME}, 1
 End Sub
-", BINDING_TARGET_NAME);
+";
         }
 
         private string CreateCallee()
         {
-            return string.Format(@"
-Public Function {0}() As LongPtr
+            return $@"
+Public Function {BINDING_TARGET_NAME}() As LongPtr
 End Function
-", BINDING_TARGET_NAME);
+";
         }
     }
 }

--- a/RubberduckTests/Binding/SimpleNameTypeBindingTests.cs
+++ b/RubberduckTests/Binding/SimpleNameTypeBindingTests.cs
@@ -29,11 +29,13 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -47,12 +49,14 @@ namespace RubberduckTests.Binding
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Project && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(state.Status, ParserState.Ready);
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(state.Status, ParserState.Ready);
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -75,11 +79,13 @@ namespace RubberduckTests.Binding
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -101,11 +107,13 @@ namespace RubberduckTests.Binding
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.ProceduralModule && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Binding")]
@@ -130,11 +138,13 @@ namespace RubberduckTests.Binding
             builder.AddProject(enclosingProject);
 
             var vbe = builder.Build();
-            var state = Parse(vbe);
+            using (var state = Parse(vbe))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BINDING_TARGET_NAME);
+                var declaration = state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.Enumeration && d.IdentifierName == BINDING_TARGET_NAME);
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         private static RubberduckParserState Parse(Mock<IVBE> vbe)
@@ -151,20 +161,20 @@ namespace RubberduckTests.Binding
 
         private string CreateEnumType(string typeName)
         {
-            return string.Format(@"
-Public Enum {0}
+            return $@"
+Public Enum {typeName}
     TestEnumMember
 End Enum
-", typeName);
+";
         }
 
         private string CreateUdt(string typeName)
         {
-            return string.Format(@"
-Public Type {0}
+            return $@"
+Public Type {typeName}
     TestTypeMember As String
 End Type
-", typeName);
+";
         }
     }
 }

--- a/RubberduckTests/CodeExplorer/CodeExplorerTests.cs
+++ b/RubberduckTests/CodeExplorer/CodeExplorerTests.cs
@@ -56,17 +56,19 @@ namespace RubberduckTests.CodeExplorer
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.AddStdModuleCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.AddStdModuleCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Add(ComponentType.StandardModule), Times.Once);
+                components.Verify(c => c.Add(ComponentType.StandardModule), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -83,17 +85,19 @@ namespace RubberduckTests.CodeExplorer
 
             var commands = new List<CommandBase> { new AddClassModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.AddClassModuleCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.AddClassModuleCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Add(ComponentType.ClassModule), Times.Once);
+                components.Verify(c => c.Add(ComponentType.ClassModule), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -110,17 +114,19 @@ namespace RubberduckTests.CodeExplorer
 
             var commands = new List<CommandBase> { new AddUserFormCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.AddUserFormCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.AddUserFormCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Add(ComponentType.UserForm), Times.Once);
+                components.Verify(c => c.Add(ComponentType.UserForm), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -138,24 +144,26 @@ namespace RubberduckTests.CodeExplorer
             var configLoader = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
             configLoader.Setup(c => c.LoadConfiguration()).Returns(GetDefaultUnitTestConfig());
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vbeWrapper = vbe.Object;
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new Rubberduck.UI.CodeExplorer.Commands.AddTestModuleCommand(vbeWrapper,
-                    new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
-            };
+                var vbeWrapper = vbe.Object;
+                var commands = new List<CommandBase>
+                {
+                    new Rubberduck.UI.CodeExplorer.Commands.AddTestModuleCommand(vbeWrapper,
+                        new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.AddTestModuleCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.AddTestModuleCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Add(ComponentType.StandardModule), Times.Once);
+                components.Verify(c => c.Add(ComponentType.StandardModule), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -173,23 +181,25 @@ namespace RubberduckTests.CodeExplorer
             var configLoader = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
             configLoader.Setup(c => c.LoadConfiguration()).Returns(GetDefaultUnitTestConfig());
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vbeWrapper = vbe.Object;
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
-            };
-            
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vbeWrapper = vbe.Object;
+                var commands = new List<CommandBase>
+                {
+                    new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
+                };
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.AddTestModuleWithStubsCommand.Execute(vm.SelectedItem);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            components.Verify(c => c.Add(ComponentType.StandardModule), Times.Once);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.AddTestModuleWithStubsCommand.Execute(vm.SelectedItem);
+
+                components.Verify(c => c.Add(ComponentType.StandardModule), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -205,22 +215,24 @@ namespace RubberduckTests.CodeExplorer
             var configLoader = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
             configLoader.Setup(c => c.LoadConfiguration()).Returns(GetDefaultUnitTestConfig());
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vbeWrapper = vbe.Object;
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
-            };
+                var vbeWrapper = vbe.Object;
+                var commands = new List<CommandBase>
+                {
+                    new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
+                vm.SelectedItem = vm.Projects.First();
 
-            Assert.IsFalse(vm.AddTestModuleWithStubsCommand.CanExecute(vm.SelectedItem));
+                Assert.IsFalse(vm.AddTestModuleWithStubsCommand.CanExecute(vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -236,22 +248,24 @@ namespace RubberduckTests.CodeExplorer
             var configLoader = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
             configLoader.Setup(c => c.LoadConfiguration()).Returns(GetDefaultUnitTestConfig());
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vbeWrapper = vbe.Object;
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
-            };
+                var vbeWrapper = vbe.Object;
+                var commands = new List<CommandBase>
+                {
+                    new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First();
+                vm.SelectedItem = vm.Projects.First().Items.First();
 
-            Assert.IsFalse(vm.AddTestModuleWithStubsCommand.CanExecute(vm.SelectedItem));
+                Assert.IsFalse(vm.AddTestModuleWithStubsCommand.CanExecute(vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -267,22 +281,24 @@ namespace RubberduckTests.CodeExplorer
             var configLoader = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
             configLoader.Setup(c => c.LoadConfiguration()).Returns(GetDefaultUnitTestConfig());
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vbeWrapper = vbe.Object;
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
-            };
+                var vbeWrapper = vbe.Object;
+                var commands = new List<CommandBase>
+                {
+                    new AddTestModuleWithStubsCommand(vbeWrapper, new Rubberduck.UI.Command.AddTestModuleCommand(vbeWrapper, state, configLoader.Object))
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First().Items.First();
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First().Items.First();
 
-            Assert.IsFalse(vm.AddTestModuleWithStubsCommand.CanExecute(vm.SelectedItem));
+                Assert.IsFalse(vm.AddTestModuleWithStubsCommand.CanExecute(vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -308,22 +324,24 @@ namespace RubberduckTests.CodeExplorer
             openFileDialog.Setup(o => o.FileNames).Returns(new[] { "C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas" });
             openFileDialog.Setup(o => o.ShowDialog()).Returns(DialogResult.OK);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ImportCommand(vbe.Object, openFileDialog.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ImportCommand(vbe.Object, openFileDialog.Object)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
-            vm.ImportCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First();
+                vm.ImportCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Once);
+                components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -349,23 +367,25 @@ namespace RubberduckTests.CodeExplorer
             openFileDialog.Setup(o => o.FileNames).Returns(new[] { "C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas", "C:\\Users\\Rubberduck\\Desktop\\ClsModule1.cls" });
             openFileDialog.Setup(o => o.ShowDialog()).Returns(DialogResult.OK);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ImportCommand(vbe.Object, openFileDialog.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ImportCommand(vbe.Object, openFileDialog.Object)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
-            vm.ImportCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First();
+                vm.ImportCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Once);
-            components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\ClsModule1.cls"), Times.Once);
+                components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Once);
+                components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\ClsModule1.cls"), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -391,22 +411,24 @@ namespace RubberduckTests.CodeExplorer
             openFileDialog.Setup(o => o.FileName).Returns("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas");
             openFileDialog.Setup(o => o.ShowDialog()).Returns(DialogResult.Cancel);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ImportCommand(vbe.Object, openFileDialog.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ImportCommand(vbe.Object, openFileDialog.Object)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.ImportCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.ImportCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Never);
+                components.Verify(c => c.Import("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Never);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -426,23 +448,25 @@ namespace RubberduckTests.CodeExplorer
             saveFileDialog.Setup(o => o.FileName).Returns("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas");
             saveFileDialog.Setup(o => o.ShowDialog()).Returns(DialogResult.OK);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ExportCommand(saveFileDialog.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ExportCommand(saveFileDialog.Object)
+                };
 
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.ExportCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.ExportCommand.Execute(vm.SelectedItem);
 
-            component.Verify(c => c.Export("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Once);
+                component.Verify(c => c.Export("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -462,22 +486,24 @@ namespace RubberduckTests.CodeExplorer
             saveFileDialog.Setup(o => o.FileName).Returns("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas");
             saveFileDialog.Setup(o => o.ShowDialog()).Returns(DialogResult.Cancel);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ExportCommand(saveFileDialog.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ExportCommand(saveFileDialog.Object)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.ExportCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.ExportCommand.Execute(vm.SelectedItem);
 
-            component.Verify(c => c.Export("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Never);
+                component.Verify(c => c.Export("C:\\Users\\Rubberduck\\Desktop\\StdModule1.bas"), Times.Never);
+            }
         }
 
         [TestCategory("Commands")]
@@ -499,22 +525,24 @@ namespace RubberduckTests.CodeExplorer
             var mockFolderBrowser = new Mock<IFolderBrowser>();
             var mockFolderBrowserFactory = new Mock<IFolderBrowserFactory>();
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ExportAllCommand(vbe.Object, mockFolderBrowserFactory.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ExportAllCommand(vbe.Object, mockFolderBrowserFactory.Object)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            project.SetupGet(m => m.VBComponents.Count).Returns(1);
-            vm.SelectedItem = vm.Projects.First();
+                project.SetupGet(m => m.VBComponents.Count).Returns(1);
+                vm.SelectedItem = vm.Projects.First();
 
-            Assert.IsTrue(vm.ExportAllCommand.CanExecute(vm.SelectedItem));
+                Assert.IsTrue(vm.ExportAllCommand.CanExecute(vm.SelectedItem));
+            }
         }
 
         [TestCategory("Commands")]
@@ -551,22 +579,24 @@ namespace RubberduckTests.CodeExplorer
             var mockFolderBrowserFactory = new Mock<IFolderBrowserFactory>();
             mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, projectPath)).Returns(mockFolderBrowser.Object);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ExportAllCommand(null, mockFolderBrowserFactory.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ExportAllCommand(null, mockFolderBrowserFactory.Object)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
-            vm.ExportAllCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First();
+                vm.ExportAllCommand.Execute(vm.SelectedItem);
 
-            project.Verify(m => m.ExportSourceFiles(path), Times.Once);
+                project.Verify(m => m.ExportSourceFiles(path), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
@@ -603,22 +633,24 @@ namespace RubberduckTests.CodeExplorer
             var mockFolderBrowserFactory = new Mock<IFolderBrowserFactory>();
             mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, projectPath)).Returns(mockFolderBrowser.Object);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new ExportAllCommand(null, mockFolderBrowserFactory.Object)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new ExportAllCommand(null, mockFolderBrowserFactory.Object)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
-            vm.ExportAllCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First();
+                vm.ExportAllCommand.Execute(vm.SelectedItem);
 
-            project.Verify(m => m.ExportSourceFiles(path), Times.Never);
+                project.Verify(m => m.ExportSourceFiles(path), Times.Never);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -633,23 +665,25 @@ namespace RubberduckTests.CodeExplorer
             var vbe = builder.AddProject(project).Build();
             var component = projectMock.MockComponents.First();
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new OpenDesignerCommand()
-            };
+                var commands = new List<CommandBase>
+                {
+                    new OpenDesignerCommand()
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.OpenDesignerCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.OpenDesignerCommand.Execute(vm.SelectedItem);
 
-            component.Verify(c => c.DesignerWindow(), Times.Once);
-            Assert.IsTrue(component.Object.DesignerWindow().IsVisible);
+                component.Verify(c => c.DesignerWindow(), Times.Once);
+                Assert.IsTrue(component.Object.DesignerWindow().IsVisible);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -675,25 +709,27 @@ namespace RubberduckTests.CodeExplorer
 
             var messageBox = new Mock<IMessageBox>();
             messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                                         It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>()))
-                      .Returns(DialogResult.Yes);
+                    It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>()))
+                .Returns(DialogResult.Yes);
 
             var commands = new List<CommandBase>
             {
                 new RemoveCommand(saveFileDialog.Object, messageBox.Object)
             };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.RemoveCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.RemoveCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Remove(component), Times.Once);
+                components.Verify(c => c.Remove(component), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -716,26 +752,28 @@ namespace RubberduckTests.CodeExplorer
 
             var messageBox = new Mock<IMessageBox>();
             messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(),
-                                         It.IsAny<MessageBoxButtons>(),
-                                         It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>()))
-                      .Returns(DialogResult.Yes);
+                    It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>()))
+                .Returns(DialogResult.Yes);
 
             var commands = new List<CommandBase>
             {
                 new RemoveCommand(saveFileDialog.Object, messageBox.Object)
             };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.RemoveCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.RemoveCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Remove(component), Times.Never);
+                components.Verify(c => c.Remove(component), Times.Never);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -757,26 +795,28 @@ namespace RubberduckTests.CodeExplorer
 
             var messageBox = new Mock<IMessageBox>();
             messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(),
-                                         It.IsAny<MessageBoxButtons>(),
-                                         It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>()))
-                      .Returns(DialogResult.No);
+                    It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>()))
+                .Returns(DialogResult.No);
 
             var commands = new List<CommandBase>
             {
                 new RemoveCommand(saveFileDialog.Object, messageBox.Object)
             };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.RemoveCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.RemoveCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Remove(component), Times.Once);
+                components.Verify(c => c.Remove(component), Times.Once);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -798,25 +838,27 @@ namespace RubberduckTests.CodeExplorer
 
             var messageBox = new Mock<IMessageBox>();
             messageBox.Setup(m =>
-                    m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                        It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>())).Returns(DialogResult.Cancel);
+                m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>(), It.IsAny<MessageBoxDefaultButton>())).Returns(DialogResult.Cancel);
 
             var commands = new List<CommandBase>
             {
                 new RemoveCommand(saveFileDialog.Object, messageBox.Object)
             };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.RemoveCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.RemoveCommand.Execute(vm.SelectedItem);
 
-            components.Verify(c => c.Remove(component), Times.Never);
+                components.Verify(c => c.Remove(component), Times.Never);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -824,13 +866,13 @@ namespace RubberduckTests.CodeExplorer
         public void IndentModule()
         {
             var inputCode =
-    @"Sub Foo()
+                @"Sub Foo()
 Dim d As Boolean
 d = True
 End Sub";
 
             var expectedCode =
-    @"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     d = True
 End Sub
@@ -839,22 +881,24 @@ End Sub
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object,() => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object,() => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.IndenterCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.IndenterCommand.Execute(vm.SelectedItem);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -862,7 +906,7 @@ End Sub
         public void IndentModule_DisabledWithNoIndentAnnotation()
         {
             var inputCode =
-    @"'@NoIndent
+                @"'@NoIndent
 
 Sub Foo()
 Dim d As Boolean
@@ -872,21 +916,23 @@ End Sub";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
 
-            Assert.IsFalse(vm.IndenterCommand.CanExecute(vm.SelectedItem));
+                Assert.IsFalse(vm.IndenterCommand.CanExecute(vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -894,13 +940,13 @@ End Sub";
         public void IndentProject()
         {
             var inputCode =
-    @"Sub Foo()
+                @"Sub Foo()
 Dim d As Boolean
 d = True
 End Sub";
 
             var expectedCode =
-    @"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     d = True
 End Sub
@@ -919,23 +965,25 @@ End Sub
             var component2 = project.Object.VBComponents[1];
             var module2 = component2.CodeModule;
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
-            vm.IndenterCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First();
+                vm.IndenterCommand.Execute(vm.SelectedItem);
 
-            Assert.AreEqual(expectedCode, module1.Content());
-            Assert.AreEqual(expectedCode, module2.Content());
+                Assert.AreEqual(expectedCode, module1.Content());
+                Assert.AreEqual(expectedCode, module2.Content());
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -943,13 +991,13 @@ End Sub
         public void IndentProject_IndentsModulesWithoutNoIndentAnnotation()
         {
             var inputCode1 =
-    @"Sub Foo()
+                @"Sub Foo()
 Dim d As Boolean
 d = True
 End Sub";
 
             var inputCode2 =
-    @"'@NoIndent
+                @"'@NoIndent
 
 Sub Foo()
 Dim d As Boolean
@@ -957,7 +1005,7 @@ d = True
 End Sub";
 
             var expectedCode =
-    @"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     d = True
 End Sub
@@ -976,23 +1024,25 @@ End Sub
             var component2 = project.Object.VBComponents[1];
             var module2 = component2.CodeModule;
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
-            vm.IndenterCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First();
+                vm.IndenterCommand.Execute(vm.SelectedItem);
 
-            Assert.AreEqual(expectedCode, module1.Content());
-            Assert.AreEqual(inputCode2, module2.Content());
+                Assert.AreEqual(expectedCode, module1.Content());
+                Assert.AreEqual(inputCode2, module2.Content());
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1000,7 +1050,7 @@ End Sub
         public void IndentProject_DisabledWhenAllModulesHaveNoIndentAnnotation()
         {
             var inputCode =
-    @"'@NoIndent
+                @"'@NoIndent
 
 Sub Foo()
 Dim d As Boolean
@@ -1015,22 +1065,24 @@ End Sub";
             var project = projectMock.Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First();
-            vm.IndenterCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First();
+                vm.IndenterCommand.Execute(vm.SelectedItem);
 
-            Assert.IsFalse(vm.IndenterCommand.CanExecute(vm.SelectedItem));
+                Assert.IsFalse(vm.IndenterCommand.CanExecute(vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1038,7 +1090,7 @@ End Sub";
         public void IndentFolder()
         {
             var inputCode =
-    @"'@Folder ""folder""
+                @"'@Folder ""folder""
 
 Sub Foo()
 Dim d As Boolean
@@ -1046,7 +1098,7 @@ d = True
 End Sub";
 
             var expectedCode =
-    @"'@Folder ""folder""
+                @"'@Folder ""folder""
 
 Sub Foo()
     Dim d As Boolean
@@ -1067,23 +1119,25 @@ End Sub
             var component2 = project.Object.VBComponents[1];
             var module2 = component2.CodeModule;
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First();
-            vm.IndenterCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First();
+                vm.IndenterCommand.Execute(vm.SelectedItem);
 
-            Assert.AreEqual(expectedCode, module1.Content());
-            Assert.AreEqual(expectedCode, module2.Content());
+                Assert.AreEqual(expectedCode, module1.Content());
+                Assert.AreEqual(expectedCode, module2.Content());
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1091,7 +1145,7 @@ End Sub
         public void IndentFolder_IndentsModulesWithoutNoIndentAnnotation()
         {
             var inputCode1 =
-    @"'@Folder ""folder""
+                @"'@Folder ""folder""
 
 Sub Foo()
 Dim d As Boolean
@@ -1099,7 +1153,7 @@ d = True
 End Sub";
 
             var inputCode2 =
-    @"'@NoIndent
+                @"'@NoIndent
 '@Folder ""folder""
 
 Sub Foo()
@@ -1108,7 +1162,7 @@ d = True
 End Sub";
 
             var expectedCode =
-    @"'@Folder ""folder""
+                @"'@Folder ""folder""
 
 Sub Foo()
     Dim d As Boolean
@@ -1129,23 +1183,25 @@ End Sub
             var component2 = project.Object.VBComponents[1];
             var module2 = component2.CodeModule;
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First();
-            vm.IndenterCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.First().Items.First();
+                vm.IndenterCommand.Execute(vm.SelectedItem);
 
-            Assert.AreEqual(expectedCode, module1.Content());
-            Assert.AreEqual(inputCode2, module2.Content());
+                Assert.AreEqual(expectedCode, module1.Content());
+                Assert.AreEqual(inputCode2, module2.Content());
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1153,7 +1209,7 @@ End Sub
         public void IndentFolder_DisabledWhenAllModulesHaveNoIndentAnnotation()
         {
             var inputCode =
-    @"'@NoIndent
+                @"'@NoIndent
 '@Folder ""folder""
 
 Sub Foo()
@@ -1169,20 +1225,22 @@ End Sub";
             var project = projectMock.Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var commands = new List<CommandBase>
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
-            };
+                var commands = new List<CommandBase>
+                {
+                    new IndentCommand(state, new Indenter(vbe.Object, () => Settings.IndenterSettingsTests.GetMockIndenterSettings()), null)
+                };
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First();
-            Assert.IsFalse(vm.IndenterCommand.CanExecute(vm.SelectedItem));
+                vm.SelectedItem = vm.Projects.First().Items.First();
+                Assert.IsFalse(vm.IndenterCommand.CanExecute(vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1190,26 +1248,28 @@ End Sub";
         public void ExpandAllNodes()
         {
             var inputCode =
-    @"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.Single();
-            vm.ExpandAllSubnodesCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.Single();
+                vm.ExpandAllSubnodesCommand.Execute(vm.SelectedItem);
 
-            Assert.IsTrue(vm.Projects.Single().IsExpanded);
-            Assert.IsTrue(vm.Projects.Single().Items.Single().IsExpanded);
-            Assert.IsTrue(vm.Projects.Single().Items.Single().Items.Single().IsExpanded);
-            Assert.IsTrue(vm.Projects.Single().Items.Single().Items.Single().Items.Single().IsExpanded);
+                Assert.IsTrue(vm.Projects.Single().IsExpanded);
+                Assert.IsTrue(vm.Projects.Single().Items.Single().IsExpanded);
+                Assert.IsTrue(vm.Projects.Single().Items.Single().Items.Single().IsExpanded);
+                Assert.IsTrue(vm.Projects.Single().Items.Single().Items.Single().Items.Single().IsExpanded);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1223,20 +1283,22 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.Projects.Single().Items.Last().IsExpanded = false;
+                vm.Projects.Single().Items.Last().IsExpanded = false;
 
-            vm.SelectedItem = vm.Projects.Single().Items.First();
-            vm.ExpandAllSubnodesCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.Single().Items.First();
+                vm.ExpandAllSubnodesCommand.Execute(vm.SelectedItem);
 
-            Assert.IsTrue(vm.Projects.Single().Items.First().IsExpanded);
-            Assert.IsFalse(vm.Projects.Single().Items.Last().IsExpanded);
+                Assert.IsTrue(vm.Projects.Single().Items.First().IsExpanded);
+                Assert.IsFalse(vm.Projects.Single().Items.Last().IsExpanded);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1244,26 +1306,28 @@ End Sub";
         public void CollapseAllNodes()
         {
             var inputCode =
-    @"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.Single();
-            vm.CollapseAllSubnodesCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.Single();
+                vm.CollapseAllSubnodesCommand.Execute(vm.SelectedItem);
 
-            Assert.IsFalse(vm.Projects.Single().IsExpanded);
-            Assert.IsFalse(vm.Projects.Single().Items.Single().IsExpanded);
-            Assert.IsFalse(vm.Projects.Single().Items.Single().Items.Single().IsExpanded);
-            Assert.IsFalse(vm.Projects.Single().Items.Single().Items.Single().Items.Single().IsExpanded);
+                Assert.IsFalse(vm.Projects.Single().IsExpanded);
+                Assert.IsFalse(vm.Projects.Single().Items.Single().IsExpanded);
+                Assert.IsFalse(vm.Projects.Single().Items.Single().Items.Single().IsExpanded);
+                Assert.IsFalse(vm.Projects.Single().Items.Single().Items.Single().Items.Single().IsExpanded);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1277,20 +1341,22 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.Projects.Single().Items.Last().IsExpanded = true;
+                vm.Projects.Single().Items.Last().IsExpanded = true;
 
-            vm.SelectedItem = vm.Projects.Single().Items.First();
-            vm.CollapseAllSubnodesCommand.Execute(vm.SelectedItem);
+                vm.SelectedItem = vm.Projects.Single().Items.First();
+                vm.CollapseAllSubnodesCommand.Execute(vm.SelectedItem);
 
-            Assert.IsFalse(vm.Projects.Single().Items.First().IsExpanded);
-            Assert.IsTrue(vm.Projects.Single().Items.Last().IsExpanded);
+                Assert.IsFalse(vm.Projects.Single().Items.First().IsExpanded);
+                Assert.IsTrue(vm.Projects.Single().Items.Last().IsExpanded);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1307,26 +1373,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = false,
-                CodeExplorer_SortByCodeOrder = true
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = false,
+                    CodeExplorer_SortByCodeOrder = true
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetNameSortCommand.Execute(true);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByName);
-            Assert.IsFalse(vm.SortByCodeOrder);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetNameSortCommand.Execute(true);
+
+                Assert.IsTrue(vm.SortByName);
+                Assert.IsFalse(vm.SortByCodeOrder);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1343,26 +1411,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = true,
-                CodeExplorer_SortByCodeOrder = false
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = true,
+                    CodeExplorer_SortByCodeOrder = false
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetNameSortCommand.Execute(false);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByName);
-            Assert.IsFalse(vm.SortByCodeOrder);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetNameSortCommand.Execute(false);
+
+                Assert.IsTrue(vm.SortByName);
+                Assert.IsFalse(vm.SortByCodeOrder);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1379,26 +1449,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = false,
-                CodeExplorer_SortByCodeOrder = false
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = false,
+                    CodeExplorer_SortByCodeOrder = false
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetNameSortCommand.Execute(true);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByName);
-            Assert.IsFalse(vm.SortByCodeOrder);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetNameSortCommand.Execute(true);
+
+                Assert.IsTrue(vm.SortByName);
+                Assert.IsFalse(vm.SortByCodeOrder);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1415,26 +1487,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = true,
-                CodeExplorer_SortByCodeOrder = true
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = true,
+                    CodeExplorer_SortByCodeOrder = true
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetNameSortCommand.Execute(true);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByName);
-            Assert.IsFalse(vm.SortByCodeOrder);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetNameSortCommand.Execute(true);
+
+                Assert.IsTrue(vm.SortByName);
+                Assert.IsFalse(vm.SortByCodeOrder);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1451,26 +1525,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = true,
-                CodeExplorer_SortByCodeOrder = false
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = true,
+                    CodeExplorer_SortByCodeOrder = false
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetCodeOrderSortCommand.Execute(true);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByCodeOrder);
-            Assert.IsFalse(vm.SortByName);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetCodeOrderSortCommand.Execute(true);
+
+                Assert.IsTrue(vm.SortByCodeOrder);
+                Assert.IsFalse(vm.SortByName);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1487,26 +1563,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = false,
-                CodeExplorer_SortByCodeOrder = true
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = false,
+                    CodeExplorer_SortByCodeOrder = true
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetCodeOrderSortCommand.Execute(false);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByCodeOrder);
-            Assert.IsFalse(vm.SortByName);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetCodeOrderSortCommand.Execute(false);
+
+                Assert.IsTrue(vm.SortByCodeOrder);
+                Assert.IsFalse(vm.SortByName);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1523,26 +1601,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = false,
-                CodeExplorer_SortByCodeOrder = false
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = false,
+                    CodeExplorer_SortByCodeOrder = false
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetCodeOrderSortCommand.Execute(true);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByCodeOrder);
-            Assert.IsFalse(vm.SortByName);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetCodeOrderSortCommand.Execute(true);
+
+                Assert.IsTrue(vm.SortByCodeOrder);
+                Assert.IsFalse(vm.SortByName);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1559,26 +1639,28 @@ End Sub";
 
             var commands = new List<CommandBase> { new AddStdModuleCommand(new AddComponentCommand(vbe.Object)) };
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-
-            var windowSettings = new WindowSettings
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
             {
-                CodeExplorer_SortByName = true,
-                CodeExplorer_SortByCodeOrder = true
-            };
-            _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+                var windowSettings = new WindowSettings
+                {
+                    CodeExplorer_SortByName = true,
+                    CodeExplorer_SortByCodeOrder = true
+                };
+                _windowSettingsProvider.Setup(s => s.Create()).Returns(windowSettings);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, commands, _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
-            vm.SetCodeOrderSortCommand.Execute(true);
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            Assert.IsTrue(vm.SortByCodeOrder);
-            Assert.IsFalse(vm.SortByName);
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First();
+                vm.SetCodeOrderSortCommand.Execute(true);
+
+                Assert.IsTrue(vm.SortByCodeOrder);
+                Assert.IsFalse(vm.SortByName);
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1624,22 +1706,24 @@ End Sub";
         public void CompareByType_ReturnsEventAboveConst()
         {
             var inputCode =
-    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 Public Const Bar = 0";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var eventNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo");
-            var constNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar = 0");
+                var eventNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo");
+                var constNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar = 0");
 
-            Assert.AreEqual(-1, new CompareByType().Compare(eventNode, constNode));
+                Assert.AreEqual(-1, new CompareByType().Compare(eventNode, constNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1647,22 +1731,24 @@ Public Const Bar = 0";
         public void CompareByType_ReturnsConstAboveField()
         {
             var inputCode =
-    @"Public Const Foo = 0
+                @"Public Const Foo = 0
 Public Bar As Boolean";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var constNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo = 0");
-            var fieldNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
+                var constNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo = 0");
+                var fieldNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
 
-            Assert.AreEqual(-1, new CompareByType().Compare(constNode, fieldNode));
+                Assert.AreEqual(-1, new CompareByType().Compare(constNode, fieldNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1670,7 +1756,7 @@ Public Bar As Boolean";
         public void CompareByType_ReturnsFieldAbovePropertyGet()
         {
             var inputCode =
-    @"Private Bar As Boolean
+                @"Private Bar As Boolean
 
 Public Property Get Foo() As Variant
 End Property
@@ -1679,16 +1765,18 @@ End Property
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var fieldNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
-            var propertyGetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
+                var fieldNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
+                var propertyGetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
 
-            Assert.AreEqual(-1, new CompareByType().Compare(fieldNode, propertyGetNode));
+                Assert.AreEqual(-1, new CompareByType().Compare(fieldNode, propertyGetNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1696,7 +1784,7 @@ End Property
         public void CompareByType_ReturnsPropertyGetEqualToPropertyLet()
         {
             var inputCode =
-    @"Public Property Get Foo() As Variant
+                @"Public Property Get Foo() As Variant
 End Property
 
 Public Property Let Foo(ByVal Value As Variant)
@@ -1706,16 +1794,18 @@ End Property
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var propertyGetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
-            var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Let)");
+                var propertyGetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
+                var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Let)");
 
-            Assert.AreEqual(0, new CompareByType().Compare(propertyGetNode, propertyLetNode));
+                Assert.AreEqual(0, new CompareByType().Compare(propertyGetNode, propertyLetNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1723,7 +1813,7 @@ End Property
         public void CompareByType_ReturnsPropertyGetEqualToPropertySet()
         {
             var inputCode =
-    @"Public Property Get Foo() As Variant
+                @"Public Property Get Foo() As Variant
 End Property
 
 Public Property Set Foo(ByVal Value As Variant)
@@ -1733,16 +1823,18 @@ End Property
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var propertyGetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
-            var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Set)");
+                var propertyGetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
+                var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Set)");
 
-            Assert.AreEqual(0, new CompareByType().Compare(propertyGetNode, propertyLetNode));
+                Assert.AreEqual(0, new CompareByType().Compare(propertyGetNode, propertyLetNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1750,7 +1842,7 @@ End Property
         public void CompareByType_ReturnsPropertyLetEqualToPropertyGet()
         {
             var inputCode =
-    @"Public Property Let Foo(ByVal Value As Variant)
+                @"Public Property Let Foo(ByVal Value As Variant)
 End Property
 
 Public Property Get Foo() As Variant
@@ -1760,16 +1852,18 @@ End Property
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Let)");
-            var propertySetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
+                var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Let)");
+                var propertySetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Get)");
 
-            Assert.AreEqual(0, new CompareByType().Compare(propertyLetNode, propertySetNode));
+                Assert.AreEqual(0, new CompareByType().Compare(propertyLetNode, propertySetNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1777,7 +1871,7 @@ End Property
         public void CompareByType_ReturnsPropertyLetEqualToPropertySet()
         {
             var inputCode =
-    @"Public Property Let Foo(ByVal Value As Variant)
+                @"Public Property Let Foo(ByVal Value As Variant)
 End Property
 
 Public Property Set Foo(ByVal Value As Variant)
@@ -1787,16 +1881,18 @@ End Property
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Let)");
-            var propertySetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Set)");
+                var propertyLetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Let)");
+                var propertySetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Set)");
 
-            Assert.AreEqual(0, new CompareByType().Compare(propertyLetNode, propertySetNode));
+                Assert.AreEqual(0, new CompareByType().Compare(propertyLetNode, propertySetNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1804,7 +1900,7 @@ End Property
         public void CompareByType_ReturnsPropertySetAboveFunction()
         {
             var inputCode =
-    @"Public Property Set Foo(ByVal Value As Variant)
+                @"Public Property Set Foo(ByVal Value As Variant)
 End Property
 
 Public Function Bar() As Boolean
@@ -1814,16 +1910,18 @@ End Function
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var propertySetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Set)");
-            var functionNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
+                var propertySetNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo (Set)");
+                var functionNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
 
-            Assert.AreEqual(-1, new CompareByType().Compare(propertySetNode, functionNode));
+                Assert.AreEqual(-1, new CompareByType().Compare(propertySetNode, functionNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1831,7 +1929,7 @@ End Function
         public void CompareByType_ReturnsSubsAndFunctionsEqual()
         {
             var inputCode =
-    @"Public Function Foo() As Boolean
+                @"Public Function Foo() As Boolean
 End Function
 
 Public Sub Bar()
@@ -1841,16 +1939,18 @@ End Sub
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var functionNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo");
-            var subNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
+                var functionNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo");
+                var subNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
 
-            Assert.AreEqual(0, new CompareByType().Compare(functionNode, subNode));
+                Assert.AreEqual(0, new CompareByType().Compare(functionNode, subNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1858,7 +1958,7 @@ End Sub
         public void CompareByType_ReturnsPublicMethodsAbovePrivateMethods()
         {
             var inputCode =
-    @"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub
 
 Public Sub Bar()
@@ -1868,16 +1968,18 @@ End Sub
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var privateNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo");
-            var publicNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
+                var privateNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Foo");
+                var publicNode = vm.Projects.First().Items.First().Items.First().Items.Single(s => s.Name == "Bar");
 
-            Assert.AreEqual(-1, new CompareByType().Compare(publicNode, privateNode));
+                Assert.AreEqual(-1, new CompareByType().Compare(publicNode, privateNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1892,20 +1994,22 @@ End Sub
             var project = projectMock.Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var docNode = vm.Projects.First().Items.First().Items.Single(s => s.Name == "Sheet1");
-            var clsNode = vm.Projects.First().Items.First().Items.Single(s => s.Name == "ClassModule1");
+                var docNode = vm.Projects.First().Items.First().Items.Single(s => s.Name == "Sheet1");
+                var clsNode = vm.Projects.First().Items.First().Items.Single(s => s.Name == "ClassModule1");
 
-            // this tests the logic I wrote to place docs above cls modules even though the parser calls them both cls modules
-            Assert.AreEqual(((ICodeExplorerDeclarationViewModel)clsNode).Declaration.DeclarationType,
-                ((ICodeExplorerDeclarationViewModel)docNode).Declaration.DeclarationType);
+                // this tests the logic I wrote to place docs above cls modules even though the parser calls them both cls modules
+                Assert.AreEqual(((ICodeExplorerDeclarationViewModel)clsNode).Declaration.DeclarationType,
+                    ((ICodeExplorerDeclarationViewModel)docNode).Declaration.DeclarationType);
 
-            Assert.AreEqual(-1, new CompareByType().Compare(docNode, clsNode));
+                Assert.AreEqual(-1, new CompareByType().Compare(docNode, clsNode));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1913,7 +2017,7 @@ End Sub
         public void CompareBySelection_ReturnsZeroForIdenticalNodes()
         {
             var inputCode =
-    @"Sub Foo()
+                @"Sub Foo()
 End Sub
 
 Sub Bar()
@@ -1923,16 +2027,18 @@ End Sub";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(item => item.Declaration.IdentifierName == "Foo");
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(item => item.Declaration.IdentifierName == "Foo");
 
-            Assert.AreEqual(0, new CompareByName().Compare(vm.SelectedItem, vm.SelectedItem));
+                Assert.AreEqual(0, new CompareByName().Compare(vm.SelectedItem, vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1940,7 +2046,7 @@ End Sub";
         public void CompareByNodeType_ReturnsCorrectMemberFirst_MemberPassedFirst()
         {
             var inputCode =
-    @"Sub Foo()
+                @"Sub Foo()
 End Sub
 
 Sub Bar()
@@ -1950,16 +2056,18 @@ End Sub";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
 
-            var memberNode1 = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(s => s.Name == "Foo");
-            var memberNode2 = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(s => s.Name == "Bar");
+                var memberNode1 = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(s => s.Name == "Foo");
+                var memberNode2 = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(s => s.Name == "Bar");
 
-            Assert.AreEqual(-1, new CompareBySelection().Compare(memberNode1, memberNode2));
+                Assert.AreEqual(-1, new CompareBySelection().Compare(memberNode1, memberNode2));
+            }
         }
 
         [TestCategory("Code Explorer")]
@@ -1967,7 +2075,7 @@ End Sub";
         public void CompareByNodeType_ReturnsZeroForIdenticalNodes()
         {
             var inputCode =
-    @"Sub Foo()
+                @"Sub Foo()
 End Sub
 
 Sub Bar()
@@ -1977,16 +2085,18 @@ End Sub";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
+            using (var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()))
+            {
+                var vm = new CodeExplorerViewModel(new FolderHelper(state), state, new List<CommandBase>(), _generalSettingsProvider.Object, _windowSettingsProvider.Object);
 
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var parser = MockParser.Create(vbe.Object, state);
+                parser.Parse(new CancellationTokenSource());
+                if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            vm.SelectedItem = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(item => item.Declaration.IdentifierName == "Foo");
+                vm.SelectedItem = vm.Projects.First().Items.First().Items.First().Items.OfType<CodeExplorerMemberViewModel>().Single(item => item.Declaration.IdentifierName == "Foo");
 
-            Assert.AreEqual(0, new CompareByNodeType().Compare(vm.SelectedItem, vm.SelectedItem));
+                Assert.AreEqual(0, new CompareByNodeType().Compare(vm.SelectedItem, vm.SelectedItem));
+            }
         }
 
         [TestCategory("Code Explorer")]

--- a/RubberduckTests/Commands/ExportAllCommandTests.cs
+++ b/RubberduckTests/Commands/ExportAllCommandTests.cs
@@ -2,7 +2,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Rubberduck.UI;
 using Rubberduck.UI.Command;
-using Rubberduck.UnitTesting;
 using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;
 using System.Linq;

--- a/RubberduckTests/Commands/FindAllImplementationsTests.cs
+++ b/RubberduckTests/Commands/FindAllImplementationsTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading;
 using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -22,13 +21,13 @@ namespace RubberduckTests.Commands
         public void FindAllImplementations_ReturnsCorrectNumber()
         {
             const string inputClass =
-@"Implements IClass1
+                @"Implements IClass1
 
 Public Sub IClass1_Foo()
 End Sub";
 
             const string inputInterface =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -39,17 +38,16 @@ End Sub";
                 .Build();
 
             var vbe = builder.AddProject(project).Build();
-            var parser = MockParser.Create(vbe.Object);
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, parser.State, vbe.Object, vm, null);
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            command.Execute(parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
-
-            Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+                Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+            }
         }
 
         [TestCategory("Commands")]
@@ -57,13 +55,13 @@ End Sub";
         public void FindAllImplementations_SelectedImplementation_ReturnsCorrectNumber()
         {
             const string inputClass =
-@"Implements IClass1
+                @"Implements IClass1
 
 Public Sub IClass1_Foo()
 End Sub";
 
             const string inputInterface =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -74,17 +72,16 @@ End Sub";
                 .Build();
 
             var vbe = builder.AddProject(project).Build();
-            var parser = MockParser.Create(vbe.Object);
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, parser.State, vbe.Object, vm, null);
+                command.Execute(state.AllUserDeclarations.First(s => s.IdentifierName == "IClass1_Foo"));
 
-            command.Execute(parser.State.AllUserDeclarations.First(s => s.IdentifierName == "IClass1_Foo"));
-
-            Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+                Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+            }
         }
 
         [TestCategory("Commands")]
@@ -92,7 +89,7 @@ End Sub";
         public void FindAllImplementations_SelectedReference_ReturnsCorrectNumber()
         {
             const string inputClass =
-@"Implements IClass1
+                @"Implements IClass1
 
 Public Sub IClass1_Foo()
 End Sub
@@ -102,7 +99,7 @@ Public Sub Buzz()
 End Sub";
 
             const string inputInterface =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -115,17 +112,15 @@ End Sub";
             var vbe = builder.AddProject(project).Build();
             vbe.Setup(v => v.ActiveCodePane).Returns(project.Object.VBComponents["Class1"].CodeModule.CodePane);
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                command.Execute(null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, parser.State, vbe.Object, vm, null);
-
-            command.Execute(null);
-
-            Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+                Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+            }
         }
 
         [TestCategory("Commands")]
@@ -133,25 +128,27 @@ End Sub";
         public void FindAllImplementations_NoResults_DisplayMessageBox()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             IVBComponent component;
-            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, default(Selection));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, messageBox.Object, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, messageBox.Object, state, vbe.Object, vm, null);
 
-            command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
@@ -159,13 +156,13 @@ End Sub";
         public void FindAllImplementations_SingleResult_Navigates()
         {
             const string inputClass =
-@"Implements IClass1
+                @"Implements IClass1
 
 Public Sub IClass1_Foo()
 End Sub";
 
             const string inputInterface =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -175,19 +172,17 @@ End Sub";
                 .Build();
 
             var vbe = builder.AddProject(project).Build();
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var navigateCommand = new Mock<INavigateCommand>();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(navigateCommand.Object, null, state, vbe.Object, vm, null);
 
-            var navigateCommand = new Mock<INavigateCommand>();
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(navigateCommand.Object, null, parser.State, vbe.Object, vm, null);
-
-            command.Execute(parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
-
-            navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+                navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
@@ -198,14 +193,15 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
+                command.Execute(null);
 
-            command.Execute(null);
-
-            Assert.IsFalse(vm.Tabs.Any());
+                Assert.IsFalse(vm.Tabs.Any());
+            }
         }
 
         [TestCategory("Commands")]
@@ -213,7 +209,7 @@ End Sub";
         public void FindAllImplementations_StateNotReady_Aborts()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Private Sub Bar()
@@ -226,16 +222,17 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
-
-            Assert.IsFalse(vm.Tabs.Any());
+                Assert.IsFalse(vm.Tabs.Any());
+            }
         }
 
         [TestCategory("Commands")]
@@ -246,12 +243,13 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
-
-            Assert.IsFalse(command.CanExecute(null));
+                Assert.IsFalse(command.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -259,7 +257,7 @@ End Sub";
         public void FindAllImplementations_CanExecute_StateNotReady()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Private Sub Bar()
@@ -272,14 +270,15 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
-
-            Assert.IsFalse(command.CanExecute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo")));
+                Assert.IsFalse(command.CanExecute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo")));
+            }
         }
 
         [TestCategory("Commands")]
@@ -290,12 +289,13 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllImplementationsCommand(null, null, state, vbe.Object, vm, null);
-
-            Assert.IsFalse(command.CanExecute(null));
+                Assert.IsFalse(command.CanExecute(null));
+            }
         }
     }
 }

--- a/RubberduckTests/Commands/FindAllReferencesTests.cs
+++ b/RubberduckTests/Commands/FindAllReferencesTests.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.UI;
 using Rubberduck.UI.Command;
@@ -22,7 +21,7 @@ namespace RubberduckTests.Commands
         public void FindAllReferences_ReturnsCorrectNumber()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Private Sub Bar()
@@ -33,14 +32,16 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
 
-            command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            Assert.AreEqual(4, vm.Tabs[0].SearchResults.Count);
+                Assert.AreEqual(4, vm.Tabs[0].SearchResults.Count);
+            }
         }
 
         [TestCategory("Commands")]
@@ -48,7 +49,7 @@ End Sub";
         public void FindAllReferences_ReferenceSelected_ReturnsCorrectNumber()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Private Sub Bar()
@@ -59,14 +60,16 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, new Selection(5, 5, 5, 5));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
 
-            command.Execute(null);
+                command.Execute(null);
 
-            Assert.AreEqual(4, vm.Tabs[0].SearchResults.Count);
+                Assert.AreEqual(4, vm.Tabs[0].SearchResults.Count);
+            }
         }
 
         [TestCategory("Commands")]
@@ -74,25 +77,27 @@ End Sub";
         public void FindAllReferences_NoResults_DisplayMessageBox()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, messageBox.Object, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, messageBox.Object, state, vbe.Object, vm, null);
 
-            command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
@@ -100,7 +105,7 @@ End Sub";
         public void FindAllReferences_SingleResult_Navigates()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Private Sub Bar()
@@ -109,16 +114,18 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var navigateCommand = new Mock<INavigateCommand>();
+                var navigateCommand = new Mock<INavigateCommand>();
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(navigateCommand.Object, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(navigateCommand.Object, null, state, vbe.Object, vm, null);
 
-            command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+                navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
@@ -129,14 +136,16 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
 
-            command.Execute(null);
+                command.Execute(null);
 
-            Assert.IsFalse(vm.Tabs.Any());
+                Assert.IsFalse(vm.Tabs.Any());
+            }
         }
 
         [TestCategory("Commands")]
@@ -144,7 +153,7 @@ End Sub";
         public void FindAllReferences_StateNotReady_Aborts()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Private Sub Bar()
@@ -157,15 +166,17 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
 
-            command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo"));
 
-            Assert.IsFalse(vm.Tabs.Any());
+                Assert.IsFalse(vm.Tabs.Any());
+            }
         }
 
         [TestCategory("Commands")]
@@ -176,12 +187,14 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
 
-            Assert.IsFalse(command.CanExecute(null));
+                Assert.IsFalse(command.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -189,7 +202,7 @@ End Sub";
         public void FindAllReferences_CanExecute_StateNotReady()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Private Sub Bar()
@@ -202,14 +215,16 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
 
-            Assert.IsFalse(command.CanExecute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo")));
+                Assert.IsFalse(command.CanExecute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Foo")));
+            }
         }
 
         [TestCategory("Commands")]
@@ -220,19 +235,21 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns(value: null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
 
-            Assert.IsFalse(command.CanExecute(null));
+                Assert.IsFalse(command.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
         [TestMethod]
         public void FindAllReferences_ControlMultipleResults_ReturnsCorrectNumber()
         {
-var code = @"
+            var code = @"
 Public Sub DoSomething()
     TextBox1.Height = 20
     TextBox1.Width = 200
@@ -247,55 +264,59 @@ End Sub
             var vbe = builder.Build();
             vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);
 
-            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()));
-            AssertParserReady(parser);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                AssertParserReady(state);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, parser.State, vbe.Object, vm, null);
-            var target = parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "TextBox1");
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var target = state.AllUserDeclarations.Single(s => s.IdentifierName == "TextBox1");
 
-            command.Execute(target);
+                command.Execute(target);
 
-            Assert.AreEqual(1, vm.Tabs.Count);
-            Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+                Assert.AreEqual(1, vm.Tabs.Count);
+                Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+            }
         }
 
         [TestCategory("Commands")]
         [TestMethod]
         public void FindAllReferences_ControlSingleResult_Navigates()
         {
-var code = @"
+            var code = @"
 Public Sub DoSomething()
     TextBox1.Height = 20
 End Sub
 ";
-            var builder = new MockVbeBuilder();            
+            var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected);
-            var form = project.MockUserFormBuilder("Form1", code).AddControl("TextBox1").Build();           
+            var form = project.MockUserFormBuilder("Form1", code).AddControl("TextBox1").Build();
 
             project.AddComponent(form);
             builder.AddProject(project.Build());
             var vbe = builder.Build();
             vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);
 
-            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()));
-            AssertParserReady(parser);
-            var navigateCommand = new Mock<INavigateCommand>();
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                AssertParserReady(state);
+                var navigateCommand = new Mock<INavigateCommand>();
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(navigateCommand.Object, null, parser.State, vbe.Object, vm, null);
-            var target = parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "TextBox1");
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(navigateCommand.Object, null, state, vbe.Object, vm, null);
+                var target = state.AllUserDeclarations.Single(s => s.IdentifierName == "TextBox1");
 
-            command.Execute(target);
+                command.Execute(target);
 
-            navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+                navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
         [TestMethod]
         public void FindAllReferences_ControlNoResults_DisplaysMessageBox()
         {
-var code = @"
+            var code = @"
 Public Sub DoSomething()
 End Sub
 ";
@@ -308,32 +329,34 @@ End Sub
             var vbe = builder.Build();
             vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);
 
-            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()));
-            AssertParserReady(parser);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                AssertParserReady(state);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
-                m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                    It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
+                    m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                        It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, messageBox.Object, parser.State, vbe.Object, vm, null);
-            var target = parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "TextBox1");
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, messageBox.Object, state, vbe.Object, vm, null);
+                var target = state.AllUserDeclarations.Single(s => s.IdentifierName == "TextBox1");
 
-            command.Execute(target);
+                command.Execute(target);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
         [TestMethod]
         public void FindAllReferences_ControlMultipleSelection_IsNotEnabled()
         {
-var code = @"
+            var code = @"
 Public Sub DoSomething()
 End Sub
-";            
+";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected);
             var form = project.MockUserFormBuilder("Form1", code).AddControl("TextBox1").AddControl("TextBox2").Build();
@@ -343,21 +366,23 @@ End Sub
             var vbe = builder.Build();
             vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);
 
-            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()));
-            AssertParserReady(parser);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                AssertParserReady(state);
 
-            var targets = parser.State.AllUserDeclarations.Where(s => s.IdentifierName.StartsWith("TextBox"));
-            var command = new FindAllReferencesCommand(null, null, parser.State, vbe.Object, null, null);
+                var targets = state.AllUserDeclarations.Where(s => s.IdentifierName.StartsWith("TextBox"));
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, null, null);
 
 
-            Assert.IsFalse(command.CanExecute(targets));
+                Assert.IsFalse(command.CanExecute(targets));
+            }
         }
 
         [TestCategory("Commands")]
         [TestMethod]
         public void FindAllReferences_FormMultipleResults_ReturnsCorrectNumber()
         {
-var code = @"
+            var code = @"
 Public Sub DoSomething()
     Form1.Width = 20
     Form1.Height = 200
@@ -370,26 +395,28 @@ End Sub
             project.AddComponent(form);
             builder.AddProject(project.Build());
             var vbe = builder.Build();
-            vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);            
+            vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);
 
-            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()));
-            AssertParserReady(parser);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                AssertParserReady(state);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, null, parser.State, vbe.Object, vm, null);
-            var target = parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "Form1");
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, null, state, vbe.Object, vm, null);
+                var target = state.AllUserDeclarations.Single(s => s.IdentifierName == "Form1");
 
-            command.Execute(target);
+                command.Execute(target);
 
-            Assert.AreEqual(1, vm.Tabs.Count);
-            Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+                Assert.AreEqual(1, vm.Tabs.Count);
+                Assert.AreEqual(2, vm.Tabs[0].SearchResults.Count);
+            }
         }
 
         [TestCategory("Commands")]
         [TestMethod]
         public void FindAllReferences_FormSingleResult_Navigates()
         {
-var code = @"
+            var code = @"
 Public Sub DoSomething()
     Form1.Height = 20
 End Sub
@@ -405,62 +432,65 @@ End Sub
             vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);
 
 
-            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()));
-            AssertParserReady(parser);            
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                AssertParserReady(state);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(navigateCommand.Object, null, parser.State, vbe.Object, vm, null);
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(navigateCommand.Object, null, state, vbe.Object, vm, null);
 
-            command.Execute(parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "Form1"));
+                command.Execute(state.AllUserDeclarations.Single(s => s.IdentifierName == "Form1"));
 
-            navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+                navigateCommand.Verify(n => n.Execute(It.IsAny<object>()), Times.Once);
+            }
         }
 
         [TestCategory("Commands")]
         [TestMethod]
         public void FindAllReferences_FormNoResults_DisplaysMessageBox()
         {
-var code = @"
+            var code = @"
 Public Sub DoSomething()
 End Sub
 ";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected);
-            var form = project.MockUserFormBuilder("Form1", code).Build();         
+            var form = project.MockUserFormBuilder("Form1", code).Build();
 
             project.AddComponent(form);
             builder.AddProject(project.Build());
             var vbe = builder.Build();
             vbe.SetupGet(v => v.SelectedVBComponent).Returns(form.Object);
 
-            var parser = MockParser.Create(vbe.Object, new RubberduckParserState(vbe.Object, new DeclarationFinderFactory()));
-            AssertParserReady(parser);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                AssertParserReady(state);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
-                m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                    It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
+                    m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                        It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var vm = new SearchResultsWindowViewModel();
-            var command = new FindAllReferencesCommand(null, messageBox.Object, parser.State, vbe.Object, vm, null);
-            var target = parser.State.AllUserDeclarations.Single(s => s.IdentifierName == "Form1");
+                var vm = new SearchResultsWindowViewModel();
+                var command = new FindAllReferencesCommand(null, messageBox.Object, state, vbe.Object, vm, null);
+                var target = state.AllUserDeclarations.Single(s => s.IdentifierName == "Form1");
 
-            command.Execute(target);
+                command.Execute(target);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+            }
         }
 
-        private void AssertParserReady(ParseCoordinator parser)
+        private void AssertParserReady(RubberduckParserState state)
         {
-            parser.Parse(new System.Threading.CancellationTokenSource());
-            if (parser.State.Status == ParserState.ResolverError)
+            if (state.Status == ParserState.ResolverError)
             {
-                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", state.Status);
             }
-            if (parser.State.Status != ParserState.Ready)
+            if (state.Status != ParserState.Ready)
             {
-                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", state.Status);
             }
         }
     }

--- a/RubberduckTests/Commands/IndentCommandTests.cs
+++ b/RubberduckTests/Commands/IndentCommandTests.cs
@@ -16,12 +16,14 @@ namespace RubberduckTests.Commands
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("", out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
-            noIndentAnnotationCommand.Execute(null);
+                var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
+                noIndentAnnotationCommand.Execute(null);
 
-            Assert.AreEqual("'@NoIndent\r\n", component.CodeModule.Content());
+                Assert.AreEqual("'@NoIndent\r\n", component.CodeModule.Content());
+            }
         }
 
         [TestCategory("Commands")]
@@ -29,28 +31,30 @@ namespace RubberduckTests.Commands
         public void AddNoIndentAnnotation_ModuleContainsCode()
         {
             var input =
-@"Option Explicit
+                @"Option Explicit
 Public Foo As Boolean
 
 Sub Foo()
 End Sub";
 
             var expected =
-@"'@NoIndent
+                @"'@NoIndent
 Option Explicit
 Public Foo As Boolean
 
 Sub Foo()
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-            
-            var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
-            noIndentAnnotationCommand.Execute(null);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            Assert.AreEqual(expected, component.CodeModule.Content());
+                var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
+                noIndentAnnotationCommand.Execute(null);
+
+                Assert.AreEqual(expected, component.CodeModule.Content());
+            }
         }
 
         [TestCategory("Commands")]
@@ -61,10 +65,12 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("", out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
-            Assert.IsFalse(noIndentAnnotationCommand.CanExecute(null));
+                var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
+                Assert.IsFalse(noIndentAnnotationCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -75,10 +81,12 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("'@NoIndent\r\n", out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
-            Assert.IsFalse(noIndentAnnotationCommand.CanExecute(null));
+                var noIndentAnnotationCommand = new NoIndentAnnotationCommand(vbe.Object, state);
+                Assert.IsFalse(noIndentAnnotationCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -86,7 +94,7 @@ End Sub";
         public void IndentModule_IndentsModule()
         {
             var input =
-@"    Option Explicit   ' at least I used it...
+                @"    Option Explicit   ' at least I used it...
     Sub InverseIndent()
 Dim d As Boolean
 Dim s As Integer
@@ -101,7 +109,7 @@ Dim d As Boolean
 ";
 
             var expected =
-@"Option Explicit                                  ' at least I used it...
+                @"Option Explicit                                  ' at least I used it...
 Sub InverseIndent()
     Dim d As Boolean
     Dim s As Integer
@@ -124,16 +132,18 @@ End Sub
             var vbe = builder.AddProject(project).Build();
             vbe.Setup(s => s.ActiveCodePane).Returns(project.Object.VBComponents["Comp2"].CodeModule.CodePane);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var indentCommand = new IndentCurrentModuleCommand(vbe.Object, CreateIndenter(vbe.Object), state);
-            indentCommand.Execute(null);
+                var indentCommand = new IndentCurrentModuleCommand(vbe.Object, CreateIndenter(vbe.Object), state);
+                indentCommand.Execute(null);
 
-            var module1 = project.Object.VBComponents["Comp1"].CodeModule;
-            var module2 = project.Object.VBComponents["Comp2"].CodeModule;
+                var module1 = project.Object.VBComponents["Comp1"].CodeModule;
+                var module2 = project.Object.VBComponents["Comp2"].CodeModule;
 
-            Assert.AreEqual(input, module1.Content());
-            Assert.AreEqual(expected, module2.Content());
+                Assert.AreEqual(input, module1.Content());
+                Assert.AreEqual(expected, module2.Content());
+            }
         }
 
         [TestCategory("Commands")]
@@ -144,10 +154,12 @@ End Sub
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("", out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var indentCommand = new IndentCurrentModuleCommand(vbe.Object, CreateIndenter(vbe.Object), state);
-            Assert.IsFalse(indentCommand.CanExecute(null));
+                var indentCommand = new IndentCurrentModuleCommand(vbe.Object, CreateIndenter(vbe.Object), state);
+                Assert.IsFalse(indentCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -156,10 +168,12 @@ End Sub
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("", out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var indentCommand = new IndentCurrentModuleCommand(vbe.Object, CreateIndenter(vbe.Object), state);
-            Assert.IsTrue(indentCommand.CanExecute(null));
+                var indentCommand = new IndentCurrentModuleCommand(vbe.Object, CreateIndenter(vbe.Object), state);
+                Assert.IsTrue(indentCommand.CanExecute(null));
+            }
         }
 
         private static IIndenter CreateIndenter(IVBE vbe)

--- a/RubberduckTests/Commands/RefactorCommandTests.cs
+++ b/RubberduckTests/Commands/RefactorCommandTests.cs
@@ -21,10 +21,12 @@ namespace RubberduckTests.Commands
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
-            Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+                var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
+                Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -33,11 +35,13 @@ namespace RubberduckTests.Commands
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
-            Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+                var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
+                Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -45,16 +49,18 @@ namespace RubberduckTests.Commands
         public void EncapsulateField_CanExecute_LocalVariable()
         {
             var input =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(2, 9, 2, 9));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
-            Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+                var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
+                Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -62,16 +68,18 @@ End Sub";
         public void EncapsulateField_CanExecute_Proc()
         {
             var input =
-@"Dim d As Boolean
+                @"Dim d As Boolean
 Sub Foo()
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(2, 7, 2, 7));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
-            Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+                var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
+                Assert.IsFalse(encapsulateFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -79,16 +87,18 @@ End Sub";
         public void EncapsulateField_CanExecute_Field()
         {
             var input =
-@"Dim d As Boolean
+                @"Dim d As Boolean
 Sub Foo()
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 5, 1, 5));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
-            Assert.IsTrue(encapsulateFieldCommand.CanExecute(null));
+                var encapsulateFieldCommand = new RefactorEncapsulateFieldCommand(vbe.Object, state, null);
+                Assert.IsTrue(encapsulateFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -99,10 +109,12 @@ End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -112,11 +124,13 @@ End Sub";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(string.Empty, ComponentType.ClassModule, out component, new Selection());
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -125,10 +139,11 @@ End Sub";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule("Option Explicit", ComponentType.ClassModule, out component, new Selection());
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -136,15 +151,17 @@ End Sub";
         public void ExtractInterface_CanExecute_Proc_StdModule()
         {
             var input =
-@"Sub foo()
+                @"Sub foo()
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -153,10 +170,12 @@ End Sub";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule("Dim d As Boolean", ComponentType.ClassModule, out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -169,11 +188,11 @@ End Sub
 ";
             var builder = new MockVbeBuilder();
             var proj1 = builder.ProjectBuilder("TestProj1", ProjectProtection.Unprotected)
-                               .AddComponent("Class1", ComponentType.ClassModule, input, Selection.Home)
-                               .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, input, Selection.Home)
+                .Build();
             var proj2 = builder.ProjectBuilder("TestProj2", ProjectProtection.Unprotected)
-                               .AddComponent("Class1", ComponentType.ClassModule, string.Empty, Selection.Home)
-                               .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, string.Empty, Selection.Home)
+                .Build();
 
             var vbe = builder
                 .AddProject(proj1)
@@ -186,9 +205,11 @@ End Sub
                 Assert.Inconclusive("The active code pane should be the one with the method stub.");
             }
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -196,7 +217,7 @@ End Sub
         public void ExtractInterface_CanExecute_ClassWithMembers_SameNameAsClassWithMembers()
         {
             var input =
-@"Sub foo()
+                @"Sub foo()
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -210,10 +231,12 @@ End Sub";
 
             vbe.Setup(s => s.ActiveCodePane).Returns(proj1.Object.VBComponents[0].CodeModule.CodePane);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -221,16 +244,18 @@ End Sub";
         public void ExtractInterface_CanExecute_Proc()
         {
             var input =
-@"Sub foo()
+                @"Sub foo()
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(input, ComponentType.ClassModule, out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            var canExecute = extractInterfaceCommand.CanExecute(null);
-            Assert.IsTrue(canExecute);
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                var canExecute = extractInterfaceCommand.CanExecute(null);
+                Assert.IsTrue(canExecute);
+            }
         }
 
         [TestCategory("Commands")]
@@ -238,15 +263,17 @@ End Sub";
         public void ExtractInterface_CanExecute_Function()
         {
             var input =
-@"Function foo() As Integer
+                @"Function foo() As Integer
 End Function";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(input, ComponentType.ClassModule, out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -254,15 +281,17 @@ End Function";
         public void ExtractInterface_CanExecute_PropertyGet()
         {
             var input =
-@"Property Get foo() As Boolean
+                @"Property Get foo() As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(input, ComponentType.ClassModule, out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -270,15 +299,17 @@ End Property";
         public void ExtractInterface_CanExecute_PropertyLet()
         {
             var input =
-@"Property Let foo(value)
+                @"Property Let foo(value)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(input, ComponentType.ClassModule, out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -286,15 +317,17 @@ End Property";
         public void ExtractInterface_CanExecute_PropertySet()
         {
             var input =
-@"Property Set foo(value)
+                @"Property Set foo(value)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(input, ComponentType.ClassModule, out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
-            Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+                var extractInterfaceCommand = new RefactorExtractInterfaceCommand(vbe.Object, state, null);
+                Assert.IsTrue(extractInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -305,10 +338,12 @@ End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(implementInterfaceCommand.CanExecute(null));
+                var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(implementInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -318,11 +353,13 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(implementInterfaceCommand.CanExecute(null));
+                var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(implementInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -331,10 +368,12 @@ End Property";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(string.Empty, ComponentType.ClassModule, out component, new Selection());
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
-            Assert.IsFalse(implementInterfaceCommand.CanExecute(null));
+                var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
+                Assert.IsFalse(implementInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -348,10 +387,12 @@ End Property";
                 .Build();
 
             var vbe = builder.AddProject(project).Build();
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
-            Assert.IsTrue(implementInterfaceCommand.CanExecute(null));
+                var implementInterfaceCommand = new RefactorImplementInterfaceCommand(vbe.Object, state, null);
+                Assert.IsTrue(implementInterfaceCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -361,11 +402,13 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsFalse(introduceFieldCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsFalse(introduceFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -375,12 +418,14 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsFalse(introduceFieldCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsFalse(introduceFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -389,11 +434,13 @@ End Property";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("Dim d As Boolean", out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsFalse(introduceFieldCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsFalse(introduceFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -401,17 +448,19 @@ End Property";
         public void IntroduceField_CanExecute_LocalVariable()
         {
             var input =
-@"Property Get foo() As Boolean
+                @"Property Get foo() As Boolean
     Dim d As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(2, 10, 2, 10));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsTrue(introduceFieldCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceFieldCommand = new RefactorIntroduceFieldCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsTrue(introduceFieldCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -421,11 +470,13 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsFalse(introduceParameterCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsFalse(introduceParameterCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -435,12 +486,14 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsFalse(introduceParameterCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsFalse(introduceParameterCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -449,11 +502,13 @@ End Property";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("Dim d As Boolean", out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsFalse(introduceParameterCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsFalse(introduceParameterCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -461,17 +516,19 @@ End Property";
         public void IntroduceParameter_CanExecute_LocalVariable()
         {
             var input =
-@"Property Get foo() As Boolean
+                @"Property Get foo() As Boolean
     Dim d As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(2, 10, 2, 10));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var msgbox = new Mock<IMessageBox>();
-            var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
-            Assert.IsTrue(introduceParameterCommand.CanExecute(null));
+                var msgbox = new Mock<IMessageBox>();
+                var introduceParameterCommand = new RefactorIntroduceParameterCommand(vbe.Object, state, msgbox.Object);
+                Assert.IsTrue(introduceParameterCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -481,10 +538,12 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -494,11 +553,13 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -507,10 +568,12 @@ End Property";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("Dim d As Boolean", out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -518,16 +581,18 @@ End Property";
         public void MoveCloserToUsage_CanExecute_LocalVariable_NoReferences()
         {
             var input =
-@"Property Get foo() As Boolean
+                @"Property Get foo() As Boolean
     Dim d As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(2, 10, 2, 10));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -536,10 +601,12 @@ End Property";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule("Private Const const_abc = 0", out component, Selection.Home);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsFalse(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -547,17 +614,19 @@ End Property";
         public void MoveCloserToUsage_CanExecute_Field()
         {
             var input =
-@"Dim d As Boolean
+                @"Dim d As Boolean
 Sub Foo()
     d = True
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 5, 1, 5));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsTrue(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsTrue(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -565,17 +634,19 @@ End Sub";
         public void MoveCloserToUsage_CanExecute_LocalVariable()
         {
             var input =
-@"Property Get foo() As Boolean
+                @"Property Get foo() As Boolean
     Dim d As Boolean
     d = True
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(2, 10, 2, 10));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsTrue(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsTrue(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -583,18 +654,20 @@ End Property";
         public void MoveCloserToUsage_CanExecute_Const()
         {
             var input =
-@"Private Const const_abc = 0
+                @"Private Const const_abc = 0
 Sub Foo()
     Dim d As Integer
     d = const_abc
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 17, 1, 17));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
-            Assert.IsTrue(moveCloserToUsageCommand.CanExecute(null));
+                var moveCloserToUsageCommand = new RefactorMoveCloserToUsageCommand(vbe.Object, state, null);
+                Assert.IsTrue(moveCloserToUsageCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -604,10 +677,12 @@ End Sub";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -617,11 +692,13 @@ End Sub";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -629,14 +706,16 @@ End Sub";
         public void RemoveParameters_CanExecute_Event_NoParams()
         {
             const string input =
-@"Public Event Foo()";
-            
+                @"Public Event Foo()";
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -644,15 +723,17 @@ End Sub";
         public void RemoveParameters_CanExecute_Proc_NoParams()
         {
             var input =
-@"Sub foo()
+                @"Sub foo()
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 6, 1, 6));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -660,15 +741,17 @@ End Sub";
         public void RemoveParameters_CanExecute_Function_NoParams()
         {
             var input =
-@"Function foo() As Integer
+                @"Function foo() As Integer
 End Function";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 11, 1, 11));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -676,15 +759,17 @@ End Function";
         public void RemoveParameters_CanExecute_PropertyGet_NoParams()
         {
             var input =
-@"Property Get foo() As Boolean
+                @"Property Get foo() As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -692,15 +777,17 @@ End Property";
         public void RemoveParameters_CanExecute_PropertyLet_OneParam()
         {
             var input =
-@"Property Let foo(value)
+                @"Property Let foo(value)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -708,15 +795,17 @@ End Property";
         public void RemoveParameters_CanExecute_PropertySet_OneParam()
         {
             var input =
-@"Property Set foo(value)
+                @"Property Set foo(value)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -724,14 +813,16 @@ End Property";
         public void RemoveParameters_CanExecute_Event_OneParam()
         {
             const string input =
-@"Public Event Foo(value)";
-            
+                @"Public Event Foo(value)";
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -739,15 +830,17 @@ End Property";
         public void RemoveParameters_CanExecute_Proc_OneParam()
         {
             var input =
-@"Sub foo(value)
+                @"Sub foo(value)
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 6, 1, 6));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -755,15 +848,17 @@ End Sub";
         public void RemoveParameters_CanExecute_Function_OneParam()
         {
             var input =
-@"Function foo(value) As Integer
+                @"Function foo(value) As Integer
 End Function";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 11, 1, 11));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -771,15 +866,17 @@ End Function";
         public void RemoveParameters_CanExecute_PropertyGet_OneParam()
         {
             var input =
-@"Property Get foo(value) As Boolean
+                @"Property Get foo(value) As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -787,15 +884,17 @@ End Property";
         public void RemoveParameters_CanExecute_PropertyLet_TwoParams()
         {
             var input =
-@"Property Let foo(value1, value2)
+                @"Property Let foo(value1, value2)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -803,15 +902,17 @@ End Property";
         public void RemoveParameters_CanExecute_PropertySet_TwoParams()
         {
             var input =
-@"Property Set foo(value1, value2)
+                @"Property Set foo(value1, value2)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(removeParametersCommand.CanExecute(null));
+                var removeParametersCommand = new RefactorRemoveParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(removeParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -821,10 +922,12 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
             vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -834,11 +937,13 @@ End Property";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvedDeclarations);
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -846,14 +951,16 @@ End Property";
         public void ReorderParameters_CanExecute_Event_OneParam()
         {
             const string input =
-@"Public Event Foo(value)";
-            
+                @"Public Event Foo(value)";
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -861,15 +968,17 @@ End Property";
         public void ReorderParameters_CanExecute_Proc_OneParam()
         {
             var input =
-@"Sub foo(value)
+                @"Sub foo(value)
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 6, 1, 6));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -877,15 +986,17 @@ End Sub";
         public void ReorderParameters_CanExecute_Function_OneParam()
         {
             var input =
-@"Function foo(value) As Integer
+                @"Function foo(value) As Integer
 End Function";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 11, 1, 11));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -893,15 +1004,17 @@ End Function";
         public void ReorderParameters_CanExecute_PropertyGet_OneParam()
         {
             var input =
-@"Property Get foo(value) As Boolean
+                @"Property Get foo(value) As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -909,15 +1022,17 @@ End Property";
         public void ReorderParameters_CanExecute_PropertyLet_TwoParams()
         {
             var input =
-@"Property Let foo(value1, value2)
+                @"Property Let foo(value1, value2)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -925,15 +1040,17 @@ End Property";
         public void ReorderParameters_CanExecute_PropertySet_TwoParams()
         {
             var input =
-@"Property Set foo(value1, value2)
+                @"Property Set foo(value1, value2)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsFalse(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -941,14 +1058,16 @@ End Property";
         public void ReorderParameters_CanExecute_Event_TwoParams()
         {
             const string input =
-@"Public Event Foo(value1, value2)";
-            
+                @"Public Event Foo(value1, value2)";
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -956,15 +1075,17 @@ End Property";
         public void ReorderParameters_CanExecute_Proc_TwoParams()
         {
             var input =
-@"Sub foo(value1, value2)
+                @"Sub foo(value1, value2)
 End Sub";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 6, 1, 6));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -972,15 +1093,17 @@ End Sub";
         public void ReorderParameters_CanExecute_Function_TwoParams()
         {
             var input =
-@"Function foo(value1, value2) As Integer
+                @"Function foo(value1, value2) As Integer
 End Function";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 11, 1, 11));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -988,15 +1111,17 @@ End Function";
         public void ReorderParameters_CanExecute_PropertyGet_TwoParams()
         {
             var input =
-@"Property Get foo(value1, value2) As Boolean
+                @"Property Get foo(value1, value2) As Boolean
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -1004,15 +1129,17 @@ End Property";
         public void ReorderParameters_CanExecute_PropertyLet_ThreeParams()
         {
             var input =
-@"Property Let foo(value1, value2, value3)
+                @"Property Let foo(value1, value2, value3)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -1020,15 +1147,17 @@ End Property";
         public void ReorderParameters_CanExecute_PropertySet_ThreeParams()
         {
             var input =
-@"Property Set foo(value1, value2, value3)
+                @"Property Set foo(value1, value2, value3)
 End Property";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component, new Selection(1, 16, 1, 16));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
-            Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+                var reorderParametersCommand = new RefactorReorderParametersCommand(vbe.Object, state, null);
+                Assert.IsTrue(reorderParametersCommand.CanExecute(null));
+            }
         }
     }
 }

--- a/RubberduckTests/Commands/UnitTestCommandTests.cs
+++ b/RubberduckTests/Commands/UnitTestCommandTests.cs
@@ -25,20 +25,22 @@ Option Private Module
 '@TestModule
 Private Assert As Object
 {0}";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Format(input, string.Empty), out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
+                var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
 
-            addTestMethodCommand.Execute(null);
-            var module = component.CodeModule;
+                addTestMethodCommand.Execute(null);
+                var module = component.CodeModule;
 
-            Assert.AreEqual(
-                string.Format(input,
-                    AddTestMethodCommand.TestMethodTemplate.Replace(AddTestMethodCommand.NamePlaceholder, "TestMethod1")) +
-                Environment.NewLine, module.Content());
+                Assert.AreEqual(
+                    string.Format(input,
+                        AddTestMethodCommand.TestMethodTemplate.Replace(AddTestMethodCommand.NamePlaceholder, "TestMethod1")) +
+                    Environment.NewLine, module.Content());
+            }
         }
 
         [TestCategory("Commands")]
@@ -52,19 +54,21 @@ Option Private Module
 '@TestModule
 Private Assert As Object
 ";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
+                var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
 
-            addTestMethodCommand.Execute(null);
-            var module = component.CodeModule;
+                addTestMethodCommand.Execute(null);
+                var module = component.CodeModule;
 
-            Assert.AreEqual(input, module.Content());
+                Assert.AreEqual(input, module.Content());
+            }
         }
 
         [TestCategory("Commands")]
@@ -73,12 +77,14 @@ Private Assert As Object
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvingReferences);
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvingReferences);
 
-            var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
-            Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+                var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
+                Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -87,10 +93,12 @@ Private Assert As Object
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
-            Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+                var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
+                Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -104,13 +112,15 @@ Option Private Module
 '@TestModule
 Private Assert As Object
 ";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
-            Assert.IsTrue(addTestMethodCommand.CanExecute(null));
+                var addTestMethodCommand = new AddTestMethodCommand(vbe.Object, state);
+                Assert.IsTrue(addTestMethodCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -124,20 +134,22 @@ Option Private Module
 '@TestModule
 Private Assert As Object
 {0}";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Format(input, string.Empty), out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
+                var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
 
-            addTestMethodCommand.Execute(null);
-            var module = component.CodeModule;
+                addTestMethodCommand.Execute(null);
+                var module = component.CodeModule;
 
-            Assert.AreEqual(
-                string.Format(input,
-                    AddTestMethodExpectedErrorCommand.TestMethodExpectedErrorTemplate.Replace(AddTestMethodExpectedErrorCommand.NamePlaceholder,
-                        "TestMethod1")) + Environment.NewLine, module.Content());
+                Assert.AreEqual(
+                    string.Format(input,
+                        AddTestMethodExpectedErrorCommand.TestMethodExpectedErrorTemplate.Replace(AddTestMethodExpectedErrorCommand.NamePlaceholder,
+                            "TestMethod1")) + Environment.NewLine, module.Content());
+            }
         }
 
         [TestCategory("Commands")]
@@ -147,11 +159,13 @@ Private Assert As Object
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            state.SetStatusAndFireStateChanged(this, ParserState.ResolvingReferences);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                state.SetStatusAndFireStateChanged(this, ParserState.ResolvingReferences);
 
-            var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
-            Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+                var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
+                Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -160,10 +174,12 @@ Private Assert As Object
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
-            Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+                var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
+                Assert.IsFalse(addTestMethodCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -177,13 +193,15 @@ Option Private Module
 '@TestModule
 Private Assert As Object
 ";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
-            Assert.IsTrue(addTestMethodCommand.CanExecute(null));
+                var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
+                Assert.IsTrue(addTestMethodCommand.CanExecute(null));
+            }
         }
 
         [TestCategory("Commands")]
@@ -197,17 +215,19 @@ Option Private Module
 '@TestModule
 Private Assert As Object
 ";
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out component);
             vbe.Setup(s => s.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
-            addTestMethodCommand.Execute(null);
-            
-            Assert.AreEqual(input, component.CodeModule.Content());
+                var addTestMethodCommand = new AddTestMethodExpectedErrorCommand(vbe.Object, state);
+                addTestMethodCommand.Execute(null);
+
+                Assert.AreEqual(input, component.CodeModule.Content());
+            }
         }
 
         [TestCategory("Commands")]
@@ -216,19 +236,21 @@ Private Assert As Object
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var settings = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
-            var config = GetUnitTestConfig();
-            settings.Setup(x => x.LoadConfiguration()).Returns(config);
+                var settings = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
+                var config = GetUnitTestConfig();
+                settings.Setup(x => x.LoadConfiguration()).Returns(config);
 
-            var addTestModuleCommand = new AddTestModuleCommand(vbe.Object, state, settings.Object);
-            addTestModuleCommand.Execute(null);
+                var addTestModuleCommand = new AddTestModuleCommand(vbe.Object, state, settings.Object);
+                addTestModuleCommand.Execute(null);
 
-            // mock suite auto-assigns "TestModule1" to the first component when we create the mock
-            var project = state.DeclarationFinder.FindProject("TestProject1");
-            var module = state.DeclarationFinder.FindStdModule("TestModule2", project);
-            Assert.IsTrue(module.Annotations.Any(a => a.AnnotationType == AnnotationType.TestModule));
+                // mock suite auto-assigns "TestModule1" to the first component when we create the mock
+                var project = state.DeclarationFinder.FindProject("TestProject1");
+                var module = state.DeclarationFinder.FindStdModule("TestModule2", project);
+                Assert.IsTrue(module.Annotations.Any(a => a.AnnotationType == AnnotationType.TestModule));
+            }
         }
 
         [TestCategory("Commands")]
@@ -287,31 +309,33 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(code, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var settings = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
-            var config = GetUnitTestConfig();
-            settings.Setup(x => x.LoadConfiguration()).Returns(config);
-
-            var project = state.DeclarationFinder.FindProject("TestProject1");
-            var module = state.DeclarationFinder.FindStdModule("TestModule1", project);
-
-            var addTestModuleCommand = new AddTestModuleCommand(vbe.Object, state, settings.Object);
-            addTestModuleCommand.Execute(module);
-
-            var testModule = state.DeclarationFinder.FindStdModule("TestModule2", project);
-
-            var stubIdentifierNames = new[]
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                "PublicProcedure_Test", "PublicFunction_Test", "GetPublicProperty_Test", "LetPublicProperty_Test", "SetPublicProperty_Test"
-            };
 
-            Assert.IsTrue(testModule.Annotations.Any(a => a.AnnotationType == AnnotationType.TestModule));
+                var settings = new Mock<ConfigurationLoader>(null, null, null, null, null, null, null);
+                var config = GetUnitTestConfig();
+                settings.Setup(x => x.LoadConfiguration()).Returns(config);
 
-            var stubs = state.DeclarationFinder.AllUserDeclarations.Where(d => d.IdentifierName.EndsWith("_Test")).ToList();
+                var project = state.DeclarationFinder.FindProject("TestProject1");
+                var module = state.DeclarationFinder.FindStdModule("TestModule1", project);
 
-            Assert.AreEqual(stubIdentifierNames.Length, stubs.Count);
-            Assert.IsTrue(stubs.All(d => stubIdentifierNames.Contains(d.IdentifierName)));
+                var addTestModuleCommand = new AddTestModuleCommand(vbe.Object, state, settings.Object);
+                addTestModuleCommand.Execute(module);
+
+                var testModule = state.DeclarationFinder.FindStdModule("TestModule2", project);
+
+                var stubIdentifierNames = new[]
+                {
+                    "PublicProcedure_Test", "PublicFunction_Test", "GetPublicProperty_Test", "LetPublicProperty_Test", "SetPublicProperty_Test"
+                };
+
+                Assert.IsTrue(testModule.Annotations.Any(a => a.AnnotationType == AnnotationType.TestModule));
+
+                var stubs = state.DeclarationFinder.AllUserDeclarations.Where(d => d.IdentifierName.EndsWith("_Test")).ToList();
+
+                Assert.AreEqual(stubIdentifierNames.Length, stubs.Count);
+                Assert.IsTrue(stubs.All(d => stubIdentifierNames.Contains(d.IdentifierName)));
+            }
         }
 
         private Configuration GetUnitTestConfig()

--- a/RubberduckTests/Grammar/ParserRuleContextExtensionTests.cs
+++ b/RubberduckTests/Grammar/ParserRuleContextExtensionTests.cs
@@ -18,7 +18,7 @@ namespace RubberduckTests.Grammar
         public void Evil_Code_Selection_Not_Evil()
         {
             const string inputCode =
-@" _
+                @" _
  _
  Function _
  _
@@ -37,14 +37,16 @@ namespace RubberduckTests.Grammar
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var declaration = state.AllDeclarations.Single(d => d.IdentifierName.Equals("Foo"));
+                var declaration = state.AllDeclarations.Single(d => d.IdentifierName.Equals("Foo"));
 
-            var actual = ((VBAParser.FunctionStmtContext)declaration.Context).GetProcedureSelection();
-            var expected = new Selection(3, 2, 11, 14);
+                var actual = ((VBAParser.FunctionStmtContext)declaration.Context).GetProcedureSelection();
+                var expected = new Selection(3, 2, 11, 14);
 
-            Assert.AreEqual(actual, expected);
+                Assert.AreEqual(actual, expected);
+            }
         }
     }
 }

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -20,14 +20,19 @@ namespace RubberduckTests.Grammar
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(code, moduleType, out component, Selection.Empty, loadStdLib);
             var parser = MockParser.Create(vbe.Object);
-
+            var state = parser.State;
             parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+
+            if (state.Status == ParserState.ResolverError)
             {
-                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", state.Status);
+            }
+            if (state.Status != ParserState.Ready)
+            {
+                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", state.Status);
             }
 
-            return parser.State;
+            return state;
         }
 
         private RubberduckParserState Resolve(params string[] classes)
@@ -44,18 +49,19 @@ namespace RubberduckTests.Grammar
             var vbe = builder.Build();
 
             var parser = MockParser.Create(vbe.Object);
-
+            var state = parser.State;
             parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status == ParserState.ResolverError)
+
+            if (state.Status == ParserState.ResolverError)
             {
-                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", state.Status);
             }
-            if (parser.State.Status != ParserState.Ready)
+            if (state.Status != ParserState.Ready)
             {
-                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", state.Status);
             }
 
-            return parser.State;
+            return state;
         }
 
         private RubberduckParserState Resolve(params Tuple<string, ComponentType>[] components)
@@ -70,20 +76,20 @@ namespace RubberduckTests.Grammar
             var project = projectBuilder.Build();
             builder.AddProject(project);
             var vbe = builder.Build();
-
             var parser = MockParser.Create(vbe.Object);
-
+            var state = parser.State;
             parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status == ParserState.ResolverError)
+
+            if (state.Status == ParserState.ResolverError)
             {
-                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", state.Status);
             }
-            if (parser.State.Status != ParserState.Ready)
+            if (state.Status != ParserState.Ready)
             {
-                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", state.Status);
             }
 
-            return parser.State;
+            return state;
         }
 
         [TestCategory("Grammar")]
@@ -96,12 +102,14 @@ Public Function Foo() As String
     Foo = 42
 End Function
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Function && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Function && item.IdentifierName == "Foo");
 
-            Assert.AreEqual(1, declaration.References.Count(item => item.IsAssignment));
+                Assert.AreEqual(1, declaration.References.Count(item => item.IsAssignment));
+            }
         }
 
         [TestCategory("Resolver")]
@@ -113,12 +121,14 @@ Public Const Foo As Long = 42
 Public Sub DoSomething(Optional ByVal bar As Long = Foo)
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Constant && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Constant && item.IdentifierName == "Foo");
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -135,12 +145,14 @@ End Function
             // We only use the second class as as target of the type expression, its contents don't matter.
             var code_class2 = string.Empty;
 
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "a");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "a");
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -157,12 +169,14 @@ End Function
             // We only use the second class as as target of the type expression, its contents don't matter.
             var code_class2 = string.Empty;
 
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.ClassModule && item.IdentifierName == "Class2");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.ClassModule && item.IdentifierName == "Class2");
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -179,14 +193,16 @@ Private Function Foo() As String
     Foo = 42
 End Function
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Function && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Function && item.IdentifierName == "Foo");
 
-            var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -207,15 +223,17 @@ Private Function Foo() As String
     Foo = 42
 End Function
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.DeclarationFinder
-                                .UserDeclarations(DeclarationType.Function)
-                                .Single(item => item.IdentifierName == "Foo");
+                var declaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Function)
+                    .Single(item => item.IdentifierName == "Foo");
 
-            var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -229,14 +247,16 @@ Public Sub DoSomething()
     a = foo
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -250,14 +270,16 @@ Public Sub DoSomething()
     a = [foo]
 End Sub
 ";
-            var state = Resolve(code, true);
+            using (var state = Resolve(code, true))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -271,14 +293,16 @@ Public Sub DoSomething()
     foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            var reference = declaration.References.SingleOrDefault(item => item.IsAssignment);
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault(item => item.IsAssignment);
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -292,14 +316,16 @@ Public Sub DoSomething()
 5:
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.LineLabel && item.IdentifierName == "5");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.LineLabel && item.IdentifierName == "5");
 
-            var reference = declaration.References.SingleOrDefault();
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault();
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -317,14 +343,16 @@ Public Sub DoSomething()
 5
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.LineLabel && item.IdentifierName == "5");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.LineLabel && item.IdentifierName == "5");
 
-            var reference = declaration.References.SingleOrDefault();
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault();
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -338,14 +366,16 @@ Public Sub DoSomething()
 foo:
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.LineLabel && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.LineLabel && item.IdentifierName == "foo");
 
-            var reference = declaration.References.SingleOrDefault();
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault();
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -362,14 +392,16 @@ Public Sub DoSomething()
     Dim a As {0}.{1}.{0}
 End Sub
 ", MockVbeBuilder.TestProjectName, MockVbeBuilder.TestModuleName);
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Project && item.IdentifierName == MockVbeBuilder.TestProjectName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Project && item.IdentifierName == MockVbeBuilder.TestProjectName);
 
-            var reference = declaration.References.SingleOrDefault();
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault();
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -386,14 +418,16 @@ Public Sub DoSomething()
     Dim a As {1}.{0}
 End Sub
 ", MockVbeBuilder.TestProjectName, MockVbeBuilder.TestModuleName);
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType && item.IdentifierName == MockVbeBuilder.TestProjectName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType && item.IdentifierName == MockVbeBuilder.TestProjectName);
 
-            var reference = declaration.References.SingleOrDefault();
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault();
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -413,12 +447,14 @@ Public foo As Integer
             var class1 = Tuple.Create(code_class1, ComponentType.ClassModule);
             var class2 = Tuple.Create(code_class2, ComponentType.ClassModule);
 
-            var state = Resolve(class1, class2);
+            using (var state = Resolve(class1, class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item => item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo" && !item.IsUndeclared);
+                var declaration = state.AllUserDeclarations.Single(item => item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo" && !item.IsUndeclared);
 
-            var reference = declaration.References.SingleOrDefault(item => item.IsAssignment);
-            Assert.IsNull(reference);
+                var reference = declaration.References.SingleOrDefault(item => item.IsAssignment);
+                Assert.IsNull(reference);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -435,16 +471,17 @@ End Sub
 Option Explicit
 Public foo As Integer
 ";
-            var state = Resolve(
+            using (var state = Resolve(
                 Tuple.Create(code_class1, ComponentType.ClassModule),
-                Tuple.Create(code_class2, ComponentType.StandardModule));
+                Tuple.Create(code_class2, ComponentType.StandardModule)))
+            {
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
-
-            var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault(item => !item.IsAssignment);
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -464,14 +501,16 @@ Public foo As Integer
             var class1 = Tuple.Create(code_class1, ComponentType.ClassModule);
             var module1 = Tuple.Create(code_module1, ComponentType.StandardModule);
 
-            var state = Resolve(class1, module1);
+            using (var state = Resolve(class1, module1))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            var reference = declaration.References.SingleOrDefault(item => item.IsAssignment);
-            Assert.IsNotNull(reference);
-            Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+                var reference = declaration.References.SingleOrDefault(item => item.IsAssignment);
+                Assert.IsNotNull(reference);
+                Assert.AreEqual("DoSomething", reference.ParentScoping.IdentifierName);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -485,12 +524,14 @@ Private Type TFoo
 End Type
 Private this As TFoo
 ";
-            var state = Resolve(code, false, ComponentType.ClassModule);
+            using (var state = Resolve(code, false, ComponentType.ClassModule))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType && item.IdentifierName == "TFoo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType && item.IdentifierName == "TFoo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault());
+                Assert.IsNotNull(declaration.References.SingleOrDefault());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -507,12 +548,14 @@ End Sub
 Option Explicit
 ";
 
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.ClassModule && item.IdentifierName == "Class2");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.ClassModule && item.IdentifierName == "Class2");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault());
+                Assert.IsNotNull(declaration.References.SingleOrDefault());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -525,12 +568,14 @@ Public Sub DoSomething(ByVal foo As Integer)
     a = foo
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault());
+                Assert.IsNotNull(declaration.References.SingleOrDefault());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -543,12 +588,14 @@ Public Sub DoSomething(ByRef foo As Integer)
     foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item => item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item => item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -564,13 +611,15 @@ End Sub
 Private Sub DoSomethingElse(ByVal foo As Integer)
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.IdentifierName == "DoSomething"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -588,14 +637,16 @@ Public Property Get Bar() As Integer
     Bar = this.Bar
 End Property
 ";
-            var state = Resolve(code, false, ComponentType.ClassModule);
+            using (var state = Resolve(code, false, ComponentType.ClassModule))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedTypeMember && item.IdentifierName == "Bar");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedTypeMember && item.IdentifierName == "Bar");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.PropertyGet
-                && item.ParentScoping.IdentifierName == "Bar"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.PropertyGet
+                    && item.ParentScoping.IdentifierName == "Bar"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -613,14 +664,16 @@ Public Property Get Bar() As Integer
     Bar = this.Bar
 End Property
 ";
-            var state = Resolve(code, false, ComponentType.ClassModule);
+            using (var state = Resolve(code, false, ComponentType.ClassModule))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "this");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "this");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.PropertyGet
-                && item.ParentScoping.IdentifierName == "Bar"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.PropertyGet
+                    && item.ParentScoping.IdentifierName == "Bar"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -640,14 +693,16 @@ Public Sub DoSomething()
     End With
 End Sub
 ";
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.PropertyGet && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.PropertyGet && item.IdentifierName == "Foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -675,14 +730,16 @@ Public Sub DoSomething()
 End Sub
 ";
 
-            var state = Resolve(code_class1, code_class2, code_class3);
+            using (var state = Resolve(code_class1, code_class2, code_class3))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.PropertyGet && item.IdentifierName == "Bar");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.PropertyGet && item.IdentifierName == "Bar");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -698,21 +755,23 @@ Private Sub DoSomething()
     foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.ParentScopeDeclaration.IdentifierName == "DoSomething"
-                && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.ParentScopeDeclaration.IdentifierName == "DoSomething"
+                    && item.IdentifierName == "foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault());
+                Assert.IsNotNull(declaration.References.SingleOrDefault());
 
-            var fieldDeclaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.ParentScopeDeclaration.DeclarationType == DeclarationType.ProceduralModule
-                && item.IdentifierName == "foo");
+                var fieldDeclaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.ParentScopeDeclaration.DeclarationType == DeclarationType.ProceduralModule
+                    && item.IdentifierName == "foo");
 
-            Assert.IsNull(fieldDeclaration.References.SingleOrDefault());
+                Assert.IsNull(fieldDeclaration.References.SingleOrDefault());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -730,13 +789,15 @@ Implements Class1
 Private Sub Class1_DoSomething()
 End Sub
 ";
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.ClassModule && item.IdentifierName == "Class1");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.ClassModule && item.IdentifierName == "Class1");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.IdentifierName == "Class2"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.IdentifierName == "Class2"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -759,14 +820,16 @@ Public Sub DoSomething(ByVal a As Class1)
     a = a.Foo.Bar
 End Sub
 ";
-            var state = Resolve(code_class1, code_class2, code_class3);
+            using (var state = Resolve(code_class1, code_class2, code_class3))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.PropertyGet && item.IdentifierName == "Bar");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.PropertyGet && item.IdentifierName == "Bar");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -784,14 +847,16 @@ Public Sub DoSomething(ByVal a As Class1)
     b = a.Foo
 End Sub
 ";
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "a");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "a");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -806,15 +871,17 @@ Public Sub DoSomething()
     Next
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "i");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "i");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -829,15 +896,17 @@ Public Sub DoSomething()
     Next
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "i");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "i");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -852,15 +921,17 @@ Public Sub DoSomething(ByVal c As Collection)
     Next
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "i");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "i");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -875,15 +946,17 @@ Public Sub DoSomething(ByVal c As Collection)
     Next
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "c");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Parameter && item.IdentifierName == "c");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && !item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && !item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -899,17 +972,19 @@ Public Sub DoSomething(ParamArray values())
     Next
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Parameter
-                && item.IdentifierName == "values"
-                && item.IsArray);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Parameter
+                    && item.IdentifierName == "values"
+                    && item.IsArray);
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && !item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && !item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -924,16 +999,18 @@ Public Sub DoSomething()
     foo(""key"") = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.IdentifierName == "foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && !item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && !item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -949,17 +1026,19 @@ Public Sub DoSomething(ParamArray values())
     Next
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Parameter
-                && item.IdentifierName == "values"
-                && item.IsArray);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Parameter
+                    && item.IdentifierName == "values"
+                    && item.IsArray);
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.DeclarationType == DeclarationType.Procedure
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.DeclarationType == DeclarationType.Procedure
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -985,16 +1064,18 @@ Public Sub DoSomething()
 End Sub
 ";
 
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.PropertyGet
-                && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.PropertyGet
+                    && item.IdentifierName == "Foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                !item.IsAssignment
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    !item.IsAssignment
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1020,16 +1101,18 @@ Public Sub DoSomething()
 End Sub
 ";
 
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.PropertySet
-                && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.PropertySet
+                    && item.IdentifierName == "Foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.IsAssignment
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.IsAssignment
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1055,16 +1138,18 @@ Public Sub DoSomething()
 End Sub
 ";
 
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.PropertyLet
-                && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.PropertyLet
+                    && item.IdentifierName == "Foo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.IsAssignment
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.IsAssignment
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1085,18 +1170,20 @@ Public Sub DoSomething()
     a = Foo
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.EnumerationMember
-                && item.IdentifierName == "Foo"
-                && item.ParentDeclaration.IdentifierName == "FooBarBaz");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.EnumerationMember
+                    && item.IdentifierName == "Foo"
+                    && item.ParentDeclaration.IdentifierName == "FooBarBaz");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                !item.IsAssignment
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    !item.IsAssignment
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
 
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1117,17 +1204,19 @@ Public Sub DoSomething()
     a = FooBarBaz.Foo
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.EnumerationMember
-                && item.IdentifierName == "Foo"
-                && item.ParentDeclaration.IdentifierName == "FooBarBaz");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.EnumerationMember
+                    && item.IdentifierName == "Foo"
+                    && item.ParentDeclaration.IdentifierName == "FooBarBaz");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                !item.IsAssignment
-                && item.ParentScoping.IdentifierName == "DoSomething"
-                && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    !item.IsAssignment
+                    && item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1148,15 +1237,17 @@ Public Sub DoSomething(ByVal a As FooBarBaz)
 End Sub
 ";
 
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Enumeration
-                && item.IdentifierName == "FooBarBaz");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Enumeration
+                    && item.IdentifierName == "FooBarBaz");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.IdentifierName == "DoSomething"
-                && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1176,13 +1267,15 @@ Public Function Foos() As Foos
 End Function
 ";
 
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Enumeration
-                && item.IdentifierName == "Foos");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Enumeration
+                    && item.IdentifierName == "Foos");
 
-            Assert.IsTrue(declaration.References.All(item => item.Selection.StartLine != 9));
+                Assert.IsTrue(declaration.References.All(item => item.Selection.StartLine != 9));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1200,15 +1293,17 @@ Public Sub DoSomething(ByVal a As TFoo)
 End Sub
 ";
 
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType
-                && item.IdentifierName == "TFoo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType
+                    && item.IdentifierName == "TFoo");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
-                item.ParentScoping.IdentifierName == "DoSomething"
-                && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething"
+                    && item.ParentScoping.DeclarationType == DeclarationType.Procedure));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1227,14 +1322,16 @@ Private Function Foo(ByVal bar As Integer)
     Foo = bar + 42
 End Function";
 
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.IsArray
-                && item.ParentScopeDeclaration.IdentifierName == "DoSomething");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.IsArray
+                    && item.ParentScopeDeclaration.IdentifierName == "DoSomething");
 
-            Assert.IsNotNull(declaration.References.SingleOrDefault(item => !item.IsAssignment));
+                Assert.IsNotNull(declaration.References.SingleOrDefault(item => !item.IsAssignment));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1249,18 +1346,20 @@ Public Sub DoSomething()
     a = foo
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && !item.IsUndeclared);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && !item.IsUndeclared);
 
-            var usage = declaration.References.Single();
-            var annotation = (IgnoreAnnotation)usage.Annotations.First();
-            Assert.IsTrue(
-                usage.Annotations.Count() == 1
-                && annotation.AnnotationType == AnnotationType.Ignore
-                && annotation.InspectionNames.Count() == 1
-                && annotation.InspectionNames.First() == "UnassignedVariableUsage");
+                var usage = declaration.References.Single();
+                var annotation = (IgnoreAnnotation)usage.Annotations.First();
+                Assert.IsTrue(
+                    usage.Annotations.Count() == 1
+                    && annotation.AnnotationType == AnnotationType.Ignore
+                    && annotation.InspectionNames.Count() == 1
+                    && annotation.InspectionNames.First() == "UnassignedVariableUsage");
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1276,22 +1375,24 @@ Public Sub DoSomething()
     a = foo
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && !item.IsUndeclared);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && !item.IsUndeclared);
 
-            var usage = declaration.References.Single();
+                var usage = declaration.References.Single();
 
-            var annotation1 = (IgnoreAnnotation)usage.Annotations.ElementAt(0);
-            var annotation2 = (IgnoreAnnotation)usage.Annotations.ElementAt(1);
+                var annotation1 = (IgnoreAnnotation)usage.Annotations.ElementAt(0);
+                var annotation2 = (IgnoreAnnotation)usage.Annotations.ElementAt(1);
 
-            Assert.AreEqual(2, usage.Annotations.Count());
-            Assert.AreEqual(AnnotationType.Ignore, annotation1.AnnotationType);
-            Assert.AreEqual(AnnotationType.Ignore, annotation2.AnnotationType);
+                Assert.AreEqual(2, usage.Annotations.Count());
+                Assert.AreEqual(AnnotationType.Ignore, annotation1.AnnotationType);
+                Assert.AreEqual(AnnotationType.Ignore, annotation2.AnnotationType);
 
-            Assert.IsTrue(usage.Annotations.Any(a => ((IgnoreAnnotation)a).InspectionNames.First() == "UseMeaningfulName"));
-            Assert.IsTrue(usage.Annotations.Any(a => ((IgnoreAnnotation)a).InspectionNames.First() == "UnassignedVariableUsage"));
+                Assert.IsTrue(usage.Annotations.Any(a => ((IgnoreAnnotation)a).InspectionNames.First() == "UseMeaningfulName"));
+                Assert.IsTrue(usage.Annotations.Any(a => ((IgnoreAnnotation)a).InspectionNames.First() == "UnassignedVariableUsage"));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1300,18 +1401,20 @@ End Sub
         public void AnnotatedDeclaration_LinesAbove_HaveAnnotations()
         {
             var code =
-@"'@TestMethod
+                @"'@TestMethod
 '@IgnoreTest
 Public Sub Foo()
 End Sub";
 
 
-            var state = Resolve(code);
-            var declaration = state.AllUserDeclarations.First(f => f.DeclarationType == DeclarationType.Procedure);
+            using (var state = Resolve(code))
+            {
+                var declaration = state.AllUserDeclarations.First(f => f.DeclarationType == DeclarationType.Procedure);
 
-            Assert.IsTrue(declaration.Annotations.Count() == 2);
-            Assert.IsTrue(declaration.Annotations.Any(a => a.AnnotationType == AnnotationType.TestMethod));
-            Assert.IsTrue(declaration.Annotations.Any(a => a.AnnotationType == AnnotationType.IgnoreTest));
+                Assert.IsTrue(declaration.Annotations.Count() == 2);
+                Assert.IsTrue(declaration.Annotations.Any(a => a.AnnotationType == AnnotationType.TestMethod));
+                Assert.IsTrue(declaration.Annotations.Any(a => a.AnnotationType == AnnotationType.IgnoreTest));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1325,14 +1428,16 @@ Public Sub DoSomething()
     a = foo '@Ignore UnassignedVariableUsage 
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && !item.IsUndeclared);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && !item.IsUndeclared);
 
-            var usage = declaration.References.Single();
+                var usage = declaration.References.Single();
 
-            Assert.IsTrue(!usage.Annotations.Any());
+                Assert.IsTrue(!usage.Annotations.Any());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1352,19 +1457,21 @@ Public Sub DoSomething()
     Foo.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
-
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType);
-
-            if (declaration.Project.Name != declaration.IdentifierName)
+            using (var state = Resolve(code))
             {
-                Assert.Inconclusive("UDT should be named after project.");
+
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType);
+
+                if (declaration.Project.Name != declaration.IdentifierName)
+                {
+                    Assert.Inconclusive("UDT should be named after project.");
+                }
+
+                var usage = declaration.References.SingleOrDefault();
+
+                Assert.IsNotNull(usage);
             }
-
-            var usage = declaration.References.SingleOrDefault();
-
-            Assert.IsNotNull(usage);
         }
 
         [TestCategory("Grammar")]
@@ -1386,19 +1493,21 @@ Public Sub DoSomething()
     Foo.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
-
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType);
-
-            if (declaration.Project.Name != declaration.IdentifierName)
+            using (var state = Resolve(code))
             {
-                Assert.Inconclusive("UDT should be named after project.");
+
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType);
+
+                if (declaration.Project.Name != declaration.IdentifierName)
+                {
+                    Assert.Inconclusive("UDT should be named after project.");
+                }
+
+                var usages = declaration.References;
+
+                Assert.AreEqual(2, usages.Count());
             }
-
-            var usages = declaration.References;
-
-            Assert.AreEqual(2, usages.Count());
         }
 
         [TestCategory("Grammar")]
@@ -1418,18 +1527,20 @@ Public Sub DoSomething()
     Foo.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
-
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable);
-
-            if (declaration.Project.Name != declaration.AsTypeName)
+            using (var state = Resolve(code))
             {
-                Assert.Inconclusive("variable should be named after project.");
-            }
-            var usages = declaration.References;
 
-            Assert.AreEqual(2, usages.Count());
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable);
+
+                if (declaration.Project.Name != declaration.AsTypeName)
+                {
+                    Assert.Inconclusive("variable should be named after project.");
+                }
+                var usages = declaration.References;
+
+                Assert.AreEqual(2, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1449,16 +1560,18 @@ Public Sub DoSomething()
     Foo.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedTypeMember
-                && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedTypeMember
+                    && item.IdentifierName == "Foo");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1482,18 +1595,20 @@ Public Sub DoSomething()
     Foo.Foo.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedTypeMember
-                && item.IdentifierName == "Foo"
-                && item.AsTypeName == item.Project.Name
-                && item.IdentifierName == item.ParentDeclaration.IdentifierName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedTypeMember
+                    && item.IdentifierName == "Foo"
+                    && item.AsTypeName == item.Project.Name
+                    && item.IdentifierName == item.ParentDeclaration.IdentifierName);
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(2, usages.Count());
+                Assert.AreEqual(2, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1517,16 +1632,18 @@ Public Sub DoSomething()
     Foo.Foo.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType
-                && item.IdentifierName == item.ComponentName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType
+                    && item.IdentifierName == item.ComponentName);
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1550,16 +1667,18 @@ Public Sub DoSomething()
     TestModule1.TestModule1.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType
-                && item.IdentifierName == item.ComponentName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType
+                    && item.IdentifierName == item.ComponentName);
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1578,16 +1697,18 @@ Public Sub DoSomething()
     Bar.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.IdentifierName == "Bar");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.IdentifierName == "Bar");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1606,16 +1727,18 @@ Public Sub DoSomething()
     a = Bar.Foo
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.IdentifierName == "Bar");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.IdentifierName == "Bar");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1634,16 +1757,18 @@ Public Sub DoSomething()
     TestModule1.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.IdentifierName == item.ComponentName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.IdentifierName == item.ComponentName);
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1662,16 +1787,18 @@ Public Sub DoSomething()
     TestModule1.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedTypeMember
-                && item.IdentifierName == "Foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedTypeMember
+                    && item.IdentifierName == "Foo");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1690,16 +1817,18 @@ Public Sub DoSomething()
     TestProject1.TestModule1.TestModule1.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Project
-                && item.IdentifierName == item.Project.Name);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Project
+                    && item.IdentifierName == item.Project.Name);
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1718,16 +1847,18 @@ Public Sub DoSomething()
     TestProject1.TestModule1.TestModule1.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.ProceduralModule
-                && item.IdentifierName == item.ComponentName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.ProceduralModule
+                    && item.IdentifierName == item.ComponentName);
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1746,16 +1877,18 @@ Public Sub DoSomething()
     TestProject1.TestModule1.TestModule1.Foo = 42
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.IdentifierName == item.ComponentName);
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.IdentifierName == item.ComponentName);
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1779,17 +1912,19 @@ End Sub";
 
             var module1 = Tuple.Create(code_module1, ComponentType.StandardModule);
             var module2 = Tuple.Create(code_module2, ComponentType.StandardModule);
-            var state = Resolve(module1, module2);
+            using (var state = Resolve(module1, module2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.Accessibility == Accessibility.Public
-                && item.IdentifierName == "Something");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.Accessibility == Accessibility.Public
+                    && item.IdentifierName == "Something");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1814,17 +1949,19 @@ End Sub
 
             var module1 = Tuple.Create(code_module1, ComponentType.StandardModule);
             var module2 = Tuple.Create(code_module2, ComponentType.StandardModule);
-            var state = Resolve(module1, module2);
+            using (var state = Resolve(module1, module2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable
-                && item.Accessibility == Accessibility.Public
-                && item.IdentifierName == "Something");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable
+                    && item.Accessibility == Accessibility.Public
+                    && item.IdentifierName == "Something");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1838,12 +1975,14 @@ Public Sub Test()
     ReDim referenced(referenced TO referenced, referenced), referenced(referenced)
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(6, declaration.References.Count());
+                Assert.AreEqual(6, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1857,12 +1996,14 @@ Public Sub Test()
     Open referenced For Binary Access Read Lock Read As #referenced Len = referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(3, declaration.References.Count());
+                Assert.AreEqual(3, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1876,12 +2017,14 @@ Public Sub Test()
     Close referenced, referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(2, declaration.References.Count());
+                Assert.AreEqual(2, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1895,12 +2038,14 @@ Public Sub Test()
     Seek #referenced, referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(2, declaration.References.Count());
+                Assert.AreEqual(2, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1914,12 +2059,14 @@ Public Sub Test()
     Lock referenced, referenced To referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(3, declaration.References.Count());
+                Assert.AreEqual(3, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1933,12 +2080,14 @@ Public Sub Test()
     Unlock referenced, referenced To referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(3, declaration.References.Count());
+                Assert.AreEqual(3, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1952,12 +2101,14 @@ Public Sub Test()
     Line Input #referenced, referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(2, declaration.References.Count());
+                Assert.AreEqual(2, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1971,12 +2122,14 @@ Public Sub Test()
     Line Input #file, content
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "content");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "content");
 
-            Assert.IsTrue(declaration.References.Single().IsAssignment);
+                Assert.IsTrue(declaration.References.Single().IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -1990,12 +2143,14 @@ Public Sub Test()
     Width #referenced, referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(2, declaration.References.Count());
+                Assert.AreEqual(2, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2009,12 +2164,14 @@ Public Sub Test()
     Print #referenced,,referenced; SPC(referenced), TAB(referenced)
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(4, declaration.References.Count());
+                Assert.AreEqual(4, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2028,12 +2185,14 @@ Public Sub Test()
     Write #referenced,,referenced; SPC(referenced), TAB(referenced)
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(4, declaration.References.Count());
+                Assert.AreEqual(4, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2047,12 +2206,14 @@ Public Sub Test()
     Input #referenced,referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(2, declaration.References.Count());
+                Assert.AreEqual(2, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2067,24 +2228,26 @@ Public Sub Test()
     Input #1, str, xCoord, yCoord, zCoord
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var strDeclaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "str");
+                var strDeclaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "str");
 
-            var xCoordDeclaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "xCoord");
+                var xCoordDeclaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "xCoord");
 
-            var yCoordDeclaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "yCoord");
+                var yCoordDeclaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "yCoord");
 
-            var zCoordDeclaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "zCoord");
+                var zCoordDeclaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "zCoord");
 
-            Assert.IsTrue(strDeclaration.References.Single().IsAssignment);
-            Assert.IsTrue(xCoordDeclaration.References.Single().IsAssignment);
-            Assert.IsTrue(yCoordDeclaration.References.Single().IsAssignment);
-            Assert.IsTrue(zCoordDeclaration.References.Single().IsAssignment);
+                Assert.IsTrue(strDeclaration.References.Single().IsAssignment);
+                Assert.IsTrue(xCoordDeclaration.References.Single().IsAssignment);
+                Assert.IsTrue(yCoordDeclaration.References.Single().IsAssignment);
+                Assert.IsTrue(zCoordDeclaration.References.Single().IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2098,12 +2261,14 @@ Public Sub Test()
     Put referenced,referenced,referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(3, declaration.References.Count());
+                Assert.AreEqual(3, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2117,12 +2282,14 @@ Public Sub Test()
     Get #referenced,referenced,referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(3, declaration.References.Count());
+                Assert.AreEqual(3, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2136,12 +2303,14 @@ Public Sub Test()
     Get #fileNumber, recordNumber, variable
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var variableDeclaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "variable");
+                var variableDeclaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "variable");
 
-            Assert.IsTrue(variableDeclaration.References.Single().IsAssignment);
+                Assert.IsTrue(variableDeclaration.References.Single().IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2155,12 +2324,14 @@ Public Sub Test()
     Me.Line (referenced, referenced)-(referenced, referenced)
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(4, declaration.References.Count());
+                Assert.AreEqual(4, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2174,12 +2345,14 @@ Public Sub Test()
     Me.Circle Step(referenced, referenced), referenced, referenced, referenced, referenced, referenced
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(7, declaration.References.Count());
+                Assert.AreEqual(7, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2193,12 +2366,14 @@ Public Sub Test()
     Scale (referenced, referenced)-(referenced, referenced)
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
 
-            Assert.AreEqual(4, declaration.References.Count());
+                Assert.AreEqual(4, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2212,12 +2387,14 @@ Public Sub Test()
     Dim a As String * Len
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Constant && item.IdentifierName == "Len");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Constant && item.IdentifierName == "Len");
 
-            Assert.AreEqual(1, declaration.References.Count());
+                Assert.AreEqual(1, declaration.References.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2237,26 +2414,26 @@ End Sub
             builder.AddProject(project.Build());
             var vbe = builder.Build();
 
-            var parser = MockParser.Create(vbe.Object);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status == ParserState.ResolverError)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
+                if (state.Status == ParserState.ResolverError)
+                {
+                    Assert.Fail("Parser state should be 'Ready', but returns '{0}'.", state.Status);
+                }
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", state.Status);
+                }
+
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Control
+                    && item.IdentifierName == "TextBox1");
+
+                var usages = declaration.References.Where(item =>
+                    item.ParentNonScoping.IdentifierName == "DoSomething");
+
+                Assert.AreEqual(1, usages.Count());
             }
-            if (parser.State.Status != ParserState.Ready)
-            {
-                Assert.Inconclusive("Parser state should be 'Ready', but returns '{0}'.", parser.State.Status);
-            }
-
-            var declaration = parser.State.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Control
-                && item.IdentifierName == "TextBox1");
-
-            var usages = declaration.References.Where(item =>
-                item.ParentNonScoping.IdentifierName == "DoSomething");
-
-            Assert.AreEqual(1, usages.Count());
         }
 
         [TestCategory("Grammar")]
@@ -2280,17 +2457,19 @@ Public Property Get Bar() As Integer
     Bar = this.Bar
 End Property
 ";
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Project
-                && item.IdentifierName == "TestProject1");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Project
+                    && item.IdentifierName == "TestProject1");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentNonScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentNonScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(state.Status, ParserState.Ready);
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(state.Status, ParserState.Ready);
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2314,16 +2493,18 @@ Public Property Get Bar() As Integer
     Bar = this.Bar
 End Property
 ";
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.ClassModule
-                && item.IdentifierName == "Class2");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.ClassModule
+                    && item.IdentifierName == "Class2");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentNonScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentNonScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2347,16 +2528,18 @@ Public Property Get Bar() As Integer
     Bar = this.Bar
 End Property
 ";
-            var state = Resolve(code_class1, code_class2);
+            using (var state = Resolve(code_class1, code_class2))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType
-                && item.IdentifierName == "TFoo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType
+                    && item.IdentifierName == "TFoo");
 
-            var usages = declaration.References.Where(item =>
-                item.ParentNonScoping.IdentifierName == "DoSomething");
+                var usages = declaration.References.Where(item =>
+                    item.ParentNonScoping.IdentifierName == "DoSomething");
 
-            Assert.AreEqual(1, usages.Count());
+                Assert.AreEqual(1, usages.Count());
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2378,12 +2561,14 @@ Public Sub bar()
     Set myClassN.myClass.foo = True
 End Sub
 ";
-            var state = Resolve(variableDeclarationClass, classVariableDeclarationClass, variableCallClass);
+            using (var state = Resolve(variableDeclarationClass, classVariableDeclarationClass, variableCallClass))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "myClassN");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "myClassN");
 
-            Assert.IsFalse(declaration.References.ElementAt(0).IsAssignment);
+                Assert.IsFalse(declaration.References.ElementAt(0).IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2405,12 +2590,14 @@ Public Sub bar()
     Set myClassN.myClass.foo = True
 End Sub
 ";
-            var state = Resolve(variableDeclarationClass, classVariableDeclarationClass, variableCallClass);
+            using (var state = Resolve(variableDeclarationClass, classVariableDeclarationClass, variableCallClass))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "myClass");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "myClass");
 
-            Assert.IsFalse(declaration.References.ElementAt(0).IsAssignment);
+                Assert.IsFalse(declaration.References.ElementAt(0).IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2432,12 +2619,14 @@ Public Sub bar()
     Set myClassN.myClass.foo = True
 End Sub
 ";
-            var state = Resolve(variableDeclarationClass, classVariableDeclarationClass, variableCallClass);
+            using (var state = Resolve(variableDeclarationClass, classVariableDeclarationClass, variableCallClass))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+                Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2452,12 +2641,14 @@ Public Sub bar()
     Set foo = New Class2
 End Sub
 ";
-            var state = Resolve(variableDeclarationClass, string.Empty);
+            using (var state = Resolve(variableDeclarationClass, string.Empty))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+                Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2472,12 +2663,14 @@ Public Sub bar()
     foo = True
 End Sub
 ";
-            var state = Resolve(variableDeclarationClass);
+            using (var state = Resolve(variableDeclarationClass))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+                Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2492,12 +2685,14 @@ Public Sub bar()
     Let foo = True
 End Sub
 ";
-            var state = Resolve(variableDeclarationClass);
+            using (var state = Resolve(variableDeclarationClass))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "foo");
 
-            Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+                Assert.IsTrue(declaration.References.ElementAt(0).IsAssignment);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2512,12 +2707,14 @@ Public Sub Test()
     Debug.Print bf
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.SingleOrDefault(item =>
-                item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "bf");
+                var declaration = state.AllUserDeclarations.SingleOrDefault(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "bf");
 
-            Assert.IsNotNull(declaration);
+                Assert.IsNotNull(declaration);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2531,12 +2728,14 @@ Public Sub Bf()
     Debug.Print ""I'm cool with that""
 End Sub
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.SingleOrDefault(item =>
-                item.DeclarationType == DeclarationType.Procedure && item.IdentifierName == "Bf");
+                var declaration = state.AllUserDeclarations.SingleOrDefault(item =>
+                    item.DeclarationType == DeclarationType.Procedure && item.IdentifierName == "Bf");
 
-            Assert.IsNotNull(declaration);
+                Assert.IsNotNull(declaration);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2551,12 +2750,14 @@ Private Type Bf
     f As Long
 End Type
 ";
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.SingleOrDefault(item =>
-                item.DeclarationType == DeclarationType.UserDefinedType && item.IdentifierName == "Bf");
+                var declaration = state.AllUserDeclarations.SingleOrDefault(item =>
+                    item.DeclarationType == DeclarationType.UserDefinedType && item.IdentifierName == "Bf");
 
-            Assert.IsNotNull(declaration);
+                Assert.IsNotNull(declaration);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2573,13 +2774,15 @@ End Sub
 ";
             var results = new[] { "VariableNotAssigned" };
 
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item => item.IdentifierName == "orgs");
+                var declaration = state.AllUserDeclarations.Single(item => item.IdentifierName == "orgs");
 
-            var annotation = declaration.Annotations.SingleOrDefault(item => item.AnnotationType == AnnotationType.Ignore);
-            Assert.IsNotNull(annotation);
-            Assert.IsTrue(results.SequenceEqual(((IgnoreAnnotation)annotation).InspectionNames));
+                var annotation = declaration.Annotations.SingleOrDefault(item => item.AnnotationType == AnnotationType.Ignore);
+                Assert.IsNotNull(annotation);
+                Assert.IsTrue(results.SequenceEqual(((IgnoreAnnotation)annotation).InspectionNames));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2597,13 +2800,15 @@ End Sub
 
             var results = new[] { "VariableNotAssigned", "UndeclaredVariable", "VariableNotUsed" };
 
-            var state = Resolve(code);
+            using (var state = Resolve(code))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item => item.IdentifierName == "orgs");
+                var declaration = state.AllUserDeclarations.Single(item => item.IdentifierName == "orgs");
 
-            var annotation = declaration.Annotations.SingleOrDefault(item => item.AnnotationType == AnnotationType.Ignore);
-            Assert.IsNotNull(annotation);
-            Assert.IsTrue(results.SequenceEqual(((IgnoreAnnotation)annotation).InspectionNames));
+                var annotation = declaration.Annotations.SingleOrDefault(item => item.AnnotationType == AnnotationType.Ignore);
+                Assert.IsNotNull(annotation);
+                Assert.IsTrue(results.SequenceEqual(((IgnoreAnnotation)annotation).InspectionNames));
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2627,17 +2832,19 @@ Private Sub DoSomething(ByVal foo As Class1)
     foo.Something = 42
 End Sub
 ";
-            var state = Resolve(class1, caller);
+            using (var state = Resolve(class1, caller))
+            {
 
-            var declaration = state.AllUserDeclarations.Single(item => item.IdentifierName == "foo" && item.DeclarationType == DeclarationType.Parameter);
-            var reference = declaration.References.Single();
+                var declaration = state.AllUserDeclarations.Single(item => item.IdentifierName == "foo" && item.DeclarationType == DeclarationType.Parameter);
+                var reference = declaration.References.Single();
 
-            Assert.IsFalse(reference.IsAssignment, "LHS member call on object is treating the object itself as an assignment target.");
+                Assert.IsFalse(reference.IsAssignment, "LHS member call on object is treating the object itself as an assignment target.");
 
-            var member = state.AllUserDeclarations.Single(item => item.IdentifierName == "Something" && item.DeclarationType == DeclarationType.PropertyLet);
-            var call = member.References.Single();
+                var member = state.AllUserDeclarations.Single(item => item.IdentifierName == "Something" && item.DeclarationType == DeclarationType.PropertyLet);
+                var call = member.References.Single();
 
-            Assert.IsTrue(call.IsAssignment, "LHS member call on object is not flagging member reference as assignment target.");
+                Assert.IsTrue(call.IsAssignment, "LHS member call on object is not flagging member reference as assignment target.");
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2652,12 +2859,14 @@ Attribute Foo.VB_Description = ""Foo description""
 Public Sub Bar()
 End Sub
 ";
-            var state = Resolve(code);
-            var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.Procedure);
+            using (var state = Resolve(code))
+            {
+                var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.Procedure);
 
-            var expectedDescription = "Foo description";
-            var actualDescription = declaration.DescriptionString;
-            Assert.AreEqual(expectedDescription, actualDescription);
+                var expectedDescription = "Foo description";
+                var actualDescription = declaration.DescriptionString;
+                Assert.AreEqual(expectedDescription, actualDescription);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2672,12 +2881,14 @@ Attribute Foo.VB_Description = ""Foo description""
 Public Sub Bar()
 End Sub
 ";
-            var state = Resolve(code);
-            var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.Function);
+            using (var state = Resolve(code))
+            {
+                var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.Function);
 
-            var expectedDescription = "Foo description";
-            var actualDescription = declaration.DescriptionString;
-            Assert.AreEqual(expectedDescription, actualDescription);
+                var expectedDescription = "Foo description";
+                var actualDescription = declaration.DescriptionString;
+                Assert.AreEqual(expectedDescription, actualDescription);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2692,12 +2903,14 @@ Attribute Foo.VB_Description = ""Foo description""
 Public Sub Bar()
 End Sub
 ";
-            var state = Resolve(code);
-            var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.PropertyGet);
+            using (var state = Resolve(code))
+            {
+                var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.PropertyGet);
 
-            var expectedDescription = "Foo description";
-            var actualDescription = declaration.DescriptionString;
-            Assert.AreEqual(expectedDescription, actualDescription);
+                var expectedDescription = "Foo description";
+                var actualDescription = declaration.DescriptionString;
+                Assert.AreEqual(expectedDescription, actualDescription);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2712,12 +2925,14 @@ Attribute Foo.VB_Description = ""Foo description""
 Public Sub Bar()
 End Sub
 ";
-            var state = Resolve(code);
-            var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.PropertyLet);
+            using (var state = Resolve(code))
+            {
+                var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.PropertyLet);
 
-            var expectedDescription = "Foo description";
-            var actualDescription = declaration.DescriptionString;
-            Assert.AreEqual(expectedDescription, actualDescription);
+                var expectedDescription = "Foo description";
+                var actualDescription = declaration.DescriptionString;
+                Assert.AreEqual(expectedDescription, actualDescription);
+            }
         }
 
         [TestCategory("Grammar")]
@@ -2732,12 +2947,14 @@ Attribute Foo.VB_Description = ""Foo description""
 Public Sub Bar()
 End Sub
 ";
-            var state = Resolve(code);
-            var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.PropertySet);
+            using (var state = Resolve(code))
+            {
+                var declaration = state.DeclarationFinder.MatchName("Foo").Single(item => item.DeclarationType == DeclarationType.PropertySet);
 
-            var expectedDescription = "Foo description";
-            var actualDescription = declaration.DescriptionString;
-            Assert.AreEqual(expectedDescription, actualDescription);
+                var expectedDescription = "Foo description";
+                var actualDescription = declaration.DescriptionString;
+                Assert.AreEqual(expectedDescription, actualDescription);
+            }
         }
     }
 }

--- a/RubberduckTests/Grammar/SelectionExtensionsTests.cs
+++ b/RubberduckTests/Grammar/SelectionExtensionsTests.cs
@@ -57,16 +57,18 @@ Debug.Print ""foo""
     End _
   Sub : 'Lame comment!
 ";
-            
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            var selection = new Selection(3, 0, 10, 5);
 
-            Assert.IsFalse(selection.Contains(context));
-            Assert.IsFalse(selection.IsContainedIn(context));
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                var selection = new Selection(3, 0, 10, 5);
+
+                Assert.IsFalse(selection.Contains(context));
+                Assert.IsFalse(selection.IsContainedIn(context));
+            }
         }
 
         [TestMethod]
@@ -88,14 +90,16 @@ Debug.Print ""foo""
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            var selection = new Selection(4, 1, 11, 8);
-            
-            Assert.IsTrue(selection.Contains(context));
-            Assert.IsFalse(selection.IsContainedIn(context));
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                var selection = new Selection(4, 1, 11, 8);
+
+                Assert.IsTrue(selection.Contains(context));
+                Assert.IsFalse(selection.IsContainedIn(context));
+            }
         }
 
         [TestMethod]
@@ -117,14 +121,16 @@ Debug.Print ""foo""
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            var selection = new Selection(5, 1, 11, 8);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                var selection = new Selection(5, 1, 11, 8);
 
-            Assert.IsFalse(selection.Contains(context));
-            Assert.IsFalse(selection.IsContainedIn(context));
+                Assert.IsFalse(selection.Contains(context));
+                Assert.IsFalse(selection.IsContainedIn(context));
+            }
         }
 
         [TestMethod]
@@ -146,14 +152,16 @@ Debug.Print ""foo""
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            var selection = new Selection(4, 1, 10, 8);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                var selection = new Selection(4, 1, 10, 8);
 
-            Assert.IsFalse(selection.Contains(context));
-            Assert.IsTrue(selection.IsContainedIn(context));
+                Assert.IsFalse(selection.Contains(context));
+                Assert.IsTrue(selection.IsContainedIn(context));
+            }
         }
 
         [TestMethod]
@@ -176,15 +184,17 @@ Debug.Print ""foo""
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            pane.Selection = new Selection(4, 1, 11, 6);
-            
-            Assert.IsTrue(context.GetSelection().Contains(pane.Selection));
-            Assert.IsTrue(pane.Selection.IsContainedIn(context));
-            Assert.IsTrue(pane.Selection.Contains(context));
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                pane.Selection = new Selection(4, 1, 11, 6);
+
+                Assert.IsTrue(context.GetSelection().Contains(pane.Selection));
+                Assert.IsTrue(pane.Selection.IsContainedIn(context));
+                Assert.IsTrue(pane.Selection.Contains(context));
+            }
         }
 
         [TestMethod]
@@ -204,15 +214,17 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            pane.Selection = new Selection(3, 0, 7, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                pane.Selection = new Selection(3, 0, 7, 7);
 
-            Assert.IsFalse(context.GetSelection().Contains(pane.Selection));
-            Assert.IsFalse(pane.Selection.IsContainedIn(context));
-            Assert.IsFalse(pane.Selection.Contains(context));
+                Assert.IsFalse(context.GetSelection().Contains(pane.Selection));
+                Assert.IsFalse(pane.Selection.IsContainedIn(context));
+                Assert.IsFalse(pane.Selection.Contains(context));
+            }
         }
 
         [TestMethod]
@@ -232,15 +244,17 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            pane.Selection = new Selection(4, 1, 8, 8);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                pane.Selection = new Selection(4, 1, 8, 8);
 
-            Assert.IsTrue(context.GetSelection().Contains(pane.Selection));
-            Assert.IsTrue(pane.Selection.IsContainedIn(context));
-            Assert.IsTrue(pane.Selection.Contains(context));
+                Assert.IsTrue(context.GetSelection().Contains(pane.Selection));
+                Assert.IsTrue(pane.Selection.IsContainedIn(context));
+                Assert.IsTrue(pane.Selection.Contains(context));
+            }
         }
 
         [TestMethod]
@@ -260,14 +274,16 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            var selection = new Selection(4, 1, 8, 8);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                var selection = new Selection(4, 1, 8, 8);
 
-            Assert.IsTrue(selection.Contains(context));
-            Assert.IsTrue(selection.IsContainedIn(context));
+                Assert.IsTrue(selection.Contains(context));
+                Assert.IsTrue(selection.IsContainedIn(context));
+            }
         }
 
         [TestMethod]
@@ -287,14 +303,16 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            var selection = new Selection(4, 2, 8, 8);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                var selection = new Selection(4, 2, 8, 8);
 
-            Assert.IsFalse(selection.Contains(context));
-            Assert.IsTrue(selection.IsContainedIn(context));
+                Assert.IsFalse(selection.Contains(context));
+                Assert.IsTrue(selection.IsContainedIn(context));
+            }
         }
 
         [TestMethod]
@@ -314,14 +332,16 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new SubStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).First();
-            var selection = new Selection(4, 1, 8, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new SubStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).First();
+                var selection = new Selection(4, 1, 8, 7);
 
-            Assert.IsFalse(selection.Contains(context));
-            Assert.IsTrue(selection.IsContainedIn(context));
+                Assert.IsFalse(selection.Contains(context));
+                Assert.IsTrue(selection.IsContainedIn(context));
+            }
         }
 
         [TestMethod]
@@ -350,14 +370,16 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var contexts = visitor.Visit(tree);
-            var selection = new Selection(6, 1, 10, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var contexts = visitor.Visit(tree);
+                var selection = new Selection(6, 1, 10, 7);
 
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // first If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // second If block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // first If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // second If block
+            }
         }
 
         [TestMethod]
@@ -387,14 +409,16 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var contexts = visitor.Visit(tree);
-            var selection = new Selection(6, 1, 10, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var contexts = visitor.Visit(tree);
+                var selection = new Selection(6, 1, 10, 7);
 
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // first If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // second If block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // first If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // second If block
+            }
         }
 
         [TestMethod]
@@ -424,14 +448,16 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var contexts = visitor.Visit(tree);
-            var selection = new Selection(12, 1, 16, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var contexts = visitor.Visit(tree);
+                var selection = new Selection(12, 1, 16, 7);
 
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(0)));  // first If block
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(1)));   // second If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(0)));  // first If block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(1)));   // second If block
+            }
         }
 
         [TestMethod]
@@ -461,16 +487,18 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var contexts = visitor.Visit(tree);
-            var token = contexts.ElementAt(1).Stop;
-            var selection = new Selection(12, 1, 16, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var contexts = visitor.Visit(tree);
+                var token = contexts.ElementAt(1).Stop;
+                var selection = new Selection(12, 1, 16, 7);
 
-            Assert.IsTrue(selection.Contains(token));                   // last token in second If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(0)));  // first If block
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(1)));   // second If block
+                Assert.IsTrue(selection.Contains(token));                   // last token in second If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(0)));  // first If block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(1)));   // second If block
+            }
         }
 
         [TestMethod]
@@ -500,14 +528,16 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var context = visitor.Visit(tree).Last();
-            var token = context.Stop;
-            var selection = new Selection(12, 1, 14, 1);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var context = visitor.Visit(tree).Last();
+                var token = context.Stop;
+                var selection = new Selection(12, 1, 14, 1);
 
-            Assert.IsFalse(selection.Contains(token));
+                Assert.IsFalse(selection.Contains(token));
+            }
         }
 
         [TestMethod]
@@ -540,17 +570,19 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var contexts = visitor.Visit(tree); 
-            var token = contexts.ElementAt(0).Stop; 
-            var selection = new Selection(8, 1, 10, 9);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var contexts = visitor.Visit(tree);
+                var token = contexts.ElementAt(0).Stop;
+                var selection = new Selection(8, 1, 10, 9);
 
-            Assert.IsTrue(selection.Contains(token));                   // last token in innermost If block
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // innermost If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // first outer If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(2)));  // second outer If block
+                Assert.IsTrue(selection.Contains(token));                   // last token in innermost If block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // innermost If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // first outer If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(2)));  // second outer If block
+            }
         }
 
         [TestMethod]
@@ -583,17 +615,19 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var contexts = visitor.Visit(tree); //returns innermost statement first then topmost consecutively
-            var token = contexts.ElementAt(0).Stop;
-            var selection = new Selection(6, 1, 13, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var contexts = visitor.Visit(tree); //returns innermost statement first then topmost consecutively
+                var token = contexts.ElementAt(0).Stop;
+                var selection = new Selection(6, 1, 13, 7);
 
-            Assert.IsTrue(selection.Contains(token));                   // last token in innermost If block
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // innermost If block
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(1)));   // first outer If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(2)));  // second outer If block
+                Assert.IsTrue(selection.Contains(token));                   // last token in innermost If block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(0)));   // innermost If block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(1)));   // first outer If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(2)));  // second outer If block
+            }
         }
 
         [TestMethod]
@@ -626,17 +660,19 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var visitor = new IfStmtContextElementCollectorVisitor();
-            var contexts = visitor.Visit(tree); //returns innermost statement first then topmost consecutively
-            var token = contexts.ElementAt(0).Stop;
-            var selection = new Selection(15, 1, 19, 7);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var visitor = new IfStmtContextElementCollectorVisitor();
+                var contexts = visitor.Visit(tree); //returns innermost statement first then topmost consecutively
+                var token = contexts.ElementAt(0).Stop;
+                var selection = new Selection(15, 1, 19, 7);
 
-            Assert.IsFalse(selection.Contains(token));                  // last token in innermost If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(0)));  // innermost If block
-            Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // first outer if block
-            Assert.IsTrue(selection.Contains(contexts.ElementAt(2)));   // second outer If block
+                Assert.IsFalse(selection.Contains(token));                  // last token in innermost If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(0)));  // innermost If block
+                Assert.IsFalse(selection.Contains(contexts.ElementAt(1)));  // first outer if block
+                Assert.IsTrue(selection.Contains(contexts.ElementAt(2)));   // second outer If block
+            }
         }
 
         [TestMethod]
@@ -652,16 +688,18 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
 
-            var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
-            var startToken = tree.Start;
-            var endToken = tree.Stop;
+                var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
+                var startToken = tree.Start;
+                var endToken = tree.Stop;
 
-            // Reminder: token columns are zero-based but lines are one-based
-            Assert.IsTrue(startToken.EndColumn() == 0);
-            Assert.IsTrue(endToken.EndColumn() == 0);
+                // Reminder: token columns are zero-based but lines are one-based
+                Assert.IsTrue(startToken.EndColumn() == 0);
+                Assert.IsTrue(endToken.EndColumn() == 0);
+            }
         }
 
         [TestMethod]
@@ -677,16 +715,18 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
 
-            var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
-            var startToken = tree.Start;
-            var endToken = tree.Stop;
+                var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
+                var startToken = tree.Start;
+                var endToken = tree.Stop;
 
-            // Reminder: token columns are zero-based but lines are one-based
-            Assert.IsTrue(startToken.EndLine() == 1);
-            Assert.IsTrue(endToken.EndLine() == 4);
+                // Reminder: token columns are zero-based but lines are one-based
+                Assert.IsTrue(startToken.EndLine() == 1);
+                Assert.IsTrue(endToken.EndLine() == 4);
+            }
         }
 
         [TestMethod]
@@ -701,16 +741,18 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
 
-            var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
-            var startToken = tree.Start;
-            var endToken = tree.Stop;
+                var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
+                var startToken = tree.Start;
+                var endToken = tree.Stop;
 
-            // Reminder: token columns are zero-based but lines are one-based
-            Assert.IsTrue(startToken.EndColumn() == 0);
-            Assert.IsTrue(endToken.EndColumn() == 3);
+                // Reminder: token columns are zero-based but lines are one-based
+                Assert.IsTrue(startToken.EndColumn() == 0);
+                Assert.IsTrue(endToken.EndColumn() == 3);
+            }
         }
 
         [TestMethod]
@@ -725,16 +767,18 @@ End Sub : 'Lame comment!
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             var pane = component.CodeModule.CodePane;
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
 
-            var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
-            var startToken = tree.Start;
-            var endToken = tree.Stop;
+                var tree = (Antlr4.Runtime.ParserRuleContext)state.GetParseTree(new QualifiedModuleName(component));
+                var startToken = tree.Start;
+                var endToken = tree.Stop;
 
-            // Reminder: token columns are zero-based but lines are one-based
-            Assert.IsTrue(startToken.EndLine() == 1);
-            Assert.IsTrue(endToken.EndLine() == 3);
+                // Reminder: token columns are zero-based but lines are one-based
+                Assert.IsTrue(startToken.EndLine() == 1);
+                Assert.IsTrue(endToken.EndLine() == 3);
+            }
         }
     }
 }

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -2145,7 +2145,7 @@ End Sub
             parser.ErrorHandler = new BailErrorStrategy();
             //parser.AddErrorListener(new ExceptionErrorListener());
             parser.Interpreter.PredictionMode = predictionMode ?? PredictionMode.Sll;
-            ParserRuleContext tree = null;
+            ParserRuleContext tree;
             try
             {
                 tree = parser.startRule();
@@ -2162,7 +2162,7 @@ End Sub
                 Debug.WriteLine(exception, "SLL Parser Exception");
                 return Parse(code, PredictionMode.Ll);
             }
-            return Tuple.Create<VBAParser, ParserRuleContext>(parser, tree);
+            return Tuple.Create(parser, tree);
         }
 
         private void AssertTree(VBAParser parser, ParserRuleContext root, string xpath)

--- a/RubberduckTests/Grammar/VBAParserValidityTests.cs
+++ b/RubberduckTests/Grammar/VBAParserValidityTests.cs
@@ -45,14 +45,21 @@ namespace RubberduckTests.Grammar
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(code, out component);
 
-            var state = new RubberduckParserState(vbe.Object, new DeclarationFinderFactory());
-            var parser = MockParser.Create(vbe.Object, state);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status == ParserState.Error) { Assert.Inconclusive("Parser Error: " + filename); }
+            string parsedCode;
+            var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                parser.Parse(new CancellationTokenSource());
 
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var parsed = tree.GetText();
-            var withoutEOF = parsed;
+                if (state.Status == ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error: " + filename);
+                }
+
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                parsedCode = tree.GetText();
+            }
+            var withoutEOF = parsedCode;
             while (withoutEOF.Length >= 5 && String.Equals(withoutEOF.Substring(withoutEOF.Length - 5, 5), "<EOF>"))
             {
                 withoutEOF = withoutEOF.Substring(0, withoutEOF.Length - 5);

--- a/RubberduckTests/Inspections/ApplicationWorksheetFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/ApplicationWorksheetFunctionInspectionTests.cs
@@ -11,7 +11,7 @@ namespace RubberduckTests.Inspections
     [TestClass]
     public class ApplicationWorksheetFunctionInspectionTests
     {
-        private static ParseCoordinator ArrangeParser(string inputCode)
+        private static RubberduckParserState ArrangeParserAndParse(string inputCode)
         {
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
@@ -24,7 +24,14 @@ namespace RubberduckTests.Inspections
             var parser = MockParser.Create(vbe.Object);
 
             parser.State.AddTestLibrary("Excel.1.8.xml");
-            return parser;
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error)
+            {
+                Assert.Inconclusive("Parser Error");
+            }
+
+            return parser.State;
         }
 
         [TestMethod]
@@ -33,21 +40,20 @@ namespace RubberduckTests.Inspections
         public void ApplicationWorksheetFunction_ReturnsResult_GlobalApplication()
         {
             const string inputCode =
-@"Sub ExcelSub()
+                @"Sub ExcelSub()
     Dim foo As Double
     foo = Application.Pi
 End Sub
 ";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -56,7 +62,7 @@ End Sub
         public void ApplicationWorksheetFunction_ReturnsResult_WithGlobalApplication()
         {
             const string inputCode =
-@"Sub ExcelSub()
+                @"Sub ExcelSub()
     Dim foo As Double
     With Application
         foo = .Pi
@@ -64,15 +70,14 @@ End Sub
 End Sub
 ";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -81,7 +86,7 @@ End Sub
         public void ApplicationWorksheetFunction_ReturnsResult_ApplicationVariable()
         {
             const string inputCode =
-@"Sub ExcelSub()
+                @"Sub ExcelSub()
     Dim foo As Double
     Dim xlApp as Excel.Application
     Set xlApp = Application
@@ -89,15 +94,14 @@ End Sub
 End Sub
 ";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -106,7 +110,7 @@ End Sub
         public void ApplicationWorksheetFunction_ReturnsResult_WithApplicationVariable()
         {
             const string inputCode =
-@"Sub ExcelSub()
+                @"Sub ExcelSub()
     Dim foo As Double
     Dim xlApp as Excel.Application
     Set xlApp = Application
@@ -116,15 +120,14 @@ End Sub
 End Sub
 ";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -133,21 +136,20 @@ End Sub
         public void ApplicationWorksheetFunction_DoesNotReturnResult_ExplicitUseGlobalApplication()
         {
             const string inputCode =
-@"Sub ExcelSub()
+                @"Sub ExcelSub()
     Dim foo As Double
     foo = Application.WorksheetFunction.Pi
 End Sub
 ";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -156,7 +158,7 @@ End Sub
         public void ApplicationWorksheetFunction_DoesNotReturnResult_ExplicitUseApplicationVariable()
         {
             const string inputCode =
-@"Sub ExcelSub()
+                @"Sub ExcelSub()
     Dim foo As Double
     Dim xlApp as Excel.Application
     Set xlApp = Application
@@ -164,15 +166,14 @@ End Sub
 End Sub
 ";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -180,7 +181,7 @@ End Sub
         public void ApplicationWorksheetFunction_DoesNotReturnResult_NoExcelReference()
         {
             const string inputCode =
-@"Sub NonExcelSub()
+                @"Sub NonExcelSub()
     Dim foo As Double
     foo = Application.Pi
 End Sub
@@ -192,15 +193,18 @@ End Sub
 
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -209,22 +213,21 @@ End Sub
         public void ApplicationWorksheetFunction_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub ExcelSub()
+                @"Sub ExcelSub()
     Dim foo As Double
     '@Ignore ApplicationWorksheetFunction
     foo = Application.Pi
 End Sub
 ";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/AssignedByValParameterInspectionTests.cs
+++ b/RubberduckTests/Inspections/AssignedByValParameterInspectionTests.cs
@@ -15,17 +15,19 @@ namespace RubberduckTests.Inspections
         public void AssignedByValParameter_ReturnsResult_Sub()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As String)
+                @"Public Sub Foo(ByVal arg1 As String)
     Let arg1 = ""test""
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -33,17 +35,19 @@ End Sub";
         public void AssignedByValParameter_ReturnsResult_Function()
         {
             const string inputCode =
-@"Function Foo(ByVal arg1 As Integer) As Boolean
+                @"Function Foo(ByVal arg1 As Integer) As Boolean
     Let arg1 = 9
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -51,18 +55,20 @@ End Function";
         public void AssignedByValParameter_ReturnsResult_MultipleParams()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
+                @"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
     Let arg1 = ""test""
     Let arg2 = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -70,16 +76,18 @@ End Sub";
         public void AssignedByValParameter_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As String)
+                @"Public Sub Foo(ByVal arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -87,18 +95,20 @@ End Sub";
         public void AssignedByValParameter_Ignored_DoesNotReturnResult_Sub()
         {
             const string inputCode =
-@"'@Ignore AssignedByValParameter
+                @"'@Ignore AssignedByValParameter
 Public Sub Foo(ByVal arg1 As String)
     Let arg1 = ""test""
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -106,7 +116,7 @@ End Sub";
         public void AssignedByValParameter_ReturnsResult_SomeAssignedByValParams()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
+                @"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
     Let arg1 = ""test""
     
     Dim var1 As Integer
@@ -115,11 +125,13 @@ End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -148,12 +160,14 @@ End Sub
                 .AddComponent("Module1", ComponentType.StandardModule, caller)
                 .MockVbeBuilder()
                 .Build();
-            
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-            
-            Assert.IsFalse(inspectionResults.Any());
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/BooleanAssignedInIfElseInspectionTests.cs
+++ b/RubberduckTests/Inspections/BooleanAssignedInIfElseInspectionTests.cs
@@ -14,7 +14,7 @@ namespace RubberduckTests.Inspections
         public void Simple()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     If True Then
         d = True
@@ -23,13 +23,15 @@ namespace RubberduckTests.Inspections
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, results.Count());
+                Assert.AreEqual(1, results.Count());
+            }
         }
 
         [TestMethod]
@@ -37,7 +39,7 @@ End Sub";
         public void QualifiedName()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Fizz.Buzz = True
     Else
@@ -45,13 +47,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, results.Count());
+                Assert.AreEqual(1, results.Count());
+            }
         }
 
         [TestMethod]
@@ -59,7 +63,7 @@ End Sub";
         public void MultipleResults()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     If True Then
         d = True
@@ -74,13 +78,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, results.Count());
+                Assert.AreEqual(2, results.Count());
+            }
         }
 
         [TestMethod]
@@ -88,7 +94,7 @@ End Sub";
         public void AssignsInteger()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If True Then
         d = 0
@@ -97,13 +103,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(results.Any());
+                Assert.IsFalse(results.Any());
+            }
         }
 
         [TestMethod]
@@ -111,7 +119,7 @@ End Sub";
         public void AssignsTheSameValue()       // worthy of an inspection in its own right
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If True Then
         d = True
@@ -120,13 +128,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(results.Any());
+                Assert.IsFalse(results.Any());
+            }
         }
 
         [TestMethod]
@@ -134,7 +144,7 @@ End Sub";
         public void AssignsToDifferentVariables()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d1, d2
     If True Then
         d1 = True
@@ -143,13 +153,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(results.Any());
+                Assert.IsFalse(results.Any());
+            }
         }
 
         [TestMethod]
@@ -157,7 +169,7 @@ End Sub";
         public void ConditionalContainsElseIfBlock()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If True Then
         d = True
@@ -168,13 +180,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(results.Any());
+                Assert.IsFalse(results.Any());
+            }
         }
 
         [TestMethod]
@@ -182,20 +196,22 @@ End Sub";
         public void ConditionalDoesNotContainElseBlock()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If True Then
         d = True
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(results.Any());
+                Assert.IsFalse(results.Any());
+            }
         }
 
         [TestMethod]
@@ -203,7 +219,7 @@ End Sub";
         public void IsIgnored()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     '@Ignore BooleanAssignedInIfElse
     If True Then
@@ -213,13 +229,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(results.Any());
+                Assert.IsFalse(results.Any());
+            }
         }
 
         [TestMethod]
@@ -227,7 +245,7 @@ End Sub";
         public void BlockContainsPrefixComment()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If True Then
         ' test
@@ -237,13 +255,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, results.Count());
+                Assert.AreEqual(1, results.Count());
+            }
         }
 
         [TestMethod]
@@ -251,7 +271,7 @@ End Sub";
         public void BlockContainsPostfixComment()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If True Then
         d = True
@@ -261,13 +281,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, results.Count());
+                Assert.AreEqual(1, results.Count());
+            }
         }
 
         [TestMethod]
@@ -275,7 +297,7 @@ End Sub";
         public void BlockContainsEOLComment()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If True Then
         d = True    ' test
@@ -284,13 +306,15 @@ End Sub";
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var results = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, results.Count());
+                Assert.AreEqual(1, results.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/ConstantNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/ConstantNotUsedInspectionTests.cs
@@ -14,17 +14,19 @@ namespace RubberduckTests.Inspections
         public void ConstantNotUsed_ReturnsResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -32,18 +34,20 @@ End Sub";
         public void ConstantNotUsed_ReturnsResult_MultipleConsts()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const const1 As Integer = 9
     Const const2 As String = ""test""
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -51,7 +55,7 @@ End Sub";
         public void ConstantNotUsed_ReturnsResult_UnusedConstant()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const const1 As Integer = 9
     Goo const1
 
@@ -62,12 +66,14 @@ Public Sub Goo(ByVal arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -75,7 +81,7 @@ End Sub";
         public void ConstantNotUsed_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const const1 As Integer = 9
     Goo const1
 End Sub
@@ -84,12 +90,14 @@ Public Sub Goo(ByVal arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -97,19 +105,21 @@ End Sub";
         public void ConstantNotUsed_IgnoreModule_All_YieldsNoResult()
         {
             const string inputCode =
-@"'@IgnoreModule
+                @"'@IgnoreModule
 
 Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -117,19 +127,21 @@ End Sub";
         public void ConstantNotUsed_IgnoreModule_AnnotationName_YieldsNoResult()
         {
             const string inputCode =
-@"'@IgnoreModule ConstantNotUsed
+                @"'@IgnoreModule ConstantNotUsed
 
 Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -137,19 +149,21 @@ End Sub";
         public void ConstantNotUsed_IgnoreModule_OtherAnnotationName_YieldsResults()
         {
             const string inputCode =
-@"'@IgnoreModule VariableNotUsed
+                @"'@IgnoreModule VariableNotUsed
 
 Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsTrue(inspectionResults.Any());
+                Assert.IsTrue(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -157,18 +171,20 @@ End Sub";
         public void ConstantNotUsed_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     '@Ignore ConstantNotUsed
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/DefaultProjectNameInspectionTests.cs
+++ b/RubberduckTests/Inspections/DefaultProjectNameInspectionTests.cs
@@ -22,15 +22,13 @@ namespace RubberduckTests.Inspections
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new DefaultProjectNameInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new DefaultProjectNameInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -43,15 +41,13 @@ namespace RubberduckTests.Inspections
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new DefaultProjectNameInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new DefaultProjectNameInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/EmptyCaseBlockInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyCaseBlockInspectionTests.cs
@@ -35,7 +35,7 @@ namespace RubberduckTests.Inspections
         public void EmptyCaseBlock_DoesNotFiresOnImplementedCaseBlocks()
         {
             const string inputCode =
-@"Sub Foo(caseNum As Long)
+                @"Sub Foo(caseNum As Long)
     Select Case caseNum
         Case 1
             MsgBox ""1""
@@ -55,7 +55,7 @@ End Sub";
         public void EmptyCaseBlock_FiresOnEmptyCaseBlocks()
         {
             const string inputCode =
-@"Sub Foo(caseNum As Long)
+                @"Sub Foo(caseNum As Long)
     Select Case caseNum
         Case 1
         Case 2
@@ -72,7 +72,7 @@ End Sub";
         public void EmptyCaseBlock_FiresOnCommentCaseBlocks()
         {
             const string inputCode =
-@"Sub Foo(caseNum As Long)
+                @"Sub Foo(caseNum As Long)
     Select Case caseNum
         Case 1
             'TODO - handle this case!
@@ -86,13 +86,14 @@ End Sub";
         private void CheckActualEmptyBlockCountEqualsExpected(string inputCode, int expectedCount)
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new EmptyCaseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var inspection = new EmptyCaseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/EmptyDoWhileBlockInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyDoWhileBlockInspectionTests.cs
@@ -36,7 +36,7 @@ namespace RubberduckTests.Inspections
         public void EmptyDoWhileBlock_DoesNotFiresOnImplementedLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo(results As Collection)
+                @"Sub Foo(results As Collection)
     Dim i As Integer
     i = 1
 
@@ -53,7 +53,7 @@ End Sub";
         public void EmptyDoWhileBlock_FiresOnEmptyLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo(results As Collection)
+                @"Sub Foo(results As Collection)
     Dim i As Integer
     i = 1
 
@@ -69,13 +69,15 @@ End Sub";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyDoWhileBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyDoWhileBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/EmptyElseBlockInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyElseBlockInspectionTests.cs
@@ -35,19 +35,21 @@ namespace RubberduckTests.Inspections
         public void EmptyElseBlock_DoesntFireOnEmptyIfBlock()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     EndIf
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 0;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 0;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -55,21 +57,23 @@ End Sub";
         public void EmptyElseBlock_HasNoContent()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 1;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 1;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -77,21 +81,23 @@ End Sub";
         public void EmptyElseBlock_HasQuoteComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
         'Some Comment
     End If
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 1;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 1;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -99,7 +105,7 @@ End Sub";
         public void EmptyElseBlock_HasRemComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
         Rem Some Comment
@@ -107,14 +113,16 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 1;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 1;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -122,7 +130,7 @@ End Sub";
         public void EmptyElseBlock_HasVariableDeclaration()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
         Dim d
@@ -130,14 +138,16 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 1;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 1;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -145,7 +155,7 @@ End Sub";
         public void EmptyElseBlock_HasConstDeclaration()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
         Const c = 0
@@ -153,14 +163,16 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 1;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 1;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -168,7 +180,7 @@ End Sub";
         public void EmptyElseBlock_HasWhitespace()
         {
             const string inputcode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
     
@@ -177,14 +189,16 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputcode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 1;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 1;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -192,7 +206,7 @@ End Sub";
         public void EmptyElseBlock_HasDeclarationStatement()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
         Dim d
@@ -200,14 +214,16 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 1;
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 1;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
 
         [TestMethod]
@@ -215,7 +231,7 @@ End Sub";
         public void EmptyElseBlock_HasExecutableStatement()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
         Dim d
@@ -224,14 +240,15 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new EmptyElseBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                const int expectedCount = 0;
 
-            var inspection = new EmptyElseBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            const int expectedCount = 0;
-
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/EmptyForEachBlockInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyForEachBlockInspectionTests.cs
@@ -36,7 +36,7 @@ namespace RubberduckTests.Inspections
         public void EmptyForEachBlock_DoesNotFiresOnImplementedLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo(results As Collection)
+                @"Sub Foo(results As Collection)
     For Each var in results
         Msgbox Cstr(var)
     next var
@@ -49,7 +49,7 @@ End Sub";
         public void EmptyForLoopBlock_FiresOnEmptyLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo(results As Collection)
+                @"Sub Foo(results As Collection)
     For Each var in results
         'Msgbox Cstr(var)
     next var
@@ -61,13 +61,15 @@ End Sub";
         {
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyForEachBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyForEachBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/EmptyForLoopBlockInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyForLoopBlockInspectionTests.cs
@@ -35,7 +35,7 @@ namespace RubberduckTests.Inspections
         public void EmptyForLoopBlock_DoesNotFiresOnImplementedLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim idx As Integer
     for idx = 1 to 100
         idx = idx + 2
@@ -49,7 +49,7 @@ End Sub";
         public void EmptyForLoopBlock_FiresOnEmptyLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim idx As Integer
     for idx = 1 to 100
     next idx
@@ -60,13 +60,15 @@ End Sub";
         private void CheckActualEmptyBlockCountEqualsExpected(string inputCode, int expectedCount)
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyForLoopBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyForLoopBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/EmptyIfBlockInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyIfBlockInspectionTests.cs
@@ -5,7 +5,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Resources;
 using RubberduckTests.Mocks;
 
-namespace RubberduckTests.Inspections   
+namespace RubberduckTests.Inspections
 {
     [TestClass, Ignore]
     public class EmptyIfBlockInspectionTests
@@ -15,19 +15,20 @@ namespace RubberduckTests.Inspections
         public void EmptyIfBlock_FiresOnEmptyIfBlock()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -35,20 +36,22 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyElseIfBlock()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     ElseIf False Then
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -56,20 +59,22 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyIfBlock_ElseBlock()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -77,7 +82,7 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptySingleLineIfStmt()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then Else Bar
 End Sub
 
@@ -85,13 +90,15 @@ Sub Bar()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -99,7 +106,7 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyIfBlock_HasNonEmptyElseBlock()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
         Dim d
@@ -108,13 +115,15 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -122,20 +131,22 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyIfBlock_HasQuoteComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         ' Im a comment
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -143,20 +154,22 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyIfBlock_HasRemComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Rem Im a comment
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -164,20 +177,22 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyIfBlock_HasVariableDeclaration()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -185,20 +200,22 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyIfBlock_HasConstDeclaration()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Const c = 0
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -206,7 +223,7 @@ End Sub";
         public void EmptyIfBlock_FiresOnEmptyIfBlock_HasWhitespace()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
 
     	
@@ -214,13 +231,15 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -228,7 +247,7 @@ End Sub";
         public void EmptyIfBlock_IfBlockHasExecutableStatement()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
         d = 0
@@ -236,13 +255,15 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -250,7 +271,7 @@ End Sub";
         public void EmptyIfBlock_SingleLineIfBlockHasExecutableStatement()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then Bar
 End Sub
 
@@ -258,13 +279,15 @@ Sub Bar()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -272,7 +295,7 @@ End Sub";
         public void EmptyIfBlock_IfAndElseIfBlockHaveExecutableStatement()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
         d = 0
@@ -283,13 +306,15 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod, Ignore]

--- a/RubberduckTests/Inspections/EmptyStringLiteralInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyStringLiteralInspectionTests.cs
@@ -15,20 +15,21 @@ namespace RubberduckTests.Inspections
         public void EmptyStringLiteral_ReturnsResult_PassToProcedure()
         {
             const string inputCode =
-@"Public Sub Bar()
+                @"Public Sub Bar()
     Foo """"
 End Sub
 
 Public Sub Foo(ByRef arg1 As String)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new EmptyStringLiteralInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var inspection = new EmptyStringLiteralInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -36,17 +37,19 @@ End Sub";
         public void EmptyStringLiteral_ReturnsResult_Assignment()
         {
             const string inputCode =
-@"Public Sub Foo(ByRef arg1 As String)
+                @"Public Sub Foo(ByRef arg1 As String)
     arg1 = """"
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyStringLiteralInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyStringLiteralInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -54,17 +57,19 @@ End Sub";
         public void NotEmptyStringLiteral_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo(ByRef arg1 As String)
+                @"Public Sub Foo(ByRef arg1 As String)
     arg1 = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyStringLiteralInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyStringLiteralInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -72,18 +77,20 @@ End Sub";
         public void EmptyStringLiteral_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo(ByRef arg1 As String)
+                @"Public Sub Foo(ByRef arg1 As String)
     '@Ignore EmptyStringLiteral
     arg1 = """"
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyStringLiteralInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyStringLiteralInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/EmptyWhileWendBlockInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyWhileWendBlockInspectionTests.cs
@@ -35,7 +35,7 @@ namespace RubberduckTests.Inspections
         public void EmptyWhileWendBlock_DoesNotFiresOnImplementedLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo(results As Collection)
+                @"Sub Foo(results As Collection)
     Dim LTotal As Integer
 
     LTotal = 1
@@ -53,7 +53,7 @@ End Sub";
         public void EmptyWhileWendBlock_FiresOnEmptyLoopBlocks()
         {
             const string inputCode =
-@"Sub Foo(results As Collection)
+                @"Sub Foo(results As Collection)
     Dim LTotal As Integer
 
     LTotal = 1
@@ -69,13 +69,15 @@ End Sub";
         private void CheckActualEmptyBlockCountEqualsExpected(string inputCode, int expectedCount)
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyWhileWendBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyWhileWendBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(expectedCount, actualResults.Count());
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/EncapsulatePublicFieldInspectionTests.cs
+++ b/RubberduckTests/Inspections/EncapsulatePublicFieldInspectionTests.cs
@@ -14,14 +14,16 @@ namespace RubberduckTests.Inspections
         public void PublicField_ReturnsResult()
         {
             const string inputCode =
-@"Public fizz As Boolean";
+                @"Public fizz As Boolean";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EncapsulatePublicFieldInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new EncapsulatePublicFieldInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -29,16 +31,18 @@ namespace RubberduckTests.Inspections
         public void MultiplePublicFields_ReturnMultipleResult()
         {
             const string inputCode =
-@"Public fizz As Boolean
+                @"Public fizz As Boolean
 Public buzz As Integer, _
        bazz As Integer";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EncapsulatePublicFieldInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new EncapsulatePublicFieldInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(3, inspectionResults.Count());
+                Assert.AreEqual(3, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -46,14 +50,16 @@ Public buzz As Integer, _
         public void PrivateField_DoesNotReturnResult()
         {
             const string inputCode =
-@"Private fizz As Boolean";
+                @"Private fizz As Boolean";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EncapsulatePublicFieldInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new EncapsulatePublicFieldInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -61,15 +67,17 @@ Public buzz As Integer, _
         public void PublicNonField_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo(ByRef arg1 As String)
+                @"Public Sub Foo(ByRef arg1 As String)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EncapsulatePublicFieldInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new EncapsulatePublicFieldInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -77,15 +85,17 @@ End Sub";
         public void PublicField_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore EncapsulatePublicField
+                @"'@Ignore EncapsulatePublicField
 Public fizz As Boolean";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EncapsulatePublicFieldInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new EncapsulatePublicFieldInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/FunctionReturnValueNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/FunctionReturnValueNotUsedInspectionTests.cs
@@ -16,19 +16,21 @@ namespace RubberduckTests.Inspections
         public void FunctionReturnValueNotUsed_ReturnsResult_ExplicitCallWithoutAssignment()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Public Sub Bar()
     Call Foo(""Test"")
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -37,19 +39,21 @@ End Sub";
         public void FunctionReturnValueNotUsed_ReturnsResult_CallWithoutAssignment()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Public Sub Bar()
     Foo ""Test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -58,19 +62,21 @@ End Sub";
         public void FunctionReturnValueNotUsed_ReturnsResult_AddressOf()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Public Sub Bar()
     Bar AddressOf Foo
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -79,18 +85,20 @@ End Sub";
         public void FunctionReturnValueNotUsed_ReturnsResult_NoReturnValueAssignment()
         {
             const string inputCode =
-@"Public Function Foo() As Integer
+                @"Public Function Foo() As Integer
 End Function
 Public Sub Bar()
     Foo
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -99,7 +107,7 @@ End Sub";
         public void FunctionReturnValueNotUsed_Ignored_DoesNotReturnResult_AddressOf()
         {
             const string inputCode =
-@"'@Ignore FunctionReturnValueNotUsed
+                @"'@Ignore FunctionReturnValueNotUsed
 Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
@@ -107,12 +115,14 @@ Public Sub Bar()
     Bar AddressOf Foo
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -121,19 +131,21 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_MultipleConsecutiveCalls()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Public Sub Baz()
     Foo Foo(Foo(""Bar""))
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -142,7 +154,7 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_IfStatement()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Public Sub Baz()
@@ -150,12 +162,14 @@ Public Sub Baz()
     End If
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -164,7 +178,7 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_ForEachStatement()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Sub Bar(ByVal fizz As Boolean)
@@ -174,12 +188,14 @@ Public Sub Baz()
     Next Bar
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -188,7 +204,7 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_WhileStatement()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Sub Bar(ByVal fizz As Boolean)
@@ -198,12 +214,14 @@ Public Sub Baz()
     Wend
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -212,7 +230,7 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_DoUntilStatement()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Sub Bar(ByVal fizz As Boolean)
@@ -222,12 +240,14 @@ Public Sub Baz()
     Loop
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -236,19 +256,21 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_ReturnValueAssignment()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Public Sub Baz()
     TestVal = Foo(""Test"")
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -257,7 +279,7 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_RecursiveFunction()
         {
             const string inputCode =
-@"Public Function Factorial(ByVal n As Long) As Long
+                @"Public Function Factorial(ByVal n As Long) As Long
     If n <= 1 Then
         Factorial = 1
     Else
@@ -265,12 +287,14 @@ End Sub";
     End If
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -279,7 +303,7 @@ End Function";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_ArgumentFunctionCall()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Integer
+                @"Public Function Foo(ByVal bar As String) As Integer
     Foo = 42
 End Function
 Sub Bar(ByVal fizz As Boolean)
@@ -288,12 +312,14 @@ Public Sub Baz()
     Bar Foo(""Test"")
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -302,17 +328,19 @@ End Sub";
         public void FunctionReturnValueNotUsed_DoesNotReturnResult_IgnoresBuiltInFunctions()
         {
             const string inputCode =
-@"Public Sub Dummy()
+                @"Public Sub Dummy()
     MsgBox ""Test""
     Workbooks.Add
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -321,17 +349,17 @@ End Sub";
         public void GivenInterfaceImplementationMember_ReturnsNoResult()
         {
             const string interfaceCode =
-@"Public Function Test() As Integer
+                @"Public Function Test() As Integer
 End Function";
 
             const string implementationCode =
-@"Implements IFoo
+                @"Implements IFoo
 Public Function IFoo_Test() As Integer
     IFoo_Test = 42
 End Function";
 
             const string callSiteCode =
-@"
+                @"
 Public Sub Baz()
     Dim testObj As IFoo
     Set testObj = new Bar
@@ -341,17 +369,19 @@ End Sub";
 
             var builder = new MockVbeBuilder();
             var vbe = builder.ProjectBuilder("TestProject", ProjectProtection.Unprotected)
-                             .AddComponent("IFoo", ComponentType.ClassModule, interfaceCode)
-                             .AddComponent("Bar", ComponentType.ClassModule, implementationCode)
-                             .AddComponent("TestModule", ComponentType.StandardModule, callSiteCode)
-                             .MockVbeBuilder().Build();
+                .AddComponent("IFoo", ComponentType.ClassModule, interfaceCode)
+                .AddComponent("Bar", ComponentType.ClassModule, implementationCode)
+                .AddComponent("TestModule", ComponentType.StandardModule, callSiteCode)
+                .MockVbeBuilder().Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -360,17 +390,17 @@ End Sub";
         public void FunctionReturnValueNotUsed_ReturnsResult_InterfaceMember()
         {
             const string interfaceCode =
-@"Public Function Test() As Integer
+                @"Public Function Test() As Integer
 End Function";
 
             const string implementationCode =
-@"Implements IFoo
+                @"Implements IFoo
 Public Function IFoo_Test() As Integer
     IFoo_Test = 42
 End Function";
 
             const string callSiteCode =
-@"
+                @"
 Public Sub Baz()
     Dim testObj As IFoo
     Set testObj = new Bar
@@ -379,17 +409,19 @@ End Sub";
 
             var builder = new MockVbeBuilder();
             var vbe = builder.ProjectBuilder("TestProject", ProjectProtection.Unprotected)
-                                        .AddComponent("IFoo", ComponentType.ClassModule, interfaceCode)
-                                        .AddComponent("Bar", ComponentType.ClassModule, implementationCode)
-                                        .AddComponent("TestModule", ComponentType.StandardModule, callSiteCode)
-                                        .MockVbeBuilder().Build();
+                .AddComponent("IFoo", ComponentType.ClassModule, interfaceCode)
+                .AddComponent("Bar", ComponentType.ClassModule, implementationCode)
+                .AddComponent("TestModule", ComponentType.StandardModule, callSiteCode)
+                .MockVbeBuilder().Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/HostSpecificExpressionInspectionTests.cs
+++ b/RubberduckTests/Inspections/HostSpecificExpressionInspectionTests.cs
@@ -35,15 +35,21 @@ End Sub
             vbe.Setup(m => m.HostApplication()).Returns(() => mockHost.Object);
 
             var parser = MockParser.Create(vbe.Object);
-            parser.State.AddTestLibrary("VBA.4.2.xml");
-            parser.State.AddTestLibrary("Excel.1.8.xml");
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("VBA.4.2.xml");
+                state.AddTestLibrary("Excel.1.8.xml");
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            var inspection = new HostSpecificExpressionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new HostSpecificExpressionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/HungarianNotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/HungarianNotationInspectionTests.cs
@@ -16,7 +16,7 @@ namespace RubberduckTests.Inspections
         public void HungarianNotation_ReturnsResult_VariableWithThreeLetterPrefix()
         {
             const string inputCode =
-@"Sub Hungarian()
+                @"Sub Hungarian()
     Dim strFoo As String
 End Sub";
 
@@ -26,15 +26,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new HungarianNotationInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new HungarianNotationInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -42,7 +40,7 @@ End Sub";
         public void HungarianNotation_ReturnsResult_VariableWithOneLetterPrefix()
         {
             const string inputCode =
-@"Sub Hungarian()
+                @"Sub Hungarian()
     Dim oFoo As Object
 End Sub";
 
@@ -52,15 +50,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new HungarianNotationInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new HungarianNotationInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -68,7 +64,7 @@ End Sub";
         public void HungarianNotation_ReturnsResult_ForClass()
         {
             const string inputCode =
-@"Sub Test()
+                @"Sub Test()
     Debug.Print ""Ez egy objektum""
 End Sub";
 
@@ -78,15 +74,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new HungarianNotationInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new HungarianNotationInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -94,7 +88,7 @@ End Sub";
         public void HungarianNotation_DoesNotReturnsResult_AllLowerCase()
         {
             const string inputCode =
-@"Sub NoHungarianHere()
+                @"Sub NoHungarianHere()
     Dim strong As Variant
 End Sub";
 
@@ -104,15 +98,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new HungarianNotationInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new HungarianNotationInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -120,7 +112,7 @@ End Sub";
         public void HungarianNotation_DoesNotReturnsResult_UpperCaseFirstLetter()
         {
             const string inputCode =
-@"Option Explicit";
+                @"Option Explicit";
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
@@ -128,15 +120,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new HungarianNotationInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new HungarianNotationInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -144,7 +134,7 @@ End Sub";
         public void HungarianNotation_DoesNotReturnsResult_ThreeLetterVariable()
         {
             const string inputCode =
-@"Sub InExcelSomewhere()
+                @"Sub InExcelSomewhere()
     Dim col As Long
 End Sub";
             var builder = new MockVbeBuilder();
@@ -153,15 +143,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new HungarianNotationInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new HungarianNotationInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -169,7 +157,7 @@ End Sub";
         public void HungarianNotation_DoesNotReturnResult_WhenIgnored()
         {
             const string inputCode =
-@"Sub MagyarRendbenVan()
+                @"Sub MagyarRendbenVan()
     '@Ignore HungarianNotation
     Dim strFoo As Variant
 End Sub";
@@ -179,15 +167,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UseMeaningfulNameInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new UseMeaningfulNameInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -195,7 +181,7 @@ End Sub";
         public void HungarianNotation_DoesNotReturnResult_WhenWhitelisted()
         {
             const string inputCode =
-@"Sub Feherlista()
+                @"Sub Feherlista()
     Dim oRange As Object
 End Sub";
             var builder = new MockVbeBuilder();
@@ -204,15 +190,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UseMeaningfulNameInspection(state, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new UseMeaningfulNameInspection(parser.State, UseMeaningfulNameInspectionTests.GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
+++ b/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
@@ -16,37 +16,41 @@ namespace RubberduckTests.Inspections
         public void NoAnnotation_NoResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
         [TestCategory("Inspections")]
         public void GivenLegalModuleAnnotation_NoResult()
         {
-            const string inputCode =@"
+            const string inputCode = @"
 Option Explicit
 '@PredeclaredId
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -66,13 +70,15 @@ Option Explicit
 '@Folder(""Legal"")
 ";
             var vbe = MockVbeBuilder.BuildFromStdModules(("Module1", inputCode1), ("Module2", inputCode2));
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -116,13 +122,15 @@ End Sub
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -130,19 +138,21 @@ End Sub
         public void SingleFolderAnnotation_NoResult()
         {
             const string inputCode =
-@"'@Folder ""Foo""
+                @"'@Folder ""Foo""
 Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -150,20 +160,22 @@ End Sub";
         public void MultipleFolderAnnotations_ReturnsResult()
         {
             const string inputCode =
-@"Option Explicit
+                @"Option Explicit
 '@Folder ""Foo.Bar""
 '@Folder ""Biz.Buz""
 Public Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -184,13 +196,15 @@ Public Sub Test1()
 End Sub
 ";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -209,13 +223,15 @@ Public Sub Test2()
 End Sub
 ";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -234,13 +250,15 @@ Public Sub Test2()
 End Sub
 ";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IllegalAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
@@ -31,17 +31,22 @@ End Sub
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-
             var parser = MockParser.Create(vbe.Object);
-            parser.State.AddTestLibrary("Excel.1.8.xml");
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("Excel.1.8.xml");
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            var inspection = new ImplicitActiveSheetReferenceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitActiveSheetReferenceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -65,16 +70,22 @@ End Sub
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-
             var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("Excel.1.8.xml");
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            var inspection = new ImplicitActiveSheetReferenceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitActiveSheetReferenceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ImplicitActiveWorkbookReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitActiveWorkbookReferenceInspectionTests.cs
@@ -31,17 +31,22 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-
             var parser = MockParser.Create(vbe.Object);
-            parser.State.AddTestLibrary("Excel.1.8.xml");
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("Excel.1.8.xml");
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            var inspection = new ImplicitActiveWorkbookReferenceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitActiveWorkbookReferenceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -65,17 +70,22 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-
             var parser = MockParser.Create(vbe.Object);
-            parser.State.AddTestLibrary("Excel.1.8.xml");
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("Excel.1.8.xml");
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            var inspection = new ImplicitActiveWorkbookReferenceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitActiveWorkbookReferenceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ImplicitByRefModifierInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitByRefModifierInspectionTests.cs
@@ -16,16 +16,18 @@ namespace RubberduckTests.Inspections
         public void ImplicitByRefModifier_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -33,16 +35,18 @@ End Sub";
         public void ImplicitByRefModifier_ReturnsResult_MultipleParameters()
         {
             const string inputCode =
-@"Sub Foo(arg1 As Integer, arg2 As Date)
+                @"Sub Foo(arg1 As Integer, arg2 As Date)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -50,16 +54,18 @@ End Sub";
         public void ImplicitByRefModifier_DoesNotReturnResult_ByRef()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -67,16 +73,18 @@ End Sub";
         public void ImplicitByRefModifier_DoesNotReturnResult_ByVal()
         {
             const string inputCode =
-@"Sub Foo(ByVal arg1 As Integer)
+                @"Sub Foo(ByVal arg1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -84,16 +92,18 @@ End Sub";
         public void ImplicitByRefModifier_ReturnsResult_SomePassedByRefImplicitly()
         {
             const string inputCode =
-@"Sub Foo(arg1 As Integer, ByRef arg2 As Date)
+                @"Sub Foo(arg1 As Integer, ByRef arg2 As Date)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -101,16 +111,18 @@ End Sub";
         public void ImplicitByRefModifier_DoesNotReturnResult_ParamArray()
         {
             const string inputCode =
-@"Sub Foo(ParamArray arg1 As Integer)
+                @"Sub Foo(ParamArray arg1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -118,11 +130,11 @@ End Sub";
         public void ImplicitByRefModifier_ReturnsResult_InterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer)
 End Sub";
@@ -134,13 +146,15 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -148,17 +162,17 @@ End Sub";
         public void ImplicitByRefModifier_ReturnsResult_MultipleInterfaceImplementations()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer)
 End Sub";
@@ -171,13 +185,15 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -185,17 +201,19 @@ End Sub";
         public void ImplicitByRefModifier_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ImplicitByRefModifier
+                @"'@Ignore ImplicitByRefModifier
 Sub Foo(arg1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ImplicitPublicMemberInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitPublicMemberInspectionTests.cs
@@ -18,12 +18,14 @@ Sub Foo()
 End Sub
 ";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitPublicMemberInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitPublicMemberInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -31,16 +33,18 @@ End Sub
         public void ImplicitPublicMember_ReturnsResult_Function()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
     Foo = True
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitPublicMemberInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitPublicMemberInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -48,18 +52,20 @@ End Function";
         public void ImplicitPublicMember_ReturnsResult_MultipleSubs()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub
 
 Sub Goo()
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitPublicMemberInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitPublicMemberInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -67,15 +73,17 @@ End Sub";
         public void ImplicitPublicMember_DoesNotReturnResult()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitPublicMemberInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitPublicMemberInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -88,12 +96,14 @@ Sub Foo()
 End Sub
 ";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitPublicMemberInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitPublicMemberInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -101,18 +111,20 @@ End Sub
         public void ImplicitPublicMember_ReturnsResult_SomeImplicitlyPublicSubs()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub
 
 Sub Goo()
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitPublicMemberInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitPublicMemberInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ImplicitVariantReturnTypeInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitVariantReturnTypeInspectionTests.cs
@@ -14,15 +14,17 @@ namespace RubberduckTests.Inspections
         public void ImplicitVariantReturnType_ReturnsResult_Function()
         {
             const string inputCode =
-@"Function Foo()
+                @"Function Foo()
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -30,7 +32,7 @@ End Function";
         public void ImplicitVariantReturnType_ReturnsResult_LibraryFunction()
         {
             const string inputCode =
-@"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
+                @"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
                                    Alias ""CreateProcessA""(ByVal lpApplicationName As String, _
                                                            ByVal lpCommandLine As String, _
                                                            lpProcessAttributes As SECURITY_ATTRIBUTES, _
@@ -42,12 +44,14 @@ End Function";
                                                            lpStartupInfo As STARTUPINFO, _
                                                            lpProcessInformation As PROCESS_INFORMATION)";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -55,7 +59,7 @@ End Function";
         public void ImplicitVariantReturnType_DoesNotReturnResult_LibraryFunction()
         {
             const string inputCode =
-@"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
+                @"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
                                    Alias ""CreateProcessA""(ByVal lpApplicationName As String, _
                                                            ByVal lpCommandLine As String, _
                                                            lpProcessAttributes As SECURITY_ATTRIBUTES, _
@@ -67,12 +71,14 @@ End Function";
                                                            lpStartupInfo As STARTUPINFO, _
                                                            lpProcessInformation As PROCESS_INFORMATION) As Long";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -80,15 +86,17 @@ End Function";
         public void ImplicitVariantReturnType_ReturnsResult_PropertyGet()
         {
             const string inputCode =
-@"Property Get Foo()
+                @"Property Get Foo()
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -96,18 +104,20 @@ End Property";
         public void ImplicitVariantReturnType_ReturnsResult_MultipleFunctions()
         {
             const string inputCode =
-@"Function Foo()
+                @"Function Foo()
 End Function
 
 Function Goo()
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -115,15 +125,17 @@ End Function";
         public void ImplicitVariantReturnType_DoesNotReturnResult()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -131,18 +143,20 @@ End Function";
         public void ImplicitVariantReturnType_ReturnsResult_MultipleSubs_SomeReturning()
         {
             const string inputCode =
-@"Function Foo()
+                @"Function Foo()
 End Function
 
 Function Goo() As String
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -150,16 +164,18 @@ End Function";
         public void ImplicitVariantReturnType_Ignored_DoesNotReturnResult_Function()
         {
             const string inputCode =
-@"'@Ignore ImplicitVariantReturnType
+                @"'@Ignore ImplicitVariantReturnType
 Function Foo()
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/IntegerDataTypeInspectionTests.cs
+++ b/RubberduckTests/Inspections/IntegerDataTypeInspectionTests.cs
@@ -15,15 +15,17 @@ namespace RubberduckTests.Inspections
         public void IntegerDataType_ReturnsResult_Function()
         {
             const string inputCode =
-@"Function Foo() As Integer
+                @"Function Foo() As Integer
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -31,15 +33,17 @@ End Function";
         public void IntegerDataType_ReturnsResult_PropertyGet()
         {
             const string inputCode =
-@"Property Get Foo() As Integer
+                @"Property Get Foo() As Integer
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -47,15 +51,17 @@ End Property";
         public void IntegerDataType_ReturnsResult_Parameter()
         {
             const string inputCode =
-@"Sub Foo(arg as Integer)
+                @"Sub Foo(arg as Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -63,16 +69,18 @@ End Sub";
         public void IntegerDataType_ReturnsResult_Variable()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim v as Integer
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -80,16 +88,18 @@ End Sub";
         public void IntegerDataType_ReturnsResult_Constant()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Const c as Integer = 0
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -97,16 +107,18 @@ End Sub";
         public void IntegerDataType_ReturnsResult_UserDefinedTypeMember()
         {
             const string inputCode =
-@"Type T
+                @"Type T
     i as Integer
 End Type";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -114,11 +126,11 @@ End Type";
         public void IntegerDataType_ReturnsResult_FunctionInterfaceImplementation()
         {
             const string inputCode1 =
-@"Function Foo() As Integer
+                @"Function Foo() As Integer
 End Function";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo() As Integer
 End Function";
@@ -130,12 +142,14 @@ End Function";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -143,11 +157,11 @@ End Function";
         public void IntegerDataType_ReturnsResult_PropertyGetInterfaceImplementation()
         {
             const string inputCode1 =
-@"Property Get Foo() As Integer
+                @"Property Get Foo() As Integer
 End Property";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo() As Integer
 End Property";
@@ -159,12 +173,14 @@ End Property";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -172,11 +188,11 @@ End Property";
         public void IntegerDataType_ReturnsResult_ParameterInterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(arg as Integer)
+                @"Sub Foo(arg as Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg As Integer)
 End Sub";
@@ -188,12 +204,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -201,17 +219,17 @@ End Sub";
         public void IntegerDataType_ReturnsResult_MultipleInterfaceImplementations()
         {
             const string inputCode1 =
-@"Sub Foo(arg As Integer)
+                @"Sub Foo(arg As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg As Integer)
 End Sub";
 
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg As Integer)
 End Sub";
@@ -224,12 +242,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -237,14 +257,16 @@ End Sub";
         public void IntegerDataType_DoesNotReturnResult_LibraryFunction()
         {
             const string inputCode =
-@"Declare Function Foo Lib ""lib.dll"" () As Integer";
+                @"Declare Function Foo Lib ""lib.dll"" () As Integer";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -252,14 +274,16 @@ End Sub";
         public void IntegerDataType_DoesNotReturnResult_LibraryFunctionParameter()
         {
             const string inputCode =
-@"Declare Function Foo Lib ""lib.dll"" (arg As Integer) As String";
+                @"Declare Function Foo Lib ""lib.dll"" (arg As Integer) As String";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -267,14 +291,16 @@ End Sub";
         public void IntegerDataType_DoesNotReturnResult_LibraryProcedureParameter()
         {
             const string inputCode =
-@"Declare Sub Foo Lib ""lib.dll"" (arg As Integer)";
+                @"Declare Sub Foo Lib ""lib.dll"" (arg As Integer)";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -282,16 +308,18 @@ End Sub";
         public void IntegerDataType_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore IntegerDataType
+                @"'@Ignore IntegerDataType
 Sub Foo(arg1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/LineLabelNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/LineLabelNotUsedInspectionTests.cs
@@ -30,12 +30,14 @@ buzz: Beep   'Line-label and instruction
 End Sub
 ";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(5, inspectionResults.Count());
+                Assert.AreEqual(5, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -43,16 +45,18 @@ End Sub
         public void LabelNotUsed_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 label1:
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -60,17 +64,19 @@ End Sub";
         public void LabelNotUsed_ReturnsResult_MultipleLabels()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 label1:
 label2:
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -78,17 +84,19 @@ End Sub";
         public void GivenGoToStatement_LabelUsed_YieldsNoResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 label1:
     GoTo label1
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -96,17 +104,19 @@ End Sub";
         public void GivenGoToStatement_GoToBeforeLabel_LabelUsed_YieldsNoResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     GoTo label1
 label1:
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -114,19 +124,21 @@ End Sub";
         public void GivenMultipleGoToStatements_BothLabelsUsed_YieldsNoResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 label1:
     GoTo label1
 label2:
     Goto label2
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -134,7 +146,7 @@ End Sub";
         public void LabelNotUsed_ReturnsResult_WithUsedLabelThatDoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     GoTo Label1:
 
 label2:
@@ -145,12 +157,14 @@ End Sub
 Sub Goo(ByVal arg1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -158,16 +172,18 @@ End Sub";
         public void LabelNotUsed_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 '@Ignore label1
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new LineLabelNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/MalformedAnnotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/MalformedAnnotationInspectionTests.cs
@@ -15,16 +15,18 @@ namespace RubberduckTests.Inspections
         public void MalformedAnnotation_ReturnsResult_Folder()
         {
             const string inputCode =
-@"'@Folder";
+                @"'@Folder";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MissingAnnotationArgumentInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MissingAnnotationArgumentInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -32,16 +34,18 @@ namespace RubberduckTests.Inspections
         public void MalformedAnnotation_DoesNotReturnResult_Folder()
         {
             const string inputCode =
-@"'@Folder ""Foo""";
+                @"'@Folder ""Foo""";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MissingAnnotationArgumentInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MissingAnnotationArgumentInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -49,16 +53,18 @@ namespace RubberduckTests.Inspections
         public void MalformedAnnotation_ReturnsResult_Ignore()
         {
             const string inputCode =
-@"'@Ignore";
+                @"'@Ignore";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MissingAnnotationArgumentInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MissingAnnotationArgumentInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -66,16 +72,18 @@ namespace RubberduckTests.Inspections
         public void MalformedAnnotation_DoesNotReturnResult_Ignore()
         {
             const string inputCode =
-@"'@Ignore ProcedureNotUsedInspection";
+                @"'@Ignore ProcedureNotUsedInspection";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MissingAnnotationArgumentInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MissingAnnotationArgumentInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -83,17 +91,19 @@ namespace RubberduckTests.Inspections
         public void MalformedAnnotation_ReturnsMultipleResults()
         {
             const string inputCode =
-@"'@Folder
+                @"'@Folder
 '@Ignore";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MissingAnnotationArgumentInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MissingAnnotationArgumentInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
+++ b/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
@@ -12,16 +12,16 @@ namespace RubberduckTests.Inspections
     [TestClass]
     public class MemberNotOnInterfaceInspectionTests
     {
-        private static ParseCoordinator ArrangeParser(string inputCode, string library = "Scripting")
+        private static RubberduckParserState ArrangeParserAndParse(string inputCode, string library = "Scripting")
         {
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("Codez", ComponentType.StandardModule, inputCode)
-                .AddReference(library, 
-                              library.Equals("Scripting") ? MockVbeBuilder.LibraryPathScripting : MockVbeBuilder.LibraryPathMsExcel,
-                              1,
-                              library.Equals("Scripting") ? 0 : 8,
-                              true)
+                .AddReference(library,
+                    library.Equals("Scripting") ? MockVbeBuilder.LibraryPathScripting : MockVbeBuilder.LibraryPathMsExcel,
+                    1,
+                    library.Equals("Scripting") ? 0 : 8,
+                    true)
                 .Build();
 
             var vbe = builder.AddProject(project).Build();
@@ -29,7 +29,14 @@ namespace RubberduckTests.Inspections
             var parser = MockParser.Create(vbe.Object);
 
             parser.State.AddTestLibrary(library.Equals("Scripting") ? "Scripting.1.0.xml" : "Excel.1.8.xml");
-            return parser;
+
+            parser.Parse(new CancellationTokenSource());
+            if (parser.State.Status >= ParserState.Error)
+            {
+                Assert.Inconclusive("Parser Error");
+            }
+
+            return parser.State;
         }
 
         [TestMethod]
@@ -38,21 +45,19 @@ namespace RubberduckTests.Inspections
         public void MemberNotOnInterface_ReturnsResult_UnDeclaredMember()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim dict As Dictionary
     Set dict = New Dictionary
     dict.NonMember
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -61,21 +66,19 @@ End Sub";
         public void MemberNotOnInterface_ReturnsResult_UnDeclaredInterfaceMember()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim dict As Dictionary
     Set dict = New Dictionary
     dict.NonMember
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -84,19 +87,17 @@ End Sub";
         public void MemberNotOnInterface_ReturnsResult_ApplicationObject()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Application.NonMember
 End Sub";
 
-            var parser = ArrangeParser(inputCode, "Excel");
+            using (var state = ArrangeParserAndParse(inputCode, "Excel"))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -105,42 +106,38 @@ End Sub";
         public void MemberNotOnInterface_ReturnsResult_UnDeclaredMemberOnParameter()
         {
             const string inputCode =
-@"Sub Foo(dict As Dictionary)
+                @"Sub Foo(dict As Dictionary)
     dict.NonMember
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
         [DeploymentItem(@"Testfiles\")]
         [TestCategory("Inspections")]
         public void MemberNotOnInterface_DoesNotReturnResult_DeclaredMember()
-        {            
+        {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim dict As Dictionary
     Set dict = New Dictionary
     Debug.Print dict.Count
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -149,20 +146,18 @@ End Sub";
         public void MemberNotOnInterface_DoesNotReturnResult_NonExtensible()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim x As File
     Debug.Print x.NonMember
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -171,22 +166,20 @@ End Sub";
         public void MemberNotOnInterface_ReturnsResult_WithBlock()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim dict As New Dictionary
     With dict
         .NonMember
     End With
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -195,21 +188,19 @@ End Sub";
         public void MemberNotOnInterface_DoesNotReturnResult_BangNotation()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim dict As Dictionary
     Set dict = New Dictionary
     dict!SomeIdentifier = 42
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -218,22 +209,20 @@ End Sub";
         public void MemberNotOnInterface_DoesNotReturnResult_WithBlockBangNotation()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim dict As New Dictionary
     With dict
         !SomeIdentifier = 42
     End With
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -242,19 +231,17 @@ End Sub";
         public void MemberNotOnInterface_DoesNotReturnResult_ProjectReference()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim dict As Scripting.Dictionary
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -263,22 +250,20 @@ End Sub";
         public void MemberNotOnInterface_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo(dict As Dictionary)
+                @"Sub Foo(dict As Dictionary)
     Dim dict As Dictionary
     Set dict = New Dictionary
     '@Ignore MemberNotOnInterface
     dict.NonMember
 End Sub";
 
-            var parser = ArrangeParser(inputCode);
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+                var inspection = new MemberNotOnInterfaceInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new MemberNotOnInterfaceInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/MissingAnnotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAnnotationInspectionTests.cs
@@ -30,12 +30,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -60,12 +62,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -88,12 +92,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -117,12 +123,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -145,12 +153,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -174,12 +184,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -206,12 +218,14 @@ End Sub
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -239,12 +253,14 @@ End Sub
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
@@ -30,12 +30,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -62,12 +64,14 @@ End Sub
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -91,12 +95,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -120,12 +126,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -148,12 +156,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -177,12 +187,14 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -209,12 +221,14 @@ End Sub
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestCategory("Inspections")]
@@ -241,12 +255,14 @@ End Sub
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/ModuleScopeDimKeywordInspectionTests.cs
+++ b/RubberduckTests/Inspections/ModuleScopeDimKeywordInspectionTests.cs
@@ -15,15 +15,17 @@ namespace RubberduckTests.Inspections
         public void ModuleScopeDimKeyword_ReturnsResult()
         {
             const string inputCode =
-@"Dim foo As String";
+                @"Dim foo As String";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -31,16 +33,18 @@ namespace RubberduckTests.Inspections
         public void ModuleScopeDimKeyword_ReturnsResult_Multiple()
         {
             const string inputCode =
-@"Dim foo
+                @"Dim foo
 Dim bar";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -48,15 +52,17 @@ Dim bar";
         public void ModuleScopeDimKeyword_DoesNotReturnResult()
         {
             const string inputCode =
-@"Private foo";
+                @"Private foo";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -64,17 +70,19 @@ Dim bar";
         public void ModuleScopeDimKeyword_IgnoreModule_All_YieldsNoResult()
         {
             const string inputCode =
-@"'@IgnoreModule
+                @"'@IgnoreModule
 
 Dim foo";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -82,17 +90,19 @@ Dim foo";
         public void ModuleScopeDimKeyword_IgnoreModule_AnnotationName_YieldsNoResult()
         {
             const string inputCode =
-@"'@IgnoreModule ModuleScopeDimKeyword
+                @"'@IgnoreModule ModuleScopeDimKeyword
 
 Dim foo";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -100,17 +110,19 @@ Dim foo";
         public void ModuleScopeDimKeyword_IgnoreModule_OtherAnnotationName_YieldsResults()
         {
             const string inputCode =
-@"'@IgnoreModule VariableNotUsed
+                @"'@IgnoreModule VariableNotUsed
 
 Dim foo";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsTrue(inspectionResults.Any());
+                Assert.IsTrue(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -118,16 +130,18 @@ Dim foo";
         public void ModuleScopeDimKeyword_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ModuleScopeDimKeyword
+                @"'@Ignore ModuleScopeDimKeyword
 Dim foo";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/MoveFieldCloserToUsageInspectionTests.cs
+++ b/RubberduckTests/Inspections/MoveFieldCloserToUsageInspectionTests.cs
@@ -14,17 +14,19 @@ namespace RubberduckTests.Inspections
         public void MoveFieldCloserToUsage_ReturnsResult()
         {
             const string inputCode =
-@"Private bar As String
+                @"Private bar As String
 Public Sub Foo()
     bar = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -32,7 +34,7 @@ End Sub";
         public void MoveFieldCloserToUsage_DoesNotReturnsResult_MultipleReferenceInDifferentScope()
         {
             const string inputCode =
-@"Private bar As String
+                @"Private bar As String
 Public Sub Foo()
     Let bar = ""test""
 End Sub
@@ -40,12 +42,14 @@ Public Sub For2()
     Let bar = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -53,17 +57,19 @@ End Sub";
         public void MoveFieldCloserToUsage_DoesNotReturnResult_Variable()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim bar As String
     bar = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -71,16 +77,18 @@ End Sub";
         public void MoveFieldCloserToUsage_DoesNotReturnsResult_NoReferences()
         {
             const string inputCode =
-@"Private bar As String
+                @"Private bar As String
 Public Sub Foo()
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -88,17 +96,19 @@ End Sub";
         public void MoveFieldCloserToUsage_DoesNotReturnsResult_ReferenceInPropertyGet()
         {
             const string inputCode =
-@"Private bar As String
+                @"Private bar As String
 Public Property Get Foo() As String
     Foo = bar
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -106,7 +116,7 @@ End Property";
         public void MoveFieldCloserToUsage_DoesNotReturnsResult_ReferenceInPropertyLet()
         {
             const string inputCode =
-@"Private bar As String
+                @"Private bar As String
 Public Property Get Foo() As String
     Foo = ""test""
 End Property
@@ -114,12 +124,14 @@ Public Property Let Foo(ByVal value As String)
     bar = value
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -127,7 +139,7 @@ End Property";
         public void MoveFieldCloserToUsage_DoesNotReturnsResult_ReferenceInPropertySet()
         {
             const string inputCode =
-@"Private bar As Variant
+                @"Private bar As Variant
 Public Property Get Foo() As Variant
     Foo = ""test""
 End Property
@@ -135,12 +147,14 @@ Public Property Set Foo(ByVal value As Variant)
     bar = value
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -148,18 +162,20 @@ End Property";
         public void MoveFieldCloserToUsage_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore MoveFieldCloserToUsage
+                @"'@Ignore MoveFieldCloserToUsage
 Private bar As String
 Public Sub Foo()
     bar = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/MultilineParameterInspectionTests.cs
+++ b/RubberduckTests/Inspections/MultilineParameterInspectionTests.cs
@@ -15,19 +15,21 @@ namespace RubberduckTests.Inspections
         public void MultilineParameter_ReturnsResult()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal _
+                @"Public Sub Foo(ByVal _
     Var1 _
     As _
     Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultilineParameterInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultilineParameterInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -35,16 +37,18 @@ End Sub";
         public void MultilineParameter_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal Var1 As Integer)
+                @"Public Sub Foo(ByVal Var1 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultilineParameterInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultilineParameterInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -52,7 +56,7 @@ End Sub";
         public void MultilineParameter_ReturnsMultipleResults()
         {
             const string inputCode =
-@"Public Sub Foo( _
+                @"Public Sub Foo( _
     ByVal _
     Var1 _
     As _
@@ -63,13 +67,15 @@ End Sub";
     Date)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultilineParameterInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultilineParameterInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -77,19 +83,21 @@ End Sub";
         public void MultilineParameter_ReturnsResults_SomeParams()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal _
+                @"Public Sub Foo(ByVal _
     Var1 _
     As _
     Integer, ByVal Var2 As Date)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultilineParameterInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultilineParameterInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -97,20 +105,22 @@ End Sub";
         public void MultilineParameter_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore MultilineParameter
+                @"'@Ignore MultilineParameter
 Public Sub Foo(ByVal _
     Var1 _
     As _
     Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultilineParameterInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultilineParameterInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/MultipleDeclarationsInspectionTests.cs
+++ b/RubberduckTests/Inspections/MultipleDeclarationsInspectionTests.cs
@@ -15,17 +15,19 @@ namespace RubberduckTests.Inspections
         public void MultipleDeclarations_ReturnsResult_Variables()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer, var2 As String
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -33,17 +35,19 @@ End Sub";
         public void MultipleDeclarations_ReturnsResult_Constants()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const var1 As Integer = 9, var2 As String = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -51,17 +55,19 @@ End Sub";
         public void MultipleDeclarations_ReturnsResult_StaticVariables()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Static var1 As Integer, var2 As String
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -69,18 +75,20 @@ End Sub";
         public void MultipleDeclarations_ReturnsResult_MultipleDeclarations()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer, var2 As String
     Dim var3 As Boolean, var4 As Date
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -88,18 +96,20 @@ End Sub";
         public void MultipleDeclarations_ReturnsResult_SomeDeclarationsSeparate()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer, var2 As String
     Dim var3 As Boolean
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -107,18 +117,20 @@ End Sub";
         public void MultipleDeclarations_Ignore_DoesNotReturnResult_Variables()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     '@Ignore MultipleDeclarations
     Dim var1 As Integer, var2 As String
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
@@ -15,15 +15,17 @@ namespace RubberduckTests.Inspections
         public void NonReturningFunction_ReturnsResult()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -31,15 +33,17 @@ End Function";
         public void NonReturningPropertyGet_ReturnsResult()
         {
             const string inputCode =
-@"Property Get Foo() As Boolean
+                @"Property Get Foo() As Boolean
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -47,18 +51,20 @@ End Property";
         public void NonReturningFunction_ReturnsResult_MultipleFunctions()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
 End Function
 
 Function Goo() As String
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -66,16 +72,18 @@ End Function";
         public void NonReturningFunction_DoesNotReturnResult_Let()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
     Foo = True
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -83,16 +91,18 @@ End Function";
         public void NonReturningFunction_DoesNotReturnResult_Set()
         {
             const string inputCode =
-@"Function Foo() As Collection
+                @"Function Foo() As Collection
     Set Foo = new Collection
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -100,16 +110,18 @@ End Function";
         public void NonReturningFunction_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore NonReturningFunction
+                @"'@Ignore NonReturningFunction
 Function Foo() As Boolean
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -117,19 +129,21 @@ End Function";
         public void NonReturningFunction_ReturnsResult_MultipleSubs_SomeReturning()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
     Foo = True
 End Function
 
 Function Goo() As String
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -138,10 +152,10 @@ End Function";
         {
             //Input
             const string inputCode1 =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
 End Function";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo() As Boolean
 End Function";
@@ -153,12 +167,14 @@ End Function";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -513,12 +513,13 @@ End Sub";
         private void AssertInputCodeYieldsExpectedInspectionResultCount(string inputCode, int expected)
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using(var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ObjectVariableNotSetInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ObjectVariableNotSetInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(expected, inspectionResults.Count());
+                Assert.AreEqual(expected, inspectionResults.Count());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/ObsoleteCallStatementInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteCallStatementInspectionTests.cs
@@ -15,18 +15,20 @@ namespace RubberduckTests.Inspections
         public void ObsoleteCallStatement_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Call Foo
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -34,18 +36,20 @@ End Sub";
         public void ObsoleteCallStatement_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Foo
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -53,18 +57,20 @@ End Sub";
         public void ObsoleteCallStatement_DoesNotReturnResult_InstructionSeparator()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Call Foo: Foo
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -72,18 +78,20 @@ End Sub";
         public void ObsoleteCallStatement_ReturnsResult_ColonInComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Call Foo ' I''ve got a colon: see?
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -91,18 +99,20 @@ End Sub";
         public void ObsoleteCallStatement_ReturnsResult_ColonInStringLiteral()
         {
             const string inputCode =
-@"Sub Foo(ByVal str As String)
+                @"Sub Foo(ByVal str As String)
     Call Foo("":"")
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -110,22 +120,24 @@ End Sub";
         public void ObsoleteCallStatement_ReturnsMultipleResults()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Call Goo(1, ""test"")
 End Sub
 
 Sub Goo(arg1 As Integer, arg1 As String)
     Call Foo
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -133,22 +145,24 @@ End Sub";
         public void ObsoleteCallStatement_ReturnsResults_SomeObsoleteCallStatements()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Call Goo(1, ""test"")
 End Sub
 
 Sub Goo(arg1 As Integer, arg1 As String)
     Foo
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -156,19 +170,21 @@ End Sub";
         public void ObsoleteCallStatement_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     '@Ignore ObsoleteCallStatement
     Call Foo
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
 

--- a/RubberduckTests/Inspections/ObsoleteCommentSyntaxInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteCommentSyntaxInspectionTests.cs
@@ -16,13 +16,15 @@ namespace RubberduckTests.Inspections
         {
             const string inputCode = @"Rem test";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -31,13 +33,15 @@ namespace RubberduckTests.Inspections
         {
             const string inputCode = @"' test";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -50,14 +54,16 @@ Sub foo()
     i = """"
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var emptyStringLiteralInspection = new EmptyStringLiteralInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection, emptyStringLiteralInspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var emptyStringLiteralInspection = new EmptyStringLiteralInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection, emptyStringLiteralInspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count(r => r.Inspection is ObsoleteCommentSyntaxInspection));
+                Assert.AreEqual(0, inspectionResults.Count(r => r.Inspection is ObsoleteCommentSyntaxInspection));
+            }
         }
 
         [TestMethod]
@@ -65,18 +71,20 @@ End Sub";
         public void ObsoleteCommentSyntax_DoesNotReturnResult_RemInStringLiteral()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim bar As String
     bar = ""iejo rem oernp"" ' test
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -84,16 +92,18 @@ End Sub";
         public void ObsoleteCommentSyntax_ReturnsMultipleResults()
         {
             const string inputCode =
-@"Rem test1
+                @"Rem test1
 Rem test2";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -101,16 +111,18 @@ Rem test2";
         public void ObsoleteCommentSyntax_ReturnsResults_SomeObsoleteCommentSyntax()
         {
             const string inputCode =
-@"Rem test1
+                @"Rem test1
 ' test2";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -121,13 +133,15 @@ Rem test2";
 '@Ignore ObsoleteCommentSyntax
 Rem test";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ObsoleteErrorSyntaxInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteErrorSyntaxInspectionTests.cs
@@ -15,17 +15,19 @@ namespace RubberduckTests.Inspections
         public void ObsoleteErrorSyntax_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Error 91
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -33,18 +35,20 @@ End Sub";
         public void ObsoleteErrorSyntax_DoesNotReturnResult_ErrorInStringLiteral()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim bar As String
     bar = ""Error 91"" ' test
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -52,18 +56,20 @@ End Sub";
         public void ObsoleteErrorSyntax_ReturnsMultipleResults()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Error 91
     Error 91
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -71,18 +77,20 @@ End Sub";
         public void ObsoleteErrorSyntax_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     '@Ignore ObsoleteErrorSyntax
     Error 91
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ObsoleteGlobalInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteGlobalInspectionTests.cs
@@ -14,14 +14,16 @@ namespace RubberduckTests.Inspections
         public void ObsoleteGlobal_ReturnsResult()
         {
             const string inputCode =
-@"Global var1 As Integer";
+                @"Global var1 As Integer";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteGlobalInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteGlobalInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -29,15 +31,17 @@ namespace RubberduckTests.Inspections
         public void ObsoleteGlobal_ReturnsResult_MultipleGlobals()
         {
             const string inputCode =
-@"Global var1 As Integer
+                @"Global var1 As Integer
 Global var2 As String";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteGlobalInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteGlobalInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -45,14 +49,16 @@ Global var2 As String";
         public void ObsoleteGlobal_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public var1 As Integer";
+                @"Public var1 As Integer";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteGlobalInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteGlobalInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -60,15 +66,17 @@ Global var2 As String";
         public void ObsoleteGlobal_ReturnsResult_SomeConstantsUsed()
         {
             const string inputCode =
-@"Public var1 As Integer
+                @"Public var1 As Integer
 Global var2 As Date";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteGlobalInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteGlobalInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -76,15 +84,17 @@ Global var2 As Date";
         public void ObsoleteGlobal_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ObsoleteGlobal
+                @"'@Ignore ObsoleteGlobal
 Global var1 As Integer";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteGlobalInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteGlobalInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ObsoleteLetStatementInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteLetStatementInspectionTests.cs
@@ -15,20 +15,22 @@ namespace RubberduckTests.Inspections
         public void ObsoleteLetStatement_ReturnsResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
     Dim var2 As Integer
     
     Let var2 = var1
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteLetStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteLetStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -36,7 +38,7 @@ End Sub";
         public void ObsoleteLetStatement_ReturnsResult_MultipleLets()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
     Dim var2 As Integer
     
@@ -44,13 +46,15 @@ End Sub";
     Let var1 = var2
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteLetStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteLetStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -58,20 +62,22 @@ End Sub";
         public void ObsoleteLetStatement_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
     Dim var2 As Integer
     
     var2 = var1
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteLetStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteLetStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -79,7 +85,7 @@ End Sub";
         public void ObsoleteLetStatement_ReturnsResult_SomeConstantsUsed()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
     Dim var2 As Integer
     
@@ -87,13 +93,15 @@ End Sub";
     var1 = var2
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteLetStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteLetStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -101,7 +109,7 @@ End Sub";
         public void ObsoleteLetStatement_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
     Dim var2 As Integer
     
@@ -109,13 +117,15 @@ End Sub";
     Let var2 = var1
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteLetStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteLetStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ObsoleteTypeHintInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObsoleteTypeHintInspectionTests.cs
@@ -14,14 +14,16 @@ namespace RubberduckTests.Inspections
         public void ObsoleteTypeHint_FieldWithLongTypeHintReturnsResult()
         {
             const string inputCode =
-@"Public Foo&";
+                @"Public Foo&";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -29,14 +31,16 @@ namespace RubberduckTests.Inspections
         public void ObsoleteTypeHint_FieldWithIntegerTypeHintReturnsResult()
         {
             const string inputCode =
-@"Public Foo%";
+                @"Public Foo%";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -44,14 +48,16 @@ namespace RubberduckTests.Inspections
         public void ObsoleteTypeHint_FieldWithDoubleTypeHintReturnsResult()
         {
             const string inputCode =
-@"Public Foo#";
+                @"Public Foo#";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -59,14 +65,16 @@ namespace RubberduckTests.Inspections
         public void ObsoleteTypeHint_FieldWithSingleTypeHintReturnsResult()
         {
             const string inputCode =
-@"Public Foo!";
+                @"Public Foo!";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -74,14 +82,16 @@ namespace RubberduckTests.Inspections
         public void ObsoleteTypeHint_FieldWithDecimalTypeHintReturnsResult()
         {
             const string inputCode =
-@"Public Foo@";
+                @"Public Foo@";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -89,14 +99,16 @@ namespace RubberduckTests.Inspections
         public void ObsoleteTypeHint_FieldWithStringTypeHintReturnsResult()
         {
             const string inputCode =
-@"Public Foo$";
+                @"Public Foo$";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -104,15 +116,17 @@ namespace RubberduckTests.Inspections
         public void ObsoleteTypeHint_FunctionReturnsResult()
         {
             const string inputCode =
-@"Public Function Foo$(ByVal bar As Boolean)
+                @"Public Function Foo$(ByVal bar As Boolean)
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -120,15 +134,17 @@ End Function";
         public void ObsoleteTypeHint_PropertyGetReturnsResult()
         {
             const string inputCode =
-@"Public Property Get Foo$(ByVal bar As Boolean)
+                @"Public Property Get Foo$(ByVal bar As Boolean)
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -136,15 +152,17 @@ End Property";
         public void ObsoleteTypeHint_ParameterReturnsResult()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar$) As Boolean
+                @"Public Function Foo(ByVal bar$) As Boolean
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -152,17 +170,19 @@ End Function";
         public void ObsoleteTypeHint_VariableReturnsResult()
         {
             const string inputCode =
-@"Public Function Foo() As Boolean
+                @"Public Function Foo() As Boolean
     Dim buzz$
     Foo = True
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -170,17 +190,19 @@ End Function";
         public void ObsoleteTypeHint_ConstantReturnsResult()
         {
             const string inputCode =
-@"Public Function Foo() As Boolean
+                @"Public Function Foo() As Boolean
     Const buzz$ = 0
     Foo = True
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -188,17 +210,19 @@ End Function";
         public void ObsoleteTypeHint_StringValueDoesNotReturnsResult()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim bar As String
     bar = ""Public baz$""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -206,15 +230,17 @@ End Sub";
         public void ObsoleteTypeHint_FieldsReturnMultipleResults()
         {
             const string inputCode =
-@"Public Foo$
+                @"Public Foo$
 Public Bar$";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -222,16 +248,18 @@ Public Bar$";
         public void ObsoleteTypeHint_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ObsoleteTypeHint
+                @"'@Ignore ObsoleteTypeHint
 Public Function Foo$(ByVal bar As Boolean)
 End Function";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/OptionBaseInspectionTests.cs
+++ b/RubberduckTests/Inspections/OptionBaseInspectionTests.cs
@@ -18,13 +18,15 @@ namespace RubberduckTests.Inspections
             const string inputCode = @"Option Base 1";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionBaseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionBaseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -34,13 +36,15 @@ namespace RubberduckTests.Inspections
             const string inputCode = @"";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionBaseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionBaseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -50,13 +54,15 @@ namespace RubberduckTests.Inspections
             const string inputCode = @"Option Base 0";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionBaseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionBaseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -72,13 +78,15 @@ namespace RubberduckTests.Inspections
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionBaseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionBaseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -95,13 +103,15 @@ namespace RubberduckTests.Inspections
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionBaseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionBaseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -109,17 +119,19 @@ namespace RubberduckTests.Inspections
         public void OptionBaseOneSpecified_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore OptionBase
+                @"'@Ignore OptionBase
 Option Base 1";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionBaseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionBaseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/OptionBaseZeroInspectionTests.cs
+++ b/RubberduckTests/Inspections/OptionBaseZeroInspectionTests.cs
@@ -15,16 +15,18 @@ namespace RubberduckTests.Inspections
         public void OptionBaseZeroStatement_ReturnsResult()
         {
             const string inputCode =
-@"Option Base 0";
+                @"Option Base 0";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantOptionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantOptionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -34,13 +36,15 @@ namespace RubberduckTests.Inspections
             var inputCode = "Option Base 1";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantOptionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantOptionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -48,17 +52,19 @@ namespace RubberduckTests.Inspections
         public void OptionBaseZeroStatement_Ignored_DoesNotReturnResult()
         {
             var inputCode =
-@"'@Ignore OptionBaseZero
+                @"'@Ignore OptionBaseZero
 Option Base 0";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/OptionExplicitInspectionTests.cs
+++ b/RubberduckTests/Inspections/OptionExplicitInspectionTests.cs
@@ -18,13 +18,15 @@ namespace RubberduckTests.Inspections
             const string inputCode = @"";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionExplicitInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionExplicitInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -34,13 +36,15 @@ namespace RubberduckTests.Inspections
             const string inputCode = @"Option Explicit";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionExplicitInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionExplicitInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -56,13 +60,15 @@ namespace RubberduckTests.Inspections
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionExplicitInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionExplicitInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -79,13 +85,15 @@ namespace RubberduckTests.Inspections
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new OptionExplicitInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new OptionExplicitInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
@@ -69,12 +69,14 @@ End Sub
                 .AddComponent("MyForm", ComponentType.UserForm, implementationCode)
                 .MockVbeBuilder().Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -82,15 +84,17 @@ End Sub
         public void ParameterCanBeByVal_NoResultForByValObjectInProperty()
         {
             const string inputCode =
-@"Public Property Set Foo(ByVal value As Object)
+                @"Public Property Set Foo(ByVal value As Object)
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -98,15 +102,17 @@ End Property";
         public void ParameterCanBeByVal_NoResultForByValObject()
         {
             const string inputCode =
-@"Sub Foo(ByVal arg1 As Collection)
+                @"Sub Foo(ByVal arg1 As Collection)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -114,15 +120,17 @@ End Sub";
         public void ParameterCanBeByVal_ReturnsResult_PassedByNotSpecified()
         {
             const string inputCode =
-@"Sub Foo(arg1 As String)
+                @"Sub Foo(arg1 As String)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -130,15 +138,17 @@ End Sub";
         public void ParameterCanBeByVal_ReturnsResult_PassedByRef_Unassigned()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As String)
+                @"Sub Foo(ByRef arg1 As String)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -146,15 +156,17 @@ End Sub";
         public void ParameterCanBeByVal_ReturnsResult_Multiple()
         {
             const string inputCode =
-@"Sub Foo(arg1 As String, arg2 As Date)
+                @"Sub Foo(arg1 As String, arg2 As Date)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -162,15 +174,17 @@ End Sub";
         public void ParameterCanBeByVal_DoesNotReturnResult_PassedByValExplicitly()
         {
             const string inputCode =
-@"Sub Foo(ByVal arg1 As String)
+                @"Sub Foo(ByVal arg1 As String)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -178,16 +192,18 @@ End Sub";
         public void ParameterCanBeByVal_DoesNotReturnResult_PassedByRefAndAssigned()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As String)
+                @"Sub Foo(ByRef arg1 As String)
     arg1 = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -195,16 +211,18 @@ End Sub";
         public void ParameterCanBeByVal_DoesNotReturnResult_BuiltInEventParam()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As String)
+                @"Sub Foo(ByRef arg1 As String)
     arg1 = ""test""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -212,15 +230,17 @@ End Sub";
         public void ParameterCanBeByVal_ReturnsResult_SomeParams()
         {
             const string inputCode =
-@"Sub Foo(arg1 As String, ByVal arg2 As Integer)
+                @"Sub Foo(arg1 As String, ByVal arg2 As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -228,15 +248,17 @@ End Sub";
         public void GivenArrayParameter_ReturnsNoResult()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1() As Variant)
+                @"Sub Foo(ByRef arg1() As Variant)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var results = inspection.GetInspectionResults().ToList();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var results = inspection.GetInspectionResults().ToList();
 
-            Assert.AreEqual(0, results.Count);
+                Assert.AreEqual(0, results.Count);
+            }
         }
 
         [TestMethod]
@@ -244,19 +266,21 @@ End Sub";
         public void ParameterCanBeByVal_ReturnsResult_PassedToByRefProc_NoAssignment()
         {
             const string inputCode =
-@"Sub DoSomething(foo As Integer)
+                @"Sub DoSomething(foo As Integer)
     DoSomethingElse foo
 End Sub
 
 Sub DoSomethingElse(ByVal bar As Integer)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -264,7 +288,7 @@ End Sub";
         public void ParameterCanBeByVal_DoesNotReturnResult_PassedToByRefProc_WithAssignment()
         {
             const string inputCode =
-@"Sub DoSomething(foo As Integer)
+                @"Sub DoSomething(foo As Integer)
     DoSomethingElse foo
 End Sub
 
@@ -272,12 +296,14 @@ Sub DoSomethingElse(ByRef bar As Integer)
     bar = 42
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -285,7 +311,7 @@ End Sub";
         public void ParameterCanBeByVal_ReturnsResult_PassedToByValProc_WithAssignment()
         {
             const string inputCode =
-@"Sub DoSomething(foo As Integer)
+                @"Sub DoSomething(foo As Integer)
     DoSomethingElse foo
 End Sub
 
@@ -293,12 +319,14 @@ Sub DoSomethingElse(ByVal bar As Integer)
     bar = 42
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -306,16 +334,18 @@ End Sub";
         public void ParameterCanBeByVal_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ParameterCanBeByVal
+                @"'@Ignore ParameterCanBeByVal
 Sub Foo(arg1 As String)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -324,10 +354,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByRef a As Integer)
+                @"Public Sub DoSomething(ByRef a As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByRef a As Integer)
 End Sub";
@@ -340,12 +370,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -354,10 +386,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer)
 End Sub";
@@ -370,12 +402,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -384,10 +418,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByRef a As Integer)
+                @"Public Sub DoSomething(ByRef a As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByRef a As Integer)
     a = 42
@@ -401,12 +435,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -415,16 +451,16 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByRef a As Integer, ByRef b As Integer)
+                @"Public Sub DoSomething(ByRef a As Integer, ByRef b As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByRef a As Integer, ByRef b As Integer)
     b = 42
 End Sub";
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByRef a As Integer, ByRef b As Integer)
 End Sub";
@@ -437,12 +473,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual("a", inspectionResults.Single().Target.IdentifierName);
+                Assert.AreEqual("a", inspectionResults.Single().Target.IdentifierName);
+            }
         }
 
         [TestMethod]
@@ -451,10 +489,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByRef arg1 As Integer)";
+                @"Public Event Foo(ByRef arg1 As Integer)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef arg1 As Integer)
 End Sub";
@@ -467,12 +505,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -481,10 +521,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg1 As Integer)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal arg1 As Integer)
 End Sub";
@@ -497,12 +537,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -511,10 +553,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByRef arg1 As Integer)";
+                @"Public Event Foo(ByRef arg1 As Integer)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef arg1 As Integer)
     arg1 = 42
@@ -528,12 +570,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -542,10 +586,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByRef arg1 As Integer, ByRef arg2 As Integer)";
+                @"Public Event Foo(ByRef arg1 As Integer, ByRef arg2 As Integer)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef arg1 As Integer, ByRef arg2 As Integer)
     arg1 = 42
@@ -559,12 +603,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual("arg2", inspectionResults.Single().Target.IdentifierName);
+                Assert.AreEqual("arg2", inspectionResults.Single().Target.IdentifierName);
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ParameterNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterNotUsedInspectionTests.cs
@@ -15,16 +15,18 @@ namespace RubberduckTests.Inspections
         public void ParameterNotUsed_ReturnsResult()
         {
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 as Integer)
+                @"Private Sub Foo(ByVal arg1 as Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -32,19 +34,21 @@ End Sub";
         public void ParameterNotUsed_ReturnsResult_MultipleSubs()
         {
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 as Integer)
+                @"Private Sub Foo(ByVal arg1 as Integer)
 End Sub
 
 Private Sub Goo(ByVal arg1 as Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -52,17 +56,19 @@ End Sub";
         public void ParameterUsed_DoesNotReturnResult()
         {
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 as Integer)
+                @"Private Sub Foo(ByVal arg1 as Integer)
     arg1 = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -70,17 +76,19 @@ End Sub";
         public void ParameterNotUsed_ReturnsResult_SomeParamsUsed()
         {
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 as Integer, ByVal arg2 as String)
+                @"Private Sub Foo(ByVal arg1 as Integer, ByVal arg2 as String)
     arg1 = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -89,10 +97,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer)
 End Sub";
@@ -104,13 +112,15 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults().ToList();
+                var inspection = new ParameterNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults().ToList();
 
-            Assert.AreEqual(1, inspectionResults.Count);
+                Assert.AreEqual(1, inspectionResults.Count);
 
+            }
         }
 
         [TestMethod]
@@ -118,17 +128,19 @@ End Sub";
         public void ParameterNotUsed_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ParameterNotUsed
+                @"'@Ignore ParameterNotUsed
 Private Sub Foo(ByVal arg1 as Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ParameterNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ProcedureNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureNotUsedInspectionTests.cs
@@ -16,16 +16,18 @@ namespace RubberduckTests.Inspections
         public void ProcedureNotUsed_ReturnsResult()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -33,19 +35,21 @@ End Sub";
         public void ProcedureNotUsed_ReturnsResult_MultipleSubs()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub
 
 Private Sub Goo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -53,7 +57,7 @@ End Sub";
         public void ProcedureUsed_DoesNotReturnResult()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Goo
 End Sub
 
@@ -62,12 +66,14 @@ Private Sub Goo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -75,7 +81,7 @@ End Sub";
         public void ProcedureNotUsed_ReturnsResult_SomeProceduresUsed()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub
 
 Private Sub Goo()
@@ -83,12 +89,14 @@ Private Sub Goo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -97,10 +105,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer)
 End Sub";
@@ -112,12 +120,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -127,7 +137,7 @@ End Sub";
             //Input
             const string inputCode1 = @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
@@ -139,12 +149,14 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count(result => result.Target.DeclarationType == DeclarationType.Procedure));
+                Assert.AreEqual(0, inspectionResults.Count(result => result.Target.DeclarationType == DeclarationType.Procedure));
+            }
         }
 
         [TestMethod]
@@ -153,16 +165,18 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Class_Initialize()
+                @"Private Sub Class_Initialize()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -171,16 +185,18 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub class_initialize()
+                @"Private Sub class_initialize()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -189,16 +205,18 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Class_Terminate()
+                @"Private Sub Class_Terminate()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -207,16 +225,18 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub class_terminate()
+                @"Private Sub class_terminate()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
 
@@ -225,17 +245,19 @@ End Sub";
         public void ProcedureNotUsed_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ProcedureNotUsed
+                @"'@Ignore ProcedureNotUsed
 Private Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
@@ -16,17 +16,18 @@ namespace RubberduckTests.Inspections
         public void ProcedureShouldBeFunction_ReturnsResult()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef foo As Boolean)
+                @"Private Sub Foo(ByRef foo As Boolean)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -34,20 +35,22 @@ End Sub";
         public void ProcedureShouldBeFunction_ReturnsResult_MultipleSubs()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef foo As Boolean)
+                @"Private Sub Foo(ByRef foo As Boolean)
 End Sub
 
 Private Sub Goo(ByRef foo As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -55,18 +58,20 @@ End Sub";
         public void ProcedureShouldBeFunction_DoesNotReturnResult_Function()
         {
             const string inputCode =
-@"Private Function Foo(ByRef bar As Integer) As Integer
+                @"Private Function Foo(ByRef bar As Integer) As Integer
     Foo = bar
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -74,17 +79,19 @@ End Function";
         public void ProcedureShouldBeFunction_DoesNotReturnResult_SingleByValParam()
         {
             const string inputCode =
-@"Private Sub Foo(ByVal foo As Integer)
+                @"Private Sub Foo(ByVal foo As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -92,17 +99,19 @@ End Sub";
         public void ProcedureShouldBeFunction_DoesNotReturnsResult_MultipleByValParams()
         {
             const string inputCode =
-@"Private Sub Foo(ByVal foo As Integer, ByVal goo As Integer)
+                @"Private Sub Foo(ByVal foo As Integer, ByVal goo As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -110,17 +119,19 @@ End Sub";
         public void ProcedureShouldBeFunction_DoesNotReturnsResult_MultipleByRefParams()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef foo As Integer, ByRef goo As Integer)
+                @"Private Sub Foo(ByRef foo As Integer, ByRef goo As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -129,10 +140,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByRef a As Integer)
+                @"Public Sub DoSomething(ByRef a As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByRef a As Integer)
 End Sub";
@@ -144,13 +155,15 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -159,9 +172,9 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByRef arg1 As Integer)";
+                @"Public Event Foo(ByRef arg1 As Integer)";
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef arg1 As Integer)
 End Sub";
@@ -173,13 +186,15 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -187,18 +202,20 @@ End Sub";
         public void ProcedureShouldBeFunction_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore ProcedureCanBeWrittenAsFunction
+                @"'@Ignore ProcedureCanBeWrittenAsFunction
 Private Sub Foo(ByRef foo As Boolean)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/RedundantByRefModifierInspectionTests.cs
+++ b/RubberduckTests/Inspections/RedundantByRefModifierInspectionTests.cs
@@ -16,17 +16,19 @@ namespace RubberduckTests.Inspections
         public void RedundantByRefModifier_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -34,17 +36,19 @@ End Sub";
         public void RedundantByRefModifier_ReturnsResult_MultipleParameters()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As Integer, ByRef arg2 As Date)
+                @"Sub Foo(ByRef arg1 As Integer, ByRef arg2 As Date)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -52,17 +56,19 @@ End Sub";
         public void RedundantByRefModifier_DoesNotReturnResult_NoModifier()
         {
             const string inputCode =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -70,17 +76,19 @@ End Sub";
         public void RedundantByRefModifier_DoesNotReturnResult_ByVal()
         {
             const string inputCode =
-@"Sub Foo(ByVal arg1 As Integer)
+                @"Sub Foo(ByVal arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -88,17 +96,19 @@ End Sub";
         public void RedundantByRefModifier_ReturnsResult_SomePassedByRef()
         {
             const string inputCode =
-@"Sub Foo(ByVal arg1 As Integer, ByRef arg2 As Date)
+                @"Sub Foo(ByVal arg1 As Integer, ByRef arg2 As Date)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -106,11 +116,11 @@ End Sub";
         public void RedundantByRefModifier_ReturnsResult_InterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg1 As Integer)
 End Sub";
@@ -122,13 +132,15 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -136,17 +148,17 @@ End Sub";
         public void RedundantByRefModifier_ReturnsResult_MultipleInterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg1 As Integer)
 End Sub";
@@ -159,13 +171,15 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -173,18 +187,20 @@ End Sub";
         public void RedundantByRefModifier_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore RedundantByRefModifier
+                @"'@Ignore RedundantByRefModifier
 Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/SelfAssignedDeclarationInspectionTests.cs
+++ b/RubberduckTests/Inspections/SelfAssignedDeclarationInspectionTests.cs
@@ -17,7 +17,7 @@ namespace RubberduckTests.Inspections
         public void SelfAssignedDeclaration_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim b As New Collection
 End Sub";
 
@@ -27,15 +27,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new SelfAssignedDeclarationInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new SelfAssignedDeclarationInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -43,7 +41,7 @@ End Sub";
         public void SelfAssignedDeclaration_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim b As Collection
 End Sub";
 
@@ -53,15 +51,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new SelfAssignedDeclarationInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new SelfAssignedDeclarationInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -69,7 +65,7 @@ End Sub";
         public void SelfAssignedDeclaration_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     '@Ignore SelfAssignedDeclaration
     Dim b As New Collection
 End Sub";
@@ -80,15 +76,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new SelfAssignedDeclarationInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new SelfAssignedDeclarationInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/StopKeywordInspectionTests.cs
+++ b/RubberduckTests/Inspections/StopKeywordInspectionTests.cs
@@ -15,18 +15,20 @@ namespace RubberduckTests.Inspections
         public void StopKeyword_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Stop
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new StopKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new StopKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -34,17 +36,19 @@ End Sub";
         public void NoStopKeyword_NoResult()
         {
             var inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new StopKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new StopKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -52,19 +56,21 @@ End Sub";
         public void StopKeyword_Ignored_DoesNotReturnResult()
         {
             var inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 '@Ignore StopKeyword
     Stop
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -72,7 +78,7 @@ End Sub";
         public void StopKeywords_Ignored_ReturnsCorrectResults()
         {
             var inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Integer
     d = 0
     Stop
@@ -84,14 +90,16 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new StopKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new StopKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(1, inspectionResults.Count());
-            Assert.AreEqual(4, inspectionResults.First().QualifiedSelection.Selection.StartLine);
+                Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(4, inspectionResults.First().QualifiedSelection.Selection.StartLine);
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/UnassignedVariableUsageInspectionTests.cs
+++ b/RubberduckTests/Inspections/UnassignedVariableUsageInspectionTests.cs
@@ -15,19 +15,21 @@ namespace RubberduckTests.Inspections
         public void UnassignedVariableUsage_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim b As Boolean
     Dim bb As Boolean
     bb = b
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new UnassignedVariableUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new UnassignedVariableUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         // this test will eventually be removed once we can fire the inspection on a specific reference
@@ -36,7 +38,7 @@ End Sub";
         public void UnassignedVariableUsage_ReturnsSingleResult_MultipleReferences()
         {
             const string inputCode =
-@"Sub tester()
+                @"Sub tester()
     Dim myarr() As Variant
     Dim i As Long
 
@@ -53,12 +55,14 @@ End Sub
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new UnassignedVariableUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new UnassignedVariableUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -66,7 +70,7 @@ End Sub
         public void UnassignedVariableUsage_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim b As Boolean
     Dim bb As Boolean
     b = True
@@ -74,12 +78,14 @@ End Sub
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new UnassignedVariableUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new UnassignedVariableUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -87,7 +93,7 @@ End Sub";
         public void UnassignedVariableUsage_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     '@Ignore UnassignedVariableUsage
     Dim b As Boolean
     Dim bb As Boolean
@@ -96,12 +102,14 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new UnassignedVariableUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new UnassignedVariableUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -109,17 +117,19 @@ End Sub";
         public void UnassignedVariableUsage_NoResultIfNoReferences()
         {
             const string inputCode =
-@"Sub DoSomething()
+                @"Sub DoSomething()
     Dim foo
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new UnassignedVariableUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new UnassignedVariableUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/UndeclaredVariableInspectionTests.cs
+++ b/RubberduckTests/Inspections/UndeclaredVariableInspectionTests.cs
@@ -16,7 +16,7 @@ namespace RubberduckTests.Inspections
         public void UndeclaredVariable_ReturnsResult()
         {
             const string inputCode =
-@"Sub Test()
+                @"Sub Test()
     a = 42
     Debug.Print a
 End Sub";
@@ -27,15 +27,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UndeclaredVariableInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new UndeclaredVariableInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -43,7 +41,7 @@ End Sub";
         public void UndeclaredVariable_ReturnsNoResultIfDeclaredLocally()
         {
             const string inputCode =
-@"Sub Test()
+                @"Sub Test()
     Dim a As Long
     a = 42
     Debug.Print a
@@ -55,15 +53,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UndeclaredVariableInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new UndeclaredVariableInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -71,7 +67,7 @@ End Sub";
         public void UndeclaredVariable_ReturnsNoResultIfDeclaredModuleScope()
         {
             const string inputCode =
-@"Private a As Long
+                @"Private a As Long
             
 Sub Test()
     a = 42
@@ -84,15 +80,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UndeclaredVariableInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new UndeclaredVariableInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         //https://github.com/rubberduck-vba/Rubberduck/issues/2525
@@ -101,7 +95,7 @@ End Sub";
         public void UndeclaredVariable_ReturnsNoResultIfAnnotated()
         {
             const string inputCode =
-@"Sub Test()
+                @"Sub Test()
     '@Ignore UndeclaredVariable
     a = 42
     Debug.Print a
@@ -113,15 +107,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UndeclaredVariableInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new UndeclaredVariableInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
     }
 }

--- a/RubberduckTests/Inspections/UntypedFunctionUsageInspectionTests.cs
+++ b/RubberduckTests/Inspections/UntypedFunctionUsageInspectionTests.cs
@@ -34,16 +34,21 @@ End Sub";
             var vbe = builder.AddProject(project).Build();
 
             var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                GetBuiltInDeclarations().ForEach(d => state.AddDeclaration(d));
 
-            GetBuiltInDeclarations().ForEach(d => parser.State.AddDeclaration(d));
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new UntypedFunctionUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new UntypedFunctionUsageInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -63,16 +68,21 @@ End Sub";
             var vbe = builder.AddProject(project).Build();
 
             var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                GetBuiltInDeclarations().ForEach(d => state.AddDeclaration(d));
 
-            GetBuiltInDeclarations().ForEach(d => parser.State.AddDeclaration(d));
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new UntypedFunctionUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new UntypedFunctionUsageInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -95,16 +105,21 @@ End Sub";
             var vbe = builder.AddProject(project).Build();
 
             var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                GetBuiltInDeclarations().ForEach(d => state.AddDeclaration(d));
 
-            GetBuiltInDeclarations().ForEach(d => parser.State.AddDeclaration(d));
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new UntypedFunctionUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new UntypedFunctionUsageInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/UseMeaningfulNameInspectionTests.cs
+++ b/RubberduckTests/Inspections/UseMeaningfulNameInspectionTests.cs
@@ -27,14 +27,13 @@ End Sub
 ";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
 
-            var parser = MockParser.Create(vbe.Object);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+            using(var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UseMeaningfulNameInspection(state, GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults().Where(i => i.Target.DeclarationType == DeclarationType.LineLabel);
 
-            var inspection = new UseMeaningfulNameInspection(parser.State, GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults().Where(i => i.Target.DeclarationType == DeclarationType.LineLabel);
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -173,14 +172,13 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using(var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UseMeaningfulNameInspection(state, GetInspectionSettings().Object);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new UseMeaningfulNameInspection(parser.State, GetInspectionSettings().Object);
-            var inspectionResults = inspection.GetInspectionResults();
-            Assert.AreEqual(expectedCount, inspectionResults.Count());
+                Assert.AreEqual(expectedCount, inspectionResults.Count());
+            }
         }
 
         internal static Mock<IPersistanceService<CodeInspectionSettings>> GetInspectionSettings()

--- a/RubberduckTests/Inspections/VariableNotAssignedInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableNotAssignedInspectionTests.cs
@@ -14,17 +14,19 @@ namespace RubberduckTests.Inspections
         public void VariableNotAssigned_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 As String
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotAssignedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -32,18 +34,20 @@ End Sub";
         public void UnassignedVariable_ReturnsResult_MultipleVariables()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 As String
     Dim var2 As Date
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotAssignedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -51,18 +55,20 @@ End Sub";
         public void UnassignedVariable_DoesNotReturnResult()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
     Dim var1 as String
     var1 = ""test""
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotAssignedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -70,7 +76,7 @@ End Function";
         public void UnassignedVariable_ReturnsResult_MultipleVariables_SomeAssigned()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 as Integer
     var1 = 8
 
@@ -78,12 +84,14 @@ End Function";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotAssignedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -91,18 +99,20 @@ End Sub";
         public void VariableNotAssigned_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 '@Ignore VariableNotAssigned
 Dim var1 As String
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotAssignedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/VariableNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableNotUsedInspectionTests.cs
@@ -14,17 +14,19 @@ namespace RubberduckTests.Inspections
         public void VariableNotUsed_ReturnsResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 As String
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -32,18 +34,20 @@ End Sub";
         public void VariableNotUsed_ReturnsResult_MultipleVariables()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 As String
     Dim var2 As Date
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -51,7 +55,7 @@ End Sub";
         public void VariableUsed_DoesNotReturnResult()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
     Dim var1 as String
     var1 = ""test""
 
@@ -62,12 +66,14 @@ Sub Goo(ByVal arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -75,7 +81,7 @@ End Sub";
         public void VariableNotUsed_ReturnsResult_MultipleVariables_SomeAssigned()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 as Integer
     var1 = 8
 
@@ -88,12 +94,14 @@ Sub Goo(ByVal arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -101,18 +109,20 @@ End Sub";
         public void VariableNotUsed_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     '@Ignore VariableNotUsed
     Dim var1 As String
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -120,18 +130,20 @@ End Sub";
         public void VariableNotUsed_DoesNotReturnsResult_UsedInNameStatement()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 As String
     Name ""foo"" As var1
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/VariableTypeNotDeclaredInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableTypeNotDeclaredInspectionTests.cs
@@ -14,15 +14,17 @@ namespace RubberduckTests.Inspections
         public void VariableTypeNotDeclared_ReturnsResult_Parameter()
         {
             const string inputCode =
-@"Sub Foo(arg1)
+                @"Sub Foo(arg1)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -30,15 +32,17 @@ End Sub";
         public void VariableTypeNotDeclared_ReturnsResult_MultipleParams()
         {
             const string inputCode =
-@"Sub Foo(arg1, arg2)
+                @"Sub Foo(arg1, arg2)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -46,15 +50,17 @@ End Sub";
         public void VariableTypeNotDeclared_DoesNotReturnResult_Parameter()
         {
             const string inputCode =
-@"Sub Foo(arg1 As Date)
+                @"Sub Foo(arg1 As Date)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -62,15 +68,17 @@ End Sub";
         public void VariableTypeNotDeclared_ReturnsResult_SomeTypesNotDeclared_Parameters()
         {
             const string inputCode =
-@"Sub Foo(arg1, arg2 As String)
+                @"Sub Foo(arg1, arg2 As String)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -78,17 +86,19 @@ End Sub";
         public void VariableTypeNotDeclared_ReturnsResult_SomeTypesNotDeclared_Variables()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1
     Dim var2 As Date
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -96,16 +106,18 @@ End Sub";
         public void VariableTypeNotDeclared_ReturnsResult_Variable()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -113,17 +125,19 @@ End Sub";
         public void VariableTypeNotDeclared_ReturnsResult_MultipleVariables()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1
     Dim var2
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -131,16 +145,18 @@ End Sub";
         public void VariableTypeNotDeclared_DoesNotReturnResult_Variable()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 As Integer
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.AreEqual(0, inspectionResults.Count());
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -148,16 +164,18 @@ End Sub";
         public void VariableTypeNotDeclared_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore VariableTypeNotDeclared
+                @"'@Ignore VariableTypeNotDeclared
 Sub Foo(arg1)
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/Inspections/WriteOnlyPropertyInspectionTests.cs
+++ b/RubberduckTests/Inspections/WriteOnlyPropertyInspectionTests.cs
@@ -17,7 +17,7 @@ namespace RubberduckTests.Inspections
         public void WriteOnlyProperty_ReturnsResult_Let()
         {
             const string inputCode =
-@"Property Let Foo(value)
+                @"Property Let Foo(value)
 End Property";
 
             var builder = new MockVbeBuilder();
@@ -26,15 +26,13 @@ End Property";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new WriteOnlyPropertyInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -42,7 +40,7 @@ End Property";
         public void WriteOnlyProperty_ReturnsResult_Set()
         {
             const string inputCode =
-@"Property Set Foo(value)
+                @"Property Set Foo(value)
 End Property";
 
             var builder = new MockVbeBuilder();
@@ -51,15 +49,13 @@ End Property";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new WriteOnlyPropertyInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(1, inspectionResults.Count());
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -67,7 +63,7 @@ End Property";
         public void WriteOnlyProperty_ReturnsResult_LetAndSet()
         {
             const string inputCode =
-@"Property Let Foo(value)
+                @"Property Let Foo(value)
 End Property
 
 Property Set Foo(value)
@@ -79,15 +75,13 @@ End Property";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new WriteOnlyPropertyInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.AreEqual(2, inspectionResults.Count());
+                Assert.AreEqual(2, inspectionResults.Count());
+            }
         }
 
         [TestMethod]
@@ -95,7 +89,7 @@ End Property";
         public void WriteOnlyProperty_DoesNotReturnsResult_Get()
         {
             const string inputCode =
-@"Property Get Foo()
+                @"Property Get Foo()
 End Property";
 
             var builder = new MockVbeBuilder();
@@ -104,15 +98,13 @@ End Property";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new WriteOnlyPropertyInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -120,7 +112,7 @@ End Property";
         public void WriteOnlyProperty_DoesNotReturnsResult_GetAndLetAndSet()
         {
             const string inputCode =
-@"Property Get Foo()
+                @"Property Get Foo()
 End Property
 
 Property Let Foo(value)
@@ -135,15 +127,13 @@ End Property";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new WriteOnlyPropertyInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]
@@ -151,7 +141,7 @@ End Property";
         public void WriteOnlyProperty_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
-@"'@Ignore WriteOnlyProperty
+                @"'@Ignore WriteOnlyProperty
 Property Let Foo(value)
 End Property";
 
@@ -161,15 +151,13 @@ End Property";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-
-            var inspection = new WriteOnlyPropertyInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            Assert.IsFalse(inspectionResults.Any());
+                Assert.IsFalse(inspectionResults.Any());
+            }
         }
 
         [TestMethod]

--- a/RubberduckTests/IoCContainer/IoCRegistrationTests.cs
+++ b/RubberduckTests/IoCContainer/IoCRegistrationTests.cs
@@ -19,7 +19,10 @@ namespace RubberduckTests.IoCContainer
             var addin = new Mock<IAddIn>().Object;
             var initialSettings = new GeneralSettings {SourceControlEnabled = true};
 
-            var container = new WindsorContainer().Install(new RubberduckIoCInstaller(ide, addin, initialSettings));
+            using (var container =
+                new WindsorContainer().Install(new RubberduckIoCInstaller(ide, addin, initialSettings)))
+            {
+            }
 
             //This test does not need an assert because it tests that no exception has been thrown.
         }
@@ -32,7 +35,10 @@ namespace RubberduckTests.IoCContainer
             var addin = new Mock<IAddIn>().Object;
             var initialSettings = new GeneralSettings {SourceControlEnabled = false};
 
-            var container = new WindsorContainer().Install(new RubberduckIoCInstaller(ide, addin, initialSettings));
+            using (var container =
+                new WindsorContainer().Install(new RubberduckIoCInstaller(ide, addin, initialSettings)))
+            {
+            }
 
             //This test does not need an assert because it tests that no exception has been thrown.
         }

--- a/RubberduckTests/IoCContainer/IoCResolvingTests.cs
+++ b/RubberduckTests/IoCContainer/IoCResolvingTests.cs
@@ -25,16 +25,23 @@ namespace RubberduckTests.IoCContainer
             IWindsorContainer container = null;
             try
             {
-                container = new WindsorContainer().Install(new RubberduckIoCInstaller(ide, addin, initialSettings));
+                try
+                {
+                    container = new WindsorContainer().Install(new RubberduckIoCInstaller(ide, addin, initialSettings));
+                }
+                catch (Exception exception)
+                {
+                    Assert.Inconclusive($"Unable to register. {Environment.NewLine} {exception}");
+                }
+
+                var inspections = container.ResolveAll<IInspection>();
+
+                //This test does not need an assert because it tests that no exception has been thrown.
             }
-            catch(Exception exception)
+            finally
             {
-                Assert.Inconclusive($"Unable to register. {Environment.NewLine} {exception}");
+                container?.Dispose();
             }
-
-            var inspections = container.ResolveAll<IInspection>();
-
-            //This test does not need an assert because it tests that no exception has been thrown.
         }
 
         [TestMethod]
@@ -48,6 +55,8 @@ namespace RubberduckTests.IoCContainer
             IWindsorContainer container = null;
             try
             {
+                try
+            {
                 container = new WindsorContainer().Install(new RubberduckIoCInstaller(ide, addin, initialSettings));
             }
             catch (Exception exception)
@@ -57,7 +66,12 @@ namespace RubberduckTests.IoCContainer
 
             var state = container.ResolveAll<RubberduckParserState>();
 
-            //This test does not need an assert because it tests that no exception has been thrown.
+                //This test does not need an assert because it tests that no exception has been thrown.
+            }
+            finally
+            {
+                container?.Dispose();
+            }
         }
     }
 }

--- a/RubberduckTests/Mocks/MockParser.cs
+++ b/RubberduckTests/Mocks/MockParser.cs
@@ -12,8 +12,6 @@ using Rubberduck.VBEditor;
 using System.Globalization;
 using System.Reflection;
 using System.Threading;
-using Antlr4.Runtime;
-using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.PreProcessing;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;

--- a/RubberduckTests/PostProcessing/ModuleRewriterTests.cs
+++ b/RubberduckTests/PostProcessing/ModuleRewriterTests.cs
@@ -60,17 +60,18 @@ namespace RubberduckTests.PostProcessing
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
 
-            var parser = MockParser.Create(vbe);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var rewriter = state.GetRewriter(component);
+                rewriter.Rewrite();
+
+                Assert.AreEqual(content, rewriter.GetText());
             }
-
-            var rewriter = parser.State.GetRewriter(component);
-            rewriter.Rewrite();
-
-            Assert.AreEqual(content, rewriter.GetText());
         }
 
         [TestMethod]
@@ -84,25 +85,25 @@ Private foo As String
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-            
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No variable was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("No variable was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);            
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -116,25 +117,25 @@ Private Const foo As String = ""Something""
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No constant was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("No constant was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -152,25 +153,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No variable was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("No variable was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -188,26 +189,26 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No constant was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                var rewrittenCode = rewriter.GetText();
+                Assert.AreEqual(expected, rewrittenCode);
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("No constant was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            var rewrittenCode = rewriter.GetText();
-            Assert.AreEqual(expected, rewrittenCode);
         }
 
         [TestMethod]
@@ -224,25 +225,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Parameter);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No parameter was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Parameter);
-            if (target == null)
-            {
-                Assert.Inconclusive("No parameter was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -257,25 +258,25 @@ Public Event SomeEvent(ByVal foo As Long)
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Parameter);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No parameter was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Parameter);
-            if (target == null)
-            {
-                Assert.Inconclusive("No parameter was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -290,25 +291,25 @@ Declare PtrSafe Function Foo Lib ""Z"" Alias ""Y"" (ByVal bar As Long) As Long
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Parameter);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No parameter was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Parameter);
-            if (target == null)
-            {
-                Assert.Inconclusive("No parameter was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -327,25 +328,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No 'foo' variable was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("No 'foo' variable was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -364,25 +365,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No 'foo' constant was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("No 'foo' constant was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -399,25 +400,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Parameter);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No 'foo' parameter was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Parameter);
-            if (target == null)
-            {
-                Assert.Inconclusive("No 'foo' parameter was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -436,25 +437,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No variable was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("No variable was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -471,25 +472,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Parameter);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No parameter was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Parameter);
-            if (target == null)
-            {
-                Assert.Inconclusive("No parameter was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -508,25 +509,25 @@ End Sub
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No 'bar' constant was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("No 'bar' constant was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -542,25 +543,25 @@ Private foo _
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No variable was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("No variable was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -576,25 +577,25 @@ Private Const foo _
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("No constant was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("No constant was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -609,25 +610,25 @@ Private bar As Long
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target variable was not found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target variable was not found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -642,25 +643,25 @@ Private Const bar As Long = 42
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target constant was not found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "foo" && d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target constant was not found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -675,25 +676,25 @@ Private foo As String
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target variable was not found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target variable was not found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -708,25 +709,25 @@ Private Const foo As String = ""Something""
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target constant was not found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target constant was not found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -741,25 +742,25 @@ Private foo As String, buzz As Integer
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target variable was not found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target variable was not found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -774,25 +775,25 @@ Private Const foo As String = ""Something"", buzz As Integer = 12
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target constant was not found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target constant was not found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -810,25 +811,25 @@ Private foo As String, _
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target variable was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Variable);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target variable was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
 
         [TestMethod]
@@ -849,25 +850,25 @@ Private Const foo _
 ";
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(content, out component).Object;
-            var parser = MockParser.Create(vbe);
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status != ParserState.Ready)
+            using (var state = MockParser.CreateAndParse(vbe))
             {
-                Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                if (state.Status != ParserState.Ready)
+                {
+                    Assert.Inconclusive("Parser isn't ready. Test cannot proceed.");
+                }
+
+                var declarations = state.AllUserDeclarations;
+                var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
+                if (target == null)
+                {
+                    Assert.Inconclusive("Target constant was found in test code.");
+                }
+
+                var rewriter = state.GetRewriter(target);
+                rewriter.Remove(target);
+
+                Assert.AreEqual(expected, rewriter.GetText());
             }
-
-            var declarations = parser.State.AllUserDeclarations;
-            var target = declarations.SingleOrDefault(d => d.IdentifierName == "bar" && d.DeclarationType == DeclarationType.Constant);
-            if (target == null)
-            {
-                Assert.Inconclusive("Target constant was found in test code.");
-            }
-
-            var rewriter = parser.State.GetRewriter(target);
-            rewriter.Remove(target);
-
-            Assert.AreEqual(expected, rewriter.GetText());
         }
     }
 }

--- a/RubberduckTests/Preprocessing/VBAPreprocessorTests.cs
+++ b/RubberduckTests/Preprocessing/VBAPreprocessorTests.cs
@@ -50,15 +50,17 @@ namespace RubberduckTests.PreProcessing
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(code, out component);
             
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var tree = state.GetParseTree(new QualifiedModuleName(component));
-            var parsed = tree.GetText();
-            var withoutEOF = parsed;
-            while (withoutEOF.Length >= 5 && String.Equals(withoutEOF.Substring(withoutEOF.Length - 5, 5), "<EOF>"))
+            using(var state = MockParser.CreateAndParse(vbe.Object))
             {
-                withoutEOF = withoutEOF.Substring(0, withoutEOF.Length - 5);
+                var tree = state.GetParseTree(new QualifiedModuleName(component));
+                var parsed = tree.GetText();
+                var withoutEOF = parsed;
+                while (withoutEOF.Length >= 5 && String.Equals(withoutEOF.Substring(withoutEOF.Length - 5, 5), "<EOF>"))
+                {
+                    withoutEOF = withoutEOF.Substring(0, withoutEOF.Length - 5);
+                }
+                return withoutEOF;
             }
-            return withoutEOF;
         }
     }
 }

--- a/RubberduckTests/QuickFixes/ApplicationWorksheetFunctionQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ApplicationWorksheetFunctionQuickFixTests.cs
@@ -40,17 +40,22 @@ End Sub
             var vbe = builder.AddProject(project).Build();
 
             var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("Excel.1.8.xml");
 
-            parser.State.AddTestLibrary("Excel.1.8.xml");
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new ApplicationWorksheetFunctionQuickFix(parser.State).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, parser.State.GetRewriter(project.Object.VBComponents.First()).GetText());
+                new ApplicationWorksheetFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(project.Object.VBComponents.First()).GetText());
+            }
         }
 
         [TestMethod]
@@ -85,17 +90,22 @@ End Sub
             var vbe = builder.AddProject(project).Build();
 
             var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("Excel.1.8.xml");
 
-            parser.State.AddTestLibrary("Excel.1.8.xml");
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new ApplicationWorksheetFunctionQuickFix(parser.State).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, parser.State.GetRewriter(project.Object.VBComponents.First()).GetText());
+                new ApplicationWorksheetFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(project.Object.VBComponents.First()).GetText());
+            }
         }
 
         [TestMethod]
@@ -126,17 +136,22 @@ End Sub
             var vbe = builder.AddProject(project).Build();
 
             var parser = MockParser.Create(vbe.Object);
+            using (var state = parser.State)
+            {
+                state.AddTestLibrary("Excel.1.8.xml");
 
-            parser.State.AddTestLibrary("Excel.1.8.xml");
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                var inspection = new ApplicationWorksheetFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ApplicationWorksheetFunctionInspection(parser.State);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new ApplicationWorksheetFunctionQuickFix(parser.State).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, parser.State.GetRewriter(project.Object.VBComponents.First()).GetText());
+                new ApplicationWorksheetFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(project.Object.VBComponents.First()).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/AssignedByValParameterMakeLocalCopyQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AssignedByValParameterMakeLocalCopyQuickFixTests.cs
@@ -19,11 +19,11 @@ namespace RubberduckTests.QuickFixes
         public void AssignedByValParameter_LocalVariableAssignment()
         {
             var inputCode =
-@"Public Sub Foo(ByVal arg1 As String)
+                @"Public Sub Foo(ByVal arg1 As String)
     Let arg1 = ""test""
 End Sub";
             var expectedCode =
-@"Public Sub Foo(ByVal arg1 As String)
+                @"Public Sub Foo(ByVal arg1 As String)
 Dim localArg1 As String
 localArg1 = arg1
     Let localArg1 = ""test""
@@ -38,7 +38,7 @@ End Sub";
         public void AssignedByValParameter_LocalVariableAssignment_ComplexFormat()
         {
             var inputCode =
-            @"Sub DoSomething(_
+                @"Sub DoSomething(_
     ByVal foo As Long, _
     ByRef _
         bar, _
@@ -50,7 +50,7 @@ End Sub";
 End Sub
 ";
             var expectedCode =
-            @"Sub DoSomething(_
+                @"Sub DoSomething(_
     ByVal foo As Long, _
     ByRef _
         bar, _
@@ -73,15 +73,15 @@ End Sub
         public void AssignedByValParameter_LocalVariableAssignment_ComputedNameAvoidsCollision()
         {
             var inputCode =
-            @"
+                    @"
 Public Sub Foo(ByVal arg1 As String)
     Dim fooVar, _
         localArg1 As Long
     Let arg1 = ""test""
 End Sub"
-;
+                ;
             var expectedCode =
-@"
+                    @"
 Public Sub Foo(ByVal arg1 As String)
 Dim localArg12 As String
 localArg12 = arg1
@@ -89,7 +89,7 @@ localArg12 = arg1
         localArg1 As Long
     Let localArg12 = ""test""
 End Sub"
-            ;
+                ;
 
             var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
             Assert.AreEqual(expectedCode, quickFixResult);
@@ -101,7 +101,7 @@ End Sub"
         {
             //Make sure the modified code stays within the specific method under repair
             var inputCode =
-            @"
+                    @"
 Public Function Bar2(ByVal arg2 As String) As String
     Dim arg1 As String
     Let arg1 = ""Test1""
@@ -117,7 +117,7 @@ Public Sub Bar(ByVal arg2 As String)
     Dim arg1 As String
     Let arg1 = ""Test2""
 End Sub"
-;
+                ;
             string[] splitToken = { "'VerifyNoChangeBelowThisLine" };
             var expectedCode = inputCode.Split(splitToken, System.StringSplitOptions.None)[1];
 
@@ -133,7 +133,7 @@ End Sub"
         {
             //Make sure the modified code stays within the specific method under repair
             var inputCode =
-@"
+                @"
 Option Explicit
 Private mBar as Long
 Public Property Let Foo(ByVal bar As Long)
@@ -170,19 +170,19 @@ End Function
         public void AssignedByValParameter_LocalVariableAssignment_UsesSet()
         {
             var inputCode =
-            @"
+                    @"
 Public Sub Foo(ByVal target As Range)
     Set target = Selection
 End Sub"
-;
+                ;
             var expectedCode =
-@"
+                    @"
 Public Sub Foo(ByVal target As Range)
 Dim localTarget As Range
 Set localTarget = target
     Set localTarget = Selection
 End Sub"
-;
+                ;
 
             var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
             Assert.AreEqual(expectedCode, quickFixResult);
@@ -193,19 +193,19 @@ End Sub"
         public void AssignedByValParameter_LocalVariableAssignment_NoAsTypeClause()
         {
             var inputCode =
-@"
+                    @"
 Public Sub Foo(FirstArg As Long, ByVal arg1)
     arg1 = Range(""A1: C4"")
 End Sub"
-;
+                ;
             var expectedCode =
-@"
+                    @"
 Public Sub Foo(FirstArg As Long, ByVal arg1)
 Dim localArg1 As Variant
 localArg1 = arg1
     localArg1 = Range(""A1: C4"")
 End Sub"
-;
+                ;
 
             var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
             Assert.AreEqual(expectedCode, quickFixResult);
@@ -216,7 +216,7 @@ End Sub"
         public void AssignedByValParameter_LocalVariableAssignment_EnumType()
         {
             var inputCode =
-@"
+                    @"
 Enum TestEnum
     EnumOne
     EnumTwo
@@ -226,9 +226,9 @@ End Enum
 Public Sub Foo(FirstArg As Long, ByVal arg1 As TestEnum)
     arg1 = EnumThree
 End Sub"
-;
+                ;
             var expectedCode =
-@"
+                    @"
 Enum TestEnum
     EnumOne
     EnumTwo
@@ -240,7 +240,7 @@ Dim localArg1 As TestEnum
 localArg1 = arg1
     localArg1 = EnumThree
 End Sub"
-;
+                ;
 
             var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
             Assert.AreEqual(expectedCode, quickFixResult);
@@ -252,18 +252,20 @@ End Sub"
 
             var mockDialogFactory = BuildMockDialogFactory(userEnteredName);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new AssignedByValParameterInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-            var result = inspectionResults.FirstOrDefault();
-            if (result == null)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Inconclusive("Inspection yielded no results.");
-            }
 
-            new AssignedByValParameterMakeLocalCopyQuickFix(state, mockDialogFactory.Object).Fix(result);
-            return state.GetRewriter(vbe.Object.ActiveVBProject.VBComponents[0]).GetText();
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+                var result = inspectionResults.FirstOrDefault();
+                if (result == null)
+                {
+                    Assert.Inconclusive("Inspection yielded no results.");
+                }
+
+                new AssignedByValParameterMakeLocalCopyQuickFix(state, mockDialogFactory.Object).Fix(result);
+                return state.GetRewriter(vbe.Object.ActiveVBProject.VBComponents[0]).GetText();
+            }
         }
 
         private Mock<IVBE> BuildMockVBE(string inputCode)

--- a/RubberduckTests/QuickFixes/ChangeDimToPrivateQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ChangeDimToPrivateQuickFixTests.cs
@@ -16,20 +16,22 @@ namespace RubberduckTests.QuickFixes
         public void ModuleScopeDimKeyword_QuickFixWorks()
         {
             const string inputCode =
-@"Dim foo As String";
+                @"Dim foo As String";
 
             const string expectedCode =
-@"Private foo As String";
+                @"Private foo As String";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeDimToPrivateQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeDimToPrivateQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -37,22 +39,24 @@ namespace RubberduckTests.QuickFixes
         public void ModuleScopeDimKeyword_QuickFixWorks_SplitDeclaration()
         {
             const string inputCode =
-@"Dim _
+                @"Dim _
       foo As String";
 
             const string expectedCode =
-@"Private _
+                @"Private _
       foo As String";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeDimToPrivateQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeDimToPrivateQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -60,22 +64,24 @@ namespace RubberduckTests.QuickFixes
         public void ModuleScopeDimKeyword_QuickFixWorks_MultipleDeclarations()
         {
             const string inputCode =
-@"Dim foo As String, _
+                @"Dim foo As String, _
       bar As Integer";
 
             const string expectedCode =
-@"Private foo As String, _
+                @"Private foo As String, _
       bar As Integer";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ModuleScopeDimKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ModuleScopeDimKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeDimToPrivateQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeDimToPrivateQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/ChangeIntegerToLongQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ChangeIntegerToLongQuickFixTests.cs
@@ -16,22 +16,24 @@ namespace RubberduckTests.QuickFixes
         public void IntegerDataType_QuickFixWorks_Function()
         {
             const string inputCode =
-@"Function Foo() As Integer
+                @"Function Foo() As Integer
 End Function";
 
             const string expectedCode =
-@"Function Foo() As Long
+                @"Function Foo() As Long
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -39,22 +41,24 @@ End Function";
         public void IntegerDataType_QuickFixWorks_FunctionWithTypeHint()
         {
             const string inputCode =
-@"Function Foo%()
+                @"Function Foo%()
 End Function";
 
             const string expectedCode =
-@"Function Foo&()
+                @"Function Foo&()
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -62,22 +66,24 @@ End Function";
         public void IntegerDataType_QuickFixWorks_PropertyGet()
         {
             const string inputCode =
-@"Property Get Foo() As Integer
+                @"Property Get Foo() As Integer
 End Property";
 
             const string expectedCode =
-@"Property Get Foo() As Long
+                @"Property Get Foo() As Long
 End Property";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -85,22 +91,24 @@ End Property";
         public void IntegerDataType_QuickFixWorks_PropertyGetWithTypeHint()
         {
             const string inputCode =
-@"Property Get Foo%()
+                @"Property Get Foo%()
 End Property";
 
             const string expectedCode =
-@"Property Get Foo&()
+                @"Property Get Foo&()
 End Property";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -108,22 +116,24 @@ End Property";
         public void IntegerDataType_QuickFixWorks_Parameter()
         {
             const string inputCode =
-@"Sub Foo(arg As Integer)
+                @"Sub Foo(arg As Integer)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(arg As Long)
+                @"Sub Foo(arg As Long)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -131,22 +141,24 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_ParameterWithTypeHint()
         {
             const string inputCode =
-@"Sub Foo(arg%)
+                @"Sub Foo(arg%)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(arg&)
+                @"Sub Foo(arg&)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -154,24 +166,26 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_Variable()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim v As Integer
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim v As Long
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -179,24 +193,26 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_VariableWithTypeHint()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim v%
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim v&
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -204,24 +220,26 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_Constant()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Const c As Integer = 0
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Const c As Long = 0
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -229,24 +247,26 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_ConstantWithTypeHint()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Const c% = 0
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Const c& = 0
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -254,24 +274,26 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_UserDefinedTypeReservedNameMember()
         {
             const string inputCode =
-@"Type T
+                @"Type T
     i as Integer
 End Type";
 
             const string expectedCode =
-@"Type T
+                @"Type T
     i as Long
 End Type";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -279,24 +301,26 @@ End Type";
         public void IntegerDataType_QuickFixWorks_UserDefinedTypeUntypedNameMember()
         {
             const string inputCode =
-@"Type T
+                @"Type T
     i() as Integer
 End Type";
 
             const string expectedCode =
-@"Type T
+                @"Type T
     i() as Long
 End Type";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -304,21 +328,21 @@ End Type";
         public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementation()
         {
             const string inputCode1 =
-@"Function Foo() As Integer
+                @"Function Foo() As Integer
 End Function";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo() As Integer
 End Function";
 
             const string expectedCode1 =
-@"Function Foo() As Long
+                @"Function Foo() As Long
 End Function";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo() As Long
 End Function";
@@ -330,19 +354,21 @@ End Function";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -350,21 +376,21 @@ End Function";
         public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementationWithTypeHints()
         {
             const string inputCode1 =
-@"Function Foo%()
+                @"Function Foo%()
 End Function";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo%()
 End Function";
 
             const string expectedCode1 =
-@"Function Foo&()
+                @"Function Foo&()
 End Function";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo&()
 End Function";
@@ -376,19 +402,21 @@ End Function";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -396,21 +424,21 @@ End Function";
         public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementationWithInterfaceTypeHint()
         {
             const string inputCode1 =
-@"Function Foo%()
+                @"Function Foo%()
 End Function";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo() As Integer
 End Function";
 
             const string expectedCode1 =
-@"Function Foo&()
+                @"Function Foo&()
 End Function";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo() As Long
 End Function";
@@ -422,19 +450,21 @@ End Function";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -442,21 +472,21 @@ End Function";
         public void IntegerDataType_QuickFixWorks_FunctionInterfaceImplementationWithImplementationTypeHint()
         {
             const string inputCode1 =
-@"Function Foo() As Integer
+                @"Function Foo() As Integer
 End Function";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo%()
 End Function";
 
             const string expectedCode1 =
-@"Function Foo() As Long
+                @"Function Foo() As Long
 End Function";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Function IClass1_Foo&()
 End Function";
@@ -468,19 +498,21 @@ End Function";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -488,21 +520,21 @@ End Function";
         public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementation()
         {
             const string inputCode1 =
-@"Property Get Foo() As Integer
+                @"Property Get Foo() As Integer
 End Property";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo() As Integer
 End Property";
 
             const string expectedCode1 =
-@"Property Get Foo() As Long
+                @"Property Get Foo() As Long
 End Property";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo() As Long
 End Property";
@@ -514,19 +546,21 @@ End Property";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -534,21 +568,21 @@ End Property";
         public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementationWithTypeHints()
         {
             const string inputCode1 =
-@"Property Get Foo%()
+                @"Property Get Foo%()
 End Property";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo%()
 End Property";
 
             const string expectedCode1 =
-@"Property Get Foo&()
+                @"Property Get Foo&()
 End Property";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo&()
 End Property";
@@ -560,19 +594,21 @@ End Property";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -580,21 +616,21 @@ End Property";
         public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementationWithInterfaceTypeHint()
         {
             const string inputCode1 =
-@"Property Get Foo%()
+                @"Property Get Foo%()
 End Property";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo() As Integer
 End Property";
 
             const string expectedCode1 =
-@"Property Get Foo&()
+                @"Property Get Foo&()
 End Property";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo() As Long
 End Property";
@@ -606,19 +642,21 @@ End Property";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -626,21 +664,21 @@ End Property";
         public void IntegerDataType_QuickFixWorks_PropertyGetInterfaceImplementationWithImplementationTypeHint()
         {
             const string inputCode1 =
-@"Property Get Foo() As Integer
+                @"Property Get Foo() As Integer
 End Property";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo%()
 End Property";
 
             const string expectedCode1 =
-@"Property Get Foo() As Long
+                @"Property Get Foo() As Long
 End Property";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Property Get IClass1_Foo&()
 End Property";
@@ -652,19 +690,21 @@ End Property";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -672,21 +712,21 @@ End Property";
         public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithTypeHints()
         {
             const string inputCode1 =
-@"Sub Foo(arg1%)
+                @"Sub Foo(arg1%)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1%)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1&)
+                @"Sub Foo(arg1&)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1&)
 End Sub";
@@ -698,19 +738,21 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -718,21 +760,21 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithInterfaceTypeHint()
         {
             const string inputCode1 =
-@"Sub Foo(arg1%)
+                @"Sub Foo(arg1%)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1&)
+                @"Sub Foo(arg1&)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Long)
 End Sub";
@@ -744,19 +786,21 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -764,21 +808,21 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithImplementationTypeHint()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1%)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1 As Long)
+                @"Sub Foo(arg1 As Long)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1&)
 End Sub";
@@ -790,19 +834,21 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -810,21 +856,21 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1 As Long)
+                @"Sub Foo(arg1 As Long)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Long)
 End Sub";
@@ -836,19 +882,21 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -856,21 +904,21 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_ParameterInterfaceImplementationWithDifferentName()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg2 As Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1 As Long)
+                @"Sub Foo(arg1 As Long)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg2 As Long)
 End Sub";
@@ -882,19 +930,21 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
+                new ChangeIntegerToLongQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -902,21 +952,21 @@ End Sub";
         public void IntegerDataType_QuickFixWorks_MultipleParameterInterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer, arg2 as Integer)
+                @"Sub Foo(arg1 As Integer, arg2 as Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer, arg2 as Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1 As Long, arg2 as Integer)
+                @"Sub Foo(arg1 As Long, arg2 as Integer)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Long, arg2 as Integer)
 End Sub";
@@ -928,26 +978,28 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new IntegerDataTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new IntegerDataTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ChangeIntegerToLongQuickFix(state).Fix(
-                inspectionResults.First(
-                    result =>
-                        ((VBAParser.ArgContext)result.Context).unrestrictedIdentifier()
-                        .identifier()
-                        .untypedIdentifier()
-                        .identifierValue()
-                        .GetText() == "arg1"));
+                new ChangeIntegerToLongQuickFix(state).Fix(
+                    inspectionResults.First(
+                        result =>
+                            ((VBAParser.ArgContext)result.Context).unrestrictedIdentifier()
+                            .identifier()
+                            .untypedIdentifier()
+                            .identifierValue()
+                            .GetText() == "arg1"));
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/ChangeProcedureToFunctionQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ChangeProcedureToFunctionQuickFixTests.cs
@@ -17,23 +17,25 @@ namespace RubberduckTests.QuickFixes
         public void ProcedureShouldBeFunction_QuickFixWorks()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef arg1 As Integer)
+                @"Private Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string expectedCode =
-@"Private Function Foo(ByVal arg1 As Integer) As Integer
+                @"Private Function Foo(ByVal arg1 As Integer) As Integer
     Foo = arg1
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -41,23 +43,25 @@ End Function";
         public void ProcedureShouldBeFunction_QuickFixWorks_NoAsTypeClauseInParam()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef arg1)
+                @"Private Sub Foo(ByRef arg1)
 End Sub";
 
             const string expectedCode =
-@"Private Function Foo(ByVal arg1) As Variant
+                @"Private Function Foo(ByVal arg1) As Variant
     Foo = arg1
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -65,7 +69,7 @@ End Function";
         public void ProcedureShouldBeFunction_QuickFixWorks_DoesNotInterfereWithBody()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef arg1 As Integer)
+                @"Private Sub Foo(ByRef arg1 As Integer)
     arg1 = 6
     Goo arg1
 End Sub
@@ -74,7 +78,7 @@ Sub Goo(ByVal a As Integer)
 End Sub";
 
             const string expectedCode =
-@"Private Function Foo(ByVal arg1 As Integer) As Integer
+                @"Private Function Foo(ByVal arg1 As Integer) As Integer
     arg1 = 6
     Goo arg1
     Foo = arg1
@@ -84,14 +88,16 @@ Sub Goo(ByVal a As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -99,27 +105,29 @@ End Sub";
         public void ProcedureShouldBeFunction_QuickFixWorks_DoesNotInterfereWithBody_BodyOnSingleLine()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef arg1 As Integer): arg1 = 6: Goo arg1: End Sub
+                @"Private Sub Foo(ByRef arg1 As Integer): arg1 = 6: Goo arg1: End Sub
 
 Sub Goo(ByVal a As Integer)
 End Sub";
 
             const string expectedCode =
-@"Private Function Foo(ByVal arg1 As Integer) As Integer: arg1 = 6: Goo arg1:     Foo = arg1
+                @"Private Function Foo(ByVal arg1 As Integer) As Integer: arg1 = 6: Goo arg1:     Foo = arg1
 End Function
 
 Sub Goo(ByVal a As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -127,27 +135,29 @@ End Sub";
         public void ProcedureShouldBeFunction_QuickFixWorks_DoesNotInterfereWithBody_BodyOnSingleLine_BodyHasStringLiteralContainingColon()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef arg1 As Integer): arg1 = 6: Goo ""test: test"": End Sub
+                @"Private Sub Foo(ByRef arg1 As Integer): arg1 = 6: Goo ""test: test"": End Sub
 
 Sub Goo(ByVal a As String)
 End Sub";
 
             const string expectedCode =
-@"Private Function Foo(ByVal arg1 As Integer) As Integer: arg1 = 6: Goo ""test: test"":     Foo = arg1
+                @"Private Function Foo(ByVal arg1 As Integer) As Integer: arg1 = 6: Goo ""test: test"":     Foo = arg1
 End Function
 
 Sub Goo(ByVal a As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -155,7 +165,7 @@ End Sub";
         public void ProcedureShouldBeFunction_QuickFixWorks_UpdatesCallsAbove()
         {
             const string inputCode =
-@"Sub Goo(ByVal a As Integer)
+                @"Sub Goo(ByVal a As Integer)
     Dim fizz As Integer
     Foo fizz
 End Sub
@@ -164,7 +174,7 @@ Private Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string expectedCode =
-@"Sub Goo(ByVal a As Integer)
+                @"Sub Goo(ByVal a As Integer)
     Dim fizz As Integer
     fizz = Foo(fizz)
 End Sub
@@ -174,14 +184,16 @@ Private Function Foo(ByVal arg1 As Integer) As Integer
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -189,7 +201,7 @@ End Function";
         public void ProcedureShouldBeFunction_QuickFixWorks_UpdatesCallsBelow()
         {
             const string inputCode =
-@"Private Sub Foo(ByRef arg1 As Integer)
+                @"Private Sub Foo(ByRef arg1 As Integer)
 End Sub
 
 Sub Goo(ByVal a As Integer)
@@ -198,7 +210,7 @@ Sub Goo(ByVal a As Integer)
 End Sub";
 
             const string expectedCode =
-@"Private Function Foo(ByVal arg1 As Integer) As Integer
+                @"Private Function Foo(ByVal arg1 As Integer) As Integer
     Foo = arg1
 End Function
 
@@ -208,14 +220,16 @@ Sub Goo(ByVal a As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ChangeProcedureToFunctionQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/ConvertToProcedureQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ConvertToProcedureQuickFixTests.cs
@@ -15,7 +15,7 @@ namespace RubberduckTests.QuickFixes
         public void FunctionReturnValueNotUsed_QuickFixWorks_NoInterface()
         {
             const string inputCode =
-@"Public Function Foo(ByVal bar As String) As Boolean
+                @"Public Function Foo(ByVal bar As String) As Boolean
     If True Then
         Foo = _
         True
@@ -25,7 +25,7 @@ namespace RubberduckTests.QuickFixes
 End Function";
 
             const string expectedCode =
-@"Public Sub Foo(ByVal bar As String)
+                @"Public Sub Foo(ByVal bar As String)
     If True Then
         
     Else
@@ -34,13 +34,15 @@ End Function";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -48,7 +50,7 @@ End Sub";
         public void FunctionReturnValueNotUsed_QuickFixWorks_NoInterface_ManyBodyStatements()
         {
             const string inputCode =
-@"Function foo(ByRef fizz As Boolean) As Boolean
+                @"Function foo(ByRef fizz As Boolean) As Boolean
     fizz = True
     goo
 label1:
@@ -59,7 +61,7 @@ Sub goo()
 End Sub";
 
             const string expectedCode =
-@"Sub foo(ByRef fizz As Boolean)
+                @"Sub foo(ByRef fizz As Boolean)
     fizz = True
     goo
 label1:
@@ -70,13 +72,15 @@ Sub goo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -84,27 +88,27 @@ End Sub";
         public void FunctionReturnValueNotUsed_QuickFixWorks_Interface()
         {
             const string inputInterfaceCode =
-@"Public Function Test() As Integer
+                @"Public Function Test() As Integer
 End Function";
 
             const string expectedInterfaceCode =
-@"Public Sub Test()
+                @"Public Sub Test()
 End Sub";
 
             const string inputImplementationCode1 =
-@"Implements IFoo
+                @"Implements IFoo
 Public Function IFoo_Test() As Integer
     IFoo_Test = 42
 End Function";
 
             const string inputImplementationCode2 =
-@"Implements IFoo
+                @"Implements IFoo
 Public Function IFoo_Test() As Integer
     IFoo_Test = 42
 End Function";
 
             const string callSiteCode =
-@"
+                @"
 Public Function Baz()
     Dim testObj As IFoo
     Set testObj = new Bar
@@ -113,21 +117,23 @@ End Function";
 
             var builder = new MockVbeBuilder();
             var vbe = builder.ProjectBuilder("TestProject", ProjectProtection.Unprotected)
-                             .AddComponent("IFoo", ComponentType.ClassModule, inputInterfaceCode)
-                             .AddComponent("Bar", ComponentType.ClassModule, inputImplementationCode1)
-                             .AddComponent("Bar2", ComponentType.ClassModule, inputImplementationCode2)
-                             .AddComponent("TestModule", ComponentType.StandardModule, callSiteCode)
-                             .MockVbeBuilder().Build();
+                .AddComponent("IFoo", ComponentType.ClassModule, inputInterfaceCode)
+                .AddComponent("Bar", ComponentType.ClassModule, inputImplementationCode1)
+                .AddComponent("Bar2", ComponentType.ClassModule, inputImplementationCode2)
+                .AddComponent("TestModule", ComponentType.StandardModule, callSiteCode)
+                .MockVbeBuilder().Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new FunctionReturnValueNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new FunctionReturnValueNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
 
-            var component = vbe.Object.VBProjects[0].VBComponents[0];
-            Assert.AreEqual(expectedInterfaceCode, state.GetRewriter(component).GetText());
+                var component = vbe.Object.VBProjects[0].VBComponents[0];
+                Assert.AreEqual(expectedInterfaceCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -135,21 +141,23 @@ End Function";
         public void NonReturningFunction_QuickFixWorks_Function()
         {
             const string inputCode =
-@"Function Foo() As Boolean
+                @"Function Foo() As Boolean
 End Function";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -157,21 +165,23 @@ End Sub";
         public void GivenFunctionNameWithTypeHint_SubNameHasNoTypeHint()
         {
             const string inputCode =
-@"Function Foo$()
+                @"Function Foo$()
 End Function";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -179,21 +189,23 @@ End Sub";
         public void NonReturningFunction_QuickFixWorks_FunctionReturnsImplicitVariant()
         {
             const string inputCode =
-@"Function Foo()
+                @"Function Foo()
 End Function";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -201,21 +213,23 @@ End Sub";
         public void NonReturningFunction_QuickFixWorks_FunctionHasVariable()
         {
             const string inputCode =
-@"Function Foo(ByVal b As Boolean) As String
+                @"Function Foo(ByVal b As Boolean) As String
 End Function";
 
             const string expectedCode =
-@"Sub Foo(ByVal b As Boolean)
+                @"Sub Foo(ByVal b As Boolean)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -223,21 +237,23 @@ End Sub";
         public void GivenNonReturningPropertyGetter_QuickFixConvertsToSub()
         {
             const string inputCode =
-@"Property Get Foo() As Boolean
+                @"Property Get Foo() As Boolean
 End Property";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -245,21 +261,23 @@ End Sub";
         public void GivenNonReturningPropertyGetWithTypeHint_QuickFixDropsTypeHint()
         {
             const string inputCode =
-@"Property Get Foo$()
+                @"Property Get Foo$()
 End Property";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -267,21 +285,23 @@ End Sub";
         public void GivenImplicitVariantPropertyGetter_StillConvertsToSub()
         {
             const string inputCode =
-@"Property Get Foo()
+                @"Property Get Foo()
 End Property";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -289,21 +309,23 @@ End Sub";
         public void GivenParameterizedPropertyGetter_QuickFixKeepsParameter()
         {
             const string inputCode =
-@"Property Get Foo(ByVal b As Boolean) As String
+                @"Property Get Foo(ByVal b As Boolean) As String
 End Property";
 
             const string expectedCode =
-@"Sub Foo(ByVal b As Boolean)
+                @"Sub Foo(ByVal b As Boolean)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new NonReturningFunctionInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new NonReturningFunctionInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ConvertToProcedureQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/DeclareAsExplicitVariantQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/DeclareAsExplicitVariantQuickFixTests.cs
@@ -15,20 +15,22 @@ namespace RubberduckTests.QuickFixes
         public void VariableTypeNotDeclared_QuickFixWorks_Parameter()
         {
             const string inputCode =
-@"Sub Foo(arg1)
+                @"Sub Foo(arg1)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(arg1 As Variant)
+                @"Sub Foo(arg1 As Variant)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -36,20 +38,22 @@ End Sub";
         public void VariableTypeNotDeclared_QuickFixWorks_SubNameContainsParameterName()
         {
             const string inputCode =
-@"Sub Foo(Foo)
+                @"Sub Foo(Foo)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(Foo As Variant)
+                @"Sub Foo(Foo As Variant)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -57,22 +61,24 @@ End Sub";
         public void VariableTypeNotDeclared_QuickFixWorks_Variable()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim var1 As Variant
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -80,20 +86,22 @@ End Sub";
         public void VariableTypeNotDeclared_QuickFixWorks_ParameterWithoutDefaultValue()
         {
             const string inputCode =
-@"Sub Foo(ByVal Fizz)
+                @"Sub Foo(ByVal Fizz)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(ByVal Fizz As Variant)
+                @"Sub Foo(ByVal Fizz As Variant)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -101,20 +109,22 @@ End Sub";
         public void VariableTypeNotDeclared_QuickFixWorks_ParameterWithDefaultValue()
         {
             const string inputCode =
-@"Sub Foo(ByVal Fizz = False)
+                @"Sub Foo(ByVal Fizz = False)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(ByVal Fizz As Variant = False)
+                @"Sub Foo(ByVal Fizz As Variant = False)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableTypeNotDeclaredInspection(state);
-            new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableTypeNotDeclaredInspection(state);
+                new DeclareAsExplicitVariantQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/MakeSingleLineParamegerQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/MakeSingleLineParamegerQuickFixTests.cs
@@ -16,7 +16,7 @@ namespace RubberduckTests.QuickFixes
         public void MultilineParameter_QuickFixWorks()
         {
             const string inputCode =
-@"Public Sub Foo( _
+                @"Public Sub Foo( _
     ByVal _
     Var1 _
     As _
@@ -24,19 +24,20 @@ namespace RubberduckTests.QuickFixes
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo( _
+                @"Public Sub Foo( _
     ByVal Var1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MultilineParameterInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var inspection = new MultilineParameterInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            new MakeSingleLineParameterQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new MakeSingleLineParameterQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/MoveFieldCloserToUsageQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/MoveFieldCloserToUsageQuickFixTests.cs
@@ -16,25 +16,26 @@ namespace RubberduckTests.QuickFixes
         public void MoveFieldCloserToUsage_QuickFixWorks()
         {
             const string inputCode =
-@"Private bar As String
+                @"Private bar As String
 Public Sub Foo()
     bar = ""test""
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim bar As String
 bar = ""test""
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MoveFieldCloserToUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new MoveFieldCloserToUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new MoveFieldCloserToUsageQuickFix(state, new Mock<IMessageBox>().Object).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                new MoveFieldCloserToUsageQuickFix(state, new Mock<IMessageBox>().Object).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/OptionExplicitQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/OptionExplicitQuickFixTests.cs
@@ -22,14 +22,15 @@ namespace RubberduckTests.QuickFixes
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new OptionExplicitInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var inspection = new OptionExplicitInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            new OptionExplicitQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new OptionExplicitQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/PassParameterByReferenceQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/PassParameterByReferenceQuickFixTests.cs
@@ -165,18 +165,14 @@ End Sub
         private string ApplyPassParameterByReferenceQuickFixToVBAFragment(string inputCode)
         {
             var vbe = BuildMockVBEStandardModuleForVBAFragment(inputCode);
-            var inspectionResults = GetAssignedByValParameterInspectionResults(vbe.Object, out var state);
+            using(var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AssignedByValParameterInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new PassParameterByReferenceQuickFix(state).Fix(inspectionResults.First());
-            return state.GetRewriter(vbe.Object.ActiveVBProject.VBComponents[0]).GetText();
-        }
-
-        private IEnumerable<IInspectionResult> GetAssignedByValParameterInspectionResults(IVBE vbe, out RubberduckParserState state)
-        {
-            state = MockParser.CreateAndParse(vbe);
-
-            var inspection = new AssignedByValParameterInspection(state);
-            return inspection.GetInspectionResults();
+                new PassParameterByReferenceQuickFix(state).Fix(inspectionResults.First());
+                return state.GetRewriter(vbe.Object.ActiveVBProject.VBComponents[0]).GetText();
+            }
         }
 
         private Mock<IVBE> BuildMockVBEStandardModuleForVBAFragment(string inputCode)

--- a/RubberduckTests/QuickFixes/PassParameterByValueQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/PassParameterByValueQuickFixTests.cs
@@ -15,20 +15,22 @@ namespace RubberduckTests.QuickFixes
         public void ParameterCanBeByVal_QuickFixWorks_SubNameStartsWithParamName()
         {
             const string inputCode =
-@"Sub foo(f)
+                @"Sub foo(f)
 End Sub";
 
             const string expectedCode =
-@"Sub foo(ByVal f)
+                @"Sub foo(ByVal f)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -36,20 +38,22 @@ End Sub";
         public void ParameterCanBeByVal_QuickFixWorks_PassedByUnspecified()
         {
             const string inputCode =
-@"Sub Foo(arg1 As String)
+                @"Sub Foo(arg1 As String)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(ByVal arg1 As String)
+                @"Sub Foo(ByVal arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -57,20 +61,22 @@ End Sub";
         public void ParameterCanBeByVal_QuickFixWorks_PassedByRef()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As String)
+                @"Sub Foo(ByRef arg1 As String)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(ByVal arg1 As String)
+                @"Sub Foo(ByVal arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -78,22 +84,24 @@ End Sub";
         public void ParameterCanBeByVal_QuickFixWorks_PassedByUnspecified_MultilineParameter()
         {
             const string inputCode =
-@"Sub Foo( _
+                @"Sub Foo( _
 arg1 As String)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo( _
+                @"Sub Foo( _
 ByVal arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -101,22 +109,24 @@ End Sub";
         public void ParameterCanBeByVal_QuickFixWorks_PassedByRef_MultilineParameter()
         {
             const string inputCode =
-@"Sub Foo(ByRef _
+                @"Sub Foo(ByRef _
 arg1 As String)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(ByVal _
+                @"Sub Foo(ByVal _
 arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -125,32 +135,32 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByRef a As Integer, ByRef b As Integer)
+                @"Public Sub DoSomething(ByRef a As Integer, ByRef b As Integer)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByRef a As Integer, ByRef b As Integer)
     b = 42
 End Sub";
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByRef a As Integer, ByRef b As Integer)
 End Sub";
 
             //Expected
             const string expectedCode1 =
-@"Public Sub DoSomething(ByVal a As Integer, ByRef b As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer, ByRef b As Integer)
 End Sub";
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByRef b As Integer)
     b = 42
 End Sub";
             const string expectedCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByRef b As Integer)
 End Sub";
@@ -167,14 +177,16 @@ End Sub";
             var component3 = project.Object.VBComponents["Class2"];
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(component1).GetText());
-            Assert.AreEqual(expectedCode2, state.GetRewriter(component2).GetText());
-            Assert.AreEqual(expectedCode3, state.GetRewriter(component3).GetText());
+                Assert.AreEqual(expectedCode1, state.GetRewriter(component1).GetText());
+                Assert.AreEqual(expectedCode2, state.GetRewriter(component2).GetText());
+                Assert.AreEqual(expectedCode3, state.GetRewriter(component3).GetText());
+            }
         }
 
         [TestMethod]
@@ -183,30 +195,30 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByRef a As Integer, ByRef b As Integer)";
+                @"Public Event Foo(ByRef a As Integer, ByRef b As Integer)";
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef a As Integer, ByRef b As Integer)
     a = 42
 End Sub";
             const string inputCode3 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef a As Integer, ByRef b As Integer)
 End Sub";
 
             //Expected
             const string expectedCode1 =
-@"Public Event Foo(ByRef a As Integer, ByVal b As Integer)";
+                @"Public Event Foo(ByRef a As Integer, ByVal b As Integer)";
             const string expectedCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef a As Integer, ByVal b As Integer)
     a = 42
 End Sub";
             const string expectedCode3 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByRef a As Integer, ByVal b As Integer)
 End Sub";
@@ -223,14 +235,16 @@ End Sub";
             var component3 = project.Object.VBComponents["Class3"];
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(component1).GetText());
-            Assert.AreEqual(expectedCode2, state.GetRewriter(component2).GetText());
-            Assert.AreEqual(expectedCode3, state.GetRewriter(component3).GetText());
+                Assert.AreEqual(expectedCode1, state.GetRewriter(component1).GetText());
+                Assert.AreEqual(expectedCode2, state.GetRewriter(component2).GetText());
+                Assert.AreEqual(expectedCode3, state.GetRewriter(component3).GetText());
+            }
         }
 
         //https://github.com/rubberduck-vba/Rubberduck/issues/2408
@@ -239,22 +253,24 @@ End Sub";
         public void ParameterCanBeByVal_QuickFixWithOptionalWorks()
         {
             const string inputCode =
-@"Sub Test(Optional foo As String = ""bar"")
+                @"Sub Test(Optional foo As String = ""bar"")
     Debug.Print foo
 End Sub";
 
             const string expectedCode =
-@"Sub Test(Optional ByVal foo As String = ""bar"")
+                @"Sub Test(Optional ByVal foo As String = ""bar"")
     Debug.Print foo
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         //https://github.com/rubberduck-vba/Rubberduck/issues/2408
@@ -263,22 +279,24 @@ End Sub";
         public void ParameterCanBeByVal_QuickFixWithOptionalByRefWorks()
         {
             const string inputCode =
-@"Sub Test(Optional ByRef foo As String = ""bar"")
+                @"Sub Test(Optional ByRef foo As String = ""bar"")
     Debug.Print foo
 End Sub";
 
             const string expectedCode =
-@"Sub Test(Optional ByVal foo As String = ""bar"")
+                @"Sub Test(Optional ByVal foo As String = ""bar"")
     Debug.Print foo
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         //https://github.com/rubberduck-vba/Rubberduck/issues/2408
@@ -287,7 +305,7 @@ End Sub";
         public void ParameterCanBeByVal_QuickFixWithOptional_LineContinuationsWorks()
         {
             const string inputCode =
-@"Sub foo(Optional _
+                @"Sub foo(Optional _
   ByRef _
   foo _
   As _
@@ -297,7 +315,7 @@ End Sub";
 End Sub";
 
             const string expectedCode =
-@"Sub foo(Optional _
+                @"Sub foo(Optional _
   ByVal _
   foo _
   As _
@@ -307,12 +325,14 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ParameterCanBeByValInspection(state);
-            new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new ParameterCanBeByValInspection(state);
+                new PassParameterByValueQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/QuickFixBaseTests.cs
+++ b/RubberduckTests/QuickFixes/QuickFixBaseTests.cs
@@ -14,12 +14,13 @@ namespace RubberduckTests.QuickFixes
         public void QuickFixBase_Register()
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var quickFix = new RemoveCommentQuickFix(state);
+                quickFix.RegisterInspections(typeof(EmptyStringLiteralInspection));
 
-            var quickFix = new RemoveCommentQuickFix(state);
-            quickFix.RegisterInspections(typeof(EmptyStringLiteralInspection));
-
-            Assert.IsTrue(quickFix.SupportedInspections.Contains(typeof(EmptyStringLiteralInspection)));
+                Assert.IsTrue(quickFix.SupportedInspections.Contains(typeof(EmptyStringLiteralInspection)));
+            }
         }
 
         [TestMethod]
@@ -27,12 +28,13 @@ namespace RubberduckTests.QuickFixes
         public void QuickFixBase_Unregister()
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(string.Empty, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var quickFix = new RemoveCommentQuickFix(state);
+                quickFix.RemoveInspections(quickFix.SupportedInspections.ToArray());
 
-            var quickFix = new RemoveCommentQuickFix(state);
-            quickFix.RemoveInspections(quickFix.SupportedInspections.ToArray());
-
-            Assert.IsFalse(quickFix.SupportedInspections.Any());
+                Assert.IsFalse(quickFix.SupportedInspections.Any());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/QuickFixProviderTests.cs
+++ b/RubberduckTests/QuickFixes/QuickFixProviderTests.cs
@@ -18,18 +18,20 @@ namespace RubberduckTests.QuickFixes
         public void ProviderDoesNotKnowAboutInspection()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var quickFixProvider = new QuickFixProvider(state, new IQuickFix[] { });
-            Assert.AreEqual(0, quickFixProvider.QuickFixes(inspectionResults.First()).Count());
+                var quickFixProvider = new QuickFixProvider(state, new IQuickFix[] { });
+                Assert.AreEqual(0, quickFixProvider.QuickFixes(inspectionResults.First()).Count());
+            }
         }
 
         [TestMethod]
@@ -37,20 +39,22 @@ End Sub";
         public void ProviderKnowsAboutInspection()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim str As String
     str = """"
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyStringLiteralInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyStringLiteralInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var quickFixProvider = new QuickFixProvider(state, new IQuickFix[] { new ReplaceEmptyStringLiteralStatementQuickFix(state) });
-            Assert.AreEqual(1, quickFixProvider.QuickFixes(inspectionResults.First()).Count());
+                var quickFixProvider = new QuickFixProvider(state, new IQuickFix[] { new ReplaceEmptyStringLiteralStatementQuickFix(state) });
+                Assert.AreEqual(1, quickFixProvider.QuickFixes(inspectionResults.First()).Count());
+            }
         }
 
         [TestMethod]
@@ -58,22 +62,24 @@ End Sub";
         public void ResultDisablesFix()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var quickFixProvider = new QuickFixProvider(state, new IQuickFix[] { new RemoveUnusedDeclarationQuickFix(state) });
+                var quickFixProvider = new QuickFixProvider(state, new IQuickFix[] { new RemoveUnusedDeclarationQuickFix(state) });
 
-            var result = inspectionResults.First();
-            result.Properties.Add("DisableFixes", nameof(RemoveUnusedDeclarationQuickFix));
+                var result = inspectionResults.First();
+                result.Properties.Add("DisableFixes", nameof(RemoveUnusedDeclarationQuickFix));
 
-            Assert.AreEqual(0, quickFixProvider.QuickFixes(result).Count());
+                Assert.AreEqual(0, quickFixProvider.QuickFixes(result).Count());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/RemoveCommentQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveCommentQuickFixTests.cs
@@ -16,20 +16,22 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteCommentSyntax_QuickFixWorks_RemoveComment()
         {
             const string inputCode =
-@"Rem test1";
+                @"Rem test1";
 
             const string expectedCode =
-@"";
+                @"";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -37,21 +39,23 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteCommentSyntax_QuickFixWorks_RemoveCommentHasContinuation()
         {
             const string inputCode =
-@"Rem test1 _
+                @"Rem test1 _
 continued";
 
             const string expectedCode =
-@"";
+                @"";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -59,20 +63,22 @@ continued";
         public void ObsoleteCommentSyntax_QuickFixWorks_RemoveComment_LineHasCode()
         {
             const string inputCode =
-@"Dim Foo As Integer: Rem This is a comment";
+                @"Dim Foo As Integer: Rem This is a comment";
 
             const string expectedCode =
-@"Dim Foo As Integer: ";
+                @"Dim Foo As Integer: ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -80,21 +86,23 @@ continued";
         public void ObsoleteCommentSyntax_QuickFixWorks_RemoveComment_LineHasCodeAndContinuation()
         {
             const string inputCode =
-@"Dim Foo As Integer: Rem This is _
+                @"Dim Foo As Integer: Rem This is _
 a comment";
 
             const string expectedCode =
-@"Dim Foo As Integer: ";
+                @"Dim Foo As Integer: ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveCommentQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveEmptyIfBlockQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveEmptyIfBlockQuickFixTests.cs
@@ -16,25 +16,27 @@ namespace RubberduckTests.QuickFixes
         public void EmptyIfBlock_QuickFixRemovesLoneIf()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -42,7 +44,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesSingleLineIf()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then Else Bar
 End Sub
 
@@ -50,7 +52,7 @@ Sub Bar()
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If Not True Then Bar
 End Sub
 
@@ -58,15 +60,17 @@ Sub Bar()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -74,26 +78,28 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesLoneIf_WithComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         ' Im a comment
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -101,7 +107,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesIf_WithElseIfAndElse()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     ElseIf False Then
         Dim d
@@ -112,7 +118,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If False Then
         Dim d
         d = 0
@@ -123,15 +129,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -139,7 +147,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElseIf()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
         d = 0
@@ -150,7 +158,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
         d = 0
@@ -161,15 +169,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -177,7 +187,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElseIf_HasComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
         d = 0
@@ -189,7 +199,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
         d = 0
@@ -200,15 +210,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -216,7 +228,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesIf_HasVariable()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
     Else
@@ -225,7 +237,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If Not True Then
         
@@ -235,15 +247,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -251,7 +265,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesIf_HasVariable_WithComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         ' comment
         Dim d
@@ -261,7 +275,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d
     If Not True Then
         ' comment
@@ -272,15 +286,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -288,7 +304,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesIf_HasVariable_WithLabel()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
 5       Dim d
 a:      Dim e
@@ -299,7 +315,7 @@ a:      Dim e
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     
 5       Dim d
 a:      Dim e
@@ -312,16 +328,18 @@ a:      Dim e
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            var rewrittenCode = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, rewrittenCode);
+                var rewrittenCode = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, rewrittenCode);
+            }
         }
 
         [TestMethod]
@@ -329,7 +347,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesIf_HasConst()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Const d = 0
     Else
@@ -338,7 +356,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Const d = 0
     If Not True Then
         
@@ -348,16 +366,18 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            var rewrittenCode = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, rewrittenCode);
+                var rewrittenCode = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, rewrittenCode);
+            }
         }
 
         [TestMethod]
@@ -365,7 +385,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElseIf_HasVariable()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim d
         d = 0
@@ -374,7 +394,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim b
     If True Then
         Dim d
@@ -383,15 +403,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -399,7 +421,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElseIf_HasConst()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Dim b
         b = 0
@@ -408,7 +430,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Const d = 0
     If True Then
         Dim b
@@ -417,15 +439,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -433,7 +457,7 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesIf_UpdatesElseIf()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     ElseIf False Then
         Dim d
@@ -441,7 +465,7 @@ End Sub";
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If False Then
         Dim d
         d = 0
@@ -449,15 +473,17 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -465,28 +491,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_SimpleCondition()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If Not True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -494,28 +522,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_Equals()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True = True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True <> True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -523,28 +553,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_NotEquals()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True <> True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True = True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -552,28 +584,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_LessThan()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True < True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True >= True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -581,28 +615,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_LessThanEquals()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True <= True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True > True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -610,28 +646,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_GreaterThan()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True > True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True <= True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -639,28 +677,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_GreaterThanEquals()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True >= True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True < True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -668,28 +708,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_Not()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If Not True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -697,28 +739,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_Not_NoWhitespace()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If Not(True) Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If (True) Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -726,28 +770,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_And()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True And True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Or True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -755,28 +801,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_Or()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Or True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True And True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -784,28 +832,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_Xor()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Xor True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If Not (True Xor True) Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -813,28 +863,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_ComplexCondition()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Or True And True Or True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Or True And True And True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -842,28 +894,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_ComplexCondition1()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True And True Or True And True Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True And True And True And True Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -871,28 +925,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_ComplexCondition_WithParentheses()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If (True Or True) And (True Or True) Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If (True Or True) Or (True Or True) Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -900,28 +956,30 @@ End Sub";
         public void EmptyIfBlock_QuickFixRemovesElse_InvertsIf_ComplexCondition2()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If 1 > 2 And 3 = 3 Or 4 <> 5 And 8 - 6 = 2 Then
     Else
     End If
 End Sub";
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     If 1 > 2 And 3 = 3 And 4 <> 5 And 8 - 6 = 2 Then
     
     End If
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new EmptyIfBlockInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new EmptyIfBlockInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
+                new RemoveEmptyIfBlockQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/RemoveExplicitByRefModifierQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveExplicitByRefModifierQuickFixTests.cs
@@ -20,23 +20,25 @@ namespace RubberduckTests.QuickFixes
         public void RedundantByRefModifier_QuickFixWorks_OptionalParameter()
         {
             const string inputCode =
-@"Sub Foo(Optional ByRef arg1 As Integer)
+                @"Sub Foo(Optional ByRef arg1 As Integer)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(Optional arg1 As Integer)
+                @"Sub Foo(Optional arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -44,29 +46,31 @@ End Sub";
         public void RedundantByRefModifier_QuickFixWorks_Optional_LineContinuations()
         {
             const string inputCode =
-@"Sub Foo(Optional ByRef _
+                @"Sub Foo(Optional ByRef _
         bar _
         As Byte)
     bar = 1
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(Optional _
+                @"Sub Foo(Optional _
         bar _
         As Byte)
     bar = 1
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -74,27 +78,29 @@ End Sub";
         public void RedundantByRefModifier_QuickFixWorks_LineContinuation()
         {
             const string inputCode =
-@"Sub Foo( ByRef bar _
+                @"Sub Foo( ByRef bar _
         As Byte)
     bar = 1
 End Sub";
 
             const string expectedCode =
-@"Sub Foo( bar _
+                @"Sub Foo( bar _
         As Byte)
     bar = 1
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -102,29 +108,31 @@ End Sub";
         public void RedundantByRefModifier_QuickFixWorks_LineContinuation_FirstLine()
         {
             const string inputCode =
-@"Sub Foo( _
+                @"Sub Foo( _
         ByRef bar _
         As Byte)
     bar = 1
 End Sub";
 
             const string expectedCode =
-@"Sub Foo( _
+                @"Sub Foo( _
         bar _
         As Byte)
     bar = 1
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -132,21 +140,21 @@ End Sub";
         public void RedundantByRefModifier_QuickFixWorks_InterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer)
 End Sub";
@@ -158,20 +166,22 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -179,21 +189,21 @@ End Sub";
         public void RedundantByRefModifier_QuickFixWorks_InterfaceImplementationDiffrentParameterName()
         {
             const string inputCode1 =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg2 As Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg2 As Integer)
 End Sub";
@@ -205,20 +215,22 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -226,21 +238,21 @@ End Sub";
         public void RedundantByRefModifier_QuickFixWorks_InterfaceImplementationWithMultipleParameters()
         {
             const string inputCode1 =
-@"Sub Foo(ByRef arg1 As Integer, ByRef arg2 as Integer)
+                @"Sub Foo(ByRef arg1 As Integer, ByRef arg2 as Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg1 As Integer, ByRef arg2 as Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(arg1 As Integer, ByRef arg2 as Integer)
+                @"Sub Foo(arg1 As Integer, ByRef arg2 as Integer)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer, ByRef arg2 as Integer)
 End Sub";
@@ -252,27 +264,29 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(
-                inspectionResults.First(
-                    result =>
-                        ((VBAParser.ArgContext)result.Context).unrestrictedIdentifier()
-                        .identifier()
-                        .untypedIdentifier()
-                        .identifierValue()
-                        .GetText() == "arg1"));
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(
+                    inspectionResults.First(
+                        result =>
+                            ((VBAParser.ArgContext)result.Context).unrestrictedIdentifier()
+                            .identifier()
+                            .untypedIdentifier()
+                            .identifierValue()
+                            .GetText() == "arg1"));
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -280,23 +294,25 @@ End Sub";
         public void RedundantByRefModifier_QuickFixWorks_PassByRef()
         {
             const string inputCode =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantByRefModifierInspection(state) { Severity = CodeInspectionSeverity.Hint };
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new RemoveExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveExplicitCallStatementQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveExplicitCallStatementQuickFixTests.cs
@@ -16,7 +16,7 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteCallStatement_QuickFixWorks_RemoveCallStatement()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Call Goo(1, ""test"")
 End Sub
 
@@ -25,7 +25,7 @@ Sub Goo(arg1 As Integer, arg1 As String)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Goo 1, ""test""
 End Sub
 
@@ -34,19 +34,20 @@ Sub Goo(arg1 As Integer, arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteCallStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            var fix = new RemoveExplicitCallStatmentQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
+                var inspection = new ObsoleteCallStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var fix = new RemoveExplicitCallStatmentQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveExplicitLetStatementQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveExplicitLetStatementQuickFixTests.cs
@@ -17,7 +17,7 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteLetStatement_QuickFixWorks()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
     Dim var2 As Integer
     
@@ -25,7 +25,7 @@ namespace RubberduckTests.QuickFixes
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
     Dim var2 As Integer
     
@@ -33,14 +33,15 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ObsoleteLetStatementInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            var inspection = new ObsoleteLetStatementInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-            new RemoveExplicitLetStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveExplicitLetStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveOptionBaseStatementQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveOptionBaseStatementQuickFixTests.cs
@@ -19,14 +19,16 @@ namespace RubberduckTests.QuickFixes
             var expectedCode = string.Empty;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantOptionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantOptionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -34,21 +36,23 @@ namespace RubberduckTests.QuickFixes
         public void OptionBaseZeroStatement_QuickFixWorks_RemoveStatement_MultipleLines()
         {
             var inputCode =
-@"Option _
+                @"Option _
 Base _
 0";
 
             var expectedCode = string.Empty;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantOptionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantOptionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -60,14 +64,16 @@ Base _
             var expectedCode = "Option Explicit: : Option Base 1";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantOptionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantOptionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -75,21 +81,23 @@ Base _
         public void OptionBaseZeroStatement_QuickFixWorks_RemoveStatement_InstructionSeparatorAndMultipleLines()
         {
             var inputCode =
-@"Option Explicit: Option _
+                @"Option Explicit: Option _
 Base _
 0: Option Base 1";
 
             var expectedCode = "Option Explicit: : Option Base 1";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new RedundantOptionInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new RedundantOptionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveOptionBaseStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveStopKeywordQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveStopKeywordQuickFixTests.cs
@@ -17,24 +17,26 @@ namespace RubberduckTests.QuickFixes
         public void StopKeyword_QuickFixWorks_RemoveKeyword()
         {
             var inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Stop
 End Sub";
 
             var expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new StopKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-            
-            new RemoveStopKeywordQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new StopKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                new RemoveStopKeywordQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -46,14 +48,16 @@ End Sub";
             var expectedCode = "Sub Foo(): : End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new StopKeywordInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new StopKeywordInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new RemoveStopKeywordQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveStopKeywordQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveTypeHintsQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveTypeHintsQuickFixTests.cs
@@ -15,24 +15,26 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteTypeHint_QuickFixWorks_Field_LongTypeHint()
         {
             const string inputCode =
-@"Public Foo&";
+                @"Public Foo&";
 
             const string expectedCode =
-@"Public Foo As Long";
+                @"Public Foo As Long";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -40,24 +42,26 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteTypeHint_QuickFixWorks_Field_IntegerTypeHint()
         {
             const string inputCode =
-@"Public Foo%";
+                @"Public Foo%";
 
             const string expectedCode =
-@"Public Foo As Integer";
+                @"Public Foo As Integer";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -65,24 +69,26 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteTypeHint_QuickFixWorks_Field_DoubleTypeHint()
         {
             const string inputCode =
-@"Public Foo#";
+                @"Public Foo#";
 
             const string expectedCode =
-@"Public Foo As Double";
+                @"Public Foo As Double";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -90,24 +96,26 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteTypeHint_QuickFixWorks_Field_SingleTypeHint()
         {
             const string inputCode =
-@"Public Foo!";
+                @"Public Foo!";
 
             const string expectedCode =
-@"Public Foo As Single";
+                @"Public Foo As Single";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -115,24 +123,26 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteTypeHint_QuickFixWorks_Field_DecimalTypeHint()
         {
             const string inputCode =
-@"Public Foo@";
+                @"Public Foo@";
 
             const string expectedCode =
-@"Public Foo As Decimal";
+                @"Public Foo As Decimal";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -140,24 +150,26 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteTypeHint_QuickFixWorks_Field_StringTypeHint()
         {
             const string inputCode =
-@"Public Foo$";
+                @"Public Foo$";
 
             const string expectedCode =
-@"Public Foo As String";
+                @"Public Foo As String";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -165,28 +177,30 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteTypeHint_QuickFixWorks_Function_StringTypeHint()
         {
             const string inputCode =
-@"Public Function Foo$(ByVal fizz As Integer)
+                @"Public Function Foo$(ByVal fizz As Integer)
     Foo = ""test""
 End Function";
 
             const string expectedCode =
-@"Public Function Foo(ByVal fizz As Integer) As String
+                @"Public Function Foo(ByVal fizz As Integer) As String
     Foo = ""test""
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -194,28 +208,30 @@ End Function";
         public void ObsoleteTypeHint_QuickFixWorks_PropertyGet_StringTypeHint()
         {
             const string inputCode =
-@"Public Property Get Foo$(ByVal fizz As Integer)
+                @"Public Property Get Foo$(ByVal fizz As Integer)
     Foo = ""test""
 End Property";
 
             const string expectedCode =
-@"Public Property Get Foo(ByVal fizz As Integer) As String
+                @"Public Property Get Foo(ByVal fizz As Integer) As String
     Foo = ""test""
 End Property";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -223,28 +239,30 @@ End Property";
         public void ObsoleteTypeHint_QuickFixWorks_Parameter_StringTypeHint()
         {
             const string inputCode =
-@"Public Sub Foo(ByVal fizz$)
+                @"Public Sub Foo(ByVal fizz$)
     Foo = ""test""
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo(ByVal fizz As String)
+                @"Public Sub Foo(ByVal fizz As String)
     Foo = ""test""
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -252,28 +270,30 @@ End Sub";
         public void ObsoleteTypeHint_QuickFixWorks_Variable_StringTypeHint()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim buzz$
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim buzz As String
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -281,28 +301,30 @@ End Sub";
         public void ObsoleteTypeHint_QuickFixWorks_Constant_StringTypeHint()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const buzz$ = """"
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const buzz As String = """"
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObsoleteTypeHintInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            var fix = new RemoveTypeHintsQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObsoleteTypeHintInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                var fix = new RemoveTypeHintsQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveUnassignedIdentifierQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveUnassignedIdentifierQuickFixTests.cs
@@ -14,21 +14,23 @@ namespace RubberduckTests.QuickFixes
         public void UnassignedVariable_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 as Integer
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            new RemoveUnassignedIdentifierQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotAssignedInspection(state);
+                new RemoveUnassignedIdentifierQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -36,7 +38,7 @@ End Sub";
         public void UnassignedVariable_VariableOnMultipleLines_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim _
 var1 _
 as _
@@ -44,16 +46,18 @@ Integer
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            new RemoveUnassignedIdentifierQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotAssignedInspection(state);
+                new RemoveUnassignedIdentifierQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -61,24 +65,25 @@ End Sub";
         public void UnassignedVariable_MultipleVariablesOnSingleLine_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As Integer, var2 As Boolean
 End Sub";
 
-            // note the extra space after "Integer"--the VBE will remove it
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As Integer
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            new RemoveUnassignedIdentifierQuickFix(state).Fix(
-                inspection.GetInspectionResults().Single(s => s.Target.IdentifierName == "var2"));
+                var inspection = new VariableNotAssignedInspection(state);
+                new RemoveUnassignedIdentifierQuickFix(state).Fix(
+                    inspection.GetInspectionResults().Single(s => s.Target.IdentifierName == "var2"));
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -86,24 +91,26 @@ End Sub";
         public void UnassignedVariable_MultipleVariablesOnMultipleLines_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As Integer, _
 var2 As Boolean
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As Integer
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotAssignedInspection(state);
-            new RemoveUnassignedIdentifierQuickFix(state).Fix(
-                inspection.GetInspectionResults().Single(s => s.Target.IdentifierName == "var2"));
+                var inspection = new VariableNotAssignedInspection(state);
+                new RemoveUnassignedIdentifierQuickFix(state).Fix(
+                    inspection.GetInspectionResults().Single(s => s.Target.IdentifierName == "var2"));
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/RemoveUnassignedVariableUsageQuickFix.cs
+++ b/RubberduckTests/QuickFixes/RemoveUnassignedVariableUsageQuickFix.cs
@@ -29,13 +29,14 @@ End Sub";
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new UnassignedVariableUsageInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new UnassignedVariableUsageInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new RemoveUnassignedVariableUsageQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new RemoveUnassignedVariableUsageQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/RemoveUnusedDeclarationQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveUnusedDeclarationQuickFixTests.cs
@@ -14,25 +14,27 @@ namespace RubberduckTests.QuickFixes
         public void ConstantNotUsed_QuickFixWorks()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 Const const1 As Integer = 9
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ConstantNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ConstantNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspectionResults.First());
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspectionResults.First());
 
-            var rewriter = state.GetRewriter(component);
-            var rewrittenCode = rewriter.GetText();
-            Assert.AreEqual(expectedCode, rewrittenCode);
+                var rewriter = state.GetRewriter(component);
+                var rewrittenCode = rewriter.GetText();
+                Assert.AreEqual(expectedCode, rewrittenCode);
+            }
         }
 
 
@@ -41,23 +43,25 @@ End Sub";
         public void LabelNotUsed_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 label1:
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new LineLabelNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -65,7 +69,7 @@ End Sub";
         public void LabelNotUsed_QuickFixWorks_MultipleLabels()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 label1:
 dim var1 as variant
 label2:
@@ -73,7 +77,7 @@ goto label1:
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 label1:
 dim var1 as variant
 
@@ -81,13 +85,15 @@ goto label1:
 End Sub"; ;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new LineLabelNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new LineLabelNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -95,21 +101,23 @@ End Sub"; ;
         public void ProcedureNotUsed_QuickFixWorks()
         {
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 as Integer)
+                @"Private Sub Foo(ByVal arg1 as Integer)
 End Sub";
 
             const string expectedCode = @"";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ProcedureNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ProcedureNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspectionResults.First());
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspectionResults.First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -117,22 +125,24 @@ End Sub";
         public void UnassignedVariable_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As String
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
 
@@ -141,24 +151,26 @@ End Sub";
         public void UnassignedVariable_WithFollowingEmptyLine_DoesNotRemoveEmptyLine()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As String
 
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -166,23 +178,25 @@ End Sub";
         public void UnassignedVariable_WithCommentOnSameLine_DoesNotRemoveComment()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As String ' Comment
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 ' Comment
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -190,7 +204,7 @@ End Sub";
         public void UnassignedVariable_WithCommentOnSameLineAndFollowingStuff_DoesNotRemoveComment()
         {
             const string inputCode =
-@"Function Foo() As String
+                @"Function Foo() As String
 Dim var1 As String ' Comment
 Dim var2 As String
 var2 = ""Something""
@@ -198,21 +212,23 @@ Foo = var2
 End Function";
 
             const string expectedCode =
-@"Function Foo() As String
+                @"Function Foo() As String
 ' Comment
 Dim var2 As String
 var2 = ""Something""
 Foo = var2
 End Function";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
 
@@ -222,24 +238,26 @@ End Function";
         public void UnassignedVariable_WithFollowingCommentLine_DoesNotRemoveCommentLine()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
 Dim var1 As String
 ' Comment
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
 ' Comment
 End Sub";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -247,7 +265,7 @@ End Sub";
         public void UnassignedVariable_InMultideclaration_WithFollowingCommentLine_DoesNotRemoveCommentLineOrOtherDeclarations()
         {
             const string inputCode =
-@"Function Foo() As String
+                @"Function Foo() As String
 Dim var1 As String, var2 As String
 ' Comment
 var2 = ""Something""
@@ -255,21 +273,23 @@ Foo = var2
 End Function";
 
             const string expectedCode =
-@"Function Foo() As String
+                @"Function Foo() As String
 Dim var2 As String
 ' Comment
 var2 = ""Something""
 Foo = var2
 End Function";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -277,7 +297,7 @@ End Function";
         public void UnassignedVariable_InMultideclarationByStmtSeparators_WithFollowingCommentLine_DoesNotRemoveCommentLineOrOtherDeclarations()
         {
             const string inputCode =
-@"Function Foo() As String
+                @"Function Foo() As String
 Dim var1 As String:Dim var2 As String
 ' Comment
 var2 = ""Something""
@@ -285,21 +305,23 @@ Foo = var2
 End Function";
 
             const string expectedCode =
-@"Function Foo() As String
+                @"Function Foo() As String
 Dim var2 As String
 ' Comment
 var2 = ""Something""
 Foo = var2
 End Function";
-            
+
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new VariableNotUsedInspection(state);
-            new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
+                var inspection = new VariableNotUsedInspection(state);
+                new RemoveUnusedDeclarationQuickFix(state).Fix(inspection.GetInspectionResults().First());
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/RemoveUnusedParameterQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveUnusedParameterQuickFixTests.cs
@@ -25,14 +25,15 @@ Private Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using(var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ParameterNotUsedInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ParameterNotUsedInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new RemoveUnusedParameterQuickFix(vbe.Object, state, new Mock<IMessageBox>().Object).Fix(
-                inspectionResults.First());
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                new RemoveUnusedParameterQuickFix(vbe.Object, state, new Mock<IMessageBox>().Object).Fix(
+                    inspectionResults.First());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/ReplaceGlobalModifierQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ReplaceGlobalModifierQuickFixTests.cs
@@ -15,19 +15,20 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteGlobal_QuickFixWorks()
         {
             const string inputCode =
-@"Global var1 As Integer";
+                @"Global var1 As Integer";
 
             const string expectedCode =
-@"Public var1 As Integer";
+                @"Public var1 As Integer";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ObsoleteGlobalInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ObsoleteGlobalInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new ReplaceGlobalModifierQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceGlobalModifierQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/ReplaceIfElseWithConditionalStatementQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ReplaceIfElseWithConditionalStatementQuickFixTests.cs
@@ -15,8 +15,8 @@ namespace RubberduckTests.QuickFixes
         [TestCategory("QuickFixes")]
         public void Simple()
         {
-            const string inputCode = 
-@"Sub Foo()
+            const string inputCode =
+                @"Sub Foo()
     Dim d As Boolean
     If True Then
         d = True
@@ -26,20 +26,22 @@ namespace RubberduckTests.QuickFixes
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     d = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -47,7 +49,7 @@ End Sub";
         public void ComplexCondition()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     If True Or False And False Xor True Then
         d = True
@@ -57,20 +59,22 @@ End Sub";
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     d = True Or False And False Xor True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -78,7 +82,7 @@ End Sub";
         public void InvertedCondition()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     If True Then
         d = False
@@ -88,20 +92,22 @@ End Sub";
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim d As Boolean
     d = Not (True)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -109,7 +115,7 @@ End Sub";
         public void QualifiedName()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     If True Then
         Fizz.Buzz = True
     Else
@@ -118,19 +124,21 @@ End Sub";
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Fizz.Buzz = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new BooleanAssignedInIfElseInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new BooleanAssignedInIfElseInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceIfElseWithConditionalStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/ReplaceObsoleteCommentMarkerQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ReplaceObsoleteCommentMarkerQuickFixTests.cs
@@ -16,20 +16,22 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteCommentSyntax_QuickFixWorks_UpdateComment()
         {
             const string inputCode =
-@"Rem test1";
+                @"Rem test1";
 
             const string expectedCode =
-@"' test1";
+                @"' test1";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -37,22 +39,24 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteCommentSyntax_QuickFixWorks_UpdateCommentHasContinuation()
         {
             const string inputCode =
-@"Rem this is _
+                @"Rem this is _
 a comment";
 
             const string expectedCode =
-@"' this is _
+                @"' this is _
 a comment";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
 
@@ -61,20 +65,22 @@ a comment";
         public void ObsoleteCommentSyntax_QuickFixWorks_UpdateComment_LineHasCode()
         {
             const string inputCode =
-@"Dim Foo As Integer: Rem This is a comment";
+                @"Dim Foo As Integer: Rem This is a comment";
 
             const string expectedCode =
-@"Dim Foo As Integer: ' This is a comment";
+                @"Dim Foo As Integer: ' This is a comment";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -82,22 +88,24 @@ a comment";
         public void ObsoleteCommentSyntax_QuickFixWorks_UpdateComment_LineHasCodeAndContinuation()
         {
             const string inputCode =
-@"Dim Foo As Integer: Rem This is _
+                @"Dim Foo As Integer: Rem This is _
 a comment";
 
             const string expectedCode =
-@"Dim Foo As Integer: ' This is _
+                @"Dim Foo As Integer: ' This is _
 a comment";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteCommentSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteCommentSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteCommentMarkerQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/ReplaceObsoleteErrorStatementQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ReplaceObsoleteErrorStatementQuickFixTests.cs
@@ -16,31 +16,33 @@ namespace RubberduckTests.QuickFixes
         public void ObsoleteCommentSyntax_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Error 91
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Err.Raise 91
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
         [TestMethod]
         [TestCategory("QuickFixes")]
         public void ObsoleteCommentSyntax_QuickFixWorks_ProcNamedError()
         {
             const string inputCode =
-@"Sub Error(val as Integer)
+                @"Sub Error(val as Integer)
 End Sub
 
 Sub Foo()
@@ -48,7 +50,7 @@ Sub Foo()
 End Sub";
 
             const string expectedCode =
-@"Sub Error(val as Integer)
+                @"Sub Error(val as Integer)
 End Sub
 
 Sub Foo()
@@ -56,14 +58,16 @@ Sub Foo()
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -71,26 +75,28 @@ End Sub";
         public void ObsoleteCommentSyntax_QuickFixWorks_UpdateCommentHasContinuation()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Error _
     91
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Err.Raise _
     91
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
 
@@ -99,24 +105,26 @@ End Sub";
         public void ObsoleteCommentSyntax_QuickFixWorks_UpdateComment_LineHasCode()
         {
             const string inputCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim foo: Error 91
 End Sub";
 
             const string expectedCode =
-@"Sub Foo()
+                @"Sub Foo()
     Dim foo: Err.Raise 91
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ObsoleteErrorSyntaxInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ObsoleteErrorSyntaxInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new ReplaceObsoleteErrorStatementQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/SetExplicitVariantReturnTypeQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/SetExplicitVariantReturnTypeQuickFixTests.cs
@@ -14,21 +14,23 @@ namespace RubberduckTests.QuickFixes
         public void ImplicitVariantReturnType_QuickFixWorks_Function()
         {
             const string inputCode =
-@"Function Foo()
+                @"Function Foo()
 End Function";
 
             const string expectedCode =
-@"Function Foo() As Variant
+                @"Function Foo() As Variant
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -36,22 +38,24 @@ End Function";
         public void ImplicitVariantReturnType_QuickFixWorks_PropertyGet()
         {
             const string inputCode =
-@"Property Get Foo()
+                @"Property Get Foo()
 End Property";
 
             const string expectedCode =
-@"Property Get Foo() As Variant
+                @"Property Get Foo() As Variant
 End Property";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
+                new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -59,7 +63,7 @@ End Property";
         public void ImplicitVariantReturnType_QuickFixWorks_LibraryFunction()
         {
             const string inputCode =
-@"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
+                @"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
                                    Alias ""CreateProcessA""(ByVal lpApplicationName As String, _
                                                            ByVal lpCommandLine As String, _
                                                            lpProcessAttributes As SECURITY_ATTRIBUTES, _
@@ -72,7 +76,7 @@ End Property";
                                                            lpProcessInformation As PROCESS_INFORMATION)";
 
             const string expectedCode =
-@"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
+                @"Declare PtrSafe Function CreateProcess Lib ""kernel32"" _
                                    Alias ""CreateProcessA""(ByVal lpApplicationName As String, _
                                                            ByVal lpCommandLine As String, _
                                                            lpProcessAttributes As SECURITY_ATTRIBUTES, _
@@ -85,14 +89,16 @@ End Property";
                                                            lpProcessInformation As PROCESS_INFORMATION) As Variant";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
+                new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -100,22 +106,24 @@ End Property";
         public void ImplicitVariantReturnType_QuickFixWorks_Function_HasComment()
         {
             const string inputCode =
-@"Function Foo()    ' comment
+                @"Function Foo()    ' comment
 End Function";
 
             const string expectedCode =
-@"Function Foo() As Variant    ' comment
+                @"Function Foo() As Variant    ' comment
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitVariantReturnTypeInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new ImplicitVariantReturnTypeInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
+                new SetExplicitVariantReturnTypeQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/QuickFixes/SpecifyExplicitByRefModifierQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/SpecifyExplicitByRefModifierQuickFixTests.cs
@@ -19,23 +19,25 @@ namespace RubberduckTests.QuickFixes
         public void ImplicitByRefModifier_QuickFixWorks_ImplicitByRefParameter()
         {
             const string inputCode =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -43,23 +45,25 @@ End Sub";
         public void ImplicitByRefModifier_QuickFixWorks_OptionalParameter()
         {
             const string inputCode =
-@"Sub Foo(Optional arg1 As Integer)
+                @"Sub Foo(Optional arg1 As Integer)
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(Optional ByRef arg1 As Integer)
+                @"Sub Foo(Optional ByRef arg1 As Integer)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -67,29 +71,31 @@ End Sub";
         public void ImplicitByRefModifier_QuickFixWorks_Optional_LineContinuations()
         {
             const string inputCode =
-@"Sub Foo(Optional _
+                @"Sub Foo(Optional _
         bar _
         As Byte)
     bar = 1
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(Optional _
+                @"Sub Foo(Optional _
         ByRef bar _
         As Byte)
     bar = 1
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -97,27 +103,29 @@ End Sub";
         public void ImplicitByRefModifier_QuickFixWorks_LineContinuation()
         {
             const string inputCode =
-@"Sub Foo(bar _
+                @"Sub Foo(bar _
         As Byte)
     bar = 1
 End Sub";
 
             const string expectedCode =
-@"Sub Foo(ByRef bar _
+                @"Sub Foo(ByRef bar _
         As Byte)
     bar = 1
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -125,29 +133,31 @@ End Sub";
         public void ImplicitByRefModifier_QuickFixWorks_LineContinuation_FirstLine()
         {
             const string inputCode =
-@"Sub Foo( _
+                @"Sub Foo( _
         bar _
         As Byte)
     bar = 1
 End Sub";
 
             const string expectedCode =
-@"Sub Foo( _
+                @"Sub Foo( _
         ByRef bar _
         As Byte)
     bar = 1
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -155,21 +165,21 @@ End Sub";
         public void ImplicitByRefModifier_QuickFixWorks_InterfaceImplementation()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg1 As Integer)
 End Sub";
@@ -181,20 +191,22 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -202,21 +214,21 @@ End Sub";
         public void ImplicitByRefModifier_QuickFixWorks_InterfaceImplementationDifferentParameterName()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer)
+                @"Sub Foo(arg1 As Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg2 As Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(ByRef arg1 As Integer)
+                @"Sub Foo(ByRef arg1 As Integer)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg2 As Integer)
 End Sub";
@@ -228,20 +240,22 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(inspectionResults.First());
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
         [TestMethod]
@@ -249,21 +263,21 @@ End Sub";
         public void ImplicitByRefModifier_QuickFixWorks_InterfaceImplementationWithMultipleParameters()
         {
             const string inputCode1 =
-@"Sub Foo(arg1 As Integer, arg2 as Integer)
+                @"Sub Foo(arg1 As Integer, arg2 as Integer)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(arg1 As Integer, arg2 as Integer)
 End Sub";
 
             const string expectedCode1 =
-@"Sub Foo(ByRef arg1 As Integer, arg2 as Integer)
+                @"Sub Foo(ByRef arg1 As Integer, arg2 as Integer)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_Foo(ByRef arg1 As Integer, arg2 as Integer)
 End Sub";
@@ -275,27 +289,29 @@ End Sub";
                 .MockVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new ImplicitByRefModifierInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new ImplicitByRefModifierInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SpecifyExplicitByRefModifierQuickFix(state).Fix(
-                inspectionResults.First(
-                    result =>
-                        ((VBAParser.ArgContext)result.Context).unrestrictedIdentifier()
-                        .identifier()
-                        .untypedIdentifier()
-                        .identifierValue()
-                        .GetText() == "arg1"));
+                new SpecifyExplicitByRefModifierQuickFix(state).Fix(
+                    inspectionResults.First(
+                        result =>
+                            ((VBAParser.ArgContext)result.Context).unrestrictedIdentifier()
+                            .identifier()
+                            .untypedIdentifier()
+                            .identifierValue()
+                            .GetText() == "arg1"));
 
-            var project = vbe.Object.VBProjects[0];
-            var interfaceComponent = project.VBComponents[0];
-            var implementationComponent = project.VBComponents[1];
+                var project = vbe.Object.VBProjects[0];
+                var interfaceComponent = project.VBComponents[0];
+                var implementationComponent = project.VBComponents[1];
 
-            Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
-            Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+                Assert.AreEqual(expectedCode1, state.GetRewriter(interfaceComponent).GetText(), "Wrong code in interface");
+                Assert.AreEqual(expectedCode2, state.GetRewriter(implementationComponent).GetText(), "Wrong code in implementation");
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/SpecifyExplicitPublicModifierQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/SpecifyExplicitPublicModifierQuickFixTests.cs
@@ -15,25 +15,26 @@ namespace RubberduckTests.QuickFixes
         public void ImplicitPublicMember_QuickFixWorks()
         {
             const string inputCode =
-@"Sub Foo(ByVal arg1 as Integer)
+                @"Sub Foo(ByVal arg1 as Integer)
 'Just an inoffensive little comment
 
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo(ByVal arg1 as Integer)
+                @"Public Sub Foo(ByVal arg1 as Integer)
 'Just an inoffensive little comment
 
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ImplicitPublicMemberInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            var inspection = new ImplicitPublicMemberInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
-
-            new SpecifyExplicitPublicModifierQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new SpecifyExplicitPublicModifierQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/SplitMultipleDeclarationsQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/SplitMultipleDeclarationsQuickFixTests.cs
@@ -16,26 +16,28 @@ namespace RubberduckTests.QuickFixes
         public void MultipleDeclarations_QuickFixWorks_Variables()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer, var2 As String
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Dim var1 As Integer
 Dim var2 As String
 
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SplitMultipleDeclarationsQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new SplitMultipleDeclarationsQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -43,26 +45,28 @@ End Sub";
         public void MultipleDeclarations_QuickFixWorks_Constants()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const var1 As Integer = 9, var2 As String = ""test""
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Const var1 As Integer = 9
 Const var2 As String = ""test""
 
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SplitMultipleDeclarationsQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new SplitMultipleDeclarationsQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -70,26 +74,28 @@ End Sub";
         public void MultipleDeclarations_QuickFixWorks_StaticVariables()
         {
             const string inputCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Static var1 As Integer, var2 As String
 End Sub";
 
             const string expectedCode =
-@"Public Sub Foo()
+                @"Public Sub Foo()
     Static var1 As Integer
 Static var2 As String
 
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new MultipleDeclarationsInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+                var inspection = new MultipleDeclarationsInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-            new SplitMultipleDeclarationsQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new SplitMultipleDeclarationsQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/SynchronizeAttributesQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/SynchronizeAttributesQuickFixTests.cs
@@ -43,22 +43,24 @@ Sub DoSomething()
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
-            if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Inconclusive("Inspection failed to return a result.");
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
+                if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+                {
+                    Assert.Inconclusive("Inspection failed to return a result.");
+                }
+
+                var fix = new SynchronizeAttributesQuickFix(state);
+                fix.Fix(result);
+
+                var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
+                var actual = rewriter.GetText();
+
+                Assert.AreEqual(expectedCode, actual);
             }
-
-            var fix = new SynchronizeAttributesQuickFix(state);
-            fix.Fix(result);
-
-            var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
-            var actual = rewriter.GetText();
-
-            Assert.AreEqual(expectedCode, actual);
         }
 
         [TestMethod]
@@ -91,22 +93,24 @@ Attribute DoSomething.VB_Description = ""Does something""
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
-            if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Inconclusive("Inspection failed to return a result.");
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
+                if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+                {
+                    Assert.Inconclusive("Inspection failed to return a result.");
+                }
+
+                var fix = new SynchronizeAttributesQuickFix(state);
+                fix.Fix(result);
+
+                var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
+                var actual = rewriter.GetText();
+
+                Assert.AreEqual(expectedCode, actual);
             }
-
-            var fix = new SynchronizeAttributesQuickFix(state);
-            fix.Fix(result);
-
-            var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
-            var actual = rewriter.GetText();
-
-            Assert.AreEqual(expectedCode, actual);
         }
 
         [TestMethod]
@@ -139,22 +143,24 @@ Attribute DoSomething.VB_UserMemId = 0
 End Sub";
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
-            if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Inconclusive("Inspection failed to return a result.");
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
+                if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+                {
+                    Assert.Inconclusive("Inspection failed to return a result.");
+                }
+
+                var fix = new SynchronizeAttributesQuickFix(state);
+                fix.Fix(result);
+
+                var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
+                var actual = rewriter.GetText();
+
+                Assert.AreEqual(expectedCode, actual);
             }
-
-            var fix = new SynchronizeAttributesQuickFix(state);
-            fix.Fix(result);
-
-            var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
-            var actual = rewriter.GetText();
-
-            Assert.AreEqual(expectedCode, actual);
         }
 
         [TestMethod]
@@ -187,22 +193,24 @@ Attribute NewEnum.VB_UserMemId = -4
 End Property";
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAnnotationInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
-            if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Inconclusive("Inspection failed to return a result.");
+                var inspection = new MissingAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
+                if (result?.Context.GetType() != typeof(VBAParser.AttributeStmtContext))
+                {
+                    Assert.Inconclusive("Inspection failed to return a result.");
+                }
+
+                var fix = new SynchronizeAttributesQuickFix(state);
+                fix.Fix(result);
+
+                var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
+                var actual = rewriter.GetText();
+
+                Assert.AreEqual(expectedCode, actual);
             }
-
-            var fix = new SynchronizeAttributesQuickFix(state);
-            fix.Fix(result);
-
-            var rewriter = state.GetRewriter(result.QualifiedSelection.QualifiedName);
-            var actual = rewriter.GetText();
-
-            Assert.AreEqual(expectedCode, actual);
         }
 
         [TestMethod]
@@ -239,22 +247,24 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
-            if (result?.Context.GetType() != typeof(VBAParser.AnnotationContext))
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Inconclusive("Inspection failed to return a result.");
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
+                if (result?.Context.GetType() != typeof(VBAParser.AnnotationContext))
+                {
+                    Assert.Inconclusive("Inspection failed to return a result.");
+                }
+
+                var fix = new SynchronizeAttributesQuickFix(state);
+                fix.Fix(result);
+
+                var rewriter = state.GetAttributeRewriter(result.QualifiedSelection.QualifiedName);
+                var actual = rewriter.GetText();
+
+                Assert.AreEqual(expectedCode, actual);
             }
-
-            var fix = new SynchronizeAttributesQuickFix(state);
-            fix.Fix(result);
-
-            var rewriter = state.GetAttributeRewriter(result.QualifiedSelection.QualifiedName);
-            var actual = rewriter.GetText();
-
-            Assert.AreEqual(expectedCode, actual);
         }
 
         [TestMethod]
@@ -291,22 +301,24 @@ Option Explicit
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, testModuleName, ComponentType.ClassModule, out _);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var inspection = new MissingAttributeInspection(state);
-            var inspector = InspectionsHelper.GetInspector(inspection);
-            var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
-            if (result?.Context.GetType() != typeof(VBAParser.AnnotationContext))
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                Assert.Inconclusive("Inspection failed to return a result.");
+                var inspection = new MissingAttributeInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var result = inspector.FindIssuesAsync(state, CancellationToken.None).Result?.SingleOrDefault();
+                if (result?.Context.GetType() != typeof(VBAParser.AnnotationContext))
+                {
+                    Assert.Inconclusive("Inspection failed to return a result.");
+                }
+
+                var fix = new SynchronizeAttributesQuickFix(state);
+                fix.Fix(result);
+
+                var rewriter = state.GetAttributeRewriter(result.QualifiedSelection.QualifiedName);
+                var actual = rewriter.GetText();
+
+                Assert.AreEqual(expectedCode, actual);
             }
-
-            var fix = new SynchronizeAttributesQuickFix(state);
-            fix.Fix(result);
-
-            var rewriter = state.GetAttributeRewriter(result.QualifiedSelection.QualifiedName);
-            var actual = rewriter.GetText();
-
-            Assert.AreEqual(expectedCode, actual);
         }
     }
 }

--- a/RubberduckTests/QuickFixes/UseSetKeywordForObjectAssignmentQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/UseSetKeywordForObjectAssignmentQuickFixTests.cs
@@ -15,7 +15,7 @@ namespace RubberduckTests.QuickFixes
         {
             var expectedResultCount = 2;
             var input =
-@"
+                @"
 Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) As Range
     If source Is Nothing Then
         CombineRanges = toCombine 'no inspection result (but there should be one!)
@@ -24,7 +24,7 @@ Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) 
     End If
 End Function";
             var expectedCode =
-            @"
+                @"
 Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) As Range
     If source Is Nothing Then
         Set CombineRanges = toCombine 'no inspection result (but there should be one!)
@@ -34,19 +34,21 @@ Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) 
 End Function";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObjectVariableNotSetInspection(state);
-            var inspectionResults = inspection.GetInspectionResults().ToList();
-
-            Assert.AreEqual(expectedResultCount, inspectionResults.Count);
-            var fix = new UseSetKeywordForObjectAssignmentQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObjectVariableNotSetInspection(state);
+                var inspectionResults = inspection.GetInspectionResults().ToList();
+
+                Assert.AreEqual(expectedResultCount, inspectionResults.Count);
+                var fix = new UseSetKeywordForObjectAssignmentQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -61,7 +63,7 @@ Public Property Get Example() As MyObject
 End Property
 ";
             var expectedCode =
-            @"
+                @"
 Private example As MyObject
 Public Property Get Example() As MyObject
     Set Example = example
@@ -69,19 +71,21 @@ End Property
 ";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(input, out var component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var inspection = new ObjectVariableNotSetInspection(state);
-            var inspectionResults = inspection.GetInspectionResults().ToList();
-
-            Assert.AreEqual(expectedResultCount, inspectionResults.Count);
-            var fix = new UseSetKeywordForObjectAssignmentQuickFix(state);
-            foreach (var result in inspectionResults)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                fix.Fix(result);
-            }
 
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                var inspection = new ObjectVariableNotSetInspection(state);
+                var inspectionResults = inspection.GetInspectionResults().ToList();
+
+                Assert.AreEqual(expectedResultCount, inspectionResults.Count);
+                var fix = new UseSetKeywordForObjectAssignmentQuickFix(state);
+                foreach (var result in inspectionResults)
+                {
+                    fix.Fix(result);
+                }
+
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/QuickFixes/WriteOnlyPropertyQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/WriteOnlyPropertyQuickFixTests.cs
@@ -15,11 +15,11 @@ namespace RubberduckTests.QuickFixes
         public void WriteOnlyProperty_AddPropertyGetQuickFixWorks_ImplicitTypesAndAccessibility()
         {
             const string inputCode =
-@"Property Let Foo(value)
+                @"Property Let Foo(value)
 End Property";
 
             const string expectedCode =
-@"Public Property Get Foo() As Variant
+                @"Public Property Get Foo() As Variant
 End Property
 
 Property Let Foo(value)
@@ -28,13 +28,15 @@ End Property";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out var component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new WriteOnlyPropertyInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new WriteOnlyPropertyQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new WriteOnlyPropertyQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -42,11 +44,11 @@ End Property";
         public void WriteOnlyProperty_AddPropertyGetQuickFixWorks_ExlicitTypesAndAccessibility()
         {
             const string inputCode =
-@"Public Property Let Foo(ByVal value As Integer)
+                @"Public Property Let Foo(ByVal value As Integer)
 End Property";
 
             const string expectedCode =
-@"Public Property Get Foo() As Integer
+                @"Public Property Get Foo() As Integer
 End Property
 
 Public Property Let Foo(ByVal value As Integer)
@@ -54,13 +56,15 @@ End Property";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out var component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new WriteOnlyPropertyInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new WriteOnlyPropertyQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new WriteOnlyPropertyQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
         [TestMethod]
@@ -68,11 +72,11 @@ End Property";
         public void WriteOnlyProperty_AddPropertyGetQuickFixWorks_MultipleParams()
         {
             const string inputCode =
-@"Public Property Let Foo(value1, ByVal value2 As Integer, ByRef value3 As Long, value4 As Date, ByVal value5, value6 As String)
+                @"Public Property Let Foo(value1, ByVal value2 As Integer, ByRef value3 As Long, value4 As Date, ByVal value5, value6 As String)
 End Property";
 
             const string expectedCode =
-@"Public Property Get Foo(ByRef value1 As Variant, ByVal value2 As Integer, ByRef value3 As Long, ByRef value4 As Date, ByVal value5 As Variant) As String
+                @"Public Property Get Foo(ByRef value1 As Variant, ByVal value2 As Integer, ByRef value3 As Long, ByRef value4 As Date, ByVal value5 As Variant) As String
 End Property
 
 Public Property Let Foo(value1, ByVal value2 As Integer, ByRef value3 As Long, value4 As Date, ByVal value5, value6 As String)
@@ -80,13 +84,15 @@ End Property";
 
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out var component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var inspection = new WriteOnlyPropertyInspection(state);
-            var inspectionResults = inspection.GetInspectionResults();
+                var inspection = new WriteOnlyPropertyInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
 
-            new WriteOnlyPropertyQuickFix(state).Fix(inspectionResults.First());
-            Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+                new WriteOnlyPropertyQuickFix(state).Fix(inspectionResults.First());
+                Assert.AreEqual(expectedCode, state.GetRewriter(component).GetText());
+            }
         }
 
     }

--- a/RubberduckTests/Refactoring/EncapsulateFieldTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateFieldTests.cs
@@ -12,7 +12,6 @@ using Rubberduck.UI.Refactorings.EncapsulateField;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.Parsing.VBA;
-using System.Threading;
 
 namespace RubberduckTests.Refactoring
 {
@@ -26,12 +25,12 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer";
+                @"Public fizz As Integer";
             var selection = new Selection(1, 1);
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -44,27 +43,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -74,7 +75,7 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public _
+                @"Public _
 fizz _
 As _
 Integer";
@@ -82,7 +83,7 @@ Integer";
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -95,27 +96,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -125,12 +128,12 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public fizz As Variant";
+                @"Public fizz As Variant";
             var selection = new Selection(1, 1);
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Variant
+                @"Private fizz As Variant
 
 Public Property Get Name() As Variant
     Set Name = fizz
@@ -143,27 +146,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = false,
-                ImplementSetSetterType = true,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = false,
+                    ImplementSetSetterType = true,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -173,12 +178,12 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public fizz As Variant";
+                @"Public fizz As Variant";
             var selection = new Selection(1, 1);
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Variant
+                @"Private fizz As Variant
 
 Public Property Get Name() As Variant
     Name = fizz
@@ -187,27 +192,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = false,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = false,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -217,7 +224,7 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 
 Sub Foo()
 End Sub
@@ -229,7 +236,7 @@ End Function";
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -248,27 +255,29 @@ End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -278,7 +287,7 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 
 Property Get Foo() As Variant
     Foo = True
@@ -293,7 +302,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -315,27 +324,29 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -345,13 +356,13 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 Public buzz As Boolean";
             var selection = new Selection(1, 1);
 
             //Expectation
             const string expectedCode =
-@"Public buzz As Boolean
+                @"Public buzz As Boolean
 Private fizz As Integer
 
 Public Property Get Name() As Integer
@@ -365,27 +376,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -395,14 +408,14 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public fizz, _
+                @"Public fizz, _
          buzz As Boolean, _
          bazz As Date";
             var selection = new Selection(1, 12);
 
             //Expectation
             const string expectedCode =
-@"Public buzz As Boolean, _
+                @"Public buzz As Boolean, _
          bazz As Date
 Private fizz As Variant
 
@@ -425,27 +438,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = true,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = true,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -455,14 +470,14 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public fizz, _
+                @"Public fizz, _
 buzz As Boolean, _
 bazz As Date";
             var selection = new Selection(2, 12);
 
             //Expectation
             const string expectedCode =
-@"Public fizz, _
+                @"Public fizz, _
 bazz As Date
 Private buzz As Boolean
 
@@ -477,27 +492,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -507,14 +524,14 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public fizz, _
+                @"Public fizz, _
 buzz As Boolean, _
 bazz As Date";
             var selection = new Selection(3, 12);
 
             //Expectation
             const string expectedCode =
-@"Public fizz, _
+                @"Public fizz, _
 buzz As Boolean
 Private bazz As Date
 
@@ -529,27 +546,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -559,12 +578,12 @@ End Property
         {
             //Input
             const string inputCode =
-@"Private fizz As Integer";
+                @"Private fizz As Integer";
             var selection = new Selection(1, 1);
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -577,27 +596,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -607,7 +628,7 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 
 Sub Foo()
     fizz = 0
@@ -620,7 +641,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -640,27 +661,29 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(model.TargetDeclaration);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(model.TargetDeclaration);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -670,13 +693,13 @@ End Sub";
         {
             //Input
             const string codeClass1 =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 
 Sub Foo()
     fizz = 1
 End Sub";
             const string codeClass2 =
-@"Sub Foo()
+                @"Sub Foo()
     Dim c As Class1
     c.fizz = 0
     Bar c.fizz
@@ -689,7 +712,7 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -704,7 +727,7 @@ Sub Foo()
 End Sub";
 
             const string expectedCode2 =
-@"Sub Foo()
+                @"Sub Foo()
     Dim c As Class1
     c.Name = 0
     Bar c.Name
@@ -722,38 +745,40 @@ End Sub";
             var component = project.Object.VBComponents[0];
             vbe.Setup(v => v.ActiveCodePane).Returns(component.CodeModule.CodePane);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var actualCode1 = module1.Content();
-            var actualCode2 = module2.Content();
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            Assert.AreEqual(expectedCode1, actualCode1);
-            Assert.AreEqual(expectedCode2, actualCode2);
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter1 = state.GetRewriter(module1.Parent);
-            Assert.AreEqual(expectedCode1, rewriter1.GetText());
+                var actualCode1 = module1.Content();
+                var actualCode2 = module2.Content();
 
-            var rewriter2 = state.GetRewriter(module2.Parent);
-            Assert.AreEqual(expectedCode2, rewriter2.GetText());
+                Assert.AreEqual(expectedCode1, actualCode1);
+                Assert.AreEqual(expectedCode2, actualCode2);
+
+                var rewriter1 = state.GetRewriter(module1.Parent);
+                Assert.AreEqual(expectedCode1, rewriter1.GetText());
+
+                var rewriter2 = state.GetRewriter(module2.Parent);
+                Assert.AreEqual(expectedCode2, rewriter2.GetText());
+            }
         }
 
         [TestMethod]
@@ -763,12 +788,12 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Integer";
+                @"Private fizz As Integer";
             var selection = new Selection(1, 1);
 
             //Expectation
             const string expectedCode =
-@"Private fizz As Integer
+                @"Private fizz As Integer
 
 Public Property Get Name() As Integer
     Name = fizz
@@ -781,27 +806,29 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            var model = new EncapsulateFieldModel(state, qualifiedSelection)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                ImplementLetSetterType = true,
-                ImplementSetSetterType = false,
-                CanImplementLet = true,
-                ParameterName = "value",
-                PropertyName = "Name"
-            };
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(state.AllUserDeclarations.FindVariable(qualifiedSelection));
+                var model = new EncapsulateFieldModel(state, qualifiedSelection)
+                {
+                    ImplementLetSetterType = true,
+                    ImplementSetSetterType = false,
+                    CanImplementLet = true,
+                    ParameterName = "value",
+                    PropertyName = "Name"
+                };
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(state.AllUserDeclarations.FindVariable(qualifiedSelection));
+
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -811,20 +838,22 @@ End Property
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var vbeWrapper = vbe.Object;
-            var factory = new EncapsulateFieldPresenterFactory(vbeWrapper, state, null);
+                var vbeWrapper = vbe.Object;
+                var factory = new EncapsulateFieldPresenterFactory(vbeWrapper, state, null);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbeWrapper, CreateIndenter(vbe.Object), factory);
-            refactoring.Refactor();
+                var refactoring = new EncapsulateFieldRefactoring(vbeWrapper, CreateIndenter(vbe.Object), factory);
+                refactoring.Refactor();
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -834,23 +863,25 @@ End Property
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
             var selection = new Selection(1, 1);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //SetupFactory
-            var factory = SetupFactory(null);
+                //SetupFactory
+                var factory = SetupFactory(null);
 
-            var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new EncapsulateFieldRefactoring(vbe.Object, CreateIndenter(vbe.Object), factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -860,17 +891,19 @@ End Property
         {
             //Input
             const string inputCode =
-@"Private fizz As Integer";
+                @"Private fizz As Integer";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            vbe.Object.ActiveCodePane = null;
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, null);
-            var actual = factory.Create();
+                vbe.Object.ActiveCodePane = null;
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, null);
+                var actual = factory.Create();
 
-            Assert.IsNull(actual);
+                Assert.IsNull(actual);
+            }
         }
 
         [TestMethod]
@@ -880,18 +913,20 @@ End Property
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
             var selection = new Selection(1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, null);
-            var presenter = factory.Create();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, null);
+                var presenter = factory.Create();
 
-            Assert.AreEqual(null, presenter.Show());
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         [TestMethod]
@@ -901,23 +936,25 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"
+                @"
 Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = Selection.Home;
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var codePane = vbe.Object.VBProjects[0].VBComponents[0].CodeModule.CodePane;
-            codePane.Selection = selection;
+                var codePane = vbe.Object.VBProjects[0].VBComponents[0].CodeModule.CodePane;
+                codePane.Selection = selection;
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, null);
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, null);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.AreEqual(null, presenter.Show());
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         [TestMethod]
@@ -927,22 +964,24 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
             var selection = new Selection(1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.Setup(v => v.DialogResult).Returns(DialogResult.OK);
-            view.SetupGet(v => v.ViewModel).Returns(new EncapsulateFieldViewModel(state, null) {ParameterName = "myVal"});
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.Setup(v => v.DialogResult).Returns(DialogResult.OK);
+                view.SetupGet(v => v.ViewModel).Returns(new EncapsulateFieldViewModel(state, null) { ParameterName = "myVal" });
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.AreEqual("myVal", presenter.Show().ParameterName);
+                Assert.AreEqual("myVal", presenter.Show().ParameterName);
+            }
         }
 
         [TestMethod]
@@ -952,22 +991,24 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.Setup(v => v.DialogResult).Returns(DialogResult.Cancel);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.Setup(v => v.DialogResult).Returns(DialogResult.Cancel);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.AreEqual(null, presenter.Show());
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         //TODO: The tests below are commented out pending some sort of refactoring that enables them
@@ -975,7 +1016,7 @@ End Sub";
         //being mocked.
         // SEE: https://github.com/rubberduck-vba/Rubberduck/issues/3072
 
-        
+
         [TestMethod]
         [Ignore]
         [TestCategory("Refactorings")]
@@ -984,24 +1025,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
             var selection = new Selection(1, 15, 1, 15);
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.IsLetSelected, true);
-            view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.IsLetSelected, true);
+                view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.AreEqual(true, presenter.Show().ImplementLetSetterType);
+                Assert.AreEqual(true, presenter.Show().ImplementLetSetterType);
+            }
         }
 
         [TestMethod]
@@ -1012,24 +1055,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
             var selection = new Selection(1, 15, 1, 15);
-            
+
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.IsSetSelected, true);
-            view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.IsSetSelected, true);
+                view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.AreEqual(true, presenter.Show().ImplementSetSetterType);
+                Assert.AreEqual(true, presenter.Show().ImplementSetSetterType);
+            }
         }
 
         [TestMethod]
@@ -1040,52 +1085,56 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Boolean";
+                @"Private fizz As Boolean";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.CanHaveLet);
+                Assert.AreEqual(true, view.Object.ViewModel.CanHaveLet);
+            }
         }
 
         [TestMethod]
-        [Ignore] 
+        [Ignore]
         [TestCategory("Refactorings")]
         [TestCategory("Encapsulate Field")]
         public void Presenter_Accept_ReturnsModelWithImplementSetNotAllowedForPrimitiveTypes_NoReferences()
         {
             //Input
             const string inputCode =
-@"Private fizz As Boolean";
+                @"Private fizz As Boolean";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.CanHaveSet, true);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.CanHaveSet, true);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(false, view.Object.ViewModel.CanHaveSet);
+                Assert.AreEqual(false, view.Object.ViewModel.CanHaveSet);
+            }
         }
 
         [TestMethod]
@@ -1096,24 +1145,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Icon";
+                @"Private fizz As Icon";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.CanHaveSet, true);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.CanHaveSet, true);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.CanHaveSet);
+                Assert.AreEqual(true, view.Object.ViewModel.CanHaveSet);
+            }
         }
 
         [TestMethod]
@@ -1124,24 +1175,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Icon";
+                @"Private fizz As Icon";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(false, view.Object.ViewModel.CanHaveLet);
+                Assert.AreEqual(false, view.Object.ViewModel.CanHaveLet);
+            }
         }
 
         [TestMethod]
@@ -1152,24 +1205,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.CanHaveLet);
+                Assert.AreEqual(true, view.Object.ViewModel.CanHaveLet);
+            }
         }
 
         [TestMethod]
@@ -1180,24 +1235,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.CanHaveLet, true);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.CanHaveLet);
+                Assert.AreEqual(true, view.Object.ViewModel.CanHaveLet);
+            }
         }
 
         [TestMethod]
@@ -1208,7 +1265,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Boolean
+                @"Private fizz As Boolean
 Sub foo()
     fizz = True
 End Sub";
@@ -1218,17 +1275,19 @@ End Sub";
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.IsLetSelected, false);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.IsLetSelected, false);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.IsLetSelected);
+                Assert.AreEqual(true, view.Object.ViewModel.IsLetSelected);
+            }
         }
 
         [TestMethod]
@@ -1239,7 +1298,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Class1
+                @"Private fizz As Class1
 Sub foo()
     Set fizz = New Class1
 End Sub";
@@ -1249,17 +1308,19 @@ End Sub";
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.IsSetSelected, false);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.IsSetSelected, false);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.IsSetSelected);
+                Assert.AreEqual(true, view.Object.ViewModel.IsSetSelected);
+            }
         }
 
         [TestMethod]
@@ -1270,7 +1331,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant
+                @"Private fizz As Variant
 Sub Foo()
     fizz = True
 End Sub";
@@ -1280,28 +1341,30 @@ End Sub";
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.IsLetSelected, false);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.IsLetSelected, false);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.IsLetSelected);
+                Assert.AreEqual(true, view.Object.ViewModel.IsLetSelected);
+            }
         }
 
         [TestMethod]
-        [Ignore] 
+        [Ignore]
         [TestCategory("Refactorings")]
         [TestCategory("Encapsulate Field")]
         public void Presenter_Accept_ReturnsModelWithImplementSetRequiredForSetVariant_References()
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant
+                @"Private fizz As Variant
 Sub foo()
     Set fizz = New Class1
 End Sub";
@@ -1311,17 +1374,19 @@ End Sub";
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.SetupProperty(v => v.ViewModel.IsSetSelected, false);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.SetupProperty(v => v.ViewModel.IsSetSelected, false);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                factory.Create().Show();
 
-            Assert.AreEqual(true, view.Object.ViewModel.IsSetSelected);
+                Assert.AreEqual(true, view.Object.ViewModel.IsSetSelected);
+            }
         }
 
 
@@ -1333,25 +1398,27 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Date";
+                @"Private fizz As Date";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            var model = factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                var model = factory.Create().Show();
 
-            Assert.AreEqual(false, model.ImplementLetSetterType);
-            Assert.AreEqual(false, model.ImplementSetSetterType);
+                Assert.AreEqual(false, model.ImplementLetSetterType);
+                Assert.AreEqual(false, model.ImplementSetSetterType);
+            }
         }
 
         [TestMethod]
@@ -1362,25 +1429,27 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Icon";
+                @"Private fizz As Icon";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            var model = factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                var model = factory.Create().Show();
 
-            Assert.AreEqual(false, model.ImplementLetSetterType);
-            Assert.AreEqual(false, model.ImplementSetSetterType);
+                Assert.AreEqual(false, model.ImplementLetSetterType);
+                Assert.AreEqual(false, model.ImplementSetSetterType);
+            }
         }
 
         [TestMethod]
@@ -1391,25 +1460,27 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Variant";
+                @"Private fizz As Variant";
             var selection = new Selection(1, 15, 1, 15);
 
             var builder = new MockVbeBuilder();
             IVBComponent component;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                if (state.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
-            var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
-            view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
+                var view = new Mock<IRefactoringDialog<EncapsulateFieldViewModel>>();
+                view.Setup(v => v.ShowDialog()).Returns(DialogResult.OK);
 
-            var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
-            var model = factory.Create().Show();
+                var factory = new EncapsulateFieldPresenterFactory(vbe.Object, state, view.Object);
+                var model = factory.Create().Show();
 
-            Assert.AreEqual(false, model.ImplementLetSetterType);
-            Assert.AreEqual(false, model.ImplementSetSetterType);
+                Assert.AreEqual(false, model.ImplementLetSetterType);
+                Assert.AreEqual(false, model.ImplementSetSetterType);
+            }
         }
         #region setup
         private static Mock<IRefactoringPresenterFactory<IEncapsulateFieldPresenter>> SetupFactory(EncapsulateFieldModel model)

--- a/RubberduckTests/Refactoring/ExtractInterfaceTests.cs
+++ b/RubberduckTests/Refactoring/ExtractInterfaceTests.cs
@@ -23,13 +23,13 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Implements ITestModule1
+                @"Implements ITestModule1
 
 Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
@@ -40,7 +40,7 @@ End Sub
 ";
 
             const string expectedInterfaceCode =
-@"Option Explicit
+                @"Option Explicit
 
 Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
@@ -49,25 +49,27 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to remove
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
-            foreach (var member in model.Members)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                member.IsSelected = true;
+
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+
+                //Specify Params to remove
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                foreach (var member in model.Members)
+                {
+                    member.IsSelected = true;
+                }
+
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
             }
-
-            //SetupFactory
-            var factory = SetupFactory(model);
-
-            var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
-
-            Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
         }
 
         [TestMethod]
@@ -135,7 +137,7 @@ End Property
 ";
 
             const string expectedInterfaceCode =
-@"Option Explicit
+                @"Option Explicit
 
 Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
@@ -156,25 +158,27 @@ End Property
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to remove
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
-            foreach (var member in model.Members)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                member.IsSelected = true;
+
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+
+                //Specify Params to remove
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                foreach (var member in model.Members)
+                {
+                    member.IsSelected = true;
+                }
+
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
             }
-
-            //SetupFactory
-            var factory = SetupFactory(model);
-
-            var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
-
-            Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
         }
 
         [TestMethod]
@@ -184,7 +188,7 @@ End Property
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
 
 Public Function Fizz(b) As Variant
@@ -203,7 +207,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Implements ITestModule1
+                @"Implements ITestModule1
 
 Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
@@ -230,7 +234,7 @@ End Function
 ";
 
             const string expectedInterfaceCode =
-@"Option Explicit
+                @"Option Explicit
 
 Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
@@ -242,28 +246,30 @@ End Function
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to remove
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
-            foreach (var member in model.Members)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                if (!member.FullMemberSignature.Contains("Property"))
+
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+
+                //Specify Params to remove
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                foreach (var member in model.Members)
                 {
-                    member.IsSelected = true;
+                    if (!member.FullMemberSignature.Contains("Property"))
+                    {
+                        member.IsSelected = true;
+                    }
                 }
+
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
             }
-
-            //SetupFactory
-            var factory = SetupFactory(model);
-
-            var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
-
-            Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
         }
 
         [TestMethod]
@@ -273,19 +279,21 @@ End Function
         {
             //Input
             const string inputCode =
-@"Public Fizz As Boolean";
+                @"Public Fizz As Boolean";
 
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
-            Assert.AreEqual(0, model.Members.Count());
+                //Specify Params to remove
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                Assert.AreEqual(0, model.Members.Count());
+            }
         }
 
         [TestMethod]
@@ -295,28 +303,30 @@ End Function
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                //Specify Params to remove
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
-            factory.Setup(f => f.Create()).Returns(value: null);
+                //SetupFactory
+                var factory = SetupFactory(model);
+                factory.Setup(f => f.Create()).Returns(value: null);
 
-            var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
-            refactoring.Refactor();
+                var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
+                refactoring.Refactor();
 
-            Assert.AreEqual(1, vbe.Object.ActiveVBProject.VBComponents.Count());
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                Assert.AreEqual(1, vbe.Object.ActiveVBProject.VBComponents.Count());
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -326,31 +336,33 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                //Specify Params to remove
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
 
-            var presenter = new Mock<IExtractInterfacePresenter>();
-            presenter.Setup(p => p.Show()).Returns(value: null);
+                var presenter = new Mock<IExtractInterfacePresenter>();
+                presenter.Setup(p => p.Show()).Returns(value: null);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
-            factory.Setup(f => f.Create()).Returns(presenter.Object);
+                //SetupFactory
+                var factory = SetupFactory(model);
+                factory.Setup(f => f.Create()).Returns(presenter.Object);
 
-            var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
-            refactoring.Refactor();
+                var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
+                refactoring.Refactor();
 
-            Assert.AreEqual(1, vbe.Object.ActiveVBProject.VBComponents.Count());
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                Assert.AreEqual(1, vbe.Object.ActiveVBProject.VBComponents.Count());
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -360,13 +372,13 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Implements ITestModule1
+                @"Implements ITestModule1
 
 Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
@@ -377,7 +389,7 @@ End Sub
 ";
 
             const string expectedInterfaceCode =
-@"Option Explicit
+                @"Option Explicit
 
 Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
@@ -386,22 +398,24 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
-            model.Members.ElementAt(0).IsSelected = true;
+                //Specify Params to remove
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                model.Members.ElementAt(0).IsSelected = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
-            refactoring.Refactor(state.AllUserDeclarations.Single(s => s.DeclarationType == DeclarationType.ClassModule));
+                var refactoring = new ExtractInterfaceRefactoring(vbe.Object, null, factory.Object);
+                refactoring.Refactor(state.AllUserDeclarations.Single(s => s.DeclarationType == DeclarationType.ClassModule));
 
-            Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedInterfaceCode, component.Collection[1].CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -411,28 +425,30 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 15, 1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
-            model.Members.ElementAt(0).IsSelected = true;
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                model.Members.ElementAt(0).IsSelected = true;
 
-            var view = new Mock<IRefactoringDialog<ExtractInterfaceViewModel>>();
-            view.Setup(v => v.ViewModel).Returns(new ExtractInterfaceViewModel());
-            view.Setup(v => v.DialogResult).Returns(DialogResult.Cancel);
+                var view = new Mock<IRefactoringDialog<ExtractInterfaceViewModel>>();
+                view.Setup(v => v.ViewModel).Returns(new ExtractInterfaceViewModel());
+                view.Setup(v => v.DialogResult).Returns(DialogResult.Cancel);
 
-            var factory = new ExtractInterfacePresenterFactory(vbe.Object, state, view.Object);
+                var factory = new ExtractInterfacePresenterFactory(vbe.Object, state, view.Object);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.AreEqual(null, presenter.Show());
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         [TestMethod]
@@ -442,23 +458,25 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 15, 1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var model = new ExtractInterfaceModel(state, qualifiedSelection);
+                var model = new ExtractInterfaceModel(state, qualifiedSelection);
 
-            var view = new Mock<IRefactoringDialog<ExtractInterfaceViewModel>>();
-            view.SetupGet(v => v.ViewModel).Returns(new ExtractInterfaceViewModel());
-            var presenter = new ExtractInterfacePresenter(view.Object, model);
+                var view = new Mock<IRefactoringDialog<ExtractInterfaceViewModel>>();
+                view.SetupGet(v => v.ViewModel).Returns(new ExtractInterfaceViewModel());
+                var presenter = new ExtractInterfacePresenter(view.Object, model);
 
-            Assert.AreEqual(null, presenter.Show());
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         [TestMethod]
@@ -468,17 +486,19 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
             var selection = new Selection(1, 15, 1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var factory = new ExtractInterfacePresenterFactory(vbe.Object, state, null);
+                var factory = new ExtractInterfacePresenterFactory(vbe.Object, state, null);
 
-            Assert.AreEqual(null, factory.Create());
+                Assert.AreEqual(null, factory.Create());
+            }
         }
 
         [TestMethod]
@@ -488,18 +508,20 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
+                vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var factory = new ExtractInterfacePresenterFactory(vbe.Object, state, null);
+                var factory = new ExtractInterfacePresenterFactory(vbe.Object, state, null);
 
-            Assert.AreEqual(null, factory.Create());
+                Assert.AreEqual(null, factory.Create());
+            }
         }
 
         #region setup

--- a/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodModelTests.cs
+++ b/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodModelTests.cs
@@ -54,33 +54,35 @@ End Sub";
         #endregion
 
         List<IExtractMethodRule> emRules = new List<IExtractMethodRule>(){
-                        new ExtractMethodRuleInSelection(),
-                        new ExtractMethodRuleIsAssignedInSelection(),
-                        new ExtractMethodRuleUsedBefore(),
-                        new ExtractMethodRuleUsedAfter(),
-                        new ExtractMethodRuleExternalReference()};
+            new ExtractMethodRuleInSelection(),
+            new ExtractMethodRuleIsAssignedInSelection(),
+            new ExtractMethodRuleUsedBefore(),
+            new ExtractMethodRuleUsedAfter(),
+            new ExtractMethodRuleExternalReference()};
 
         [TestMethod]
         [TestCategory("ExtractMethodModelTests")]
         public void shouldClassifyDeclarations()
         {
             QualifiedModuleName qualifiedModuleName;
-            var state = MockParser.ParseString(internalVariable, out qualifiedModuleName);
-            var declarations = state.AllDeclarations;
+            using (var state = MockParser.ParseString(internalVariable, out qualifiedModuleName))
+            {
+                var declarations = state.AllDeclarations;
 
-            var selection = new Selection(8, 1, 12, 24);
-            QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                var selection = new Selection(8, 1, 12, 24);
+                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-            var extractedMethod = new Mock<IExtractedMethod>();
-            var extractedMethodProc = new Mock<IExtractMethodProc>();
-            var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                var extractedMethod = new Mock<IExtractedMethod>();
+                var extractedMethodProc = new Mock<IExtractMethodProc>();
+                var paramClassify = new Mock<IExtractMethodParameterClassification>();
 
-            var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
-            SUT.extract(declarations, qSelection.Value, selectedCode);
+                var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                SUT.extract(declarations, qSelection.Value, selectedCode);
 
-            paramClassify.Verify(
-                pc => pc.classifyDeclarations(qSelection.Value, It.IsAny<Declaration>()),
-                Times.Exactly(3));
+                paramClassify.Verify(
+                    pc => pc.classifyDeclarations(qSelection.Value, It.IsAny<Declaration>()),
+                    Times.Exactly(3));
+            }
         }
 
         [TestClass]
@@ -133,22 +135,24 @@ End Sub";
                 public void shouldThrowAnException()
                 {
                     QualifiedModuleName qualifiedModuleName;
-                    var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                    var declarations = state.AllDeclarations;
+                    using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                    {
+                        var declarations = state.AllDeclarations;
 
-                    var selection = new Selection(21, 1, 22, 17);
-                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                        var selection = new Selection(21, 1, 22, 17);
+                        QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                    var emr = new Mock<IExtractMethodRule>();
-                    var extractedMethod = new Mock<IExtractedMethod>();
-                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
-                    var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                        var emr = new Mock<IExtractMethodRule>();
+                        var extractedMethod = new Mock<IExtractedMethod>();
+                        var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                        var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
 
-                    //Act
-                    SUT.extract(declarations, qSelection.Value, selectedCode);
+                        //Act
+                        SUT.extract(declarations, qSelection.Value, selectedCode);
 
-                    //Assert
-                    // ExpectedException
+                        //Assert
+                        // ExpectedException
+                    }
                 }
 
             }
@@ -158,23 +162,25 @@ End Sub";
             public void shouldProvideAListOfDimsNoLongerNeededInTheContainingMethod()
             {
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var selection = new Selection(10, 1, 12, 17);
-                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
-                var extractDecl = declarations.Where(x => x.IdentifierName.Equals("y"));
+                    var selection = new Selection(10, 1, 12, 17);
+                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    var extractDecl = declarations.Where(x => x.IdentifierName.Equals("y"));
 
-                var emr = new Mock<IExtractMethodRule>();
-                var extractedMethod = new Mock<IExtractedMethod>();
-                var paramClassify = new Mock<IExtractMethodParameterClassification>();
-                paramClassify.Setup(pc => pc.DeclarationsToMove).Returns(extractDecl);
-                var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
-                SUT.extract(declarations, qSelection.Value, selectedCode);
+                    var emr = new Mock<IExtractMethodRule>();
+                    var extractedMethod = new Mock<IExtractedMethod>();
+                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                    paramClassify.Setup(pc => pc.DeclarationsToMove).Returns(extractDecl);
+                    var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                    SUT.extract(declarations, qSelection.Value, selectedCode);
 
-                Assert.AreEqual(1, SUT.DeclarationsToMove.Count());
-                Assert.IsTrue(SUT.DeclarationsToMove.Contains(extractDecl.First()), "The selectionToRemove should contain the Declaration being moved");
+                    Assert.AreEqual(1, SUT.DeclarationsToMove.Count());
+                    Assert.IsTrue(SUT.DeclarationsToMove.Contains(extractDecl.First()), "The selectionToRemove should contain the Declaration being moved");
 
+                }
             }
 
             [TestMethod]
@@ -182,35 +188,37 @@ End Sub";
             public void shouldProvideTheSelectionOfLinesOfToRemove()
             {
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var selection = new Selection(10, 2, 12, 17);
-                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    var selection = new Selection(10, 2, 12, 17);
+                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                var emr = new Mock<IExtractMethodRule>();
-                var extractedMethod = new Mock<IExtractedMethod>();
-                var paramClassify = new Mock<IExtractMethodParameterClassification>();
-                var extractDecl = declarations.Where(x => x.IdentifierName.Equals("y"));
-                paramClassify.Setup(pc => pc.DeclarationsToMove).Returns(extractDecl);
-                var extractedMethodModel = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                    var emr = new Mock<IExtractMethodRule>();
+                    var extractedMethod = new Mock<IExtractedMethod>();
+                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                    var extractDecl = declarations.Where(x => x.IdentifierName.Equals("y"));
+                    paramClassify.Setup(pc => pc.DeclarationsToMove).Returns(extractDecl);
+                    var extractedMethodModel = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
 
-                //Act
-                extractedMethodModel.extract(declarations, qSelection.Value, selectedCode);
+                    //Act
+                    extractedMethodModel.extract(declarations, qSelection.Value, selectedCode);
 
-                //Assert
-                var actual = extractedMethodModel.RowsToRemove;
-                var yDimSelection = new Selection(5, 9, 5, 10);
-                var expected = new[] { selection, yDimSelection }
-                    .Select(x => new Selection(x.StartLine, 1, x.EndLine, 1));
-                var missing = expected.Except(actual);
-                var extra = actual.Except(expected);
-                missing.ToList().ForEach(x => Trace.WriteLine(string.Format("missing item {0}", x)));
-                extra.ToList().ForEach(x => Trace.WriteLine(string.Format("extra item {0}", x)));
+                    //Assert
+                    var actual = extractedMethodModel.RowsToRemove;
+                    var yDimSelection = new Selection(5, 9, 5, 10);
+                    var expected = new[] { selection, yDimSelection }
+                        .Select(x => new Selection(x.StartLine, 1, x.EndLine, 1));
+                    var missing = expected.Except(actual);
+                    var extra = actual.Except(expected);
+                    missing.ToList().ForEach(x => Trace.WriteLine(string.Format("missing item {0}", x)));
+                    extra.ToList().ForEach(x => Trace.WriteLine(string.Format("extra item {0}", x)));
 
-                Assert.AreEqual(expected.Count(), actual.Count(), "Selection To Remove doesn't have the right number of members");
-                expected.ToList().ForEach(s => Assert.IsTrue(actual.Contains(s), string.Format("selection {0} missing from actual SelectionToRemove", s)));
+                    Assert.AreEqual(expected.Count(), actual.Count(), "Selection To Remove doesn't have the right number of members");
+                    expected.ToList().ForEach(s => Assert.IsTrue(actual.Contains(s), string.Format("selection {0} missing from actual SelectionToRemove", s)));
 
+                }
             }
 
             [TestMethod]
@@ -218,23 +226,25 @@ End Sub";
             public void shouldProvideTheExtractMethodCaller()
             {
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var selection = new Selection(10, 1, 12, 17);
-                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    var selection = new Selection(10, 1, 12, 17);
+                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                var emr = new Mock<IExtractMethodRule>();
-                var extractedMethod = new Mock<IExtractedMethod>();
-                var paramClassify = new Mock<IExtractMethodParameterClassification>();
-                var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
-
-
-                var x = SUT.NewMethodCall;
-
-                extractedMethod.Verify(em => em.NewMethodCall());
+                    var emr = new Mock<IExtractMethodRule>();
+                    var extractedMethod = new Mock<IExtractedMethod>();
+                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                    var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
 
 
+                    var x = SUT.NewMethodCall;
+
+                    extractedMethod.Verify(em => em.NewMethodCall());
+
+
+                }
             }
 
             [TestMethod]
@@ -242,22 +252,24 @@ End Sub";
             public void shouldProvideThePositionForTheMethodCall()
             {
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var selection = new Selection(10, 1, 12, 17);
-                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    var selection = new Selection(10, 1, 12, 17);
+                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                var emr = new Mock<IExtractMethodRule>();
-                var extractedMethod = new Mock<IExtractedMethod>();
-                var paramClassify = new Mock<IExtractMethodParameterClassification>();
-                var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
-                SUT.extract(declarations, qSelection.Value, selectedCode);
+                    var emr = new Mock<IExtractMethodRule>();
+                    var extractedMethod = new Mock<IExtractedMethod>();
+                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                    var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                    SUT.extract(declarations, qSelection.Value, selectedCode);
 
-                var expected = new Selection(10, 1, 10, 1);
-                var actual = SUT.PositionForMethodCall;
+                    var expected = new Selection(10, 1, 10, 1);
+                    var actual = SUT.PositionForMethodCall;
 
-                Assert.AreEqual(expected, actual, "Call should have been at row " + expected + " but is at " + actual);
+                    Assert.AreEqual(expected, actual, "Call should have been at row " + expected + " but is at " + actual);
+                }
             }
 
             [TestMethod]
@@ -265,26 +277,28 @@ End Sub";
             public void shouldProvideThePositionForTheNewMethod()
             {
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var selection = new Selection(10, 1, 12, 17);
-                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    var selection = new Selection(10, 1, 12, 17);
+                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                var emr = new Mock<IExtractMethodRule>();
-                var extractedMethod = new Mock<IExtractedMethod>();
-                var extractedMethodProc = new Mock<IExtractMethodProc>();
-                var paramClassify = new Mock<IExtractMethodParameterClassification>();
-                var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
-                //Act
-                SUT.extract(declarations, qSelection.Value, selectedCode);
+                    var emr = new Mock<IExtractMethodRule>();
+                    var extractedMethod = new Mock<IExtractedMethod>();
+                    var extractedMethodProc = new Mock<IExtractMethodProc>();
+                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                    var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                    //Act
+                    SUT.extract(declarations, qSelection.Value, selectedCode);
 
-                //Assert
-                var expected = new Selection(18, 1, 18, 1);
-                var actual = SUT.PositionForNewMethod;
+                    //Assert
+                    var expected = new Selection(18, 1, 18, 1);
+                    var actual = SUT.PositionForNewMethod;
 
-                Assert.AreEqual(expected, actual, "Call should have been at row " + expected + " but is at " + actual);
+                    Assert.AreEqual(expected, actual, "Call should have been at row " + expected + " but is at " + actual);
 
+                }
             }
 
         }
@@ -329,26 +343,28 @@ Debug.Print y";
                 #endregion
 
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var selection = new Selection(10, 1, 12, 17);
-                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
-                var extractedMethod = new Mock<IExtractedMethod>();
-                extractedMethod.Setup(em => em.NewMethodCall())
-                    .Returns("NewMethod x");
-                var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                    var selection = new Selection(10, 1, 12, 17);
+                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    var extractedMethod = new Mock<IExtractedMethod>();
+                    extractedMethod.Setup(em => em.NewMethodCall())
+                        .Returns("NewMethod x");
+                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
 
-                var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                    var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
 
-                //Act
-                SUT.extract(declarations, qSelection.Value, selectedCode);
+                    //Act
+                    SUT.extract(declarations, qSelection.Value, selectedCode);
 
-                //Assert
-                var actual = SUT.Method.NewMethodCall();
-                var expected = "NewMethod x";
+                    //Assert
+                    var actual = SUT.Method.NewMethodCall();
+                    var expected = "NewMethod x";
 
-                Assert.AreEqual(expected, actual);
+                    Assert.AreEqual(expected, actual);
+                }
             }
 
         }
@@ -407,23 +423,25 @@ end sub
                 #endregion
 
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
-                var selection = new Selection(8, 1, 12, 50);
-                QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
-                var extractedMethod = new Mock<IExtractedMethod>();
-                var paramClassify = new Mock<IExtractMethodParameterClassification>();
-                var yDecl = declarations.Where(decl => decl.IdentifierName.Equals("z"));
-                var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
-                //Act
-                var actual = SUT.splitSelection(selection, declarations);
-                //Assert
-                var selection1 = new Selection(8, 1, 9, 1);
-                var selection2 = new Selection(11, 1, 12, 1);
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
+                    var selection = new Selection(8, 1, 12, 50);
+                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    var extractedMethod = new Mock<IExtractedMethod>();
+                    var paramClassify = new Mock<IExtractMethodParameterClassification>();
+                    var yDecl = declarations.Where(decl => decl.IdentifierName.Equals("z"));
+                    var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
+                    //Act
+                    var actual = SUT.splitSelection(selection, declarations);
+                    //Assert
+                    var selection1 = new Selection(8, 1, 9, 1);
+                    var selection2 = new Selection(11, 1, 12, 1);
 
-                Assert.AreEqual(selection1, actual.First(), "Top selection does not match");
-                Assert.AreEqual(selection2, actual.Skip(1).First(), "Bottom selection does not match");
+                    Assert.AreEqual(selection1, actual.First(), "Top selection does not match");
+                    Assert.AreEqual(selection2, actual.Skip(1).First(), "Bottom selection does not match");
 
+                }
             }
 
 

--- a/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodParameterClassificationTests.cs
+++ b/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodParameterClassificationTests.cs
@@ -41,25 +41,27 @@ End Sub
             public void shouldUseEachRuleInRulesCollectionToCheckEachReference()
             {
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(codeSnippet, out qualifiedModuleName);
-                var declaration = state.AllUserDeclarations.Where(decl => decl.IdentifierName == "x").First();
-                var selection = new Selection(5, 1, 7, 20);
-                var qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                using (var state = MockParser.ParseString(codeSnippet, out qualifiedModuleName))
+                {
+                    var declaration = state.AllUserDeclarations.Where(decl => decl.IdentifierName == "x").First();
+                    var selection = new Selection(5, 1, 7, 20);
+                    var qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                var emRule = new Mock<IExtractMethodRule>();
-                emRule.Setup(emr => emr.setValidFlag(It.IsAny<IdentifierReference>(), It.IsAny<Selection>())).Returns(2);
-                var emRules = new List<IExtractMethodRule>() { emRule.Object, emRule.Object };
-                var sut = new ExtractMethodParameterClassification(emRules);
+                    var emRule = new Mock<IExtractMethodRule>();
+                    emRule.Setup(emr => emr.setValidFlag(It.IsAny<IdentifierReference>(), It.IsAny<Selection>())).Returns(2);
+                    var emRules = new List<IExtractMethodRule>() { emRule.Object, emRule.Object };
+                    var sut = new ExtractMethodParameterClassification(emRules);
 
-                //Act
-                sut.classifyDeclarations(qSelection, declaration);
+                    //Act
+                    sut.classifyDeclarations(qSelection, declaration);
 
-                //Assert
-                // 2 rules on 2 references = 4 validation checks
-                var expectedToVerify = 4;
-                emRule.Verify(emr => emr.setValidFlag(It.IsAny<IdentifierReference>(), selection),
-                    Times.Exactly(expectedToVerify));
+                    //Assert
+                    // 2 rules on 2 references = 4 validation checks
+                    var expectedToVerify = 4;
+                    emRule.Verify(emr => emr.setValidFlag(It.IsAny<IdentifierReference>(), selection),
+                        Times.Exactly(expectedToVerify));
 
+                }
             }
         }
 
@@ -73,26 +75,28 @@ End Sub
             {
 
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(codeSnippet, out qualifiedModuleName);
-                var declaration = state.AllUserDeclarations.Where(decl => decl.IdentifierName == "x").First();
+                using (var state = MockParser.ParseString(codeSnippet, out qualifiedModuleName))
+                {
+                    var declaration = state.AllUserDeclarations.Where(decl => decl.IdentifierName == "x").First();
 
-                // Above setup is headache from lack of ability to extract declarations simply.
-                // exact declaration and qSelection are irrelevant for this test and could be mocked.
+                    // Above setup is headache from lack of ability to extract declarations simply.
+                    // exact declaration and qSelection are irrelevant for this test and could be mocked.
 
-                var emByRefRule = new Mock<IExtractMethodRule>();
-                emByRefRule.Setup(em => em.setValidFlag(It.IsAny<IdentifierReference>(), It.IsAny<Selection>())).Returns(14);
-                var emRules = new List<IExtractMethodRule>() { emByRefRule.Object };
+                    var emByRefRule = new Mock<IExtractMethodRule>();
+                    emByRefRule.Setup(em => em.setValidFlag(It.IsAny<IdentifierReference>(), It.IsAny<Selection>())).Returns(14);
+                    var emRules = new List<IExtractMethodRule>() { emByRefRule.Object };
 
-                var qSelection = new QualifiedSelection();
-                var SUT = new ExtractMethodParameterClassification(emRules);
-                //Act
-                SUT.classifyDeclarations(qSelection, declaration);
-                var extractedParameter = SUT.ExtractedParameters.First();
-                Assert.IsTrue(SUT.ExtractedParameters.Count() > 0);
+                    var qSelection = new QualifiedSelection();
+                    var SUT = new ExtractMethodParameterClassification(emRules);
+                    //Act
+                    SUT.classifyDeclarations(qSelection, declaration);
+                    var extractedParameter = SUT.ExtractedParameters.First();
+                    Assert.IsTrue(SUT.ExtractedParameters.Count() > 0);
 
-                //Assert
-                Assert.AreEqual(extractedParameter.Passed, ExtractedParameter.PassedBy.ByVal);
+                    //Assert
+                    Assert.AreEqual(extractedParameter.Passed, ExtractedParameter.PassedBy.ByVal);
 
+                }
             }
 
             [TestMethod]
@@ -101,28 +105,30 @@ End Sub
             {
 
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(codeSnippet, out qualifiedModuleName);
-                var declaration = state.AllUserDeclarations.Where(decl => decl.IdentifierName == "x").First();
-                var selection = new Selection(5, 1, 7, 20);
-                var qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                using (var state = MockParser.ParseString(codeSnippet, out qualifiedModuleName))
+                {
+                    var declaration = state.AllUserDeclarations.Where(decl => decl.IdentifierName == "x").First();
+                    var selection = new Selection(5, 1, 7, 20);
+                    var qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                // Above setup is headache from lack of ability to extract declarations simply.
-                // exact declaration and qSelection are irrelevant for this test and could be mocked.
+                    // Above setup is headache from lack of ability to extract declarations simply.
+                    // exact declaration and qSelection are irrelevant for this test and could be mocked.
 
-                var emByRefRule = new Mock<IExtractMethodRule>();
-                emByRefRule.Setup(em => em.setValidFlag(It.IsAny<IdentifierReference>(), It.IsAny<Selection>())).Returns(10);
-                var emRules = new List<IExtractMethodRule>() { emByRefRule.Object };
+                    var emByRefRule = new Mock<IExtractMethodRule>();
+                    emByRefRule.Setup(em => em.setValidFlag(It.IsAny<IdentifierReference>(), It.IsAny<Selection>())).Returns(10);
+                    var emRules = new List<IExtractMethodRule>() { emByRefRule.Object };
 
-                var SUT = new ExtractMethodParameterClassification(emRules);
-                //Act
-                SUT.classifyDeclarations(qSelection, declaration);
-                var extractedParameter = SUT.ExtractedParameters.First();
-                Assert.IsTrue(SUT.ExtractedParameters.Count() > 0);
+                    var SUT = new ExtractMethodParameterClassification(emRules);
+                    //Act
+                    SUT.classifyDeclarations(qSelection, declaration);
+                    var extractedParameter = SUT.ExtractedParameters.First();
+                    Assert.IsTrue(SUT.ExtractedParameters.Count() > 0);
 
-                //Assert
-                Assert.AreEqual(extractedParameter.Passed, ExtractedParameter.PassedBy.ByRef);
+                    //Assert
+                    Assert.AreEqual(extractedParameter.Passed, ExtractedParameter.PassedBy.ByRef);
 
+                }
             }
         }
     }
- } 
+}

--- a/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodSelectionValidationTests.cs
+++ b/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodSelectionValidationTests.cs
@@ -40,17 +40,19 @@ Private Sub NewMethod4
 End Sub";
 
                     QualifiedModuleName qualifiedModuleName;
-                    var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                    var declarations = state.AllDeclarations;
-                    var selection = new Selection(4, 4, 10, 14);
-                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                    {
+                        var declarations = state.AllDeclarations;
+                        var selection = new Selection(4, 4, 10, 14);
+                        QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                    var SUT = new ExtractMethodSelectionValidation(declarations);
+                        var SUT = new ExtractMethodSelectionValidation(declarations);
 
-                    var actual = SUT.withinSingleProcedure(qSelection.Value);
-                    var expected = false;
-                    Assert.AreEqual(expected, actual);
+                        var actual = SUT.withinSingleProcedure(qSelection.Value);
+                        var expected = false;
+                        Assert.AreEqual(expected, actual);
 
+                    }
                 }
             }
             [TestClass]
@@ -81,18 +83,20 @@ Private Sub NewMethod4
 End Sub";
 
                     QualifiedModuleName qualifiedModuleName;
-                    var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                    var declarations = state.AllDeclarations;
-                    var selection = new Selection(4, 4, 5, 14);
-                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                    {
+                        var declarations = state.AllDeclarations;
+                        var selection = new Selection(4, 4, 5, 14);
+                        QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                    var SUT = new ExtractMethodSelectionValidation(declarations);
+                        var SUT = new ExtractMethodSelectionValidation(declarations);
 
-                    var actual = SUT.withinSingleProcedure(qSelection.Value);
+                        var actual = SUT.withinSingleProcedure(qSelection.Value);
 
-                    var expected = true;
-                    Assert.AreEqual(expected, actual);
+                        var expected = true;
+                        Assert.AreEqual(expected, actual);
 
+                    }
                 }
 
                 [TestMethod]
@@ -114,17 +118,19 @@ End Sub";
 
 
                     QualifiedModuleName qualifiedModuleName;
-                    var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                    var declarations = state.AllDeclarations;
-                    var selection = new Selection(4, 4, 7, 14);
-                    QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
+                    using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                    {
+                        var declarations = state.AllDeclarations;
+                        var selection = new Selection(4, 4, 7, 14);
+                        QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
 
-                    var SUT = new ExtractMethodSelectionValidation(declarations);
+                        var SUT = new ExtractMethodSelectionValidation(declarations);
 
-                    var actual = SUT.withinSingleProcedure(qSelection.Value);
+                        var actual = SUT.withinSingleProcedure(qSelection.Value);
 
-                    var expected = false;
-                    Assert.AreEqual(expected, actual);
+                        var expected = false;
+                        Assert.AreEqual(expected, actual);
+                    }
                 }
             }
         }

--- a/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodTests.cs
+++ b/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodTests.cs
@@ -51,19 +51,21 @@ Private Sub Foo()
 End Sub";
 
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var SUT = new ExtractedMethod();
+                    var SUT = new ExtractedMethod();
 
-                var expected = "NewMethod";
-                //Act
-                var actual = SUT.getNewMethodName(declarations);
+                    var expected = "NewMethod";
+                    //Act
+                    var actual = SUT.getNewMethodName(declarations);
 
-                //Assert
+                    //Assert
 
-                Assert.AreEqual(expected, actual);
+                    Assert.AreEqual(expected, actual);
 
+                }
             }
 
         }
@@ -89,18 +91,20 @@ End Sub";
                 #endregion inputCode
 
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var SUT = new ExtractedMethod();
+                    var SUT = new ExtractedMethod();
 
-                var expected = "NewMethod1";
-                //Act
-                var actual = SUT.getNewMethodName(declarations);
+                    var expected = "NewMethod1";
+                    //Act
+                    var actual = SUT.getNewMethodName(declarations);
 
-                //Assert
-                Assert.AreEqual(expected, actual);
+                    //Assert
+                    Assert.AreEqual(expected, actual);
 
+                }
             }
 
         }
@@ -134,18 +138,20 @@ End Sub";
                 #endregion inputCode
 
                 QualifiedModuleName qualifiedModuleName;
-                var state = MockParser.ParseString(inputCode, out qualifiedModuleName);
-                var declarations = state.AllDeclarations;
+                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                {
+                    var declarations = state.AllDeclarations;
 
-                var SUT = new ExtractedMethod();
+                    var SUT = new ExtractedMethod();
 
-                var expected = "NewMethod2";
-                //Act
-                var actual = SUT.getNewMethodName(declarations);
+                    var expected = "NewMethod2";
+                    //Act
+                    var actual = SUT.getNewMethodName(declarations);
 
-                //Assert
-                Assert.AreEqual(expected, actual);
+                    //Assert
+                    Assert.AreEqual(expected, actual);
 
+                }
             }
 
         }

--- a/RubberduckTests/Refactoring/ImplementInterfaceTests.cs
+++ b/RubberduckTests/Refactoring/ImplementInterfaceTests.cs
@@ -16,15 +16,15 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode1 =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Sub Class1_Foo()
     Err.Raise 5 'TODO implement interface member
@@ -33,21 +33,23 @@ End Sub
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -57,18 +59,18 @@ End Sub
         {
             //Input
             const string inputCode1 =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub";
 
             const string inputCode2 =
-@"Implements Class1
+                @"Implements Class1
 
 Public Sub Bar()
 End Sub";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Public Sub Bar()
 End Sub
@@ -80,21 +82,23 @@ End Sub
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -104,15 +108,15 @@ End Sub
         {
             //Input
             const string inputCode1 =
-@"Public Sub Foo(ByVal a As Integer, ByRef b, c, d As Long)
+                @"Public Sub Foo(ByVal a As Integer, ByRef b, c, d As Long)
 End Sub";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Sub Class1_Foo(ByVal a As Integer, ByRef b As Variant, ByRef c As Variant, ByRef d As Long)
     Err.Raise 5 'TODO implement interface member
@@ -121,21 +125,23 @@ End Sub
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -145,15 +151,15 @@ End Sub
         {
             //Input
             const string inputCode1 =
-@"Public Function Foo() As Integer
+                @"Public Function Foo() As Integer
 End Function";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Function Class1_Foo() As Integer
     Err.Raise 5 'TODO implement interface member
@@ -162,21 +168,23 @@ End Function
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -186,15 +194,15 @@ End Function
         {
             //Input
             const string inputCode1 =
-@"Public Function Foo()
+                @"Public Function Foo()
 End Function";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Function Class1_Foo() As Variant
     Err.Raise 5 'TODO implement interface member
@@ -203,21 +211,23 @@ End Function
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -227,15 +237,15 @@ End Function
         {
             //Input
             const string inputCode1 =
-@"Public Function Foo(a)
+                @"Public Function Foo(a)
 End Function";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Function Class1_Foo(ByRef a As Variant) As Variant
     Err.Raise 5 'TODO implement interface member
@@ -244,21 +254,23 @@ End Function
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -268,15 +280,15 @@ End Function
         {
             //Input
             const string inputCode1 =
-@"Public Property Get Foo() As Integer
+                @"Public Property Get Foo() As Integer
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Property Get Class1_Foo() As Integer
     Err.Raise 5 'TODO implement interface member
@@ -285,21 +297,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -309,15 +323,15 @@ End Property
         {
             //Input
             const string inputCode1 =
-@"Public Property Get Foo()
+                @"Public Property Get Foo()
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Property Get Class1_Foo() As Variant
     Err.Raise 5 'TODO implement interface member
@@ -326,21 +340,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -350,15 +366,15 @@ End Property
         {
             //Input
             const string inputCode1 =
-@"Public Property Get Foo(a)
+                @"Public Property Get Foo(a)
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Property Get Class1_Foo(ByRef a As Variant) As Variant
     Err.Raise 5 'TODO implement interface member
@@ -367,21 +383,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -391,15 +409,15 @@ End Property
         {
             //Input
             const string inputCode1 =
-@"Public Property Let Foo(ByRef value As Long)
+                @"Public Property Let Foo(ByRef value As Long)
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Property Let Class1_Foo(ByRef value As Long)
     Err.Raise 5 'TODO implement interface member
@@ -408,21 +426,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -432,15 +452,15 @@ End Property
         {
             //Input
             const string inputCode1 =
-@"Public Property Let Foo(a)
+                @"Public Property Let Foo(a)
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Property Let Class1_Foo(ByRef a As Variant)
     Err.Raise 5 'TODO implement interface member
@@ -449,21 +469,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -473,15 +495,15 @@ End Property
         {
             //Input
             const string inputCode1 =
-@"Public Property Set Foo(ByRef value As Variant)
+                @"Public Property Set Foo(ByRef value As Variant)
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Property Set Class1_Foo(ByRef value As Variant)
     Err.Raise 5 'TODO implement interface member
@@ -490,21 +512,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -514,15 +538,15 @@ End Property
         {
             //Input
             const string inputCode1 =
-@"Public Property Set Foo(a)
+                @"Public Property Set Foo(a)
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Property Set Class1_Foo(ByRef a As Variant)
     Err.Raise 5 'TODO implement interface member
@@ -531,21 +555,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -555,7 +581,7 @@ End Property
         {
             //Input
             const string inputCode1 =
-@"Public Sub Foo()
+                @"Public Sub Foo()
 End Sub
 
 Public Function Bar(ByVal a As Integer) As Boolean
@@ -568,11 +594,11 @@ Public Property Let Buz(ByVal a As Boolean, ByRef value As Integer)
 End Property";
 
             const string inputCode2 =
-@"Implements Class1";
+                @"Implements Class1";
 
             //Expectation
             const string expectedCode =
-@"Implements Class1
+                @"Implements Class1
 
 Private Sub Class1_Foo()
     Err.Raise 5 'TODO implement interface member
@@ -593,21 +619,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
-                 .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
-                 .Build();
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -617,7 +645,7 @@ End Property
         {
             //Input
             const string interfaceCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
 
 Public Function Fizz(b)
@@ -633,11 +661,11 @@ Public Property Set Buzz(value)
 End Property";
 
             const string inputCode =
-@"Implements IClassModule";
+                @"Implements IClassModule";
 
             //Expectation
             const string expectedCode =
-@"Implements IClassModule
+                @"Implements IClassModule
 
 Private Sub IClassModule_Foo(ByVal arg1 As Integer, ByVal arg2 As String)
     Err.Raise 5 'TODO implement interface member
@@ -662,21 +690,23 @@ End Property
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                 .AddComponent("IClassModule", ComponentType.ClassModule, interfaceCode)
-                 .AddComponent("Class1", ComponentType.ClassModule, inputCode)
-                 .Build();
+                .AddComponent("IClassModule", ComponentType.ClassModule, interfaceCode)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode)
+                .Build();
             var vbe = builder.AddProject(project).Build();
             var component = project.Object.VBComponents[1];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -706,17 +736,19 @@ End Sub
             var project = vbe.Object.VBProjects[0];
             var component = project.VBComponents["Sheet1"];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
- 
+
         [TestMethod]
         [TestCategory("Refactorings")]
         [TestCategory("Implement Interface")]
@@ -744,15 +776,17 @@ End Sub
             var project = vbe.Object.VBProjects[0];
             var component = project.VBComponents["Form1"];
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), Selection.Home);
 
-            var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ImplementInterfaceRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/Refactoring/IntroduceFieldTests.cs
+++ b/RubberduckTests/Refactoring/IntroduceFieldTests.cs
@@ -23,28 +23,30 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Dim bar As Boolean
 End Sub";
             var selection = new Selection(2, 10, 2, 13);
 
             //Expectation
             const string expectedCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -54,7 +56,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Function Foo() As Boolean
+                @"Private Function Foo() As Boolean
 Dim bar As Boolean
 Foo = True
 End Function";
@@ -62,22 +64,24 @@ End Function";
 
             //Expectation
             const string expectedCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Function Foo() As Boolean
 Foo = True
 End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -87,7 +91,7 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 Private Sub Foo(ByVal buz As Integer)
 Dim bar As Boolean
 End Sub";
@@ -95,22 +99,24 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 Private bar As Boolean
 Private Sub Foo(ByVal buz As Integer)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -120,7 +126,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 Private Sub Foo(ByVal buz As Integer)
 Dim _
 bar _
@@ -131,22 +137,24 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 Private bar As Boolean
 Private Sub Foo(ByVal buz As Integer)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -156,7 +164,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 Public buzz As Integer
 Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
@@ -166,7 +174,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Public fizz As Integer
+                @"Public fizz As Integer
 Public buzz As Integer
 Private bar As Boolean
 Private Sub Foo(ByVal buz As Integer, _
@@ -175,15 +183,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -193,7 +203,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, _
 bat As Date, _
@@ -203,7 +213,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bat As Date, _
@@ -212,15 +222,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -247,15 +259,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bat");
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bat");
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, new Mock<IMessageBox>().Object);
-            refactoring.Refactor(target);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, new Mock<IMessageBox>().Object);
+                refactoring.Refactor(target);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -265,7 +279,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, _
 bat As Date, _
@@ -275,7 +289,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private bap As Integer
+                @"Private bap As Integer
 Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, _
@@ -284,15 +298,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -302,7 +318,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, bat As Date, bap As Integer
 End Sub";
@@ -310,7 +326,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bat As Date, bap As Integer
@@ -318,15 +334,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -336,7 +354,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Boolean
+                @"Private fizz As Boolean
 
 Private Sub Foo()
 End Sub";
@@ -344,21 +362,23 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -368,7 +388,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Boolean
+                @"Private fizz As Boolean
 
 Private Sub Foo()
 End Sub";
@@ -376,23 +396,25 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(inputCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(inputCode, actual);
+            }
         }
 
         [TestMethod]
@@ -402,28 +424,30 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Dim bar As Boolean
 End Sub";
             var selection = new Selection(2, 10, 2, 13);
 
             //Expectation
             const string expectedCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceFieldRefactoring((vbe.Object), state, null);
-            refactoring.Refactor(state.AllUserDeclarations.FindVariable(qualifiedSelection));
+                var refactoring = new IntroduceFieldRefactoring((vbe.Object), state, null);
+                refactoring.Refactor(state.AllUserDeclarations.FindVariable(qualifiedSelection));
 
-            var actual = state.GetRewriter(component).GetText();
-            Assert.AreEqual(expectedCode, actual);
+                var actual = state.GetRewriter(component).GetText();
+                Assert.AreEqual(expectedCode, actual);
+            }
         }
 
         [TestMethod]
@@ -433,37 +457,39 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Dim bar As Boolean
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
-
-            var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, messageBox.Object);
-
-            try
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                refactoring.Refactor(state.AllUserDeclarations.First(d => d.DeclarationType != DeclarationType.Variable));
-            }
-            catch (ArgumentException e)
-            {
-                messageBox.Verify(m =>
-                    m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                    It.IsAny<MessageBoxIcon>()), Times.Once);
 
-                Assert.AreEqual("target", e.ParamName);
-                var actual = state.GetRewriter(component).GetText();
-                Assert.AreEqual(inputCode, actual);
-                return;
-            }
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            Assert.Fail();
+                var refactoring = new IntroduceFieldRefactoring(vbe.Object, state, messageBox.Object);
+
+                try
+                {
+                    refactoring.Refactor(state.AllUserDeclarations.First(d => d.DeclarationType != DeclarationType.Variable));
+                }
+                catch (ArgumentException e)
+                {
+                    messageBox.Verify(m =>
+                        m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                            It.IsAny<MessageBoxIcon>()), Times.Once);
+
+                    Assert.AreEqual("target", e.ParamName);
+                    var actual = state.GetRewriter(component).GetText();
+                    Assert.AreEqual(inputCode, actual);
+                    return;
+                }
+
+                Assert.Fail();
+            }
         }
     }
 }

--- a/RubberduckTests/Refactoring/IntroduceParameterTests.cs
+++ b/RubberduckTests/Refactoring/IntroduceParameterTests.cs
@@ -22,27 +22,29 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Dim bar As Boolean
 End Sub";
             var selection = new Selection(2, 10, 2, 13);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal bar As Boolean)
+                @"Private Sub Foo(ByVal bar As Boolean)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -52,7 +54,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Function Foo() As Boolean
+                @"Private Function Foo() As Boolean
 Dim bar As Boolean
 Foo = True
 End Function";
@@ -60,21 +62,23 @@ End Function";
 
             //Expectation
             const string expectedCode =
-@"Private Function Foo(ByVal bar As Boolean) As Boolean
+                @"Private Function Foo(ByVal bar As Boolean) As Boolean
 Foo = True
 End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -84,27 +88,29 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer)
+                @"Private Sub Foo(ByVal buz As Integer)
 Dim bar As Boolean
 End Sub";
             var selection = new Selection(2, 10, 2, 13);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal buz As Integer, ByVal bar As Boolean)
+                @"Private Sub Foo(ByVal buz As Integer, ByVal bar As Boolean)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -114,7 +120,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer)
+                @"Private Sub Foo(ByVal buz As Integer)
 Dim _
 bar _
 As _
@@ -124,20 +130,22 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal buz As Integer, ByVal bar As Boolean)
+                @"Private Sub Foo(ByVal buz As Integer, ByVal bar As Boolean)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -147,7 +155,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean
 End Sub";
@@ -155,21 +163,23 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date, ByVal bar As Boolean)
 End Sub";   // note: the VBE removes extra spaces
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -179,7 +189,7 @@ End Sub";   // note: the VBE removes extra spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, _
 bat As Date, _
@@ -189,7 +199,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date, ByVal bar As Boolean)
 Dim bat As Date, _
 bap As Integer
@@ -197,15 +207,17 @@ End Sub";   // note: the VBE removes extra spaces
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -215,7 +227,7 @@ End Sub";   // note: the VBE removes extra spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, _
 bat As Date, _
@@ -224,7 +236,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date, ByVal bat As Date)
 Dim bar As Boolean, _
 bap As Integer
@@ -232,15 +244,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bat");
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bat");
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, new Mock<IMessageBox>().Object);
-            refactoring.Refactor(target);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, new Mock<IMessageBox>().Object);
+                refactoring.Refactor(target);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -250,7 +264,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, _
 bat As Date, _
@@ -258,7 +272,7 @@ bap As Integer
 End Sub";
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date, ByVal bap As Integer)
 Dim bar As Boolean, _
 bat As Date
@@ -266,15 +280,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bap");
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bap");
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(target);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(target);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -284,29 +300,31 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date)
 Dim bar As Boolean, bat As Date, bap As Integer
 End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal buz As Integer, _
+                @"Private Sub Foo(ByVal buz As Integer, _
 ByRef baz As Date, ByVal bar As Boolean)
 Dim bat As Date, bap As Integer
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar");
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar");
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(target);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(target);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -316,29 +334,31 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Boolean
+                @"Private fizz As Boolean
 
 Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz");
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz");
+                refactoring.Refactor(target);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -348,29 +368,31 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private fizz As Boolean
+                @"Private fizz As Boolean
 
 Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz");
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz");
+                refactoring.Refactor(target);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -380,7 +402,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Property Get Foo(ByVal fizz As Boolean) As Boolean
+                @"Property Get Foo(ByVal fizz As Boolean) As Boolean
 Dim bar As Integer
 Foo = fizz
 End Property
@@ -390,7 +412,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Property Get Foo(ByVal fizz As Boolean, ByVal bar As Integer) As Boolean
+                @"Property Get Foo(ByVal fizz As Boolean, ByVal bar As Integer) As Boolean
 Foo = fizz
 End Property
 
@@ -399,15 +421,17 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar");
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar");
+                refactoring.Refactor(target);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -417,7 +441,7 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Property Get Foo(ByVal fizz As Boolean) As Variant
+                @"Property Get Foo(ByVal fizz As Boolean) As Variant
 Dim bar As Integer
 Foo = fizz
 End Property
@@ -427,7 +451,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Property Get Foo(ByVal fizz As Boolean, ByVal bar As Integer) As Variant
+                @"Property Get Foo(ByVal fizz As Boolean, ByVal bar As Integer) As Variant
 Foo = fizz
 End Property
 
@@ -436,15 +460,17 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar");
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar");
+                refactoring.Refactor(target);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -454,22 +480,22 @@ End Property";
         {
             //Input
             const string inputCode1 =
-            @"Sub fizz(ByVal boo As Boolean)
+                @"Sub fizz(ByVal boo As Boolean)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_fizz(ByVal boo As Boolean)
 Dim fizz As Date
 End Sub";
             //Expectation
             const string expectedCode1 =
-@"Sub fizz(ByVal boo As Boolean, ByVal fizz As Date)
+                @"Sub fizz(ByVal boo As Boolean, ByVal fizz As Date)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_fizz(ByVal boo As Boolean, ByVal fizz As Date)
 End Sub";
@@ -484,22 +510,24 @@ End Sub";
             var component1 = project.Object.VBComponents[1];
             vbe.Setup(v => v.ActiveCodePane).Returns(component1.CodeModule.CodePane);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz" && e.DeclarationType == DeclarationType.Variable);
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz" && e.DeclarationType == DeclarationType.Variable);
+                refactoring.Refactor(target);
 
-            var rewriter1 = state.GetRewriter(component0);
-            Assert.AreEqual(expectedCode1, rewriter1.GetText());
+                var rewriter1 = state.GetRewriter(component0);
+                Assert.AreEqual(expectedCode1, rewriter1.GetText());
 
-            var rewriter2 = state.GetRewriter(component1);
-            Assert.AreEqual(expectedCode2, rewriter2.GetText());
+                var rewriter2 = state.GetRewriter(component1);
+                Assert.AreEqual(expectedCode2, rewriter2.GetText());
+            }
         }
 
         [TestMethod]
@@ -509,35 +537,35 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Sub fizz(ByVal boo As Boolean)
+                @"Sub fizz(ByVal boo As Boolean)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_fizz(ByVal boo As Boolean)
 Dim fizz As Date
 End Sub";
 
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_fizz(ByVal boo As Boolean)
 End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Sub fizz(ByVal boo As Boolean, ByVal fizz As Date)
+                @"Sub fizz(ByVal boo As Boolean, ByVal fizz As Date)
 End Sub";
 
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_fizz(ByVal boo As Boolean, ByVal fizz As Date)
 End Sub";
 
             const string expectedCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_fizz(ByVal boo As Boolean, ByVal fizz As Date)
 End Sub";
@@ -554,25 +582,27 @@ End Sub";
             var component3 = project.Object.VBComponents[2];
             vbe.Setup(v => v.ActiveCodePane).Returns(component2.CodeModule.CodePane);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz" && e.DeclarationType == DeclarationType.Variable);
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz" && e.DeclarationType == DeclarationType.Variable);
+                refactoring.Refactor(target);
 
-            var rewriter1 = state.GetRewriter(component1);
-            Assert.AreEqual(expectedCode1, rewriter1.GetText());
+                var rewriter1 = state.GetRewriter(component1);
+                Assert.AreEqual(expectedCode1, rewriter1.GetText());
 
-            var rewriter2 = state.GetRewriter(component2);
-            Assert.AreEqual(expectedCode2, rewriter2.GetText());
+                var rewriter2 = state.GetRewriter(component2);
+                Assert.AreEqual(expectedCode2, rewriter2.GetText());
 
-            var rewriter3 = state.GetRewriter(component3);
-            Assert.AreEqual(expectedCode3, rewriter3.GetText());
+                var rewriter3 = state.GetRewriter(component3);
+                Assert.AreEqual(expectedCode3, rewriter3.GetText());
+            }
         }
 
         [TestMethod]
@@ -582,11 +612,11 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-            @"Sub fizz(ByVal boo As Boolean)
+                @"Sub fizz(ByVal boo As Boolean)
 End Sub";
 
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Sub IClass1_fizz(ByVal boo As Boolean)
 Dim fizz As Date
@@ -602,22 +632,24 @@ End Sub";
             var component2 = project.Object.VBComponents[1];
             vbe.Setup(v => v.ActiveCodePane).Returns(component2.CodeModule.CodePane);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.No);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.No);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz" && e.DeclarationType == DeclarationType.Variable);
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "fizz" && e.DeclarationType == DeclarationType.Variable);
+                refactoring.Refactor(target);
 
-            var rewriter1 = state.GetRewriter(component1);
-            Assert.AreEqual(inputCode1, rewriter1.GetText());
+                var rewriter1 = state.GetRewriter(component1);
+                Assert.AreEqual(inputCode1, rewriter1.GetText());
 
-            var rewriter2 = state.GetRewriter(component2);
-            Assert.AreEqual(inputCode2, rewriter2.GetText());
+                var rewriter2 = state.GetRewriter(component2);
+                Assert.AreEqual(inputCode2, rewriter2.GetText());
+            }
         }
 
         [TestMethod]
@@ -627,26 +659,28 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Dim bar As Boolean
 End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal bar As Boolean)
+                @"Private Sub Foo(ByVal bar As Boolean)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, null);
 
-            var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar" && e.DeclarationType == DeclarationType.Variable);
-            refactoring.Refactor(target);
+                var target = state.AllUserDeclarations.SingleOrDefault(e => e.IdentifierName == "bar" && e.DeclarationType == DeclarationType.Variable);
+                refactoring.Refactor(target);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -656,27 +690,29 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Dim bar As Boolean
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
-            refactoring.Refactor(state.AllUserDeclarations.First(d => d.DeclarationType != DeclarationType.Variable));
+                var refactoring = new IntroduceParameterRefactoring(vbe.Object, state, messageBox.Object);
+                refactoring.Refactor(state.AllUserDeclarations.First(d => d.DeclarationType != DeclarationType.Variable));
 
-            messageBox.Verify(m =>
-                m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
+                messageBox.Verify(m =>
+                    m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                        It.IsAny<MessageBoxIcon>()), Times.Once);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
+++ b/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
@@ -22,7 +22,7 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
     bar = True
 End Sub";
@@ -30,22 +30,24 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Boolean
 bar = True
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -55,7 +57,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private _
+                @"Private _
 bar _
 As _
 Boolean
@@ -66,22 +68,24 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Boolean
 bar = True
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -91,20 +95,20 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public bar As Boolean";
+                @"Public bar As Boolean";
 
             const string inputCode2 =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Module1.bar = True
 End Sub";
             var selection = new Selection(1, 1);
 
             //Expectation
             const string expectedCode1 =
-@"";
+                @"";
 
             const string expectedCode2 =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 Dim bar As Boolean
 bar = True
 End Sub";
@@ -116,20 +120,22 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0];
-            var module2 = project.Object.VBComponents[1];
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0];
+                var module2 = project.Object.VBComponents[1];
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter1 = state.GetRewriter(module1);
-            Assert.AreEqual(expectedCode1, rewriter1.GetText());
+                var rewriter1 = state.GetRewriter(module1);
+                Assert.AreEqual(expectedCode1, rewriter1.GetText());
 
-            var rewriter2 = state.GetRewriter(module2);
-            Assert.AreEqual(expectedCode2, rewriter2.GetText());
+                var rewriter2 = state.GetRewriter(module2);
+                Assert.AreEqual(expectedCode2, rewriter2.GetText());
+            }
         }
 
         [TestMethod]
@@ -139,7 +145,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Boolean
     Dim bat As Integer
     bar = True
@@ -148,7 +154,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bat As Integer
     Dim bar As Boolean
 bar = True
@@ -156,15 +162,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -174,7 +182,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim _
     bar _
     As _
@@ -186,7 +194,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bat As Integer
     Dim bar As Boolean
 bar = True
@@ -194,15 +202,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -212,7 +222,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Integer
+                @"Private bar As Integer
 Private bat As Boolean
 Private bay As Date
 
@@ -223,7 +233,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private bar As Integer
+                @"Private bar As Integer
 Private bay As Date
 
 Private Sub Foo()
@@ -233,15 +243,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -251,7 +263,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Integer, _
+                @"Private bar As Integer, _
           bat As Boolean, _
           bay As Date
 
@@ -262,7 +274,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private bat As Boolean, _
+                @"Private bat As Boolean, _
           bay As Date
 
 Private Sub Foo()
@@ -272,15 +284,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -290,7 +304,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Integer, _
+                @"Private bar As Integer, _
           bat As Boolean, _
           bay As Date
 
@@ -301,7 +315,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private bar As Integer, _
+                @"Private bar As Integer, _
           bay As Date
 
 Private Sub Foo()
@@ -311,15 +325,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -329,7 +345,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Integer, _
+                @"Private bar As Integer, _
           bat As Boolean, _
           bay As Date
 
@@ -340,7 +356,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private bar As Integer, _
+                @"Private bar As Integer, _
           bat As Boolean
 
 Private Sub Foo()
@@ -350,15 +366,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -368,7 +386,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Integer, _
         bat As Boolean, _
         bay As Date
@@ -380,7 +398,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bat As Boolean, _
         bay As Date
 
@@ -391,15 +409,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -409,7 +429,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Integer, _
         bat As Boolean, _
         bay As Date
@@ -421,7 +441,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Integer, _
         bay As Date
 
@@ -432,15 +452,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -450,7 +472,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Integer, _
         bat As Boolean, _
         bay As Date
@@ -462,7 +484,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Integer, _
         bat As Boolean
 
@@ -473,15 +495,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -491,30 +515,32 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
 End Sub";
             var selection = new Selection(1, 1);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -524,7 +550,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
     bar = True
 End Sub
@@ -535,22 +561,24 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m =>
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                It.IsAny<MessageBoxIcon>()), Times.Once);
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                messageBox.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
+                    It.IsAny<MessageBoxIcon>()), Times.Once);
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -560,13 +588,13 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo(ByRef bat As Boolean)
     bat = bar
 End Sub";
 
             const string expectedCode =
-@"Private Sub Foo(ByRef bat As Boolean)
+                @"Private Sub Foo(ByRef bat As Boolean)
     Dim bar As Boolean
 bat = bar
 End Sub";
@@ -574,15 +602,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -592,7 +622,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
     Baz bar
 End Sub
@@ -600,7 +630,7 @@ Sub Baz(ByVal bat As Boolean)
 End Sub";
 
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Boolean
 Baz bar
 End Sub
@@ -610,15 +640,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -628,7 +660,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
     Baz True, _
         True, _
@@ -638,7 +670,7 @@ Sub Baz(ByVal bat As Boolean, ByVal bas As Boolean, ByVal bac As Boolean)
 End Sub";
 
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
     Dim bar As Boolean
 Baz True, _
         True, _
@@ -650,15 +682,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -668,7 +702,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo(): Baz True, True, bar: End Sub
 Private Sub Baz(ByVal bat As Boolean, ByVal bas As Boolean, ByVal bac As Boolean): End Sub";
 
@@ -676,21 +710,23 @@ Private Sub Baz(ByVal bat As Boolean, ByVal bas As Boolean, ByVal bac As Boolean
 
             // Yeah, this code is a mess.  That is why we got the SmartIndenter
             const string expectedCode =
-@"Private Sub Foo(): Dim bar As Boolean
+                @"Private Sub Foo(): Dim bar As Boolean
 Baz True, True, bar: End Sub
 Private Sub Baz(ByVal bat As Boolean, ByVal bas As Boolean, ByVal bac As Boolean): End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -700,7 +736,7 @@ Private Sub Baz(ByVal bat As Boolean, ByVal bas As Boolean, ByVal bac As Boolean
         {
             //Input
             const string inputCode =
-@"
+                @"
 Private foo As Long
 
 Public Sub Test()
@@ -713,7 +749,7 @@ End Sub";
 
             var selection = new Selection(2, 1);
             const string expectedCode =
-@"
+                @"
 Public Sub Test()
     Dim foo As Long
 SomeSub someParam:=foo
@@ -725,15 +761,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -743,7 +781,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private foo As Long
+                @"Private foo As Long
 
 Public Sub Test(): SomeSub someParam:=foo: End Sub
 
@@ -753,7 +791,7 @@ End Sub";
 
             var selection = new Selection(1, 1);
             const string expectedCode =
-@"Public Sub Test(): Dim foo As Long
+                @"Public Sub Test(): Dim foo As Long
 SomeSub someParam:=foo: End Sub
 
 Public Sub SomeSub(ByVal someParam As Long)
@@ -762,15 +800,17 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(expectedCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -780,27 +820,29 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
     bar = True
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
-            refactoring.Refactor(state.AllUserDeclarations.First(d => d.DeclarationType != DeclarationType.Variable));
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
+                refactoring.Refactor(state.AllUserDeclarations.First(d => d.DeclarationType != DeclarationType.Variable));
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
 
-            messageBox.Verify(m =>
+                messageBox.Verify(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
                         It.IsAny<MessageBoxIcon>()), Times.Once);
+            }
         }
 
         [TestMethod]
@@ -810,7 +852,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private bar As Boolean
+                @"Private bar As Boolean
 Private Sub Foo()
     bar = True
 End Sub";
@@ -818,23 +860,25 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            messageBox.Verify(m =>
+                messageBox.Verify(m =>
                     m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(),
-                    It.IsAny<MessageBoxIcon>()), Times.Once);
+                        It.IsAny<MessageBoxIcon>()), Times.Once);
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
     }
 }

--- a/RubberduckTests/Refactoring/RemoveParametersTests.cs
+++ b/RubberduckTests/Refactoring/RemoveParametersTests.cs
@@ -24,32 +24,34 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters.ForEach(arg => arg.IsRemoved = true);
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters.ForEach(arg => arg.IsRemoved = true);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -59,32 +61,34 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg1 As Integer)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters.ForEach(arg => arg.IsRemoved = true);
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters.ForEach(arg => arg.IsRemoved = true);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -94,32 +98,34 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg2 As String)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -129,32 +135,34 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg1 As Integer)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -164,7 +172,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Double)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Double)
 End Sub
 
 Public Sub Goo()
@@ -175,7 +183,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
 
 Public Sub Goo()
@@ -185,21 +193,23 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[2].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[2].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -209,7 +219,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Sub foo(a, b, c)
+                @"Sub foo(a, b, c)
 
 End Sub
 
@@ -220,7 +230,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Sub foo(a, b)
+                @"Sub foo(a, b)
 
 End Sub
 
@@ -230,21 +240,23 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[2].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[2].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -254,32 +266,34 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
+                @"Private Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
 End Function";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Function Foo(ByVal arg1 As Integer) As Boolean
+                @"Private Function Foo(ByVal arg1 As Integer) As Boolean
 End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -289,32 +303,34 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Private Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
+                @"Private Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
 End Function";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Function Foo() As Boolean
+                @"Private Function Foo() As Boolean
 End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters.ForEach(p => p.IsRemoved = true);
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters.ForEach(p => p.IsRemoved = true);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -324,7 +340,7 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Private Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
+                @"Private Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
 End Function
 
 Private Sub Goo(ByVal arg1 As Integer, ByVal arg2 As String)
@@ -335,7 +351,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Private Function Foo() As Boolean
+                @"Private Function Foo() As Boolean
 End Function
 
 Private Sub Goo(ByVal arg1 As Integer, ByVal arg2 As String)
@@ -345,21 +361,23 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters.ForEach(p => p.IsRemoved = true);
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters.ForEach(p => p.IsRemoved = true);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -369,7 +387,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Private Sub foo(a, b, c, d, e, f, g)
+                @"Private Sub foo(a, b, c, d, e, f, g)
 End Sub
 
 Private Sub goo()
@@ -379,7 +397,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub foo(a, b, e, g)
+                @"Private Sub foo(a, b, e, g)
 End Sub
 
 Private Sub goo()
@@ -388,23 +406,25 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters.ElementAt(2).IsRemoved = true;
-            model.Parameters.ElementAt(3).IsRemoved = true;
-            model.Parameters.ElementAt(5).IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters.ElementAt(2).IsRemoved = true;
+                model.Parameters.ElementAt(3).IsRemoved = true;
+                model.Parameters.ElementAt(5).IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -414,32 +434,34 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Property Get Foo(ByVal arg1 As Integer) As Boolean
+                @"Private Property Get Foo(ByVal arg1 As Integer) As Boolean
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Property Get Foo() As Boolean
+                @"Private Property Get Foo() As Boolean
 End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters.ForEach(p => p.IsRemoved = true);
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters.ForEach(p => p.IsRemoved = true);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -459,24 +481,26 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var parameter = state.AllUserDeclarations.SingleOrDefault(p => 
-                p.DeclarationType == DeclarationType.Parameter && p.IdentifierName == "arg1");
-            if (parameter == null) { Assert.Inconclusive("Can't find 'arg1' parameter/target."); }
+                var parameter = state.AllUserDeclarations.SingleOrDefault(p =>
+                    p.DeclarationType == DeclarationType.Parameter && p.IdentifierName == "arg1");
+                if (parameter == null) { Assert.Inconclusive("Can't find 'arg1' parameter/target."); }
 
-            var qualifiedSelection = parameter.QualifiedSelection;
+                var qualifiedSelection = parameter.QualifiedSelection;
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.QuickFix(state, qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.QuickFix(state, qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -486,32 +510,34 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Property Set Foo(ByVal arg2 As String)
+                @"Private Property Set Foo(ByVal arg2 As String)
 End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -521,7 +547,7 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
 
 Private Sub Bar()
@@ -532,7 +558,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg2 As String)
 End Sub
 
 Private Sub Bar()
@@ -542,21 +568,23 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -566,7 +594,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Private Sub bar()
+                @"Private Sub bar()
     Dim x As Integer
     Dim y As Integer
     y = foo(x, 42)
@@ -581,7 +609,7 @@ End Function";
 
             //Expectation
             const string expectedCode =
-@"Private Sub bar()
+                @"Private Sub bar()
     Dim x As Integer
     Dim y As Integer
     y = foo(42)
@@ -595,21 +623,23 @@ End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -619,7 +649,7 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
 
 Private Sub Bar()
@@ -630,7 +660,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg1 As Integer)
 End Sub
 
 Private Sub Bar()
@@ -640,21 +670,23 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -664,7 +696,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Sub Foo(ByVal arg1 As String, ParamArray arg2())
+                @"Sub Foo(ByVal arg1 As String, ParamArray arg2())
 End Sub
 
 Public Sub Goo(ByVal arg1 As Integer, _
@@ -681,7 +713,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Sub Foo(ByVal arg1 As String)
+                @"Sub Foo(ByVal arg1 As String)
 End Sub
 
 Public Sub Goo(ByVal arg1 As Integer, _
@@ -697,21 +729,23 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -721,19 +755,21 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
+                @"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
 
-            Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from setter
+                Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from setter
+            }
         }
 
         [TestMethod]
@@ -743,19 +779,21 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
+                @"Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
 
-            Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from letter
+                Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from letter
+            }
         }
 
         [TestMethod]
@@ -765,7 +803,7 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Get Foo(ByVal arg1 As Integer)
+                @"Private Property Get Foo(ByVal arg1 As Integer)
 End Property
 
 Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String)
@@ -774,7 +812,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Private Property Get Foo()
+                @"Private Property Get Foo()
 End Property
 
 Private Property Set Foo(ByVal arg2 As String)
@@ -782,21 +820,23 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -806,7 +846,7 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Get Foo(ByVal arg1 As Integer)
+                @"Private Property Get Foo(ByVal arg1 As Integer)
 End Property
 
 Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String)
@@ -815,7 +855,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Private Property Get Foo()
+                @"Private Property Get Foo()
 End Property
 
 Private Property Let Foo(ByVal arg2 As String)
@@ -823,21 +863,23 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -847,7 +889,7 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, Optional ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, Optional ByVal arg2 As String)
 End Sub
 
 Private Sub Goo(ByVal arg1 As Integer)
@@ -857,7 +899,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(Optional ByVal arg2 As String)
+                @"Private Sub Foo(Optional ByVal arg2 As String)
 End Sub
 
 Private Sub Goo(ByVal arg1 As Integer)
@@ -866,21 +908,23 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -890,7 +934,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, Optional ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, Optional ByVal arg2 As String)
 End Sub
 
 Private Sub Goo(ByVal arg1 As Integer)
@@ -901,7 +945,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg1 As Integer)
 End Sub
 
 Private Sub Goo(ByVal arg1 As Integer)
@@ -911,21 +955,23 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -935,7 +981,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, _
+                @"Private Sub Foo(ByVal arg1 As Integer, _
                   ByVal arg2 As String, _
                   ByVal arg3 As Date)
 End Sub";
@@ -943,27 +989,29 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, _
+                @"Private Sub Foo(ByVal arg2 As String, _
                   ByVal arg3 As Date)
 End Sub";   // note: VBE removes excess spaces
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -973,7 +1021,7 @@ End Sub";   // note: VBE removes excess spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, _
+                @"Private Sub Foo(ByVal arg1 As Integer, _
                   ByVal arg2 As String, _
                   ByVal arg3 As Date)
 End Sub";
@@ -981,27 +1029,29 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg1 As Integer, _
+                @"Private Sub Foo(ByVal arg1 As Integer, _
                   ByVal arg3 As Date)
 End Sub";   // note: VBE removes excess spaces
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1011,7 +1061,7 @@ End Sub";   // note: VBE removes excess spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, _
+                @"Private Sub Foo(ByVal arg1 As Integer, _
                   ByVal arg2 As String, _
                   ByVal arg3 As Date)
 End Sub";
@@ -1019,27 +1069,29 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg1 As Integer, _
+                @"Private Sub Foo(ByVal arg1 As Integer, _
                   ByVal arg2 As String)
 End Sub";   // note: VBE removes excess spaces
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[2].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[2].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1049,7 +1101,7 @@ End Sub";   // note: VBE removes excess spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, _
+                @"Private Sub Foo(ByVal arg1 As Integer, _
                   ByVal arg2 As String, _
                   ByVal arg3 As Date)
 End Sub";
@@ -1057,27 +1109,29 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, _
+                @"Private Sub Foo(ByVal arg2 As String, _
                   ByVal arg3 As Date)
 End Sub";   // note: VBE removes excess spaces
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(model.TargetDeclaration);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(model.TargetDeclaration);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1087,7 +1141,7 @@ End Sub";   // note: VBE removes excess spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
 End Sub
 
 Private Sub Goo(ByVal arg1 as Integer, ByVal arg2 As String, ByVal arg3 As Date)
@@ -1102,7 +1156,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, ByVal arg3 As Date)
+                @"Private Sub Foo(ByVal arg2 As String, ByVal arg3 As Date)
 End Sub
 
 Private Sub Goo(ByVal arg1 as Integer, ByVal arg2 As String, ByVal arg3 As Date)
@@ -1115,21 +1169,23 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[0].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[0].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1139,10 +1195,10 @@ End Sub
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
@@ -1151,10 +1207,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Sub DoSomething(ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer)
 End Sub";
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1166,24 +1222,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1193,10 +1251,10 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v1 As Integer, ByVal v2 As String)
 End Sub";
@@ -1205,10 +1263,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Sub DoSomething(ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer)
 End Sub";
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v1 As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1220,24 +1278,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1247,15 +1307,15 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v1 As Integer, ByVal v2 As String)
 End Sub";
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal i As Integer, ByVal s As String)
 End Sub";
@@ -1264,15 +1324,15 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Sub DoSomething(ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer)
 End Sub";
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v1 As Integer)
 End Sub";   // note: IDE removes excess spaces
             const string expectedCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal i As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1285,26 +1345,28 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
-            var module3 = project.Object.VBComponents[2].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
+                var module3 = project.Object.VBComponents[2].CodeModule;
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
-            Assert.AreEqual(expectedCode3, module3.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode3, module3.Content());
+            }
         }
 
         [TestMethod]
@@ -1314,10 +1376,10 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
@@ -1326,10 +1388,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Event Foo(ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg1 As Integer)";
 
             const string expectedCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal arg1 As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1341,24 +1403,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1368,25 +1432,25 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Private WithEvents abc As Class2
+                @"Private WithEvents abc As Class2
 
 Private Sub abc_Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
 
             const string inputCode2 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             var selection = new Selection(3, 15, 3, 15);
 
             //Expectation
             const string expectedCode1 =
-@"Private WithEvents abc As Class2
+                @"Private WithEvents abc As Class2
 
 Private Sub abc_Foo(ByVal arg1 As Integer)
 End Sub";   // note: IDE removes excess spaces
 
             const string expectedCode2 =
-@"Public Event Foo(ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg1 As Integer)";
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
@@ -1395,24 +1459,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Last().IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Last().IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1422,10 +1488,10 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub";
@@ -1434,10 +1500,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Event Foo(ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg1 As Integer)";
 
             const string expectedCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1449,24 +1515,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1476,15 +1544,15 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub";
             const string inputCode3 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal v1 As Integer, ByVal v2 As String)
 End Sub";
@@ -1493,15 +1561,15 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Event Foo(ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg1 As Integer)";
 
             const string expectedCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer)
 End Sub";   // note: IDE removes excess spaces
             const string expectedCode3 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal v1 As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1514,26 +1582,28 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
-            var module3 = project.Object.VBComponents[2].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
+                var module3 = project.Object.VBComponents[2].CodeModule;
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
-            Assert.AreEqual(expectedCode3, module3.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode3, module3.Content());
+            }
         }
 
         [TestMethod]
@@ -1543,25 +1613,25 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
 
             var selection = new Selection(3, 23, 3, 23);
 
             //Expectation
             const string expectedCode1 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer)
 End Sub";   // note: IDE removes excess spaces
 
             const string expectedCode2 =
-@"Public Sub DoSomething(ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal a As Integer)
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -1571,28 +1641,30 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.Yes);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.Yes);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, messageBox.Object);
-            model.Parameters[1].IsRemoved = true;
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, messageBox.Object);
+                model.Parameters[1].IsRemoved = true;
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1602,12 +1674,12 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
 
             var selection = new Selection(3, 23, 3, 23);
@@ -1619,16 +1691,18 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.No);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.No);
 
-            //Specify Params to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, messageBox.Object);
-            Assert.IsNull(model.TargetDeclaration);
+                //Specify Params to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, messageBox.Object);
+                Assert.IsNull(model.TargetDeclaration);
+            }
         }
 
         [TestMethod]
@@ -1638,36 +1712,38 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //set up model
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
-
-            var factory = SetupFactory(model);
-
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-
-            try
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                refactoring.Refactor(
-                    model.Declarations.FirstOrDefault(
-                        i => i.DeclarationType == DeclarationType.ProceduralModule));
-            }
-            catch (ArgumentException e)
-            {
-                Assert.AreEqual("Invalid declaration type", e.Message);
-                return;
-            }
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            Assert.Fail();
+                //set up model
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
+
+                var factory = SetupFactory(model);
+
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+
+                try
+                {
+                    refactoring.Refactor(
+                        model.Declarations.FirstOrDefault(
+                            i => i.DeclarationType == DeclarationType.ProceduralModule));
+                }
+                catch (ArgumentException e)
+                {
+                    Assert.AreEqual("Invalid declaration type", e.Message);
+                    return;
+                }
+
+                Assert.Fail();
+            }
         }
 
         [TestMethod]
@@ -1677,19 +1753,21 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, null);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, null);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory);
-            refactoring.Refactor();
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory);
+                refactoring.Refactor();
 
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1699,26 +1777,28 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to remove
-            var model = new RemoveParametersModel(state, qualifiedSelection, null);
+                //Specify Param(s) to remove
+                var model = new RemoveParametersModel(state, qualifiedSelection, null);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new RemoveParametersRefactoring(vbe.Object, factory.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1728,24 +1808,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg1 As Integer)
 End Sub";
             var selection = new Selection(1, 15, 1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var model = new RemoveParametersModel(state, qualifiedSelection, new Mock<IMessageBox>().Object);
-            model.Parameters[0].IsRemoved = true;
+                var model = new RemoveParametersModel(state, qualifiedSelection, new Mock<IMessageBox>().Object);
+                model.Parameters[0].IsRemoved = true;
 
-            var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, null);
+                var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, null);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.IsTrue(model.Parameters[0].Declaration.Equals(presenter.Show().Parameters[0].Declaration));
+                Assert.IsTrue(model.Parameters[0].Declaration.Equals(presenter.Show().Parameters[0].Declaration));
+            }
         }
 
         [TestMethod]
@@ -1755,7 +1837,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
             var selection = new Selection(1, 15, 1, 15);
 
@@ -1766,15 +1848,17 @@ End Sub";
             builder.AddProject(project);
             var vbe = builder.Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>())).Returns(DialogResult.OK);
 
-            var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, messageBox.Object);
-            var presenter = factory.Create();
+                var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, messageBox.Object);
+                var presenter = factory.Create();
 
-            Assert.AreEqual(null, presenter.Show());
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         [TestMethod]
@@ -1784,7 +1868,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -1794,12 +1878,14 @@ End Sub";
             builder.AddProject(project);
             var vbe = builder.Build();
 
-            vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane) null);
+            vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var state = MockParser.CreateAndParse(vbe.Object);
-            var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, null);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var factory = new RemoveParametersPresenterFactory(vbe.Object, null, state, null);
 
-            Assert.IsNull(factory.Create());
+                Assert.IsNull(factory.Create());
+            }
         }
 
         #region setup

--- a/RubberduckTests/Refactoring/RenameTests.cs
+++ b/RubberduckTests/Refactoring/RenameTests.cs
@@ -33,11 +33,11 @@ namespace RubberduckTests.Refactoring
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Foo()
+                    @"Private Sub Foo()
     Dim va|l1 As Integer
 End Sub",
                 Expected =
-@"Private Sub Foo()
+                    @"Private Sub Foo()
     Dim val2 As Integer
 End Sub"
             };
@@ -53,12 +53,12 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Foo()
+                    @"Private Sub Foo()
     Dim v|al1 As Integer
     val1 = val1 + 5
 End Sub",
                 Expected =
-@"Private Sub Foo()
+                    @"Private Sub Foo()
     Dim val2 As Integer
     val2 = val2 + 5
 End Sub"
@@ -78,10 +78,10 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Foo(ByVal ar|g1 As String)
+                    @"Private Sub Foo(ByVal ar|g1 As String)
 End Sub",
                 Expected =
-@"Private Sub Foo(ByVal arg2 As String)
+                    @"Private Sub Foo(ByVal arg2 As String)
 End Sub"
             };
             PerformExpectedVersusActualRenameTests(tdo, inputOutput);
@@ -96,11 +96,11 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Foo(ByVal arg1 As String, _
+                    @"Private Sub Foo(ByVal arg1 As String, _
         ByVal ar|g3 As String)
 End Sub",
                 Expected =
-@"Private Sub Foo(ByVal arg1 As String, _
+                    @"Private Sub Foo(ByVal arg1 As String, _
         ByVal arg2 As String)
 End Sub"
             };
@@ -116,11 +116,11 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Foo(ByVal ar|g1 As String)
+                    @"Private Sub Foo(ByVal ar|g1 As String)
     arg1 = ""test""
 End Sub",
                 Expected =
-@"Private Sub Foo(ByVal arg2 As String)
+                    @"Private Sub Foo(ByVal arg2 As String)
     arg2 = ""test""
 End Sub"
             };
@@ -136,7 +136,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("ClassFoo")
             {
                 Input =
-@"Property Get Foo(ByVal in|dex As Integer) As Variant
+                    @"Property Get Foo(ByVal in|dex As Integer) As Variant
     Dim d As Integer
     d = index
 End Property
@@ -152,7 +152,7 @@ Property Set Foo(ByVal index As Integer, ByVal value As Variant)
 End Property",
 
                 Expected =
-@"Property Get Foo(ByVal renamed As Integer) As Variant
+                    @"Property Get Foo(ByVal renamed As Integer) As Variant
     Dim d As Integer
     d = renamed
 End Property
@@ -179,7 +179,7 @@ End Property"
             var inputOutput = new RenameTestModuleDefinition("ClassFoo")
             {
                 Input =
-@"Property Let Foo(ByVal index As Integer, ByVal va|lue As Variant)
+                    @"Property Let Foo(ByVal index As Integer, ByVal va|lue As Variant)
     Dim d As Variant
     d = value
 End Property
@@ -189,7 +189,7 @@ Property Set Foo(ByVal index As Integer, ByVal value As Variant)
     d = value
 End Property",
                 Expected =
-@"Property Let Foo(ByVal index As Integer, ByVal renamed As Variant)
+                    @"Property Let Foo(ByVal index As Integer, ByVal renamed As Variant)
     Dim d As Variant
     d = renamed
 End Property
@@ -211,7 +211,7 @@ End Property"
             var inputOutput = new RenameTestModuleDefinition("ClassFoo")
             {
                 Input =
-@"Property Get Foo(ByVal index As Integer) As Variant
+                    @"Property Get Foo(ByVal index As Integer) As Variant
 End Property
 
 Property Let Foo(ByVal index As Integer, ByVal v|alue As Variant)
@@ -224,7 +224,7 @@ Property Set Foo(ByVal index As Integer, ByVal fizz As Variant)
     d = fizz
 End Property",
                 Expected =
-@"Property Get Foo(ByVal index As Integer) As Variant
+                    @"Property Get Foo(ByVal index As Integer) As Variant
 End Property
 
 Property Let Foo(ByVal index As Integer, ByVal renamed As Variant)
@@ -252,11 +252,11 @@ End Property"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Fo|o()
+                    @"Private Sub Fo|o()
     Dim Goo As Integer
 End Sub",
                 Expected =
-@"Private Sub Foo()
+                    @"Private Sub Foo()
     Dim Goo As Integer
 End Sub"
             };
@@ -273,11 +273,11 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Fo|o()
+                    @"Private Sub Fo|o()
     Dim Goo As Integer
 End Sub",
                 Expected =
-@"Private Sub Goo()
+                    @"Private Sub Goo()
     Dim Goo As Integer
 End Sub"
             };
@@ -293,14 +293,14 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub Fo|o()
+                    @"Private Sub Fo|o()
 End Sub
 
 Private Sub Goo()
     Foo
 End Sub",
                 Expected =
-@"Private Sub Hoo()
+                    @"Private Sub Hoo()
 End Sub
 
 Private Sub Goo()
@@ -318,14 +318,14 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("ClassFoo")
             {
                 Input =
-@"Private Property Get F|oo(ByVal arg1 As Integer) As String
+                    @"Private Property Get F|oo(ByVal arg1 As Integer) As String
     Foo = ""Hello""
 End Property
 
 Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
 End Property",
                 Expected =
-@"Private Property Get Goo(ByVal arg1 As Integer) As String
+                    @"Private Property Get Goo(ByVal arg1 As Integer) As String
     Goo = ""Hello""
 End Property
 
@@ -344,13 +344,13 @@ End Property"
             var inputOutput = new RenameTestModuleDefinition("ClassFoo")
             {
                 Input =
-@"Private Property Get Foo() 
+                    @"Private Property Get Foo() 
 End Property
 
 Private Property Let F|oo(ByVal arg1 As String) 
 End Property",
                 Expected =
-@"Private Property Get Goo() 
+                    @"Private Property Get Goo() 
 End Property
 
 Private Property Let Goo(ByVal arg1 As String) 
@@ -368,11 +368,11 @@ End Property"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Function Foo() As Boolean
+                    @"Private Function Foo() As Boolean
     Fo|o = True
 End Function",
                 Expected =
-@"Private Function Hoo() As Boolean
+                    @"Private Function Hoo() As Boolean
     Hoo = True
 End Function"
             };
@@ -388,7 +388,7 @@ End Function"
             var inputOutput = new RenameTestModuleDefinition("ClassFoo")
             {
                 Input =
-@"Private Function Fo|o() As Boolean
+                    @"Private Function Fo|o() As Boolean
     Foo = True
 End Function
 
@@ -397,7 +397,7 @@ Private Sub Goo()
     var1 = Foo()
 End Sub",
                 Expected =
-@"Private Function Hoo() As Boolean
+                    @"Private Function Hoo() As Boolean
     Hoo = True
 End Function
 
@@ -422,7 +422,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("UserForm1", ComponentType.UserForm)
             {
                 Input =
-@"Private Sub cmdBtn1_Cl|ick()
+                    @"Private Sub cmdBtn1_Cl|ick()
 End Sub
 
 Private Sub tbEnterName_Change()
@@ -433,7 +433,7 @@ Private Sub UserForm_Click()
     cmdBtn1.Caption = ""Click This""
 End Sub",
                 Expected =
-@"Private Sub cmdBigButton_Click()
+                    @"Private Sub cmdBigButton_Click()
 End Sub
 
 Private Sub tbEnterName_Change()
@@ -455,7 +455,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("UserForm1", ComponentType.UserForm)
             {
                 Input =
-@"Private Sub cmdBtn1_Cl|ick()
+                    @"Private Sub cmdBtn1_Cl|ick()
     cmdBtn1_PoorlyNamedHelper
 End Sub
 
@@ -467,7 +467,7 @@ Private Sub cmdBtn1_PoorlyNamedHelper()
     cmdBtn1.Caption = ""Click This""
 End Sub",
                 Expected =
-@"Private Sub cmdBigButton_Click()
+                    @"Private Sub cmdBigButton_Click()
     cmdBtn1_PoorlyNamedHelper
 End Sub
 
@@ -490,7 +490,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("UserForm1", ComponentType.UserForm)
             {
                 Input =
-@"Private Sub cmdBtn1_Click()
+                    @"Private Sub cmdBtn1_Click()
 End Sub
 
 Private Sub tbEnterName_Change()
@@ -501,7 +501,7 @@ Private Sub UserForm_Click()
     cmd|Btn1.Caption = ""Click This""
 End Sub",
                 Expected =
-@"Private Sub cmdBigButton_Click()
+                    @"Private Sub cmdBigButton_Click()
 End Sub
 
 Private Sub tbEnterName_Change()
@@ -525,7 +525,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("UserForm1", ComponentType.UserForm)
             {
                 Input =
-@"Private Sub cmdBtn1_Click()
+                    @"Private Sub cmdBtn1_Click()
 End Sub
 
 Private Sub tbEnterName_Change()
@@ -536,7 +536,7 @@ Private Sub UserForm_Click()
     cmdBtn1.Caption = ""Click This""
 End Sub",
                 Expected =
-@"Private Sub cmdBigButton_Click()
+                    @"Private Sub cmdBigButton_Click()
 End Sub
 
 Private Sub tbEnterName_Change()
@@ -560,10 +560,10 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("UserForm1", ComponentType.UserForm)
             {
                 Input =
-@"Private Sub bigBut|ton_ClickAgain_Click()
+                    @"Private Sub bigBut|ton_ClickAgain_Click()
 End Sub",
                 Expected =
-@"Private Sub bigButton_ClickAgain_AndAgain_Click()
+                    @"Private Sub bigButton_ClickAgain_AndAgain_Click()
 End Sub"
             };
             inputOutput.ControlNames.Add("bigButton_ClickAgain");
@@ -577,7 +577,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("UserForm1", ComponentType.UserForm)
             {
                 Input =
-@"Private Sub bigBu|tton_Click()
+                    @"Private Sub bigBu|tton_Click()
 End Sub
 
 Private Sub bigButton_Changed()
@@ -586,7 +586,7 @@ End Sub
 Private Sub bigButton_Click_Click()
 End Sub",
                 Expected =
-@"Private Sub smallButton_Click()
+                    @"Private Sub smallButton_Click()
 End Sub
 
 Private Sub smallButton_Changed()
@@ -612,10 +612,10 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Public Event Fo|o(ByVal arg1 As Integer, ByVal arg2 As String)",
+                    @"Public Event Fo|o(ByVal arg1 As Integer, ByVal arg2 As String)",
 
                 Expected =
-@"Public Event Goo(ByVal arg1 As Integer, ByVal arg2 As String)"
+                    @"Public Event Goo(ByVal arg1 As Integer, ByVal arg2 As String)"
             };
             PerformExpectedVersusActualRenameTests(tdo, inputOutput1);
         }
@@ -629,20 +629,20 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Public Event Fo|o(ByVal arg1 As Integer, ByVal arg2 As String)",
+                    @"Public Event Fo|o(ByVal arg1 As Integer, ByVal arg2 As String)",
 
                 Expected =
-@"Public Event Goo(ByVal arg1 As Integer, ByVal arg2 As String)"
+                    @"Public Event Goo(ByVal arg1 As Integer, ByVal arg2 As String)"
             };
             var inputOutput2 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private WithEvents abc As Class1
+                    @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub",
                 Expected =
-@"Private WithEvents abc As Class1
+                    @"Private WithEvents abc As Class1
 
 Private Sub abc_Goo(ByVal i As Integer, ByVal s As String)
 End Sub"
@@ -659,18 +659,18 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
 
                 Expected =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)"
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)"
             };
             var inputOutput2 = new RenameTestModuleDefinition("Class2")
             {   //Note: no withEvents declaration, abc_Foo is just a Sub
                 Input =
-@"Private Sub abc_Fo|o(ByVal i As Integer, ByVal s As String)
+                    @"Private Sub abc_Fo|o(ByVal i As Integer, ByVal s As String)
 End Sub",
                 Expected =
-@"Private Sub abc_Goo(ByVal i As Integer, ByVal s As String)
+                    @"Private Sub abc_Goo(ByVal i As Integer, ByVal s As String)
 End Sub"
             };
             PerformExpectedVersusActualRenameTests(tdo, inputOutput1, inputOutput2);
@@ -685,15 +685,15 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
 
                 Expected =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)"
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)"
             };
             var inputOutput2 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private WithEvents abc As Class1
+                    @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub
@@ -701,7 +701,7 @@ End Sub
 Private Sub def_F|oo(ByVal i As Integer, ByVal s As String)
 End Sub",
                 Expected =
-@"Private WithEvents abc As Class1
+                    @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub
@@ -721,25 +721,25 @@ End Sub"
             var inputOutputWithSelection = new RenameTestModuleDefinition("EventClass1")
             {
                 Input =
-@"Public Event Fo|o(ByVal arg1 As Integer, ByVal arg2 As String)
+                    @"Public Event Fo|o(ByVal arg1 As Integer, ByVal arg2 As String)
 Public Event Bar()",
 
                 Expected =
-@"Public Event Goo(ByVal arg1 As Integer, ByVal arg2 As String)
+                    @"Public Event Goo(ByVal arg1 As Integer, ByVal arg2 As String)
 Public Event Bar()"
             };
             var inputOutput2 = new RenameTestModuleDefinition("EventClass2")
             {
                 Input =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
 
                 Expected =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
             };
             var inputOutput3 = new RenameTestModuleDefinition("WithEvents1")
             {
                 Input =
-@"Private WithEvents abc As EventClass1
+                    @"Private WithEvents abc As EventClass1
 Private WithEvents otherEvents As EventClass2
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
@@ -751,7 +751,7 @@ End Sub
 Private Sub otherEvents_Foo(ByVal i As Integer, ByVal s As String)
 End Sub",
                 Expected =
-@"Private WithEvents abc As EventClass1
+                    @"Private WithEvents abc As EventClass1
 Private WithEvents otherEvents As EventClass2
 
 Private Sub abc_Goo(ByVal i As Integer, ByVal s As String)
@@ -766,7 +766,7 @@ End Sub"
             var inputOutput4 = new RenameTestModuleDefinition("WithEvents2")
             {
                 Input =
-@"Private WithEvents myEvents As EventClass1
+                    @"Private WithEvents myEvents As EventClass1
 Private WithEvents evenMoreEvents As EventClass2
 
 Private Sub myEvents_Foo(ByVal i As Integer, ByVal s As String)
@@ -778,7 +778,7 @@ End Sub
 Private Sub evenMoreEvents_Foo(ByVal i As Integer, ByVal s As String)
 End Sub",
                 Expected =
-@"Private WithEvents myEvents As EventClass1
+                    @"Private WithEvents myEvents As EventClass1
 Private WithEvents evenMoreEvents As EventClass2
 
 Private Sub myEvents_Goo(ByVal i As Integer, ByVal s As String)
@@ -802,14 +802,14 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("CEventClass")
             {
                 Input =
-@"
+                    @"
 Public Event MyEv|ent(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
     RaiseEvent MyEvent(1234, False)
 End Sub",
                 Expected =
-@"
+                    @"
 Public Event YourEvent(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
@@ -819,7 +819,7 @@ End Sub"
             var inputOutput2 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"
+                    @"
 Private WithEvents XLEvents As CEventClass
 
 Private Sub Class_Initialize()
@@ -830,7 +830,7 @@ Private Sub XLEvents_MyEvent(IDNumber As Long, Cancel As Boolean)
     Cancel = True
 End Sub",
                 Expected =
-@"
+                    @"
 Private WithEvents XLEvents As CEventClass
 
 Private Sub Class_Initialize()
@@ -853,13 +853,13 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("CEventClass")
             {
                 Input =
-@"Public Event MyEvent(IDNumber As Long, ByRef Cancel As Boolean)
+                    @"Public Event MyEvent(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
     RaiseEvent MyEvent(1234, False)
 End Sub",
                 Expected =
-@"Public Event MyEvent(IDNumber As Long, ByRef Cancel As Boolean)
+                    @"Public Event MyEvent(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
     RaiseEvent MyEvent(1234, False)
@@ -869,7 +869,7 @@ End Sub"
             var inputOutputWithRenameTarget = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private WithEvents XLEve|nts As CEventClass
+                    @"Private WithEvents XLEve|nts As CEventClass
 
 Private Sub Class_Initialize()
     Set XLEvents = New CEventClass
@@ -879,7 +879,7 @@ Private Sub XLEvents_MyEvent(IDNumber As Long, Cancel As Boolean)
     Cancel = True
 End Sub",
                 Expected =
-@"Private WithEvents NewEventImpl As CEventClass
+                    @"Private WithEvents NewEventImpl As CEventClass
 
 Private Sub Class_Initialize()
     Set NewEventImpl = New CEventClass
@@ -901,15 +901,15 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)",
 
                 Expected =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)"
+                    @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)"
             };
             var inputOutput2 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private WithEvents a|bc As Class1
+                    @"Private WithEvents a|bc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub
@@ -917,7 +917,7 @@ End Sub
 Private Sub abc_HorriblyNamedSub()
 End Sub",
                 Expected =
-@"Private WithEvents def As Class1
+                    @"Private WithEvents def As Class1
 
 Private Sub def_Foo(ByVal i As Integer, ByVal s As String)
 End Sub
@@ -937,14 +937,14 @@ End Sub",
             var inputOutput1 = new RenameTestModuleDefinition("CEventClass")
             {
                 Input =
-@"
+                    @"
 Public Event MyEvent(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
     RaiseEvent MyEvent(1234, False)
 End Sub",
                 Expected =
-@"
+                    @"
 Public Event YourEvent_withUnderscore(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
@@ -955,7 +955,7 @@ End Sub"
             var inputOutput2 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private WithEvents XLEvents As CEventClass
+                    @"Private WithEvents XLEvents As CEventClass
 
 Private Sub Class_Initialize()
     Set XLEvents = New CEventClass
@@ -971,7 +971,7 @@ Private Function DumbFunction() As Long
 End Function",
 
                 Expected =
-@"Private WithEvents XLEvents As CEventClass
+                    @"Private WithEvents XLEvents As CEventClass
 
 Private Sub Class_Initialize()
     Set XLEvents = New CEventClass
@@ -998,14 +998,14 @@ End Function"
             var inputOutput1 = new RenameTestModuleDefinition("CEventClass")
             {
                 Input =
-@"
+                    @"
 Public Event MyEvent(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
     RaiseEvent My|Event(1234, False)
 End Sub",
                 Expected =
-@"
+                    @"
 Public Event YourEvent(IDNumber As Long, ByRef Cancel As Boolean)
 
 Sub AAA()
@@ -1027,21 +1027,21 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoSo|mething(ByVal a As Integer, ByVal b As String)
+                    @"Public Sub DoSo|mething(ByVal a As Integer, ByVal b As String)
 End Sub",
                 Expected =
-@"Public Sub DoNothing(ByVal a As Integer, ByVal b As String)
+                    @"Public Sub DoNothing(ByVal a As Integer, ByVal b As String)
 End Sub"
             };
             var inputOutput2 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub",
                 Expected =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoNothing(ByVal a As Integer, ByVal b As String)
 End Sub"
@@ -1060,25 +1060,25 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoS|omething()
+                    @"Public Sub DoS|omething()
 End Sub",
                 Expected =
-@"Public Sub DoNothing()
+                    @"Public Sub DoNothing()
 End Sub"
             };
             var inputOutput2 = new RenameTestModuleDefinition("IClass2")
             {
                 Input =
-@"Public Sub DoSomething()
+                    @"Public Sub DoSomething()
 End Sub",
                 Expected =
-@"Public Sub DoSomething()
+                    @"Public Sub DoSomething()
 End Sub"
             };
             var inputOutput3 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoSomething()
 End Sub",
@@ -1087,7 +1087,7 @@ End Sub",
             var inputOutput4 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Implements IClass2
+                    @"Implements IClass2
 
 Private Sub IClass2_DoSomething()
 End Sub",
@@ -1105,21 +1105,21 @@ End Sub",
             var inputOutputWithSelection = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoS|omething()
+                    @"Public Sub DoS|omething()
 End Sub",
                 Expected =
-@"Public Sub DoNothing()
+                    @"Public Sub DoNothing()
 End Sub"
             };
             var inputOutput2 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoSomething()
 End Sub",
                 Expected =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoNothing()
 End Sub"
@@ -1127,7 +1127,7 @@ End Sub"
             var inputOutput3 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoSomething
@@ -1141,7 +1141,7 @@ Private Sub RefTheInterface2()
     c1.DoSomething
 End Sub",
                 Expected =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoNothing
@@ -1167,21 +1167,21 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoSomething()
+                    @"Public Sub DoSomething()
 End Sub",
                 Expected =
-@"Public Sub DoNothing()
+                    @"Public Sub DoNothing()
 End Sub"
             };
             var inputOutputWithSelection = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IC|lass1_DoSomething()
 End Sub",
                 Expected =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoNothing()
 End Sub"
@@ -1189,7 +1189,7 @@ End Sub"
             var inputOutput3 = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoSomething
@@ -1203,7 +1203,7 @@ Private Sub RefTheInterface2()
     c1.DoSomething
 End Sub",
                 Expected =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoNothing
@@ -1231,13 +1231,13 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Property Set Something(arg1 As Long)
+                    @"Public Property Set Something(arg1 As Long)
 End Property
 
 Public Property Get Something() As Long
 End Property",
                 Expected =
-@"Public Property Set Nothing(arg1 As Long)
+                    @"Public Property Set Nothing(arg1 As Long)
 End Property
 
 Public Property Get Nothing() As Long
@@ -1247,7 +1247,7 @@ End Property"
             var inputOutputWithSelection = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Property Set IClass1_Some|thing(arg1 As Long)
 End Property
@@ -1255,7 +1255,7 @@ End Property
 Private Property Get IClass1_Something() As Long
 End Property",
                 Expected =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Property Set IClass1_Nothing(arg1 As Long)
 End Property
@@ -1267,7 +1267,7 @@ End Property"
             var inputOutput3 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.Something 7
@@ -1281,7 +1281,7 @@ Private Sub RefTheInterface2()
     c1.Something 7
 End Sub",
                 Expected =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.Nothing 7
@@ -1309,10 +1309,10 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub Do|Something()
+                    @"Public Sub Do|Something()
 End Sub",
                 Expected =
-@"Public Sub DoNothing()
+                    @"Public Sub DoNothing()
 End Sub"
             };
             PerformExpectedVersusActualRenameTests(tdo, inputOutput1);
@@ -1329,22 +1329,22 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoSomething(arg1 As Long)
+                    @"Public Sub DoSomething(arg1 As Long)
 End Sub",
                 Expected =
-@"Public Sub DoNothing(arg1 As Long)
+                    @"Public Sub DoNothing(arg1 As Long)
 End Sub",
             };
 
             var inputOutput2 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoSomething(arg1 As Long)
 End Sub",
                 Expected =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoNothing(arg1 As Long)
 End Sub"
@@ -1353,7 +1353,7 @@ End Sub"
             var inputOutputWithSelection = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoS|omething
@@ -1367,7 +1367,7 @@ Private Sub RefTheInterface2()
     c3.DoSomething
 End Sub",
                 Expected =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoNothing
@@ -1393,22 +1393,22 @@ End Sub"
             var inputOutputWithSelection = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoSo|mething()
+                    @"Public Sub DoSo|mething()
 End Sub",
                 Expected =
-@"Public Sub DoNothing()
+                    @"Public Sub DoNothing()
 End Sub"
             };
 
             var inputOutput2 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoSomething()
 End Sub",
                 Expected =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoNothing()
 End Sub"
@@ -1417,7 +1417,7 @@ End Sub"
             var inputOutput3 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoSomething
@@ -1432,7 +1432,7 @@ Private Sub RefTheInterface2()
     c2.DoSomething
 End Sub",
                 Expected =
-@"Private Sub RefTheInterface()
+                    @"Private Sub RefTheInterface()
     Dim c1 As Class1
     Set c1 = new IClass1
     c1.DoNothing
@@ -1459,12 +1459,12 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub ICla|ss1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub",
                 Expected =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoNothing(ByVal a As Integer, ByVal b As String)
 End Sub"
@@ -1473,10 +1473,10 @@ End Sub"
             var inputOutput2 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                    @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub",
                 Expected =
-@"Public Sub DoNothing(ByVal a As Integer, ByVal b As String)
+                    @"Public Sub DoNothing(ByVal a As Integer, ByVal b As String)
 End Sub"
             };
             PerformExpectedVersusActualRenameTests(tdo, inputOutput1, inputOutput2);
@@ -1493,7 +1493,7 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub ICla|ss1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub"
@@ -1503,7 +1503,7 @@ End Sub"
             var inputOutput2 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                    @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub"
             };
             inputOutput2.Expected = inputOutput2.Input;
@@ -1526,19 +1526,19 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("IClass1")
             {
                 Input =
-@"Public Sub DoSomething()
+                    @"Public Sub DoSomething()
 End Sub",
                 CheckExpectedEqualsActual = false
             };
             var inputOutputWithSelection = new RenameTestModuleDefinition("Class1")
             {
                 Input =
-@"Implements ICl|ass1
+                    @"Implements ICl|ass1
 
 Private Sub IClass1_DoSomething()
 End Sub",
                 Expected =
-@"Implements INewClass
+                    @"Implements INewClass
 
 Private Sub INewClass_DoSomething()
 End Sub"
@@ -1546,12 +1546,12 @@ End Sub"
             var inputOutput3 = new RenameTestModuleDefinition("Class2")
             {
                 Input =
-@"Implements IClass1
+                    @"Implements IClass1
 
 Private Sub IClass1_DoSomething()
 End Sub",
                 Expected =
-@"Implements INewClass
+                    @"Implements INewClass
 
 Private Sub INewClass_DoSomething()
 End Sub"
@@ -1568,7 +1568,7 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("CTestClass")
             {
                 Input =
-@"
+                    @"
 Sub Foo()
 End Sub"
             };
@@ -1578,14 +1578,14 @@ End Sub"
             {
                 Input =
 
-@"
+                    @"
 Sub Foo2()
     Dim c1 As CTes|tClass
     Set c1 = new CTestClass
     c1.Foo
 End Sub",
                 Expected =
-@"
+                    @"
 Sub Foo2()
     Dim c1 As CMyTestClass
     Set c1 = new CMyTestClass
@@ -1608,32 +1608,34 @@ End Sub"
 
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal a As Integer, ByVal b As String)
+                @"Private Sub Foo(ByVal a As Integer, ByVal b As String)
 End Sub";
 
             var selection = new Selection(3, 27, 3, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, "Class1", ComponentType.ClassModule, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var msgbox = new Mock<IMessageBox>();
-            msgbox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.YesNo, It.IsAny<MessageBoxIcon>()))
-                  .Returns(DialogResult.Yes);
+                var msgbox = new Mock<IMessageBox>();
+                msgbox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.YesNo, It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.Yes);
 
-            var vbeWrapper = vbe.Object;
-            var model = new RenameModel(vbeWrapper, state, qualifiedSelection) { NewName = newName };
-            model.Target = model.Declarations.FirstOrDefault(i => i.DeclarationType == DeclarationType.ClassModule && i.IdentifierName == "Class1");
+                var vbeWrapper = vbe.Object;
+                var model = new RenameModel(vbeWrapper, state, qualifiedSelection) { NewName = newName };
+                model.Target = model.Declarations.FirstOrDefault(i => i.DeclarationType == DeclarationType.ClassModule && i.IdentifierName == "Class1");
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RenameRefactoring(vbeWrapper, factory.Object, msgbox.Object, state);
-            refactoring.Refactor(model.Target);
+                var refactoring = new RenameRefactoring(vbeWrapper, factory.Object, msgbox.Object, state);
+                refactoring.Refactor(model.Target);
 
-            Assert.AreSame(newName, component.CodeModule.Name);
+                Assert.AreSame(newName, component.CodeModule.Name);
+            }
         }
 
         #endregion
@@ -1649,27 +1651,29 @@ End Sub";
 
             var builder = new MockVbeBuilder();
             var vbe = builder.ProjectBuilder(oldName, ProjectProtection.Unprotected)
-                             .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
-                             .MockVbeBuilder()
-                             .Build();
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .MockVbeBuilder()
+                .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var msgbox = new Mock<IMessageBox>();
-            msgbox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.YesNo, It.IsAny<MessageBoxIcon>()))
-                  .Returns(DialogResult.Yes);
+                var msgbox = new Mock<IMessageBox>();
+                msgbox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.YesNo, It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.Yes);
 
-            var vbeWrapper = vbe.Object;
-            var model = new RenameModel(vbeWrapper, state, default(QualifiedSelection)) { NewName = newName };
-            model.Target = model.Declarations.First(i => i.DeclarationType == DeclarationType.Project && i.IsUserDefined);
+                var vbeWrapper = vbe.Object;
+                var model = new RenameModel(vbeWrapper, state, default(QualifiedSelection)) { NewName = newName };
+                model.Target = model.Declarations.First(i => i.DeclarationType == DeclarationType.Project && i.IsUserDefined);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new RenameRefactoring(vbeWrapper, factory.Object, msgbox.Object, state);
-            refactoring.Refactor(model.Target);
+                var refactoring = new RenameRefactoring(vbeWrapper, factory.Object, msgbox.Object, state);
+                refactoring.Refactor(model.Target);
 
-            Assert.AreEqual(newName, vbe.Object.VBProjects[0].Name);
+                Assert.AreEqual(newName, vbe.Object.VBProjects[0].Name);
+            }
         }
 
         #endregion
@@ -1684,7 +1688,7 @@ End Sub";
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Option Explicit
+                    @"Option Explicit
 
 Public Enum Frui|tType
     Apple = 1
@@ -1696,7 +1700,7 @@ Sub DoSomething()
     MsgBox CStr(FruitType.Apple)
 End Sub",
                 Expected =
-@"Option Explicit
+                    @"Option Explicit
 
 Public Enum Fruits
     Apple = 1
@@ -1722,7 +1726,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Option Explicit
+                    @"Option Explicit
 
 Public Enum FruitType
     App|le = 1
@@ -1734,7 +1738,7 @@ Sub DoSomething()
     MsgBox CStr(Apple)
 End Sub",
                 Expected =
-@"Option Explicit
+                    @"Option Explicit
 
 Public Enum FruitType
     CranApple = 1
@@ -1762,7 +1766,7 @@ End Sub"
             var inputOutput1 = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"Option Explicit
+                    @"Option Explicit
 
 Sub DoSomething()
     On Error goto EH
@@ -1773,7 +1777,7 @@ E|H:
     MsgBox ""We had an error""
 End Sub",
                 Expected =
-@"Option Explicit
+                    @"Option Explicit
 
 Sub DoSomething()
     On Error goto ErrorHandler
@@ -1803,10 +1807,10 @@ End Sub"
                 var inputOutput = new RenameTestModuleDefinition("Class1")
                 {
                     Input =
-@"Private Sub F|oo()
+                        @"Private Sub F|oo()
 End Sub",
                     Expected =
-@"Private Sub Goo()
+                        @"Private Sub Goo()
 End Sub"
                 };
                 tdo.RefactorParamType = param;
@@ -1823,26 +1827,28 @@ End Sub"
         public void Rename_PresenterIsNull()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var codePaneMock = new Mock<ICodePane>();
-            codePaneMock.Setup(c => c.CodeModule).Returns(component.CodeModule);
-            codePaneMock.Setup(c => c.Selection);
-            vbe.Setup(v => v.ActiveCodePane).Returns(codePaneMock.Object);
+                var codePaneMock = new Mock<ICodePane>();
+                codePaneMock.Setup(c => c.CodeModule).Returns(component.CodeModule);
+                codePaneMock.Setup(c => c.Selection);
+                vbe.Setup(v => v.ActiveCodePane).Returns(codePaneMock.Object);
 
-            var vbeWrapper = vbe.Object;
-            var factory = new RenamePresenterFactory(vbeWrapper, null, state);
+                var vbeWrapper = vbe.Object;
+                var factory = new RenamePresenterFactory(vbeWrapper, null, state);
 
-            var refactoring = new RenameRefactoring(vbeWrapper, factory, null, state);
-            refactoring.Refactor();
+                var refactoring = new RenameRefactoring(vbeWrapper, factory, null, state);
+                refactoring.Refactor();
 
-            var rewriter = state.GetRewriter(component);
-            Assert.AreEqual(inputCode, rewriter.GetText());
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(inputCode, rewriter.GetText());
+            }
         }
 
         [TestMethod]
@@ -1851,25 +1857,27 @@ End Sub";
         public void Presenter_TargetIsNull()
         {
             const string inputCode =
-@"
+                @"
 Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var codePaneMock = new Mock<ICodePane>();
-            codePaneMock.Setup(c => c.CodeModule).Returns(component.CodeModule);
-            codePaneMock.Setup(c => c.Selection);
-            vbe.Setup(v => v.ActiveCodePane).Returns(codePaneMock.Object);
+                var codePaneMock = new Mock<ICodePane>();
+                codePaneMock.Setup(c => c.CodeModule).Returns(component.CodeModule);
+                codePaneMock.Setup(c => c.Selection);
+                vbe.Setup(v => v.ActiveCodePane).Returns(codePaneMock.Object);
 
-            var vbeWrapper = vbe.Object;
-            var factory = new RenamePresenterFactory(vbeWrapper, null, state);
+                var vbeWrapper = vbe.Object;
+                var factory = new RenamePresenterFactory(vbeWrapper, null, state);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            Assert.AreEqual(null, presenter.Show());
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         [TestMethod]
@@ -1878,23 +1886,25 @@ End Sub";
         public void Factory_SelectionIsNull()
         {
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var codePaneMock = new Mock<ICodePane>();
-            codePaneMock.Setup(c => c.CodeModule).Returns(component.CodeModule);
-            codePaneMock.Setup(c => c.Selection);
-            vbe.Setup(v => v.ActiveCodePane).Returns(codePaneMock.Object);
+                var codePaneMock = new Mock<ICodePane>();
+                codePaneMock.Setup(c => c.CodeModule).Returns(component.CodeModule);
+                codePaneMock.Setup(c => c.Selection);
+                vbe.Setup(v => v.ActiveCodePane).Returns(codePaneMock.Object);
 
-            var vbeWrapper = vbe.Object;
-            var factory = new RenamePresenterFactory(vbeWrapper, null, state);
+                var vbeWrapper = vbe.Object;
+                var factory = new RenamePresenterFactory(vbeWrapper, null, state);
 
-            var presenter = factory.Create();
-            Assert.AreEqual(null, presenter.Show());
+                var presenter = factory.Create();
+                Assert.AreEqual(null, presenter.Show());
+            }
         }
 
         [TestMethod]
@@ -1906,7 +1916,7 @@ End Sub";
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
-@"#Const Bar = 42
+                    @"#Const Bar = 42
 
 #If False Then
 Private Sub Goo(ByVal arg1 As String)
@@ -1917,7 +1927,7 @@ Private Sub Foo(ByVal arg1 As String, arg2 As String)
 #End If
 End Sub",
                 Expected =
-@"#Const Bar = 42
+                    @"#Const Bar = 42
 
 #If False Then
 Private Sub Goo(ByVal arg1 As String)
@@ -1940,7 +1950,7 @@ End Sub"
             var inputOutput = new RenameTestModuleDefinition("TestClass")
             {
                 Input =
-@"Private Sub Foo()
+                    @"Private Sub Foo()
     Dim va|l1 As Integer
 End Sub",
                 CheckExpectedEqualsActual = false
@@ -1962,9 +1972,16 @@ End Sub",
             , RenameTestModuleDefinition? inputOutput3 = null
             , RenameTestModuleDefinition? inputOutput4 = null)
         {
-            InitializeTestDataObject(tdo, inputOutput1, inputOutput2, inputOutput3, inputOutput4);
-            RunRenameRefactorScenario(tdo);
-            CheckRenameRefactorTestResults(tdo);
+            try
+            {
+                InitializeTestDataObject(tdo, inputOutput1, inputOutput2, inputOutput3, inputOutput4);
+                RunRenameRefactorScenario(tdo);
+                CheckRenameRefactorTestResults(tdo);
+            }
+            finally
+            {
+                tdo.ParserState?.Dispose();
+            }
         }
 
         private static void InitializeTestDataObject(RenameTestsDataObject tdo
@@ -2009,7 +2026,7 @@ End Sub",
 
             tdo.MsgBox = new Mock<IMessageBox>();
             tdo.MsgBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                  .Returns(tdo.MsgBoxReturn);
+                .Returns(tdo.MsgBoxReturn);
 
             tdo.VBE = tdo.VBE ?? BuildProject(tdo.ProjectName, tdo.ModuleTestSetupDefs);
             tdo.ParserState = MockParser.CreateAndParse(tdo.VBE);

--- a/RubberduckTests/Refactoring/ReorderParametersTests.cs
+++ b/RubberduckTests/Refactoring/ReorderParametersTests.cs
@@ -24,31 +24,33 @@ namespace RubberduckTests.Refactoring
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            var factory = SetupFactory(model);
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -58,31 +60,33 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(a, ba)
+                @"Private Sub Foo(a, ba)
 End Sub";
             var selection = new Selection(1, 16, 1, 16);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ba, a)
+                @"Private Sub Foo(ba, a)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            var factory = SetupFactory(model);
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -92,7 +96,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(a, ba)
+                @"Private Sub Foo(a, ba)
 End Sub
 
 Sub Goo()
@@ -102,7 +106,7 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ba, a)
+                @"Private Sub Foo(ba, a)
 End Sub
 
 Sub Goo()
@@ -111,20 +115,22 @@ End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            var factory = SetupFactory(model);
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -134,31 +140,33 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            var factory = SetupFactory(model);
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(model.TargetDeclaration);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(model.TargetDeclaration);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -168,37 +176,39 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
-
-            var factory = SetupFactory(model);
-
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-
-            try
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                refactoring.Refactor(
-                    model.Declarations.FirstOrDefault(
-                        i => i.DeclarationType == Rubberduck.Parsing.Symbols.DeclarationType.ProceduralModule));
-            }
-            catch (ArgumentException e)
-            {
-                Assert.AreEqual("Invalid declaration type", e.Message);
-                return;
-            }
 
-            Assert.Fail();
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
+
+                var factory = SetupFactory(model);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+
+                try
+                {
+                    refactoring.Refactor(
+                        model.Declarations.FirstOrDefault(
+                            i => i.DeclarationType == Rubberduck.Parsing.Symbols.DeclarationType.ProceduralModule));
+                }
+                catch (ArgumentException e)
+                {
+                    Assert.AreEqual("Invalid declaration type", e.Message);
+                    return;
+                }
+
+                Assert.Fail();
+            }
         }
 
         [TestMethod]
@@ -208,38 +218,40 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, Optional ByVal arg3 As Boolean = True)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, Optional ByVal arg3 As Boolean = True)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer, Optional ByVal arg3 As Boolean = True)
+                @"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer, Optional ByVal arg3 As Boolean = True)
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>()
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[1],
-                model.Parameters[0],
-                model.Parameters[2]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var factory = SetupFactory(model);
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>()
+                {
+                    model.Parameters[1],
+                    model.Parameters[0],
+                    model.Parameters[2]
+                };
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                model.Parameters = reorderedParams;
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                var factory = SetupFactory(model);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -249,7 +261,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub
 
 Private Sub Bar()
@@ -260,7 +272,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer)
 End Sub
 
 Private Sub Bar()
@@ -270,20 +282,22 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            var factory = SetupFactory(model);
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -293,7 +307,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Private Sub bar()
+                @"Private Sub bar()
     Dim x As Integer
     Dim y As Integer
     y = foo(x, 42)
@@ -308,7 +322,7 @@ End Function";
 
             //Expectation
             const string expectedCode =
-@"Private Sub bar()
+                @"Private Sub bar()
     Dim x As Integer
     Dim y As Integer
     y = foo(42, x)
@@ -322,20 +336,22 @@ End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            var factory = SetupFactory(model);
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -345,7 +361,7 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Double)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Double)
 End Sub
 
 Public Sub Goo()
@@ -356,7 +372,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg3 As Double, ByVal arg2 As String)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg3 As Double, ByVal arg2 As String)
 End Sub
 
 Public Sub Goo()
@@ -366,28 +382,30 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>()
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[0],
-                model.Parameters[2],
-                model.Parameters[1]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>()
+                {
+                    model.Parameters[0],
+                    model.Parameters[2],
+                    model.Parameters[1]
+                };
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                model.Parameters = reorderedParams;
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -397,34 +415,36 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Public Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
+                @"Public Function Foo(ByVal arg1 As Integer, ByVal arg2 As String) As Boolean
     Foo = True
 End Function";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Public Function Foo(ByVal arg2 As String, ByVal arg1 As Integer) As Boolean
+                @"Public Function Foo(ByVal arg2 As String, ByVal arg1 As Integer) As Boolean
     Foo = True
 End Function";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -434,7 +454,7 @@ End Function";
         {
             //Input
             const string inputCode =
-@"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, Optional ByVal arg3 As Double)
+                @"Public Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, Optional ByVal arg3 As Double)
 End Sub
 
 Public Sub Goo()
@@ -445,7 +465,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Public Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer, Optional ByVal arg3 As Double)
+                @"Public Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer, Optional ByVal arg3 As Double)
 End Sub
 
 Public Sub Goo()
@@ -455,28 +475,30 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>()
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[1],
-                model.Parameters[0],
-                model.Parameters[2]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>()
+                {
+                    model.Parameters[1],
+                    model.Parameters[0],
+                    model.Parameters[2]
+                };
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                model.Parameters = reorderedParams;
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -486,39 +508,41 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Private Property Get Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date) As Boolean
+                @"Private Property Get Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date) As Boolean
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Property Get Foo(ByVal arg2 As String, ByVal arg3 As Date, ByVal arg1 As Integer) As Boolean
+                @"Private Property Get Foo(ByVal arg2 As String, ByVal arg3 As Date, ByVal arg1 As Integer) As Boolean
 End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>()
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[1],
-                model.Parameters[2],
-                model.Parameters[0]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>()
+                {
+                    model.Parameters[1],
+                    model.Parameters[2],
+                    model.Parameters[0]
+                };
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                model.Parameters = reorderedParams;
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                //SetupFactory
+                var factory = SetupFactory(model);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -528,32 +552,34 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
+                @"Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Property Let Foo(ByVal arg2 As String, ByVal arg1 As Integer, ByVal arg3 As Date)
+                @"Private Property Let Foo(ByVal arg2 As String, ByVal arg1 As Integer, ByVal arg3 As Date)
 End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -563,32 +589,34 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
+                @"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             //Expectation
             const string expectedCode =
-@"Private Property Set Foo(ByVal arg2 As String, ByVal arg1 As Integer, ByVal arg3 As Date)
+                @"Private Property Set Foo(ByVal arg2 As String, ByVal arg1 As Integer, ByVal arg3 As Date)
 End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -598,19 +626,21 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
+                @"Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
 
-            Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from setter
+                Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from setter
+            }
         }
 
         [TestMethod]
@@ -620,19 +650,21 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
+                @"Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String) 
 End Property";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
 
-            Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from letter
+                Assert.AreEqual(1, model.Parameters.Count); // doesn't allow removing last param from letter
+            }
         }
 
         [TestMethod]
@@ -642,7 +674,7 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, _
+                @"Private Sub Foo(ByVal arg1 As Integer, _
                   ByVal arg2 As String, _
                   ByVal arg3 As Date)
 End Sub";
@@ -650,28 +682,30 @@ End Sub";
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg3 As Date, _
+                @"Private Sub Foo(ByVal arg3 As Date, _
                   ByVal arg2 As String, _
                   ByVal arg1 As Integer)
 End Sub";   // note: IDE removes excess spaces
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -681,7 +715,7 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
 End Sub
 
 Private Sub Goo(ByVal arg1 as Integer, ByVal arg2 As String, ByVal arg3 As Date)
@@ -696,7 +730,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg3 As Date, ByVal arg2 As String, ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg3 As Date, ByVal arg2 As String, ByVal arg1 As Integer)
 End Sub
 
 Private Sub Goo(ByVal arg1 as Integer, ByVal arg2 As String, ByVal arg3 As Date)
@@ -710,21 +744,23 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -734,7 +770,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Sub Foo(ByVal arg1 As String, ParamArray arg2())
+                @"Sub Foo(ByVal arg1 As String, ParamArray arg2())
 End Sub
 
 Public Sub Goo(ByVal arg1 As Integer, _
@@ -751,24 +787,26 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -778,7 +816,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Sub Foo(ByVal arg1 As String, ByVal arg2 As Date, ParamArray arg3())
+                @"Sub Foo(ByVal arg1 As String, ByVal arg2 As Date, ParamArray arg3())
 End Sub
 
 Public Sub Goo(ByVal arg As Date, _
@@ -796,7 +834,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Sub Foo(ByVal arg2 As Date, ByVal arg1 As String, ParamArray arg3())
+                @"Sub Foo(ByVal arg2 As Date, ByVal arg1 As String, ParamArray arg3())
 End Sub
 
 Public Sub Goo(ByVal arg As Date, _
@@ -813,31 +851,33 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[1],
-                model.Parameters[0],
-                model.Parameters[2]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>
+                {
+                    model.Parameters[1],
+                    model.Parameters[0],
+                    model.Parameters[2]
+                };
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
+                model.Parameters = reorderedParams;
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -847,7 +887,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Sub Foo(ByVal arg1 As String, ByVal arg2 As Date, ParamArray arg3())
+                @"Sub Foo(ByVal arg1 As String, ByVal arg2 As Date, ParamArray arg3())
 End Sub
 
 Public Sub Goo(ByVal arg As Date, _
@@ -872,7 +912,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Sub Foo(ByVal arg2 As Date, ByVal arg1 As String, ParamArray arg3())
+                @"Sub Foo(ByVal arg2 As Date, ByVal arg1 As String, ParamArray arg3())
 End Sub
 
 Public Sub Goo(ByVal arg As Date, _
@@ -896,31 +936,33 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>()
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[1],
-                model.Parameters[0],
-                model.Parameters[2]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>()
+                {
+                    model.Parameters[1],
+                    model.Parameters[0],
+                    model.Parameters[2]
+                };
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
+                model.Parameters = reorderedParams;
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -930,36 +972,38 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, Optional ByVal arg2 As String, Optional ByVal arg3 As Boolean = True)
+                @"Private Sub Foo(ByVal arg1 As Integer, Optional ByVal arg2 As String, Optional ByVal arg3 As Boolean = True)
 End Sub";
             var selection = new Selection(1, 23, 1, 27);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>()
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[1],
-                model.Parameters[2],
-                model.Parameters[0]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var factory = SetupFactory(model);
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>()
+                {
+                    model.Parameters[1],
+                    model.Parameters[2],
+                    model.Parameters[0]
+                };
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
+                model.Parameters = reorderedParams;
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
-            refactoring.Refactor(qualifiedSelection);
+                var factory = SetupFactory(model);
 
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButtons.OK, MessageBoxIcon.Warning)).Returns(DialogResult.OK);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, messageBox.Object);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -969,7 +1013,7 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, Optional ByVal arg3 As Boolean = True)
+                @"Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String, Optional ByVal arg3 As Boolean = True)
 End Sub
 
 Private Sub Goo(ByVal arg1 As Integer, ByVal arg2 As String)
@@ -980,7 +1024,7 @@ End Sub
 
             //Expectation
             const string expectedCode =
-@"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer, Optional ByVal arg3 As Boolean = True)
+                @"Private Sub Foo(ByVal arg2 As String, ByVal arg1 As Integer, Optional ByVal arg3 As Boolean = True)
 End Sub
 
 Private Sub Goo(ByVal arg1 As Integer, ByVal arg2 As String)
@@ -990,27 +1034,29 @@ End Sub
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
-
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
-
-            //set up model
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            var reorderedParams = new List<Parameter>()
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                model.Parameters[1],
-                model.Parameters[0],
-                model.Parameters[2]
-            };
 
-            model.Parameters = reorderedParams;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            var factory = SetupFactory(model);
+                //set up model
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                var reorderedParams = new List<Parameter>()
+                {
+                    model.Parameters[1],
+                    model.Parameters[0],
+                    model.Parameters[2]
+                };
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                model.Parameters = reorderedParams;
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                var factory = SetupFactory(model);
+
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
+
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1020,7 +1066,7 @@ End Sub
         {
             //Input
             const string inputCode =
-@"Private Property Get Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Property Get Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Property
 
 Private Property Set Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
@@ -1029,7 +1075,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Private Property Get Foo(ByVal arg2 As String, ByVal arg1 As Integer)
+                @"Private Property Get Foo(ByVal arg2 As String, ByVal arg1 As Integer)
 End Property
 
 Private Property Set Foo(ByVal arg2 As String, ByVal arg1 As Integer, ByVal arg3 As Date)
@@ -1037,21 +1083,23 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Param(s) to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Param(s) to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1061,7 +1109,7 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Property Get Foo(ByVal arg1 As Integer, ByVal arg2 As String)
+                @"Private Property Get Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Property
 
 Private Property Let Foo(ByVal arg1 As Integer, ByVal arg2 As String, ByVal arg3 As Date)
@@ -1070,7 +1118,7 @@ End Property";
 
             //Expectation
             const string expectedCode =
-@"Private Property Get Foo(ByVal arg2 As String, ByVal arg1 As Integer)
+                @"Private Property Get Foo(ByVal arg2 As String, ByVal arg1 As Integer)
 End Property
 
 Private Property Let Foo(ByVal arg2 As String, ByVal arg1 As Integer, ByVal arg3 As Date)
@@ -1078,21 +1126,23 @@ End Property";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
 
-            //Specify Params to reorder
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to reorder
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode, component.CodeModule.Content());
+                Assert.AreEqual(expectedCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1102,19 +1152,21 @@ End Property";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, null);
+                var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, null);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory, null);
-            refactoring.Refactor();
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory, null);
+                refactoring.Refactor();
 
-            Assert.AreEqual(inputCode, component.CodeModule.Content());
+                Assert.AreEqual(inputCode, component.CodeModule.Content());
+            }
         }
 
         [TestMethod]
@@ -1124,10 +1176,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
@@ -1136,10 +1188,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
 End Sub";
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal b As String, ByVal a As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1151,24 +1203,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1178,10 +1232,10 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v1 As Integer, ByVal v2 As String)
 End Sub";
@@ -1190,10 +1244,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
 End Sub";
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v2 As String, ByVal v1 As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1205,24 +1259,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1232,15 +1288,15 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v1 As Integer, ByVal v2 As String)
 End Sub";
             const string inputCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal i As Integer, ByVal s As String)
 End Sub";
@@ -1249,15 +1305,15 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
 End Sub";
             const string expectedCode2 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal v2 As String, ByVal v1 As Integer)
 End Sub";   // note: IDE removes excess spaces
             const string expectedCode3 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal s As String, ByVal i As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1270,26 +1326,28 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
-            var module3 = project.Object.VBComponents[2].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
+                var module3 = project.Object.VBComponents[2].CodeModule;
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
-            Assert.AreEqual(expectedCode3, module3.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode3, module3.Content());
+            }
         }
 
         [TestMethod]
@@ -1299,25 +1357,25 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
 
             var selection = new Selection(3, 23, 3, 27);
 
             //Expectation
             const string expectedCode1 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal b As String, ByVal a As Integer)
 End Sub";   // note: IDE removes excess spaces
 
             const string expectedCode2 =
-@"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
+                @"Public Sub DoSomething(ByVal b As String, ByVal a As Integer)
 End Sub";
 
             var builder = new MockVbeBuilder();
@@ -1327,29 +1385,31 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(
-                m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                .Returns(DialogResult.Yes);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(
+                        m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.Yes);
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, messageBox.Object);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, messageBox.Object);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1359,12 +1419,12 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Implements IClass1
+                @"Implements IClass1
 
 Private Sub IClass1_DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
             const string inputCode2 =
-@"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
+                @"Public Sub DoSomething(ByVal a As Integer, ByVal b As String)
 End Sub";
 
             var selection = new Selection(3, 23, 3, 27);
@@ -1376,17 +1436,19 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.No);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.No);
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, messageBox.Object);
-            Assert.IsNull(model.TargetDeclaration);
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, messageBox.Object);
+                Assert.IsNull(model.TargetDeclaration);
+            }
         }
 
         [TestMethod]
@@ -1396,10 +1458,10 @@ End Sub";
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
@@ -1408,10 +1470,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
 
             const string expectedCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal arg2 As String, ByVal arg1 As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1423,24 +1485,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1450,25 +1514,25 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Private WithEvents abc As Class2
+                @"Private WithEvents abc As Class2
 
 Private Sub abc_Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
 
             const string inputCode2 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             var selection = new Selection(3, 15, 3, 15);
 
             //Expectation
             const string expectedCode1 =
-@"Private WithEvents abc As Class2
+                @"Private WithEvents abc As Class2
 
 Private Sub abc_Foo(ByVal arg2 As String, ByVal arg1 As Integer)
 End Sub";   // note: IDE removes excess spaces
 
             const string expectedCode2 =
-@"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
@@ -1477,24 +1541,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1504,10 +1570,10 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub";
@@ -1516,10 +1582,10 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
 
             const string expectedCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal s As String, ByVal i As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1531,24 +1597,26 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+            }
         }
 
         [TestMethod]
@@ -1558,15 +1626,15 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode1 =
-@"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
+                @"Public Event Foo(ByVal arg1 As Integer, ByVal arg2 As String)";
 
             const string inputCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal i As Integer, ByVal s As String)
 End Sub";
             const string inputCode3 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal v1 As Integer, ByVal v2 As String)
 End Sub";
@@ -1575,16 +1643,16 @@ End Sub";
 
             //Expectation
             const string expectedCode1 =
-@"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
+                @"Public Event Foo(ByVal arg2 As String, ByVal arg1 As Integer)";
 
             const string expectedCode2 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal s As String, ByVal i As Integer)
 End Sub";   // note: IDE removes excess spaces
 
             const string expectedCode3 =
-@"Private WithEvents abc As Class1
+                @"Private WithEvents abc As Class1
 
 Private Sub abc_Foo(ByVal v2 As String, ByVal v1 As Integer)
 End Sub";   // note: IDE removes excess spaces
@@ -1597,26 +1665,28 @@ End Sub";   // note: IDE removes excess spaces
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
-            var module1 = project.Object.VBComponents[0].CodeModule;
-            var module2 = project.Object.VBComponents[1].CodeModule;
-            var module3 = project.Object.VBComponents[2].CodeModule;
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(project.Object.VBComponents[0]), selection);
+                var module1 = project.Object.VBComponents[0].CodeModule;
+                var module2 = project.Object.VBComponents[1].CodeModule;
+                var module3 = project.Object.VBComponents[2].CodeModule;
 
-            //Specify Params to remove
-            var model = new ReorderParametersModel(state, qualifiedSelection, null);
-            model.Parameters.Reverse();
+                //Specify Params to remove
+                var model = new ReorderParametersModel(state, qualifiedSelection, null);
+                model.Parameters.Reverse();
 
-            //SetupFactory
-            var factory = SetupFactory(model);
+                //SetupFactory
+                var factory = SetupFactory(model);
 
-            var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
-            refactoring.Refactor(qualifiedSelection);
+                var refactoring = new ReorderParametersRefactoring(vbe.Object, factory.Object, null);
+                refactoring.Refactor(qualifiedSelection);
 
-            Assert.AreEqual(expectedCode1, module1.Content());
-            Assert.AreEqual(expectedCode2, module2.Content());
-            Assert.AreEqual(expectedCode3, module3.Content());
+                Assert.AreEqual(expectedCode1, module1.Content());
+                Assert.AreEqual(expectedCode2, module2.Content());
+                Assert.AreEqual(expectedCode3, module3.Content());
+            }
         }
 
         [TestMethod]
@@ -1626,24 +1696,26 @@ End Sub";   // note: IDE removes excess spaces
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
             var selection = new Selection(1, 15, 1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, messageBox.Object);
-            var presenter = factory.Create();
+                var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, messageBox.Object);
+                var presenter = factory.Create();
 
-            var result = presenter.Show();
+                var result = presenter.Show();
 
-            Assert.IsNull(result);
+                Assert.IsNull(result);
+            }
         }
 
         [TestMethod]
@@ -1653,24 +1725,26 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo(ByVal arg1 As Integer)
+                @"Private Sub Foo(ByVal arg1 As Integer)
 End Sub";
             var selection = new Selection(1, 15, 1, 15);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var messageBox = new Mock<IMessageBox>();
-            messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
-                      .Returns(DialogResult.OK);
+                var messageBox = new Mock<IMessageBox>();
+                messageBox.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButtons>(), It.IsAny<MessageBoxIcon>()))
+                    .Returns(DialogResult.OK);
 
-            var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, messageBox.Object);
-            var presenter = factory.Create();
+                var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, messageBox.Object);
+                var presenter = factory.Create();
 
-            var result = presenter.Show();
+                var result = presenter.Show();
 
-            Assert.IsNull(result);
+                Assert.IsNull(result);
+            }
         }
 
         [TestMethod]
@@ -1680,22 +1754,24 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"
+                @"
 Private Sub Foo(ByVal arg1 As Integer, ByVal arg2 As String)
 End Sub";
             var selection = new Selection(1, 1, 1, 1);
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component, selection);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, null);
+                var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, null);
 
-            var presenter = factory.Create();
+                var presenter = factory.Create();
 
-            var result = presenter.Show();
+                var result = presenter.Show();
 
-            Assert.IsNull(result);
+                Assert.IsNull(result);
+            }
         }
 
         [TestMethod]
@@ -1705,20 +1781,22 @@ End Sub";
         {
             //Input
             const string inputCode =
-@"Private Sub Foo()
+                @"Private Sub Foo()
 End Sub";
 
             IVBComponent component;
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out component);
-            var state = MockParser.CreateAndParse(vbe.Object);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
 
-            vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
+                vbe.Setup(v => v.ActiveCodePane).Returns((ICodePane)null);
 
-            var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, null);
+                var factory = new ReorderParametersPresenterFactory(vbe.Object, null, state, null);
 
-            var result = factory.Create();
+                var result = factory.Create();
 
-            Assert.IsNull(result);
+                Assert.IsNull(result);
+            }
         }
 
         #region setup

--- a/RubberduckTests/UnitTesting/ViewModelTests.cs
+++ b/RubberduckTests/UnitTesting/ViewModelTests.cs
@@ -29,12 +29,18 @@ End Sub";
             var vbe = builder.Build().Object;
 
             var parser = MockParser.Create(vbe);
-            var model = new TestExplorerModel(vbe, parser.State);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-            
-            Assert.AreEqual(1, model.Tests.Count);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
+
+                Assert.AreEqual(1, model.Tests.Count);
+            }
         }
 
         [TestMethod]
@@ -53,20 +59,28 @@ End Sub";
 
             var vbe = builder.Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-            
-            Assert.AreEqual(2, model.Tests.Count);
+                Assert.AreEqual(2, model.Tests.Count);
 
-            project.RemoveComponent(project.MockComponents[1]);
-            
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
-            
-            Assert.AreEqual(1, model.Tests.Count);
+                project.RemoveComponent(project.MockComponents[1]);
+
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
+
+                Assert.AreEqual(1, model.Tests.Count);
+            }
         }
 
         [TestMethod]
@@ -84,16 +98,21 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                model.Tests.First().Result = new TestResult(TestOutcome.Succeeded);
+                model.AddExecutedTest(model.Tests.First());
 
-            model.Tests.First().Result = new TestResult(TestOutcome.Succeeded);
-            model.AddExecutedTest(model.Tests.First());
-
-            Assert.AreEqual(model.ProgressBarColor, Colors.LimeGreen);
+                Assert.AreEqual(model.ProgressBarColor, Colors.LimeGreen);
+            }
         }
 
         [TestMethod]
@@ -110,16 +129,21 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, parser.State);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                model.Tests.First().Result = new TestResult(TestOutcome.Failed);
+                model.AddExecutedTest(model.Tests.First());
 
-            model.Tests.First().Result = new TestResult(TestOutcome.Failed);
-            model.AddExecutedTest(model.Tests.First());
-
-            Assert.AreEqual(model.ProgressBarColor, Colors.Red);
+                Assert.AreEqual(model.ProgressBarColor, Colors.Red);
+            }
         }
 
         [TestMethod]
@@ -136,16 +160,21 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                model.Tests.First().Result = new TestResult(TestOutcome.Inconclusive);
+                model.AddExecutedTest(model.Tests.First());
 
-            model.Tests.First().Result = new TestResult(TestOutcome.Inconclusive);
-            model.AddExecutedTest(model.Tests.First());
-
-            Assert.AreEqual(model.ProgressBarColor, Colors.Gold);
+                Assert.AreEqual(model.ProgressBarColor, Colors.Gold);
+            }
         }
 
         [TestMethod]
@@ -174,23 +203,28 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
+                model.Tests[1].Result = new TestResult(TestOutcome.Inconclusive);
+                model.Tests[2].Result = new TestResult(TestOutcome.Failed);
+                model.Tests[3].Result = new TestResult(TestOutcome.Ignored);
 
-            model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
-            model.Tests[1].Result = new TestResult(TestOutcome.Inconclusive);
-            model.Tests[2].Result = new TestResult(TestOutcome.Failed);
-            model.Tests[3].Result = new TestResult(TestOutcome.Ignored);
+                model.AddExecutedTest(model.Tests[0]);
+                model.AddExecutedTest(model.Tests[1]);
+                model.AddExecutedTest(model.Tests[2]);
+                model.AddExecutedTest(model.Tests[3]);
 
-            model.AddExecutedTest(model.Tests[0]);
-            model.AddExecutedTest(model.Tests[1]);
-            model.AddExecutedTest(model.Tests[2]);
-            model.AddExecutedTest(model.Tests[3]);
-
-            Assert.AreEqual(model.ProgressBarColor, Colors.Red);
+                Assert.AreEqual(model.ProgressBarColor, Colors.Red);
+            }
         }
 
         [TestMethod]
@@ -215,21 +249,26 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
+                model.Tests[1].Result = new TestResult(TestOutcome.Inconclusive);
+                model.Tests[2].Result = new TestResult(TestOutcome.Ignored);
 
-            model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
-            model.Tests[1].Result = new TestResult(TestOutcome.Inconclusive);
-            model.Tests[2].Result = new TestResult(TestOutcome.Ignored);
+                model.AddExecutedTest(model.Tests[0]);
+                model.AddExecutedTest(model.Tests[1]);
+                model.AddExecutedTest(model.Tests[2]);
 
-            model.AddExecutedTest(model.Tests[0]);
-            model.AddExecutedTest(model.Tests[1]);
-            model.AddExecutedTest(model.Tests[2]);
-
-            Assert.AreEqual(model.ProgressBarColor, Colors.Gold);
+                Assert.AreEqual(model.ProgressBarColor, Colors.Gold);
+            }
         }
 
         [TestMethod]
@@ -250,19 +289,24 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
+                model.Tests[1].Result = new TestResult(TestOutcome.Ignored);
 
-            model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
-            model.Tests[1].Result = new TestResult(TestOutcome.Ignored);
+                model.AddExecutedTest(model.Tests[0]);
+                model.AddExecutedTest(model.Tests[1]);
 
-            model.AddExecutedTest(model.Tests[0]);
-            model.AddExecutedTest(model.Tests[1]);
-
-            Assert.AreEqual(model.ProgressBarColor, Colors.LimeGreen);
+                Assert.AreEqual(model.ProgressBarColor, Colors.LimeGreen);
+            }
         }
 
         [TestMethod]
@@ -279,18 +323,23 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                Assert.AreEqual(0, model.ExecutedCount);
 
-            Assert.AreEqual(0, model.ExecutedCount);
+                model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
+                model.AddExecutedTest(model.Tests[0]);
 
-            model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
-            model.AddExecutedTest(model.Tests[0]);
-
-            Assert.AreEqual(1, model.ExecutedCount);
+                Assert.AreEqual(1, model.ExecutedCount);
+            }
         }
 
         [TestMethod]
@@ -307,18 +356,23 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                Assert.AreEqual(0, model.LastRun.Count);
 
-            Assert.AreEqual(0, model.LastRun.Count);
+                model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
+                model.AddExecutedTest(model.Tests[0]);
 
-            model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
-            model.AddExecutedTest(model.Tests[0]);
-
-            Assert.AreEqual(1, model.LastRun.Count);
+                Assert.AreEqual(1, model.LastRun.Count);
+            }
         }
 
         [TestMethod]
@@ -335,20 +389,25 @@ End Sub";
 
             var vbe = builder.AddProject(project.Build()).Build().Object;
             var parser = MockParser.Create(vbe);
+            using (var state = parser.State)
+            {
+                var model = new TestExplorerModel(vbe, state);
 
-            var model = new TestExplorerModel(vbe, parser.State);
+                parser.Parse(new CancellationTokenSource());
+                if (state.Status >= ParserState.Error)
+                {
+                    Assert.Inconclusive("Parser Error");
+                }
 
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
+                model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
+                model.AddExecutedTest(model.Tests[0]);
 
-            model.Tests[0].Result = new TestResult(TestOutcome.Succeeded);
-            model.AddExecutedTest(model.Tests[0]);
+                Assert.AreEqual(1, model.LastRun.Count);
 
-            Assert.AreEqual(1, model.LastRun.Count);
+                model.ClearLastRun();
 
-            model.ClearLastRun();
-
-            Assert.AreEqual(0, model.LastRun.Count);
+                Assert.AreEqual(0, model.LastRun.Count);
+            }
         }
 
         private const string RawInput = @"Option Explicit


### PR DESCRIPTION
This PR closes #3405 

This PR does not remove the registration to static events, which is the underlying reason why the `RubberduckParserState`s in the tests do not get GCed unless getting disposed. Instaed it fixes the tests to use using statements for their parser states in order to actually dispose of the parser states. (The dispose method unregisters the state's handlers from the static events.)

As a result of introducing appropriate using statements in all tests using a parser state, which is about 95% of our tests, the peak memory consumption when running all tests dropped to about 440MB for me.

Apart from a few manual adjustments, the PR is basically an application of variations of the following regex replace pattern pair to all test classes using a parser state, followed by a reindent.

Find:
`(var state = MockParser.CreateAndParse\(vbe.Object\));((([^{}]|\n|\r)+|{(?<DEPTH>)|}(?<-DEPTH>))*)(?(DEPTH)(?!))}`

Replace:
`using($1)\r\n{$2}\r\n}`

Should anyone get a merge conflict because of this PR---I am quite sure someone will---just discard my changes and use the regex replace pair with _Find and Replace in File_ on the corresponding test class.
