### PR TITLE
Fixing the reported line number on parser errors

### DIFF
--- a/Rubberduck.Parsing/VBA/IAttributeParser.cs
+++ b/Rubberduck.Parsing/VBA/IAttributeParser.cs
@@ -10,6 +10,6 @@ namespace Rubberduck.Parsing.VBA
 {
     public interface IAttributeParser
     {
-        IDictionary<Tuple<string, DeclarationType>, Attributes> Parse(IVBComponent component, CancellationToken token, out ITokenStream stream, out IParseTree tree);
+        (IParseTree tree, ITokenStream tokenStream, IDictionary<Tuple<string, DeclarationType>, Attributes> attributes) Parse(IVBComponent component, CancellationToken cancellationToken);
     }
 }

--- a/Rubberduck.Parsing/VBA/VBAModuleParser.cs
+++ b/Rubberduck.Parsing/VBA/VBAModuleParser.cs
@@ -11,7 +11,7 @@ namespace Rubberduck.Parsing.VBA
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public IParseTree Parse(string moduleName, CommonTokenStream moduleTokens, IParseTreeListener[] listeners, BaseErrorListener errorListener, out ITokenStream outStream)
+        public (IParseTree tree, ITokenStream tokenStream) Parse(string moduleName, CommonTokenStream moduleTokens, IParseTreeListener[] listeners, BaseErrorListener errorListener)
         {
             moduleTokens.Reset();
             var parser = new VBAParser(moduleTokens);
@@ -34,8 +34,7 @@ namespace Rubberduck.Parsing.VBA
             {
                 ParseTreeWalker.Default.Walk(listener, tree);
             }
-            outStream = moduleTokens;
-            return tree;
+            return (tree, moduleTokens);
         }
     }
 }


### PR DESCRIPTION
This PR kind of addreses issue #3180.

It does not directly implement what has been proposed there, but instead reverts the order of the attributes pass and the code pane pass. This way, any parser error that happens also happens in the code pane pass will happen there. Only the very rare parser errors that only happen in the attributes pass will get a line number from the exported modules.

As a littele add-on, this PR contains a little refactoring of the `ComponentsParseTask` and the parseres with a little C#7 tuple niceness.
