### PR TITLE
Small process adjustments

### DIFF
--- a/Rubberduck.Inspections/Concrete/BooleanAssignedInIfElseInspection.cs
+++ b/Rubberduck.Inspections/Concrete/BooleanAssignedInIfElseInspection.cs
@@ -48,7 +48,12 @@ namespace Rubberduck.Inspections.Concrete
 
             public override void ExitIfStmt(VBAParser.IfStmtContext context)
             {
-                if (context.elseIfBlock().Any())
+                if (context.elseIfBlock() != null && context.elseIfBlock().Any())
+                {
+                    return;
+                }
+
+                if (context.elseBlock() == null)
                 {
                     return;
                 }
@@ -60,6 +65,7 @@ namespace Rubberduck.Inspections.Concrete
                 }
 
                 // make sure the assignments are the opposite
+
                 if (!(ParserRuleContextHelper.GetDescendent<VBAParser.BooleanLiteralIdentifierContext>(context.block()).GetText() == Tokens.True ^
                       ParserRuleContextHelper.GetDescendent<VBAParser.BooleanLiteralIdentifierContext>(context.elseBlock().block()).GetText() == Tokens.True))
                 {


### PR DESCRIPTION
This PR has three parts:

1) I made the `Inspector` use `Parallel.ForEach` in one task to run all inspections. `Parrallel.ForEach` is more optimized towards computation bound tasks than running everything in separate tasks.

2) Testing that 1. did not break things, I found a missing null check in the `BooleanIsAssignedInIfElseInspection`. (It now bails out if there is no else block instead of crashing the inspection.) 

3)  I simplified the handling of cancellation token sources in the `ParseCoordinator`. We really only ever have one active cancellation token source and replace it under a lock. So there is no need for a collection.