### PR TITLE
Empty module inspection

### DIFF
--- a/Rubberduck.Inspections/Concrete/EmptyModuleInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyModuleInspection.cs
@@ -1,26 +1,103 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Inspections.Resources;
+using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace Rubberduck.Inspections.Concrete
 {
-    class EmptyModuleInspection : InspectionBase
+
+    public sealed class EmptyModuleInspection : InspectionBase
     {
-        public EmptyModuleInspection(RubberduckParserState state, CodeInspectionSeverity defaultSeverity = CodeInspectionSeverity.Hint) 
-        :base(state, defaultSeverity)
-        { }
+        private EmptyModuleVisitor _emptyModuleVisitor;
+
+        public EmptyModuleInspection(RubberduckParserState state,
+            CodeInspectionSeverity defaultSeverity = CodeInspectionSeverity.Hint)
+            : base(state, defaultSeverity)
+        {
+            _emptyModuleVisitor = new EmptyModuleVisitor();
+        }
 
         public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
-            throw new NotImplementedException();
+            var modulesToInspect = State.DeclarationFinder.AllModules
+                .Where(qmn => qmn.ComponentType == ComponentType.ClassModule
+                        || qmn.ComponentType == ComponentType.StandardModule).ToHashSet();
+
+            var treesToInspect = State.ParseTrees.Where(kvp => modulesToInspect.Contains(kvp.Key));
+
+            var emptyModules = treesToInspect
+                .Where(kvp => _emptyModuleVisitor.Visit(kvp.Value))
+                .Select(kvp => kvp.Key)
+                .ToHashSet();
+
+            var emptyModuleDeclarations = State.DeclarationFinder.UserDeclarations(DeclarationType.Module)
+                .Where(declaration => emptyModules.Contains(declaration.QualifiedName.QualifiedModuleName)
+                                        && !IsIgnoringInspectionResultFor(declaration, AnnotationName));
+
+            return emptyModuleDeclarations.Select(declaration =>
+                new DeclarationInspectionResult(this, string.Format(InspectionsUI.EmptyModuleInspectionResultFormat, declaration.IdentifierName), declaration));
+        }
+    }
+
+    internal sealed class EmptyModuleVisitor : VBAParserBaseVisitor<bool>
+    {
+        //If not specified otherwise, any context makes a module non-empty.
+        protected override bool DefaultResult => false;
+
+        protected override bool AggregateResult(bool aggregate, bool nextResult)
+        {
+            return aggregate && nextResult;
+        }
+
+        //We bail out whenever we already know that the module is non-empty.
+        protected override bool ShouldVisitNextChild(Antlr4.Runtime.Tree.IRuleNode node, bool currentResult)
+        {
+            return currentResult;
+        }
+
+
+        public override bool VisitStartRule(VBAParser.StartRuleContext context)
+        {
+            return Visit(context.module());
+        }
+
+        public override bool VisitModule(VBAParser.ModuleContext context)
+        {
+            return context.moduleConfig() == null
+                && Visit(context.moduleBody())
+                && Visit(context.moduleDeclarations());
+        }
+
+        public override bool VisitModuleBody(VBAParser.ModuleBodyContext context)
+        {
+            return !context.moduleBodyElement().Any();
+        }
+
+        public override bool VisitModuleDeclarations(VBAParser.ModuleDeclarationsContext context)
+        {
+            return !context.moduleDeclarationsElement().Any()
+                   || context.moduleDeclarationsElement().All(Visit);
+        }
+
+        public override bool VisitModuleDeclarationsElement(VBAParser.ModuleDeclarationsElementContext context)
+        {
+            return context.variableStmt() == null
+                   && context.constStmt() == null
+                   && context.enumerationStmt() == null
+                   && context.privateTypeDeclaration() == null
+                   && context.publicTypeDeclaration() == null
+                   && context.eventStmt() == null
+                   && context.implementsStmt() == null
+                   && context.declareStmt() == null;
         }
     }
 }

--- a/Rubberduck.Inspections/Concrete/EmptyModuleInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyModuleInspection.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Inspections.Resources;
+using Rubberduck.Parsing.VBA;
+
+namespace Rubberduck.Inspections.Concrete
+{
+    class EmptyModuleInspection : InspectionBase
+    {
+        public EmptyModuleInspection(RubberduckParserState state, CodeInspectionSeverity defaultSeverity = CodeInspectionSeverity.Hint) 
+        :base(state, defaultSeverity)
+        { }
+
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Rubberduck.Inspections/Rubberduck.Inspections.csproj
+++ b/Rubberduck.Inspections/Rubberduck.Inspections.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Abstract\ParseTreeInspectionBase.cs" />
     <Compile Include="Concrete\ApplicationWorksheetFunctionInspection.cs" />
     <Compile Include="Concrete\AssignedByValParameterInspection.cs" />
+    <Compile Include="Concrete\EmptyModuleInspection.cs" />
     <Compile Include="Concrete\EmptyBlockInspectionListenerBase.cs" />
     <Compile Include="Concrete\EmptyCaseBlockInspection.cs" />
     <Compile Include="Concrete\EmptyDoWhileBlockInspection.cs" />

--- a/Rubberduck.Parsing/Inspections/Resources/InspectionsUI.de.resx
+++ b/Rubberduck.Parsing/Inspections/Resources/InspectionsUI.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -130,7 +130,7 @@
     <value>Konstante wird nicht verwendet</value>
   </data>
   <data name="DefaultProjectNameInspectionMeta" xml:space="preserve">
-    <value>Erwäge dem VBA-Projekt einen Namen zu egeben.</value>
+    <value>Erwäge dem VBA-Projekt einen Namen zu geben.</value>
   </data>
   <data name="DefaultProjectNameInspectionName" xml:space="preserve">
     <value>Das Projekt hat den Standard-Projektnamen.</value>
@@ -289,7 +289,7 @@
     <value>Variable wird genutzt ohne das ihr ein Wert zugewiesen wurde.</value>
   </data>
   <data name="UntypedFunctionUsageInspectionMeta" xml:space="preserve">
-    <value>Eine gibt eine Funktion, die einen String Äquivalent zurückgibt. Diese sollte bevorzugt genutzt werden, um implitizite Typumwandlungen zu vermeiden.
+    <value>Es gibt eine äquivalente Funktion, die einen String zurückgibt. Diese sollte bevorzugt genutzt werden, um implitizite Typumwandlungen zu vermeiden.
 Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' an die Funktion zu übergeben, die einen String erwartet würde zu einem "Type Mismatch"-Laufzeitfehler führen.</value>
   </data>
   <data name="UntypedFunctionUsageInspectionName" xml:space="preserve">
@@ -866,5 +866,14 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   </data>
   <data name="BooleanAssignedInIfElseInspectionResultFormat" xml:space="preserve">
     <value>Boolean Ausdruck '{0}' wurde in einer trivialen If/Else-Verzweigung zugewiesen</value>
+  </data>
+  <data name="EmptyModuleInspectionName" xml:space="preserve">
+    <value>Leeres Modul</value>
+  </data>
+  <data name="EmptyModuleInspectionMeta" xml:space="preserve">
+    <value>Leere Module und Klassen weisen entweder auf noch nicht implementierte Funktionalitäten hin oder stellen unnötigen Ballast dar, der die Wartbarkeit eines Projekts behindern kann.</value>
+  </data>
+  <data name="EmptyModuleInspectionResultFormat" xml:space="preserve">
+    <value>Modul/Klasse {0} ist leer.</value>
   </data>
 </root>

--- a/Rubberduck.Parsing/Inspections/Resources/InspectionsUI.resx
+++ b/Rubberduck.Parsing/Inspections/Resources/InspectionsUI.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -877,5 +877,14 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   </data>
   <data name="ReplaceIfElseWithConditionalStatementQuickFix" xml:space="preserve">
     <value>Replace If/Else with single assignment</value>
+  </data>
+  <data name="EmptyModuleInspectionName" xml:space="preserve">
+    <value>Empty module</value>
+  </data>
+  <data name="EmptyModuleInspectionMeta" xml:space="preserve">
+    <value>Empty modules and classes either point to not yet implemented functionality or represent unnecessary baggage that can hurt the maintainability of a project.</value>
+  </data>
+  <data name="EmptyModuleInspectionResultFormat" xml:space="preserve">
+    <value>Module/class {0} is empty.</value>
   </data>
 </root>

--- a/Rubberduck.Parsing/Inspections/Resources/InspectionsUI1.Designer.cs
+++ b/Rubberduck.Parsing/Inspections/Resources/InspectionsUI1.Designer.cs
@@ -502,6 +502,33 @@ namespace Rubberduck.Parsing.Inspections.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Empty modules and classes either point to not yet implemented functionality or represent unnecessary baggage that can hurt the maintainability of a project..
+        /// </summary>
+        public static string EmptyModuleInspectionMeta {
+            get {
+                return ResourceManager.GetString("EmptyModuleInspectionMeta", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Empty module.
+        /// </summary>
+        public static string EmptyModuleInspectionName {
+            get {
+                return ResourceManager.GetString("EmptyModuleInspectionName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Module/class {0} is empty..
+        /// </summary>
+        public static string EmptyModuleInspectionResultFormat {
+            get {
+                return ResourceManager.GetString("EmptyModuleInspectionResultFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Prefer &apos;vbNullString&apos; to an empty string literal.
         /// </summary>
         public static string EmptyStringLiteralInspection {

--- a/RubberduckTests/Inspections/EmptyModuleInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyModuleInspectionTests.cs
@@ -288,7 +288,7 @@ End Type
         {
             const string inputCode = "";
 
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.Document, out _);
             using (var state = MockParser.CreateAndParse(vbe.Object))
             {
 

--- a/RubberduckTests/Inspections/EmptyModuleInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyModuleInspectionTests.cs
@@ -1,0 +1,355 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Resources;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestClass]
+    public class EmptyModuleInspectionTests
+    {
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithContentNotRepresentingFunctionality_ReturnsResult()
+        {
+            const string inputCode =
+                @"Option Base 1
+Option Compare Binary
+Option Explicit
+Option Private Module
+
+'Nothing to see here. 
+
+DefBool B: DefByte Y: DefInt I: DefLng L: DefLngLng N: DefLngPtr P: DefCur C: DefSng G: DefDbl D: DefDate T: DefStr E: DefObj O: DefVar V
+
+'Here, neither! _
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ClassWithContentNotRepresentingFunctionality_ReturnsResult()
+        {
+            const string inputCode =
+                @"Option Base 1
+Option Compare Binary
+Option Explicit
+
+'Nothing to see here. 
+
+DefBool B: DefByte Y: DefInt I: DefLng L: DefLngLng N: DefLngPtr P: DefCur C: DefSng G: DefDbl D: DefDate T: DefStr E: DefObj O: DefVar V
+
+'Here, neither! _
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.ClassModule, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithFunction_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Private Function Foo() As String
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithProcedure_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Private Sub Foo()
+End Sub
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithPropertyGet_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Public Property Get Foo()
+End Property
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithPropertySet_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Public Property Set Foo(rhs As Variant)
+End Property
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithPropertyLet_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Public Property Let Foo(rhs As Variant)
+End Property
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.UserForm, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithEnum_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Private Enum Foo
+Bar
+End Enum
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithPrivateUDT_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Private Type Foo
+Bar As String
+End Type
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithPublicUDT_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Public Type Foo
+Bar As String
+End Type
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithInstanceVariable_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Private foo As String";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithConstant_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Private Const foo As String = """"";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void ModuleWithEvent_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Public Event Foo(bar As Variant)";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void EmptyDocumentModule_DoesNotReturnResult()
+        {
+            const string inputCode = "";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void EmptyUserForm_DoesNotReturnResult()
+        {
+            const string inputCode = "";
+
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.Document, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void EmptyModule_Ignored_DoesNotReturnResult()
+        {
+            const string inputCode = "'@Ignore EmptyModule";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new EmptyModuleInspection(state);
+                var inspectionResults = inspection.GetInspectionResults();
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void InspectionType()
+        {
+            var inspection = new EmptyModuleInspection(null);
+            Assert.AreEqual(CodeInspectionType.MaintainabilityAndReadabilityIssues, inspection.InspectionType);
+        }
+
+        [TestMethod]
+        [TestCategory("Inspections")]
+        public void InspectionName()
+        {
+            const string inspectionName = "EmptyModuleInspection";
+            var inspection = new EmptyModuleInspection(null);
+
+            Assert.AreEqual(inspectionName, inspection.Name);
+        }
+    }
+}

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Inspections\ShadowedDeclarationInspectionTests.cs" />
     <Compile Include="Inspections\StopKeywordInspectionTests.cs" />
     <Compile Include="Inspections\OptionBaseZeroInspectionTests.cs" />
+    <Compile Include="Inspections\EmptyModuleInspectionTests.cs" />
     <Compile Include="QuickFixes\AssignedByValParameterMakeLocalCopyQuickFixTests.cs" />
     <Compile Include="QuickFixes\ChangeProcedureToFunctionQuickFixTests.cs" />
     <Compile Include="QuickFixes\DeclareAsExplicitVariantQuickFixTests.cs" />


### PR DESCRIPTION
This PR closes #1732 

I went and implemented the empty module inspectioan. This deems a module empty if there is nothing but module options, comments, and def directives, which all do not constitute functionality.

It uses a parse tree visitor to check whether a module is empty. I chose this approach over a listener since the inspection only has to look at the top levels of the parse tree to determine whether it is empty.