### PR TITLE
QMNs for module state changes and saved exceptions

### DIFF
--- a/RetailCoder.VBE/UI/Command/AddTestMethodCommand.cs
+++ b/RetailCoder.VBE/UI/Command/AddTestMethodCommand.cs
@@ -82,7 +82,7 @@ namespace Rubberduck.UI.Command
                 module.InsertLines(module.CountOfLines, body);
             }
 
-            _state.OnParseRequested(this, _vbe.SelectedVBComponent);
+            _state.OnParseRequested(this);
         }
 
         private string GetNextTestMethodName(IVBComponent component)

--- a/RetailCoder.VBE/UI/Command/AddTestMethodExpectedErrorCommand.cs
+++ b/RetailCoder.VBE/UI/Command/AddTestMethodExpectedErrorCommand.cs
@@ -101,7 +101,7 @@ namespace Rubberduck.UI.Command
                 module.InsertLines(module.CountOfLines, body);
             }
 
-            _state.OnParseRequested(this, _vbe.SelectedVBComponent);
+            _state.OnParseRequested(this);
         }
 
         private string GetNextTestMethodName(IVBComponent component)

--- a/RetailCoder.VBE/UI/Command/AddTestModuleCommand.cs
+++ b/RetailCoder.VBE/UI/Command/AddTestModuleCommand.cs
@@ -212,7 +212,7 @@ namespace Rubberduck.UI.Command
             }
 
             component.Activate();
-            _state.OnParseRequested(this, component);
+            _state.OnParseRequested(this);
         }
 
         private string GetNextTestModuleName(IVBProject project)

--- a/RetailCoder.VBE/UI/Command/IndentCurrentModuleCommand.cs
+++ b/RetailCoder.VBE/UI/Command/IndentCurrentModuleCommand.cs
@@ -33,7 +33,7 @@ namespace Rubberduck.UI.Command
             _indenter.IndentCurrentModule();
             if (_state.Status >= ParserState.Ready || _state.Status == ParserState.Pending)
             {
-                _state.OnParseRequested(this, _vbe.ActiveCodePane.CodeModule.Parent);
+                _state.OnParseRequested(this);
             }
         }
     }

--- a/RetailCoder.VBE/UI/Command/IndentCurrentProcedureCommand.cs
+++ b/RetailCoder.VBE/UI/Command/IndentCurrentProcedureCommand.cs
@@ -34,7 +34,7 @@ namespace Rubberduck.UI.Command
             _indenter.IndentCurrentProcedure();
             if (_state.Status >= ParserState.Ready || _state.Status == ParserState.Pending)
             {
-                _state.OnParseRequested(this, _vbe.ActiveCodePane.CodeModule.Parent);
+                _state.OnParseRequested(this);
             }
         }
     }

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractMethodCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractMethodCommand.cs
@@ -105,7 +105,7 @@ namespace Rubberduck.UI.Command.Refactorings
 
                 var extraction = new ExtractMethodExtraction();
                 // bug: access to disposed closure - todo: make ExtractMethodRefactoring request reparse like everyone else.
-                Action<object> parseRequest = obj => _state.OnParseRequested(obj, component); 
+                Action<object> parseRequest = obj => _state.OnParseRequested(obj); 
 
                 var refactoring = new ExtractMethodRefactoring(module, parseRequest, createMethodModel, extraction);
                 refactoring.InvalidSelection += HandleInvalidSelection;

--- a/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
@@ -9,7 +9,6 @@ using Rubberduck.Parsing.VBA;
 using Rubberduck.UI.Command.MenuItems;
 using Rubberduck.UI.Controls;
 using Rubberduck.VBEditor;
-using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.Command
 {
@@ -105,24 +104,18 @@ namespace Rubberduck.UI.Command
             return viewModel;
         }
 
-        private Declaration FindModuleDeclaration(IVBComponent component)
+        private Declaration FindModuleDeclaration(QualifiedModuleName module)
         {
-            var components = component.Collection;
-            var refProject = components.Parent;
-            {
-                var projectId = refProject.HelpFile;
-                var project = _state.AllUserDeclarations.SingleOrDefault(item =>
-                    item.DeclarationType == DeclarationType.Project && item.ProjectId == projectId);
+            var projectId = module.ProjectId;
+            var project = _state.DeclarationFinder.UserDeclarations(DeclarationType.Project)
+                    .SingleOrDefault(item => item.ProjectId == projectId);
 
-                var result = _state.AllUserDeclarations.SingleOrDefault(item => 
-                    item.ProjectId == component.Collection.Parent.HelpFile
-                    && item.QualifiedName.QualifiedModuleName.ComponentName == component.Name
-                    && (item.DeclarationType == DeclarationType.ClassModule || item.DeclarationType == DeclarationType.ProceduralModule));
+            var result = _state.DeclarationFinder.UserDeclarations(DeclarationType.Module)
+                    .SingleOrDefault(item => item.QualifiedName.QualifiedModuleName.Equals(module));
 
-                // FIXME dirty hack for project.Scope in case project is null. Clean up!
-                var declaration = new Declaration(new QualifiedMemberName(new QualifiedModuleName(component), component.Name), project, project?.Scope, component.Name, null, false, false, Accessibility.Global, DeclarationType.ProceduralModule, false, null, true);
-                return result ?? declaration; // module isn't in parser state - give it a dummy declaration, just so the ViewModel has something to chew on
-            }
+            // FIXME dirty hack for project.Scope in case project is null. Clean up!
+            var declaration = new Declaration(new QualifiedMemberName(module, module.ComponentName), project, project?.Scope, module.ComponentName, null, false, false, Accessibility.Global, DeclarationType.ProceduralModule, false, null, true);
+            return result ?? declaration; // module isn't in parser state - give it a dummy declaration, just so the ViewModel has something to chew on
         }
 
         public void Dispose()

--- a/Rubberduck.Parsing/IParseResultProvider.cs
+++ b/Rubberduck.Parsing/IParseResultProvider.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using Rubberduck.Parsing.VBA;
-using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing
 {
     public class ParseProgressEventArgs : EventArgs
     {
-        private readonly IVBComponent _component;
+        private readonly QualifiedModuleName _module;
         private readonly ParserState _state;
         private readonly ParserState _oldState;
 
-        public ParseProgressEventArgs(IVBComponent component, ParserState state, ParserState oldState)
+        public ParseProgressEventArgs(QualifiedModuleName module, ParserState state, ParserState oldState)
         {
-            _component = component;
+            _module = module;
             _state = state;
             _oldState = oldState;
         }
 
-        public IVBComponent Component { get { return _component; } }
+        public QualifiedModuleName Module { get { return _module; } }
         public ParserState State { get { return _state; } }
         public ParserState OldState { get { return _oldState; } }
     }

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
This PR removes the last questionable uses of `IVBComponents` from the `RubberduckParserState`: the `ParserProgressEventArgs` now contain a QMN instead of the component and the saved exceptions now use QMNs as keys. 

These changes allow the `SearchResultViewModel` to find module declarations without any COM access. This should eliminate the non-recoverable parser error after removing a component that had a parser error.

Moreover, I took the liberty to remove the second optional argument from `OnParseRequested`, which was a lie, anyway: there is no possibility to request a parse just for one module, nor would that make too much sense. (Everything in a dirty state has to be parsed to produce a sensible result.)