### PR TITLE
Bring user form export encoding in line with the vbe

### DIFF
--- a/RetailCoder.VBE/Common/ModuleExporter.cs
+++ b/RetailCoder.VBE/Common/ModuleExporter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;

--- a/Rubberduck.Parsing/VBA/AttributeParser.cs
+++ b/Rubberduck.Parsing/VBA/AttributeParser.cs
@@ -4,6 +4,7 @@ using Rubberduck.Parsing.Symbols;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using Rubberduck.Parsing.PreProcessing;
 using Rubberduck.Parsing.Symbols.ParsingExceptions;
@@ -37,7 +38,17 @@ namespace Rubberduck.Parsing.VBA
                 // a document component without any code wouldn't be exported (file would be empty anyway).
                 return (null, null, new Dictionary<Tuple<string, DeclarationType>, Attributes>());
             }
-            var code = File.ReadAllText(path);
+
+            string code;
+            if (module.ComponentType == ComponentType.Document)
+            {
+                code = File.ReadAllText(path, Encoding.UTF8);   //We export the code from Documents as UTF8.
+            }
+            else
+            {
+                code = File.ReadAllText(path, Encoding.Default);    //The VBE exports encoded in the current ANSI codepage from the windows settings.
+            }
+
             try
             {
                 File.Delete(path);

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -114,7 +114,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
             var tempFile = ExportToTempFile();
             var tempFilePath = Directory.GetParent(tempFile).FullName;
-            var contents = File.ReadAllLines(tempFile, System.Text.Encoding.UTF7);
+            var fileEncoding = System.Text.Encoding.Default;    //We use the current ANSI codepage because that is what the VBE does.
+            var contents = File.ReadAllLines(tempFile, fileEncoding);
             var nonAttributeLines = contents.TakeWhile(line => !line.StartsWith("Attribute")).Count();
             var attributeLines = contents.Skip(nonAttributeLines).TakeWhile(line => line.StartsWith("Attribute")).Count();
             var declarationsStartLine = nonAttributeLines + attributeLines + 1;
@@ -130,7 +131,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                        contents.Skip(declarationsStartLine + emptyLineCount - legitEmptyLineCount))
                                .ToArray();
             }
-            File.WriteAllLines(path, code);
+            File.WriteAllLines(path, code, fileEncoding);
 
             // LINQ hates this search, therefore, iterate the long way
             foreach (string line in contents)
@@ -165,8 +166,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             var lineCount = CodeModule.CountOfLines;
             if (lineCount > 0)
             {
+                //One cannot reimport document modules as such in the VBE; so we simply export and import the contents of the code pane.
+                //Because of this, it is OK, and actually preferable, to use the standard UTF8 encoding.
                 var text = CodeModule.GetLines(1, lineCount);
-                File.WriteAllText(path, text);
+                File.WriteAllText(path, text);  
             }
         }
 

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.SafeComWrappers.Office.Core.Abstract;
@@ -167,9 +168,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             if (lineCount > 0)
             {
                 //One cannot reimport document modules as such in the VBE; so we simply export and import the contents of the code pane.
-                //Because of this, it is OK, and actually preferable, to use the standard UTF8 encoding.
+                //Because of this, it is OK, and actually preferable, to use the default UTF8 encoding.
                 var text = CodeModule.GetLines(1, lineCount);
-                File.WriteAllText(path, text);  
+                File.WriteAllText(path, text, Encoding.UTF8);  
             }
         }
 

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
@@ -123,7 +123,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 var component = this[name];
                 component.CodeModule.Clear();
 
-                var codeString = File.ReadAllText(path);
+                var codeString = File.ReadAllText(path, Encoding.UTF8);
                 component.CodeModule.AddFromString(codeString);
             }
             else if (ext == ComponentTypeExtensions.FormExtension)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
@@ -108,8 +109,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 return;
             }
 
-            var codeString = File.ReadAllText(path);
-            var codeLines = codeString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
             if (ext == ComponentTypeExtensions.DocClassExtension)
             {
                 try
@@ -123,6 +122,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
                 var component = this[name];
                 component.CodeModule.Clear();
+
+                var codeString = File.ReadAllText(path);
                 component.CodeModule.AddFromString(codeString);
             }
             else if (ext == ComponentTypeExtensions.FormExtension)
@@ -137,6 +138,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 }
 
                 var component = this[name];
+
+                var codeString = File.ReadAllText(path, Encoding.Default);  //The VBE uses the current ANSI codepage from the windows settings to export and import.
+                var codeLines = codeString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
 
                 var nonAttributeLines = codeLines.TakeWhile(line => !line.StartsWith("Attribute")).Count();
                 var attributeLines = codeLines.Skip(nonAttributeLines).TakeWhile(line => line.StartsWith("Attribute")).Count();


### PR DESCRIPTION
Doing some reseach, I found an MS support reply that stated that the VBE always uses the ANSI codepage from the windows settings of the system a project has last been saved on. For our purposes, this should always be the current system, I think.

Accordingly, I changed the encoding for reading and writing the code of user forms, for which we have a special handling, to the current windows ANSI codepage, `Encoding.Default`. Previously, we read the file as UTF7, which eliminates all `+` characters since these are special characters in UTF7. Then we wrote the results of the special handling to the file in the default UTF8 encoding. When importing the file, we still used the default encoding heuristic.

In addition, I made it explicit in the code that the code in document modules gets exported and imported as UTF8. (We write directly to the code pane since the VBE cannot import document modules as such.)

This PR closes #3518, but might reopen issue #3461, which had been closed with the change to UTF7 on the read side of the special export handling.