### PR TITLE
Fixing try catch on dispatch

### DIFF
--- a/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
@@ -27,6 +27,8 @@ namespace Rubberduck.UI.Command
         private readonly SearchResultPresenterInstanceManager _presenterService;
         private readonly IVBE _vbe;
 
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         public FindAllImplementationsCommand(INavigateCommand navigateCommand, IMessageBox messageBox,
             RubberduckParserState state, IVBE vbe, ISearchResultsWindowViewModel viewModel,
             SearchResultPresenterInstanceManager presenterService)
@@ -63,28 +65,35 @@ namespace Rubberduck.UI.Command
 
         private void UpdateTab()
         {
-            var findImplementationsTabs = _viewModel.Tabs.Where(
-                t => t.Header.StartsWith(RubberduckUI.AllImplementations_Caption.Replace("'{0}'", ""))).ToList();
-
-            foreach (var tab in findImplementationsTabs)
+            try
             {
-                var newTarget = FindNewDeclaration(tab.Target);
-                if (newTarget == null)
-                {
-                    tab.CloseCommand.Execute(null);
-                    return;
-                }
+                var findImplementationsTabs = _viewModel.Tabs.Where(
+                    t => t.Header.StartsWith(RubberduckUI.AllImplementations_Caption.Replace("'{0}'", ""))).ToList();
 
-                var vm = CreateViewModel(newTarget);
-                if (vm.SearchResults.Any())
+                foreach (var tab in findImplementationsTabs)
                 {
-                    tab.SearchResults = vm.SearchResults;
-                    tab.Target = vm.Target;
+                    var newTarget = FindNewDeclaration(tab.Target);
+                    if (newTarget == null)
+                    {
+                        tab.CloseCommand.Execute(null);
+                        return;
+                    }
+
+                    var vm = CreateViewModel(newTarget);
+                    if (vm.SearchResults.Any())
+                    {
+                        tab.SearchResults = vm.SearchResults;
+                        tab.Target = vm.Target;
+                    }
+                    else
+                    {
+                        tab.CloseCommand.Execute(null);
+                    }
                 }
-                else
-                {
-                    tab.CloseCommand.Execute(null);
-                }
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, "Exception thrown while trying to update the find implementations tab.");
             }
         }
 

--- a/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
@@ -61,28 +61,35 @@ namespace Rubberduck.UI.Command
 
         private void UpdateTab()
         {
-            var findReferenceTabs = _viewModel.Tabs.Where(
-                t => t.Header.StartsWith(RubberduckUI.AllReferences_Caption.Replace("'{0}'", ""))).ToList();
-
-            foreach (var tab in findReferenceTabs)
+            try
             {
-                var newTarget = FindNewDeclaration(tab.Target);
-                if (newTarget == null)
-                {
-                    tab.CloseCommand.Execute(null);
-                    return;
-                }
+                var findReferenceTabs = _viewModel.Tabs.Where(
+                    t => t.Header.StartsWith(RubberduckUI.AllReferences_Caption.Replace("'{0}'", ""))).ToList();
 
-                var vm = CreateViewModel(newTarget);
-                if (vm.SearchResults.Any())
+                foreach (var tab in findReferenceTabs)
                 {
-                    tab.SearchResults = vm.SearchResults;
-                    tab.Target = vm.Target;
+                    var newTarget = FindNewDeclaration(tab.Target);
+                    if (newTarget == null)
+                    {
+                        tab.CloseCommand.Execute(null);
+                        return;
+                    }
+
+                    var vm = CreateViewModel(newTarget);
+                    if (vm.SearchResults.Any())
+                    {
+                        tab.SearchResults = vm.SearchResults;
+                        tab.Target = vm.Target;
+                    }
+                    else
+                    {
+                        tab.CloseCommand.Execute(null);
+                    }
                 }
-                else
-                {
-                    tab.CloseCommand.Execute(null);
-                }
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, "Exception thrown while trying to update the find all references tab.");
             }
         }
 

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -107,11 +107,19 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
             UiDispatcher.Invoke(() =>
             {
-                reparseCommandButton.SetCaption(caption);
-                reparseCommandButton.SetToolTip(string.Format(RubberduckUI.ReparseToolTipText, caption));
-                if (errorCount.HasValue && errorCount.Value > 0)
+                try
                 {
-                    showErrorsCommandButton.SetToolTip(string.Format(RubberduckUI.ParserErrorToolTipText, errorCount.Value));
+                    reparseCommandButton.SetCaption(caption);
+                    reparseCommandButton.SetToolTip(string.Format(RubberduckUI.ReparseToolTipText, caption));
+                    if (errorCount.HasValue && errorCount.Value > 0)
+                    {
+                        showErrorsCommandButton.SetToolTip(
+                            string.Format(RubberduckUI.ParserErrorToolTipText, errorCount.Value));
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Logger.Error(exception, "Exception thrown trying to set the status label caption on the UI thread.");
                 }
             });
             Localize();
@@ -125,9 +133,16 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
             UiDispatcher.Invoke(() =>
             {
-                contextLabel?.SetCaption(caption);
-                contextReferences?.SetCaption(contextReferenceCount);
-                contextDescription?.SetCaption(description);
+                try
+                {
+                    contextLabel?.SetCaption(caption);
+                    contextReferences?.SetCaption(contextReferenceCount);
+                    contextDescription?.SetCaption(description);
+                }
+                catch (Exception exception)
+                {
+                    Logger.Error(exception, "Exception thrown trying to set the context selection caption on the UI thread.");
+                }
             });
             Localize();
         }

--- a/RetailCoder.VBE/UI/Command/MenuItems/UiDispatcher.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/UiDispatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Windows.Threading;
+using NLog;
 
 namespace Rubberduck.UI.Command.MenuItems
 {
@@ -61,7 +62,11 @@ namespace Rubberduck.UI.Command.MenuItems
 
         public static void Shutdown()
         {
-            Invoke(() => Dispatcher.CurrentDispatcher.InvokeShutdown());
+            Invoke(() =>
+            {
+                LogManager.GetCurrentClassLogger().Debug("Invoking shutdown on UI thread dispatcher.");
+                Dispatcher.CurrentDispatcher.InvokeShutdown();
+            });
         }
     }
 }

--- a/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
@@ -47,29 +47,36 @@ namespace Rubberduck.UI.Command
 
         private void UpdateTab()
         {
-            if (_viewModel == null)
+            try
             {
-                return;
-            }
-
-            var vm = CreateViewModel();
-
-            var tab = _viewModel.Tabs.FirstOrDefault(t => t.Header == RubberduckUI.Parser_ParserError);
-            if (tab != null)
-            {
-                if (_state.Status != ParserState.Error)
+                if (_viewModel == null)
                 {
-                    tab.CloseCommand.Execute(null);
+                    return;
                 }
-                else
+
+                var vm = CreateViewModel();
+
+                var tab = _viewModel.Tabs.FirstOrDefault(t => t.Header == RubberduckUI.Parser_ParserError);
+                if (tab != null)
                 {
-                    tab.SearchResults = vm.SearchResults;
+                    if (_state.Status != ParserState.Error)
+                    {
+                        tab.CloseCommand.Execute(null);
+                    }
+                    else
+                    {
+                        tab.SearchResults = vm.SearchResults;
+                    }
+                }
+                else if (_state.Status == ParserState.Error)
+                {
+                    _viewModel.AddTab(vm);
+                    _viewModel.SelectedTab = vm;
                 }
             }
-            else if (_state.Status == ParserState.Error)
+            catch (Exception exception)
             {
-                _viewModel.AddTab(vm);
-                _viewModel.SelectedTab = vm;
+                Logger.Error(exception, "Exception thrown while trying to update the parser errors tab.");
             }
         }
 

--- a/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
+++ b/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
@@ -41,6 +41,8 @@ namespace Rubberduck.UI.Inspections
         private readonly IGeneralConfigService _configService;
         private readonly IOperatingSystem _operatingSystem;
 
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         public InspectionResultsViewModel(RubberduckParserState state, IInspector inspector, IQuickFixProvider quickFixProvider,
             INavigateCommand navigateCommand, ReparseCommand reparseCommand,
             IClipboardWriter clipboard, IGeneralConfigService configService, IOperatingSystem operatingSystem)
@@ -305,10 +307,17 @@ namespace Rubberduck.UI.Inspections
 
             UiDispatcher.Invoke(() =>
             {
-                IsBusy = false;
-                OnPropertyChanged("EmptyUIRefreshVisibility");
-                IsRefreshing = false;
-                SelectedItem = null;
+                try
+                {
+                    IsBusy = false;
+                    OnPropertyChanged("EmptyUIRefreshVisibility");
+                    IsRefreshing = false;
+                    SelectedItem = null;
+                }
+                catch (Exception exception)
+                {
+                    Logger.Error(exception, "Exception thrown trying to refresh the inspection results view on th UI thread.");
+                }
             });
 
             stopwatch.Stop();


### PR DESCRIPTION
Closes #3542 

This PR removes a bug where a try catch block has been around a dispatch instead of in the dispatched delegate. I also took the liberty to implement a log and swallow approach around all delegates dispatched to the UI thread, except those from the API. 

Moreover, this adds some more safety against COM exceptions in `AppCommandBarBase`. 
