### PR TITLE
Updated LibGit2Sharp to version v0.24.0 fixes #2497

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ $RECYCLE.BIN/
 *.xlsm
 Installers/
 *.xlsx
+
+CodeGraphData/

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="..\packages\Antlr4.4.3.0\build\Antlr4.props" Condition="Exists('..\packages\Antlr4.4.3.0\build\Antlr4.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -12,7 +13,8 @@
     <AssemblyName>Rubberduck</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>480c0557</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
@@ -256,9 +258,9 @@
     <Reference Include="Infralution.Localization.Wpf">
       <HintPath>..\libs\Infralution.Localization.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\LibGit2Sharp.0.22.0-pre20150516171636\lib\net40\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\Microsoft.Expression.Interactions.dll</HintPath>
@@ -1485,6 +1487,7 @@
     <Error Condition="!Exists('..\packages\Antlr4.4.3.0\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.4.3.0\build\Antlr4.props'))" />
     <Error Condition="!Exists('..\packages\Antlr4.4.3.0\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.4.3.0\build\Antlr4.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <Import Project="..\packages\Antlr4.4.3.0\build\Antlr4.targets" Condition="Exists('..\packages\Antlr4.4.3.0\build\Antlr4.targets')" />
   <PropertyGroup>

--- a/RetailCoder.VBE/packages.config
+++ b/RetailCoder.VBE/packages.config
@@ -7,6 +7,8 @@
   <package id="Castle.Windsor" version="4.0.0" targetFramework="net45" />
   <package id="EasyHook" version="2.7.6270" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="NLog" version="4.0.1" targetFramework="net45" />
   <package id="NLog.Schema" version="4.0.1" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />

--- a/Rubberduck.SourceControl/GitProvider.cs
+++ b/Rubberduck.SourceControl/GitProvider.cs
@@ -464,8 +464,6 @@ namespace Rubberduck.SourceControl
         {
             try
             {
-                // https://github.com/libgit2/libgit2sharp/wiki/Git-add
-                //_repo.Stage(filePath); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Stage(_repo, filePath);
             }
             catch (LibGit2SharpException ex)

--- a/Rubberduck.SourceControl/GitProvider.cs
+++ b/Rubberduck.SourceControl/GitProvider.cs
@@ -193,7 +193,7 @@ namespace Rubberduck.SourceControl
                     //The default behavior of LibGit2Sharp.Repo.Commit is to throw an exception if no signature is found,
                     // but BuildSignature() does not throw if a signature is not found, it returns "unknown" instead.
                     // so we pass a signature that won't throw along to the commit.
-                    repo.Commit("Initial Commit", GetSignature(repo), GetSignature(repo));
+                    repo.Commit("Initial Commit", author: GetSignature(repo), committer: GetSignature(repo));
                 }
                 catch(LibGit2SharpException ex)
                 {
@@ -291,7 +291,7 @@ namespace Rubberduck.SourceControl
                 //The default behavior of LibGit2Sharp.Repo.Commit is to throw an exception if no signature is found,
                 // but BuildSignature() does not throw if a signature is not found, it returns "unknown" instead.
                 // so we pass a signature that won't throw along to the commit.
-                _repo.Commit(message, GetSignature(), GetSignature());
+                _repo.Commit(message, author: GetSignature(), committer: GetSignature());
             }
             catch (LibGit2SharpException ex)
             {

--- a/Rubberduck.SourceControl/GitProvider.cs
+++ b/Rubberduck.SourceControl/GitProvider.cs
@@ -185,7 +185,6 @@ namespace Rubberduck.SourceControl
                 var status = repo.RetrieveStatus(new StatusOptions {DetectRenamesInWorkDir = true});
                 foreach (var stat in status.Untracked)
                 {
-                    // repo.Stage(stat.FilePath); //deprecated from LibGit2Sharp v0.24
                     LibGit2Sharp.Commands.Stage(repo, stat.FilePath);
                 }
 
@@ -247,13 +246,7 @@ namespace Rubberduck.SourceControl
 
                 if (remote != null)
                 {
-                    //_repo.Network.Fetch(remote); // deprecated on LibGit2Sharp from v0.24.0
-                    /* 
-                     * The new functionality requires a refSpec. 
-                     * As I suppose we're just tracking by default the whole remote,
-                     * then I choose to hardcode the refSpec here:
-                     */
-                     // NOTE: hardcoded string
+                     // FIXME: hardcoded string
                      IEnumerable<string> refSpec = new List<string>() {"+refs/heads/*:refs/remotes/origin/*"};
                     LibGit2Sharp.Commands.Fetch(_repo, remoteName, refSpec, null,"");
                 }
@@ -279,7 +272,6 @@ namespace Rubberduck.SourceControl
                 };
 
                 var signature = GetSignature();
-                //_repo.Network.Pull(signature, options); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Pull(_repo, signature, options);
 
                 base.Pull();
@@ -311,7 +303,6 @@ namespace Rubberduck.SourceControl
         {
             try
             {
-                // _repo.Stage(filePath); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Stage(_repo, filePath);
             }
             catch (LibGit2SharpException ex)
@@ -324,7 +315,6 @@ namespace Rubberduck.SourceControl
         {
             try
             {
-                //_repo.Stage(filePaths); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Stage(_repo, filePaths);
             }
             catch (LibGit2SharpException ex)
@@ -360,7 +350,6 @@ namespace Rubberduck.SourceControl
         {
             try
             {
-                //_repo.Checkout(_repo.Branches[branch]); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Checkout(_repo, branch);
                 base.Checkout(branch);
 
@@ -377,7 +366,6 @@ namespace Rubberduck.SourceControl
             try
             {
                 _repo.CreateBranch(branch);
-                //_repo.Checkout(branch); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Checkout(_repo,branch);
 
                 RequeryUnsyncedCommits();
@@ -393,7 +381,6 @@ namespace Rubberduck.SourceControl
             try
             {
                 _repo.CreateBranch(branch, _repo.Branches[sourceBranch].Commits.Last());
-                //_repo.Checkout(branch); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Checkout(_repo, branch);
 
                 RequeryUnsyncedCommits();
@@ -432,7 +419,6 @@ namespace Rubberduck.SourceControl
         {
             try
             {
-                //var remote = _repo.Branches[branch].Remote; // deprecated on LibGit2Sharp from v0.24.0
                 var remote = _repo.Network.Remotes[branch];
 
                 _repo.Branches.Update(_repo.Branches[branch], b => b.Remote = remote.Name,
@@ -498,7 +484,6 @@ namespace Rubberduck.SourceControl
             try
             {
                 NotifyExternalFileChanges = false;
-                //_repo.Remove(filePath, removeFromWorkingDirectory); // deprecated on LibGit2Sharp from v0.24.0
                 LibGit2Sharp.Commands.Remove(_repo, filePath, removeFromWorkingDirectory);
                 NotifyExternalFileChanges = true;
             }
@@ -572,7 +557,6 @@ namespace Rubberduck.SourceControl
                             };
                         }
 
-                        //_repo.Network.Push(branch.Remote, ":" + _repo.Branches[branchName].UpstreamBranchCanonicalName, options); // deprecated on LibGit2Sharp from v0.24.0
                         _repo.Network.Push(_repo.Network.Remotes[branchName], ":" + _repo.Branches[branchName].UpstreamBranchCanonicalName, options);
                     }
 

--- a/Rubberduck.SourceControl/Rubberduck.SourceControl.csproj
+++ b/Rubberduck.SourceControl/Rubberduck.SourceControl.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.0.22.0-pre20150516171636\build\net40\LibGit2Sharp.props" Condition="Exists('..\packages\LibGit2Sharp.0.22.0-pre20150516171636\build\net40\LibGit2Sharp.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,6 +39,7 @@
   <ItemGroup>
     <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
+      <private>True</private>
       <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Vbe.Interop, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
@@ -108,7 +108,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.0.22.0-pre20150516171636\build\net40\LibGit2Sharp.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.0.22.0-pre20150516171636\build\net40\LibGit2Sharp.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Rubberduck.SourceControl/Rubberduck.SourceControl.csproj
+++ b/Rubberduck.SourceControl/Rubberduck.SourceControl.csproj
@@ -38,9 +38,9 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibGit2Sharp">
-      <HintPath>..\packages\LibGit2Sharp.0.22.0-pre20150516171636\lib\net40\LibGit2Sharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Vbe.Interop, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
       <SpecificVersion>False</SpecificVersion>
@@ -82,6 +82,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <None Include="_SourceControlClassDiagram.cd" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Rubberduck.SourceControl/_SourceControlClassDiagram.cd
+++ b/Rubberduck.SourceControl/_SourceControlClassDiagram.cd
@@ -1,0 +1,237 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1">
+  <Class Name="Rubberduck.SourceControl.Branch" BaseTypeListCollapsed="true">
+    <Position X="8.25" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>IAAAAAAAAAAAAAgAAAAAAAQAAAAAACAAAAAIAAAAAAA=</HashCode>
+      <FileName>Branch.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Commit" BaseTypeListCollapsed="true">
+    <Position X="11.75" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAACAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAIAAAAAA=</HashCode>
+      <FileName>Commit.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.CredentialsBase&lt;TPassword&gt;" Collapsed="true">
+    <Position X="4.25" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAQAAAAAAAAAAAAACAAAAAAAAAAA=</HashCode>
+      <FileName>Credentials.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Credentials">
+    <Position X="4.25" Y="1.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Credentials.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rubberduck.SourceControl.SecureCredentials">
+    <Position X="6" Y="1.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Credentials.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rubberduck.SourceControl.DefaultSettings" Collapsed="true">
+    <Position X="8.25" Y="3.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAQA=</HashCode>
+      <FileName>DefaultSettings.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rubberduck.SourceControl.FileStatusEntry" Collapsed="true" BaseTypeListCollapsed="true">
+    <Position X="11.75" Y="3.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAIAAA=</HashCode>
+      <FileName>FileStatusEntry.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.GitProvider">
+    <Position X="2.25" Y="1.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>IIBAgEIEECAABCYAAEEEQAAAAAQAWQAAAMgCAAIQiBA=</HashCode>
+      <FileName>GitProvider.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Repository" Collapsed="true" BaseTypeListCollapsed="true">
+    <Position X="13.5" Y="3.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AgACAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Repository.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.SourceControlConfigProvider" Collapsed="true" BaseTypeListCollapsed="true">
+    <Position X="10" Y="4.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAIAAAAAAAAAAAAAAAAAAAAAAAEAAAAQAIIAAAAA=</HashCode>
+      <FileName>SourceControlConfigProvider.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.SourceControlException" Collapsed="true">
+    <Position X="11.75" Y="4.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>SourceControlException.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rubberduck.SourceControl.SourceControlProviderBase">
+    <Position X="0.5" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>IoBAgFAEEABABCYCAEEECIAAAAQASQAAAIgCAIIQiBA=</HashCode>
+      <FileName>SourceControlProviderBase.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.SourceControlSettings" Collapsed="true" BaseTypeListCollapsed="true">
+    <Position X="13.5" Y="4.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAQAAAAAAAAAgAAAAAQAIAAAAAAAAQAAAgAAAAA=</HashCode>
+      <FileName>SourceControlSettings.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.SourceControlText">
+    <Position X="8.25" Y="5.25" Width="1.75" />
+    <TypeIdentifier>
+      <HashCode>CAAAAAAAQAAAoAAgAkABEAIAEQAAIlQEABAgAEAAAIg=</HashCode>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Interop.Branches" BaseTypeListCollapsed="true">
+    <Position X="10" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AIAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Interop\Branches.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Interop.Credentials" BaseTypeListCollapsed="true">
+    <Position X="13.5" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAQAAAAAAAAAAAAACAAAAAAAAAAA=</HashCode>
+      <FileName>Interop\Credentials.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Interop.FileStatusEntries" Collapsed="true" BaseTypeListCollapsed="true">
+    <Position X="10" Y="3.25" Width="1.5" />
+    <Compartments>
+      <Compartment Name="Methods" Collapsed="true" />
+    </Compartments>
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAABAAAAAgAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Interop\FileStatusEntries.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Interop.GitProvider">
+    <Position X="4" Y="3" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AIAAAEAEAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAABA=</HashCode>
+      <FileName>Interop\GitProvider.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rubberduck.SourceControl.Interop.SourceControlClassFactory" Collapsed="true" BaseTypeListCollapsed="true">
+    <Position X="8.25" Y="4.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAABAAAAAAAAAgAAAAAQAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Interop\SourceControlClassFactory.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Interface Name="Rubberduck.SourceControl.IBranch" Collapsed="true">
+    <Position X="12.25" Y="6.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>IAAAAAAAAAAAAAgAAAAAAAQAAAAAACAAAAAIAAAAAAA=</HashCode>
+      <FileName>Branch.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.ICommit" Collapsed="true">
+    <Position X="14" Y="6.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAACAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAIAAAAAA=</HashCode>
+      <FileName>Commit.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.ICredentials&lt;TPassword&gt;" Collapsed="true">
+    <Position X="16" Y="6.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAQAAAAAAAAAAAAACAAAAAAAAAAA=</HashCode>
+      <FileName>Credentials.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.IFileStatusEntry" Collapsed="true">
+    <Position X="12.25" Y="7.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAIAAA=</HashCode>
+      <FileName>FileStatusEntry.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.IRepository" Collapsed="true">
+    <Position X="14" Y="7.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AgACAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>IRepository.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.ISourceControlProvider" Collapsed="true">
+    <Position X="16" Y="7.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>IoBAgFAEEAAABCYCAEEEAIAAAAQASQAAAIgCAIIQiBA=</HashCode>
+      <FileName>ISourceControlProvider.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.ISourceControlSettings" Collapsed="true">
+    <Position X="12.25" Y="8" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAQAAAAAAAAAAAAAAAQAIAAAAAAAAQAAAgAAAAA=</HashCode>
+      <FileName>SourceControlSettings.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.Interop.ICredentials" Collapsed="true">
+    <Position X="10.5" Y="7.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAQAAAAAAAAAAAAACAAAAAAAAAAA=</HashCode>
+      <FileName>Interop\Credentials.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.Interop.ISourceControlProvider" Collapsed="true">
+    <Position X="10.5" Y="8" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>IIBAAFAEEAAABAIAAAEAAAAAAAQAAQAAAAACAAIQiBA=</HashCode>
+      <FileName>Interop\ISourceControlProvider.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rubberduck.SourceControl.Interop._ISourceControlClassFactory" Collapsed="true">
+    <Position X="10.5" Y="6.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAABAAAAAAAAAgAAAAAQAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Interop\SourceControlClassFactory.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Enum Name="Rubberduck.SourceControl.GitSettingsFile" Collapsed="true">
+    <Position X="12.25" Y="9" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAACAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>DefaultSettings.cs</FileName>
+    </TypeIdentifier>
+  </Enum>
+  <Enum Name="Rubberduck.SourceControl.FileStatus" Collapsed="true">
+    <Position X="10.5" Y="9" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAEgAAqAIAAEAAABAAAEABAACAAAAAAAgAAAAAEQA=</HashCode>
+      <FileName>FileStatus.cs</FileName>
+    </TypeIdentifier>
+  </Enum>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/Rubberduck.SourceControl/packages.config
+++ b/Rubberduck.SourceControl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp" version="0.22.0-pre20150516171636" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -49,8 +49,9 @@
     <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="LibGit2Sharp">
-      <HintPath>..\packages\LibGit2Sharp.0.22.0-pre20150516171636\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Vbe.Interop, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">

--- a/RubberduckTests/packages.config
+++ b/RubberduckTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.1.1" targetFramework="net45" />
   <package id="Castle.Windsor" version="4.0.0" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.22.0-pre20150516171636" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="NLog" version="4.0.1" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />


### PR DESCRIPTION
#2497 
API changed:
-> repository.commit() now mandates 'author' and 'commiter' as two distinct parameters. I pass into both the same value by default.
-> repository.Stage() passes to the static class 'Commands' taking the repo as a first parameters.
-> repository.Pull() undergoes the same change
-> repository.Checkout() also
-> repository.Remove() also
-> repository.Fetch() takes the biggest changes.
    -It now requires by default a refSpec. As we will usually fetch everything, I hardcoded on the code the classic "+refs/heads/*:refs/remotes/origin/*".
    -It also requires a logMessage, which I hardoced empty ("")
-> repository.Branches[branch].Remote changes as well. Now this collection moves to the .Network class member of the repository, as repo.Network.Remotes[branch]

 Changes to be committed:
	modified:   RetailCoder.VBE/Rubberduck.csproj
	modified:   RetailCoder.VBE/packages.config
	modified:   Rubberduck.SourceControl/GitProvider.cs
	modified:   Rubberduck.SourceControl/Rubberduck.SourceControl.csproj
	new file:   Rubberduck.SourceControl/_SourceControlClassDiagram.cd
	modified:   Rubberduck.SourceControl/packages.config
	modified:   RubberduckTests/RubberduckTests.csproj

Yeah, sorry for the ClassDiagram. But it's really helping me visualise the whole structure of the project