### PR TITLE
More COM release on shutdown

### DIFF
--- a/RetailCoder.VBE/AppMenu.cs
+++ b/RetailCoder.VBE/AppMenu.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using NLog;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.UI;
@@ -16,6 +18,8 @@ namespace Rubberduck
         private readonly IParseCoordinator _parser;
         private readonly ISelectionChangeService _selectionService;
         private readonly RubberduckCommandBar _stateBar;
+
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
         public AppMenu(IEnumerable<IParentMenuItem> menus, IParseCoordinator parser, ISelectionChangeService selectionService, RubberduckCommandBar stateBar)
         {
@@ -77,7 +81,13 @@ namespace Rubberduck
         {
             foreach (var menu in _menus.Where(menu => menu.Item != null))
             {
+                _logger.Debug($"Starting removal of top-level menu {menu.GetType()}.");
                 menu.RemoveMenu();
+                //We do this here and not in the menu items because we only want to release the parents of the top level parent menus.
+                //The parents further down get released as part of the remove chain.
+                _logger.Trace($"Removing parent menu of top-level menu {menu.GetType()}.");
+                menu.Parent.Release(); 
+                menu.Parent = null;
             }
         }
     }

--- a/RetailCoder.VBE/AppMenu.cs
+++ b/RetailCoder.VBE/AppMenu.cs
@@ -86,7 +86,7 @@ namespace Rubberduck
                 //We do this here and not in the menu items because we only want to release the parents of the top level parent menus.
                 //The parents further down get released as part of the remove chain.
                 _logger.Trace($"Removing parent menu of top-level menu {menu.GetType()}.");
-                menu.Parent.Release(); 
+                menu.Parent.Release(true);  //todo: Find a way around this!!!
                 menu.Parent = null;
             }
         }

--- a/RetailCoder.VBE/AppMenu.cs
+++ b/RetailCoder.VBE/AppMenu.cs
@@ -83,9 +83,10 @@ namespace Rubberduck
             {
                 _logger.Debug($"Starting removal of top-level menu {menu.GetType()}.");
                 menu.RemoveMenu();
-                //We do this here and not in the menu items because we only want to release the parents of the top level parent menus.
-                //The parents further down get released as part of the remove chain.
+                //We do this here and not in the menu items because we only want to dispose of/release the parents of the top level parent menus.
+                //The parents further down get disposed of/released as part of the remove chain.
                 _logger.Trace($"Removing parent menu of top-level menu {menu.GetType()}.");
+                menu.Parent.Dispose();
                 menu.Parent.Release(true);  //todo: Find a way around this!!!
                 menu.Parent = null;
             }

--- a/RetailCoder.VBE/Extension.cs
+++ b/RetailCoder.VBE/Extension.cs
@@ -265,6 +265,18 @@ namespace Rubberduck
                     _container = null;
                 }
 
+                if (_addin != null)
+                {
+                    _addin.Release();
+                    _addin = null;
+                }
+
+                if (_ide != null)
+                {
+                    _ide.Release();
+                    _ide = null;
+                }
+
                 _isInitialized = false;
                 _logger.Log(LogLevel.Info, "No exceptions were thrown.");
             }

--- a/RetailCoder.VBE/Extension.cs
+++ b/RetailCoder.VBE/Extension.cs
@@ -267,13 +267,15 @@ namespace Rubberduck
 
                 if (_addin != null)
                 {
-                    _addin.Release();
+                    _logger.Log(LogLevel.Trace, "Disposing AddIn wrapper...");
+                    _addin.Dispose();
                     _addin = null;
                 }
 
                 if (_ide != null)
                 {
-                    _ide.Release();
+                    _logger.Log(LogLevel.Trace, "Disposing VBE wrapper...");
+                    _ide.Dispose();
                     _ide = null;
                 }
 

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
@@ -175,9 +175,9 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                     Logger.Debug("Removing commandbar.");
                     RemoveChildren();
                     Item.Delete();
-                    Item.Release();
+                    Item.Dispose();
                     Item = null;
-                    Parent?.Release();
+                    Parent?.Dispose();
                     Parent = null;
                 }
             }
@@ -203,7 +203,7 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                         button.Click -= child_Click;
                     }
                     button.Delete();
-                    button.Release();
+                    button.Dispose();
                 }
             }
             catch (COMException exception)

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
@@ -170,12 +170,16 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
         {
             try
             {
-                Logger.Debug("Removing commandbar.");
-                RemoveChildren();
-                Item?.Delete();
-                Item?.Release();
-                Item = null;
-                Parent = null;
+                if (Item != null)
+                {
+                    Logger.Debug("Removing commandbar.");
+                    RemoveChildren();
+                    Item.Delete();
+                    Item.Release();
+                    Item = null;
+                    Parent?.Release();
+                    Parent = null;
+                }
             }
             catch (COMException exception)
             {

--- a/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
@@ -92,7 +92,7 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
             Logger.Debug($"Removing menu {_key}.");
             RemoveChildren();
             Item?.Delete();
-            Item?.Release();
+            Item?.Dispose();
             Item = null;
         }
 
@@ -106,7 +106,7 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
             {
                 child.Click -= child_Click;
                 child.Delete();
-                child.Release();
+                child.Dispose();
             }
         }
 

--- a/RetailCoder.VBE/UI/DockableToolwindowPresenter.cs
+++ b/RetailCoder.VBE/UI/DockableToolwindowPresenter.cs
@@ -20,7 +20,7 @@ namespace Rubberduck.UI
         UserControl UserControl { get; }
     }
 
-    public abstract class DockableToolwindowPresenter : IDockablePresenter
+    public abstract class DockableToolwindowPresenter : IDockablePresenter, IDisposable
     {
         private readonly IAddIn _addin;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
@@ -99,6 +99,23 @@ namespace Rubberduck.UI
 
         public virtual void Show() => _window.IsVisible = true;
         public virtual void Hide() => _window.IsVisible = false;
+
+
+        private bool _isDisposed;
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            Logger.Trace($"Disposing DockableWindowPresenter of type {this.GetType()}.");
+
+            _window.Dispose();
+
+            _isDisposed = true;
+        }
+
 
         ~DockableToolwindowPresenter()
         {

--- a/Rubberduck.VBEEditor/SafeComWrappers/Abstract/ISafeComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Abstract/ISafeComWrapper.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
 {
-    public interface ISafeComWrapper : INullObjectWrapper
+    public interface ISafeComWrapper : INullObjectWrapper, IDisposable
     {
         void Release(bool final = false);
         bool HasBeenReleased { get; }

--- a/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
@@ -15,7 +15,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers
         }
 
         private int? _rcwReferenceCount;
-        public virtual void Release(bool final = false)
+        public void Release(bool final = false)
         {
             if (HasBeenReleased)
             {
@@ -103,5 +103,22 @@ namespace Rubberduck.VBEditor.SafeComWrappers
         {
             return !(a == b);
         }
-   }
+
+
+        private bool _isDisposed;
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (!HasBeenReleased)
+            {
+                Release();
+            }
+
+            _isDisposed = true;
+        }
+    }
 }

--- a/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using NLog;
@@ -105,15 +106,21 @@ namespace Rubberduck.VBEditor.SafeComWrappers
         }
 
 
-        private bool _isDisposed;
         public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool _isDisposed;
+        protected virtual void Dispose(bool disposing)
         {
             if (_isDisposed)
             {
                 return;
             }
 
-            if (!HasBeenReleased)
+            if (disposing && !HasBeenReleased)
             {
                 Release();
             }


### PR DESCRIPTION
This PR increases the number of COM wrappers we release on shutdown and reduces the number of access violations. 

This is still WIP since I still have to release the window objects of the dockable tool windows. 

Currently, 13 access violations are remaining on my system for Excel. (21 before this PR)

Please note that I currently have to resort to final releasing the parents of the top-level windows; I simply have not found out yet who else is holding a different wrapper for them.


Apart from adding more `Release`/`Dispose` calls, I implemented `IDisposable` on the `SafeComWrapper`: `Dispose` releases the underlying COM object if it has not yet been released.