### PR TITLE
More shutdown tweaks

### DIFF
--- a/RetailCoder.VBE/AppMenu.cs
+++ b/RetailCoder.VBE/AppMenu.cs
@@ -87,7 +87,6 @@ namespace Rubberduck
                 //The parents further down get disposed of/released as part of the remove chain.
                 _logger.Trace($"Removing parent menu of top-level menu {menu.GetType()}.");
                 menu.Parent.Dispose();
-                menu.Parent.Release(true);  //todo: Find a way around this!!!
                 menu.Parent = null;
             }
         }

--- a/RetailCoder.VBE/Extension.cs
+++ b/RetailCoder.VBE/Extension.cs
@@ -249,7 +249,8 @@ namespace Rubberduck
                 _logger.Log(LogLevel.Trace, "Broadcasting shutdown...");
                 using (var mainWindow = _ide.MainWindow)
                 {
-                    UiDispatcher.Invoke(() => User32.EnumChildWindows(mainWindow.Handle(), EnumCallback, new IntPtr(0)));
+                    var mainWindosHndl = mainWindow.Handle();
+                    UiDispatcher.Invoke(() => User32.EnumChildWindows(mainWindosHndl, EnumCallback, new IntPtr(0)));
                 }
 
                 _logger.Log(LogLevel.Trace, "Releasing dockable hosts...");

--- a/RetailCoder.VBE/Extension.cs
+++ b/RetailCoder.VBE/Extension.cs
@@ -16,6 +16,7 @@ using NLog;
 using Rubberduck.Root;
 using Rubberduck.Settings;
 using Rubberduck.SettingsProvider;
+using Rubberduck.UI.Command.MenuItems;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.WindowsApi;
@@ -246,7 +247,10 @@ namespace Rubberduck
                 VBENativeServices.UnhookEvents();
 
                 _logger.Log(LogLevel.Trace, "Broadcasting shutdown...");
-                User32.EnumChildWindows(_ide.MainWindow.Handle(), EnumCallback, new IntPtr(0));
+                using (var mainWindow = _ide.MainWindow)
+                {
+                    UiDispatcher.Invoke(() => User32.EnumChildWindows(mainWindow.Handle(), EnumCallback, new IntPtr(0)));
+                }
 
                 _logger.Log(LogLevel.Trace, "Releasing dockable hosts...");
                 Windows.ReleaseDockableHosts();

--- a/RetailCoder.VBE/Root/RubberduckIoCInstaller.cs
+++ b/RetailCoder.VBE/Root/RubberduckIoCInstaller.cs
@@ -257,9 +257,7 @@ namespace Rubberduck.Root
         private void RegisterRubberduckMenu(IWindsorContainer container)
         {
             const int windowMenuId = 30009;
-            var commandBars = _vbe.CommandBars;
-            var menuBar = commandBars[MenuBar];
-            var controls = menuBar.Controls;
+            var controls = MainCommandBarControls(MenuBar);
             var beforeIndex = FindRubberduckMenuInsertionIndex(controls, windowMenuId);
             var menuItemTypes = RubberduckMenuItems();
             RegisterMenu<RubberduckParentMenu>(container, controls, beforeIndex, menuItemTypes);
@@ -296,24 +294,36 @@ namespace Rubberduck.Root
         {
             for (var i = 1; i <= controls.Count; i++)
             {
-                var item = controls[i];
-                if (item.IsBuiltIn && item.Id == beforeId)
+                using (var item = controls[i])
                 {
-                    return i;
+                    if (item.IsBuiltIn && item.Id == beforeId)
+                    {
+                        return i;
+                    }
                 }
             }
 
             return controls.Count;
         }
 
+        private ICommandBarControls MainCommandBarControls(int commandBarIndex)
+        {
+            ICommandBarControls controls;
+            using (var commandBars = _vbe.CommandBars)
+            {
+                using (var menuBar = commandBars[commandBarIndex])
+                {
+                    controls = menuBar.Controls;
+                }
+            }
+            return controls;
+        }
+
         private void RegisterCodePaneContextMenu(IWindsorContainer container)
         {
             const int listMembersMenuId = 2529;
-            var commandBars = _vbe.CommandBars;
-            var menuBar = commandBars[CodeWindow];
-            var controls = menuBar.Controls;
-            var beforeControl = controls.FirstOrDefault(control => control.Id == listMembersMenuId);
-            var beforeIndex = beforeControl == null ? 1 : beforeControl.Index;
+            var controls = MainCommandBarControls(CodeWindow);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, listMembersMenuId);
             var menuItemTypes = CodePaneContextMenuItems();
             RegisterMenu<CodePaneContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
         }
@@ -333,11 +343,8 @@ namespace Rubberduck.Root
         private void RegisterFormDesignerContextMenu(IWindsorContainer container)
         {
             const int viewCodeMenuId = 2558;
-            var commandBars = _vbe.CommandBars;
-            var menuBar = commandBars[MsForms];
-            var controls = menuBar.Controls;
-            var beforeControl = controls.FirstOrDefault(control => control.Id == viewCodeMenuId);
-            var beforeIndex = beforeControl?.Index ?? 1;
+            var controls = MainCommandBarControls(MsForms);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, viewCodeMenuId);
             var menuItemTypes = FormDesignerContextMenuItems();
             RegisterMenu<FormDesignerContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
         }
@@ -354,11 +361,8 @@ namespace Rubberduck.Root
         private void RegisterFormDesignerControlContextMenu(IWindsorContainer container)
         {
             const int viewCodeMenuId = 2558;
-            var commandBars = _vbe.CommandBars;
-            var menuBar = commandBars[MsFormsControl];
-            var controls = menuBar.Controls;
-            var beforeControl = controls.FirstOrDefault(control => control.Id == viewCodeMenuId);
-            var beforeIndex = beforeControl?.Index ?? 1;
+            var controls = MainCommandBarControls(MsFormsControl);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, viewCodeMenuId);
             var menuItemTypes = FormDesignerContextMenuItems();
             RegisterMenu<FormDesignerControlContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
         }
@@ -366,11 +370,8 @@ namespace Rubberduck.Root
         private void RegisterProjectExplorerContextMenu(IWindsorContainer container)
         {
             const int projectPropertiesMenuId = 2578;
-            var commandBars = _vbe.CommandBars;
-            var menuBar = commandBars[ProjectWindow];
-            var controls = menuBar.Controls;
-            var beforeControl = controls.FirstOrDefault(control => control.Id == projectPropertiesMenuId);
-            var beforeIndex = beforeControl?.Index ?? 1;
+            var controls = MainCommandBarControls(ProjectWindow);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, projectPropertiesMenuId);
             var menuItemTypes = ProjectWindowContextMenuItems();
             RegisterMenu<ProjectWindowContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
         }

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
@@ -114,7 +114,11 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                 return null;
             }
 
-            var child = CommandBarButtonFactory.Create(Item.Controls);
+            ICommandBarButton child;
+            using (var controls = Item.Controls)
+            {
+                child = CommandBarButtonFactory.Create(controls);
+            }
             child.Style = item.ButtonStyle;
             child.Picture = item.Image;
             child.Mask = item.Mask;

--- a/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
@@ -101,6 +101,7 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
             foreach (var child in _items.Keys.Select(item => item as IParentMenuItem).Where(child => child != null))
             {
                 child.RemoveMenu();
+                child.Parent.Dispose();
             }
             foreach (var child in _items.Values.Select(item => item as ICommandBarButton).Where(child => child != null))
             {
@@ -155,7 +156,11 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
                 return null;
             }
 
-            var child = CommandBarButtonFactory.Create(Item.Controls);
+            ICommandBarButton child;
+            using (var controls = Item.Controls)
+            {
+                child = CommandBarButtonFactory.Create(controls);
+            }
             child.Picture = item.Image;
             child.Mask = item.Mask;
             child.ApplyIcon();

--- a/RetailCoder.VBE/UI/Controls/SearchResultPresenterInstanceManager.cs
+++ b/RetailCoder.VBE/UI/Controls/SearchResultPresenterInstanceManager.cs
@@ -54,6 +54,8 @@ namespace Rubberduck.UI.Controls
             {
                 _view.ViewModel.LastTabClosed -= viewModel_LastTabClosed;
             }
+            _presenter?.Dispose();
+
             _disposed = true;
         }
     }

--- a/RetailCoder.VBE/UI/DockableToolwindowPresenter.cs
+++ b/RetailCoder.VBE/UI/DockableToolwindowPresenter.cs
@@ -123,7 +123,7 @@ namespace Rubberduck.UI
         ~DockableToolwindowPresenter()
         {
             // destructor for tracking purposes only - do not suppress unless 
-            Debug.WriteLine("DockableToolwindowPresenter finalized.");
+            Debug.WriteLine($"DockableToolwindowPresenter of type {this.GetType()} finalized.");
         }
     }
 }

--- a/RetailCoder.VBE/UI/DockableToolwindowPresenter.cs
+++ b/RetailCoder.VBE/UI/DockableToolwindowPresenter.cs
@@ -50,9 +50,12 @@ namespace Rubberduck.UI
             IWindow toolWindow;
             try
             {
-                var info = _vbe.Windows.CreateToolWindow(_addin, _DockableWindowHost.RegisteredProgId, control.Caption, control.ClassId);
-                _userControlObject = info.UserControl;
-                toolWindow = info.ToolWindow;
+                using (var windows = _vbe.Windows)
+                {
+                    var info = windows.CreateToolWindow(_addin, _DockableWindowHost.RegisteredProgId, control.Caption, control.ClassId);
+                    _userControlObject = info.UserControl;
+                    toolWindow = info.ToolWindow;
+                }
             }
             catch (COMException exception)
             {

--- a/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
@@ -54,8 +54,17 @@ namespace Rubberduck.VBEditor.SafeComWrappers
                 else
                 {
                     _rcwReferenceCount = Marshal.ReleaseComObject(Target);
-                    _logger.Trace($"Released COM wrapper of type {this.GetType()} with remaining reference count {_rcwReferenceCount}.");
+                    if (_rcwReferenceCount >= 0)
+                    {
+                        _logger.Trace($"Released COM wrapper of type {this.GetType()} with remaining reference count {_rcwReferenceCount}.");
+                    }
+                    else
+                    {
+                        _logger.Warn($"Released COM wrapper of type {this.GetType()} whose underlying RCW has already been released from outside the SafeComWrapper.");
+                    }
                 }
+
+                
             }
             catch(COMException exception)
             {
@@ -73,7 +82,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers
             }
         }
 
-        public bool HasBeenReleased => _rcwReferenceCount == 0;
+        public bool HasBeenReleased => _rcwReferenceCount <= 0;
 
         public bool IsWrappingNullReference => Target == null;
         object INullObjectWrapper.Target => Target;

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Windows.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Windows.cs
@@ -1,5 +1,8 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Office.Interop.Outlook;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using VB = Microsoft.Vbe.Interop;
 
@@ -40,6 +43,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 dynamic host = item.Value;
                 host.Release();
             }
+            _dockableHosts.Clear();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/WindowsApi/SubclassingWindow.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/SubclassingWindow.cs
@@ -13,14 +13,16 @@ namespace Rubberduck.VBEditor.WindowsApi
 
         private readonly object _subclassLock = new object();
 
-        public delegate int SubClassCallback(IntPtr hWnd, IntPtr msg, IntPtr wParam, IntPtr lParam, IntPtr uIdSubclass, IntPtr dwRefData);
+        public delegate int SubClassCallback(IntPtr hWnd, IntPtr msg, IntPtr wParam, IntPtr lParam, IntPtr uIdSubclass,
+            IntPtr dwRefData);
 
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool IsWindow(IntPtr hWnd);
 
         [DllImport("ComCtl32.dll", CharSet = CharSet.Auto)]
-        private static extern int SetWindowSubclass(IntPtr hWnd, SubClassCallback newProc, IntPtr uIdSubclass, IntPtr dwRefData);
+        private static extern int SetWindowSubclass(IntPtr hWnd, SubClassCallback newProc, IntPtr uIdSubclass,
+            IntPtr dwRefData);
 
         [DllImport("ComCtl32.dll", CharSet = CharSet.Auto)]
         private static extern int RemoveWindowSubclass(IntPtr hWnd, SubClassCallback newProc, IntPtr uIdSubclass);
@@ -38,18 +40,10 @@ namespace Rubberduck.VBEditor.WindowsApi
             AssignHandle();
         }
 
-        private bool _disposed;
         public void Dispose()
         {
-            if (_disposed)
-            {
-                return;
-            }
-
-            ReleaseHandle();
-            _thisHandle.Free();
-
-            _disposed = true;
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         private void AssignHandle()
@@ -89,7 +83,8 @@ namespace Rubberduck.VBEditor.WindowsApi
             }
         }
 
-        public virtual int SubClassProc(IntPtr hWnd, IntPtr msg, IntPtr wParam, IntPtr lParam, IntPtr uIdSubclass, IntPtr dwRefData)
+        public virtual int SubClassProc(IntPtr hWnd, IntPtr msg, IntPtr wParam, IntPtr lParam, IntPtr uIdSubclass,
+            IntPtr dwRefData)
         {
             if (!_listening)
             {
@@ -97,11 +92,29 @@ namespace Rubberduck.VBEditor.WindowsApi
                 return DefSubclassProc(hWnd, msg, wParam, lParam);
             }
 
-            if ((uint)msg == (uint)WM.RUBBERDUCK_SINKING || (uint)msg == (uint)WM.DESTROY)
-            {               
-                ReleaseHandle();                
+            if ((uint) msg == (uint) WM.RUBBERDUCK_SINKING || (uint) msg == (uint) WM.DESTROY)
+            {
+                ReleaseHandle();
             }
             return DefSubclassProc(hWnd, msg, wParam, lParam);
+        }
+
+        private bool _disposed;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                ReleaseHandle();
+            }
+
+            _thisHandle.Free();
+
+            _disposed = true;
         }
     }
 }


### PR DESCRIPTION
This PR contains some more tweaks relating to the shutdown issue.

Following the leads provided by @WaynePhillipsEA I added disposal code for some more com wrappers.
Doing this in the IoC installer allowed to remove the final release code in the app menu disposal. 

In addition, I changed the disposal of the subclasing windows and dockable hosts somewhat to allow them to be collected when we are unloaded via the menu. 

Atm, for me shutdown has a chance of about 50% to have no access violation and of 50% to have one. However, when I comment out the forced GC at shutdown, I get lots of access violations. 