### PR TITLE
Refine criteria for matching TODO markers

### DIFF
--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -5512,7 +5512,7 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to BUG .
+        ///   Looks up a localized string similar to BUG.
         /// </summary>
         public static string TodoMarkerBug {
             get {
@@ -5521,7 +5521,7 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NOTE .
+        ///   Looks up a localized string similar to NOTE.
         /// </summary>
         public static string TodoMarkerNote {
             get {
@@ -5530,7 +5530,7 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO .
+        ///   Looks up a localized string similar to TODO.
         /// </summary>
         public static string TodoMarkerTodo {
             get {

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -382,13 +382,13 @@ Warning: All customized settings will be lost.  Your old file will be saved in '
     <value>Version {0}</value>
   </data>
   <data name="TodoMarkerBug" xml:space="preserve">
-    <value>BUG </value>
+    <value>BUG</value>
   </data>
   <data name="TodoMarkerNote" xml:space="preserve">
-    <value>NOTE </value>
+    <value>NOTE</value>
   </data>
   <data name="TodoMarkerTodo" xml:space="preserve">
-    <value>TODO </value>
+    <value>TODO</value>
   </data>
   <data name="AllImplementations_Caption" xml:space="preserve">
     <value>Implementations of '{0}'</value>

--- a/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
+using System.Text.RegularExpressions;
 using NLog;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Settings;
@@ -245,7 +246,7 @@ namespace Rubberduck.UI.ToDoItems
         {
             var markers = _configService.LoadConfiguration().UserSettings.ToDoListSettings.ToDoMarkers;
             return markers.Where(marker => !string.IsNullOrEmpty(marker.Text)
-                                         && comment.CommentText.ToLowerInvariant().Contains(marker.Text.ToLowerInvariant()))
+                                         && Regex.IsMatch(comment.CommentText, @"\b" + Regex.Escape(marker.Text) + @"\b", RegexOptions.IgnoreCase))
                            .Select(marker => new ToDoItem(marker.Text, comment));
         }
 

--- a/Retailcoder.VBE/UI/RubberduckUI.resx
+++ b/Retailcoder.VBE/UI/RubberduckUI.resx
@@ -382,13 +382,13 @@ Warning: All customized settings will be lost.  Your old file will be saved in '
     <value>Version {0}</value>
   </data>
   <data name="TodoMarkerBug" xml:space="preserve">
-    <value>BUG </value>
+    <value>BUG</value>
   </data>
   <data name="TodoMarkerNote" xml:space="preserve">
-    <value>NOTE </value>
+    <value>NOTE</value>
   </data>
   <data name="TodoMarkerTodo" xml:space="preserve">
-    <value>TODO </value>
+    <value>TODO</value>
   </data>
   <data name="AllImplementations_Caption" xml:space="preserve">
     <value>Implementations of '{0}'</value>

--- a/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
+++ b/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
@@ -32,7 +32,8 @@ namespace RubberduckTests.TodoExplorer
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                var vm = new ToDoExplorerViewModel(state, GetConfigService(), GetOperatingSystemMock().Object);
+                var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
+                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -42,7 +43,7 @@ namespace RubberduckTests.TodoExplorer
 
                 var comments = vm.Items.Select(s => s.Type);
 
-                Assert.IsTrue(comments.SequenceEqual(new[] { "TODO ", "NOTE ", "BUG " }));
+                Assert.IsTrue(comments.SequenceEqual(new[] { "TODO", "NOTE", "BUG" }));
             }
         }
 
@@ -65,7 +66,8 @@ namespace RubberduckTests.TodoExplorer
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                var vm = new ToDoExplorerViewModel(state, GetConfigService(), GetOperatingSystemMock().Object);
+                var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
+                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -75,7 +77,7 @@ namespace RubberduckTests.TodoExplorer
 
                 var comments = vm.Items.Select(s => s.Type);
 
-                Assert.IsTrue(comments.SequenceEqual(new[] { "TODO ", "NOTE ", "BUG ", "BUG " }));
+                Assert.IsTrue(comments.SequenceEqual(new[] { "TODO", "NOTE", "BUG", "BUG" }));
             }
         }
 
@@ -98,7 +100,8 @@ namespace RubberduckTests.TodoExplorer
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                var vm = new ToDoExplorerViewModel(state, GetConfigService(), GetOperatingSystemMock().Object);
+                var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
+                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -115,24 +118,19 @@ namespace RubberduckTests.TodoExplorer
             }
         }
 
-        private IGeneralConfigService GetConfigService()
+        private IGeneralConfigService GetConfigService(string[] markers)
         {
             var configService = new Mock<IGeneralConfigService>();
-            configService.Setup(c => c.LoadConfiguration()).Returns(GetTodoConfig);
+            configService.Setup(c => c.LoadConfiguration()).Returns(GetTodoConfig(markers));
 
             return configService.Object;
         }
 
-        private Configuration GetTodoConfig()
+        private Configuration GetTodoConfig(string[] markers)
         {
             var todoSettings = new ToDoListSettings
             {
-                ToDoMarkers = new[]
-                {
-                    new ToDoMarker("NOTE "),
-                    new ToDoMarker("TODO "),
-                    new ToDoMarker("BUG ")
-                }
+                ToDoMarkers = markers.Select(m => new ToDoMarker(m)).ToArray()
             };
 
             var userSettings = new UserSettings(null, null, todoSettings, null, null, null, null);

--- a/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
+++ b/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
@@ -90,7 +90,8 @@ namespace RubberduckTests.TodoExplorer
             const string inputCode =
                 @"' To-do - this is a todo comment
 ' N@TE this is a note comment
-' bug: this should work with a colon separator
+' bug this should work with a trailing space
+' bug: this should not be seen due to the colon
 ";
 
             var builder = new MockVbeBuilder();
@@ -102,7 +103,7 @@ namespace RubberduckTests.TodoExplorer
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                var cs = GetConfigService(new[] { "TO-DO", "N@TE", "BUG" });
+                var cs = GetConfigService(new[] { "TO-DO", "N@TE", "BUG " });
                 var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
 
                 parser.Parse(new CancellationTokenSource());
@@ -113,7 +114,7 @@ namespace RubberduckTests.TodoExplorer
 
                 var comments = vm.Items.Select(s => s.Type);
 
-                Assert.IsTrue(comments.SequenceEqual(new[] { "TO-DO", "N@TE", "BUG" }));
+                Assert.IsTrue(comments.SequenceEqual(new[] { "TO-DO", "N@TE", "BUG " }));
             }
         }
 


### PR DESCRIPTION
Closes #3642

Previously the TODO markers had a trailing space in the settings (not in the German localisation however) which served as the word boundary test for identifying TODO markers in comments. This change is to use regular expressions to match the TODO markers as whole words which is more flexible and less likely to get false positive from words ending with any of the TODO markers.

Notes
1) French localised settings file also has trailing spaces but not updated as doing this created a great many XML changes (about space="preserve") so not sure if doing this right. If this is okay, I can modify the pull request.
2) Two copies of the file RubberduckUI.resx appear in the change log even though only one was changed. Seems to already have two copies in the repository (in RetailCoder.VBE/UI and Retailcoder.VBE/UI - note difference in capitalisation of letter C)
