### PR TITLE
Smarten up the Codecov Report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,30 @@ coverage:
   round: nearest
   precision: 2
   range: 40..80 
+  status:
+    # don't check patch coverage
+    patch: off
+    changes: yes
+    # allow decrease by up to 5 %
+    threshold: 5
+    base: auto
+    project:
+      core:
+        # restrict core decrease to 1.5%
+        threshold: 1.5
+        flags: core
+  
+comment:
+  layout: "diff, files, changes, footer"
+  behavior: new
+  require_changes: yes
+  
+flags:
+  core:
+    paths:
+      - Rubberduck.Parsing
+      - Rubberduck.VBEEditor
+  inspections:
+    paths:
+      - Rubberduck.Inspections
+  


### PR DESCRIPTION
Instead of checking a flat number, we allow up to 5% coverage decrease, unless in RD's core from a PR.
inspection coverage can now be checked separately.

Additionally we do not check the patches themselves. We have no really good way to check for UI changes, so it makes no sense to require patches to have coverage...
lastly the comment behaviour has been adjusted a bit to be less imagey and a tad shorter