### PR TITLE
Minor tweaks

### DIFF
--- a/RetailCoder.VBE/Common/Hotkeys/Hotkey.cs
+++ b/RetailCoder.VBE/Common/Hotkeys/Hotkey.cs
@@ -71,14 +71,14 @@ namespace Rubberduck.Common.Hotkeys
 
             if (!User32.UnregisterHotKey(_hWndVbe, HotkeyInfo.HookId))
             {
-                Logger.Warn($"Error calling UnregisterHotKey; the error was {Marshal.GetLastWin32Error()}; going to delete the atom anyway... The memory may leak.");
+                Logger.Warn($"Error calling UnregisterHotKey on hokey with id {HotkeyInfo.HookId} for command of type {Command.GetType()}; the error was {Marshal.GetLastWin32Error()}; going to delete the atom anyway... The memory may leak.");
             }
             Kernel32.SetLastError(Kernel32.ERROR_SUCCESS);
             Kernel32.GlobalDeleteAtom(HotkeyInfo.HookId);
             var lastError = Marshal.GetLastWin32Error();
             if (lastError != Kernel32.ERROR_SUCCESS)
             {
-                Logger.Warn($"Error calling DeleteGlobalAtom; the error was {lastError} and the id was {HotkeyInfo.HookId}.");
+                Logger.Warn($"Error calling DeleteGlobalAtom; the error was {lastError}, the id {HotkeyInfo.HookId} and the type of the associated command {Command.GetType()}.");
             }
             ClearCommandShortcutText();
         }
@@ -101,9 +101,11 @@ namespace Rubberduck.Common.Hotkeys
             if (!success)
             {
                 Logger.Debug(RubberduckUI.CommonHotkey_KeyNotRegistered, key);
+                return;
             }
 
             HotkeyInfo = new HotkeyInfo(hookId, Combo);
+            Logger.Trace($"Hotkey for the associated command {Command.GetType()} was registered with id {HotkeyInfo.HookId}");
         }
 
         private void SetCommandShortcutText()

--- a/RetailCoder.VBE/Common/Hotkeys/Hotkey.cs
+++ b/RetailCoder.VBE/Common/Hotkeys/Hotkey.cs
@@ -80,6 +80,8 @@ namespace Rubberduck.Common.Hotkeys
             {
                 Logger.Warn($"Error calling DeleteGlobalAtom; the error was {lastError}, the id {HotkeyInfo.HookId} and the type of the associated command {Command.GetType()}.");
             }
+
+            HotkeyInfo = new HotkeyInfo(IntPtr.Zero, Combo);
             ClearCommandShortcutText();
         }
 

--- a/RetailCoder.VBE/Settings/CodeInspectionSettings.cs
+++ b/RetailCoder.VBE/Settings/CodeInspectionSettings.cs
@@ -52,7 +52,7 @@ namespace Rubberduck.Settings
                 {
                     return existing;
                 }
-                var proto = Convert.ChangeType(Activator.CreateInstance(inspectionType), inspectionType);
+                var proto = Convert.ChangeType(Activator.CreateInstance(inspectionType, new object[]{null}), inspectionType);
                 var setting = new CodeInspectionSetting(proto as IInspectionModel);
                 CodeInspections.Add(setting);
                 return setting;

--- a/RubberduckTests/Inspections/InspectionsHelper.cs
+++ b/RubberduckTests/Inspections/InspectionsHelper.cs
@@ -28,7 +28,8 @@ namespace RubberduckTests.Inspections
             settings.CodeInspections.Add(new CodeInspectionSetting
             {
                 Description = inspection.Description,
-                Severity = inspection.Severity
+                Severity = inspection.Severity, 
+                Name = inspection.ToString()
             });
             return new Configuration
             {


### PR DESCRIPTION
Add a missing `return` in a fail case for the `Hotkey.cs` and add `null` for RPS for the code inspection and also fix the `InspectionHelper` to provide name for the inspection so that it can locate in the settings correctly.