### PR TITLE
Wrapping the designer

### DIFF
--- a/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
@@ -100,17 +100,23 @@ namespace Rubberduck.Refactorings.ExtractInterface
 
             AddInterfaceMembersToClass(rewriter);
 
-            var components = _model.TargetDeclaration.Project.VBComponents;
-            var interfaceComponent = components.Add(ComponentType.ClassModule);
-            var interfaceModule = interfaceComponent.CodeModule;
-            interfaceComponent.Name = _model.InterfaceName;
-
-            var optionPresent = interfaceModule.CountOfLines > 1;
-            if (!optionPresent)
+            using (var components = _model.TargetDeclaration.Project.VBComponents)
             {
-                interfaceModule.InsertLines(1, $"{Tokens.Option} {Tokens.Explicit}{Environment.NewLine}");
+                using (var interfaceComponent = components.Add(ComponentType.ClassModule))
+                {
+                    using (var interfaceModule = interfaceComponent.CodeModule)
+                    {
+                        interfaceComponent.Name = _model.InterfaceName;
+
+                        var optionPresent = interfaceModule.CountOfLines > 1;
+                        if (!optionPresent)
+                        {
+                            interfaceModule.InsertLines(1, $"{Tokens.Option} {Tokens.Explicit}{Environment.NewLine}");
+                        }
+                        interfaceModule.InsertLines(3, GetInterfaceModuleBody());
+                    }
+                }
             }
-            interfaceModule.InsertLines(3, GetInterfaceModuleBody());
         }
 
         private void AddInterfaceMembersToClass(IModuleRewriter rewriter)

--- a/RetailCoder.VBE/Refactorings/ImplementInterface/ImplementInterfaceRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ImplementInterface/ImplementInterfaceRefactoring.cs
@@ -77,16 +77,23 @@ namespace Rubberduck.Refactorings.ImplementInterface
             QualifiedSelection? oldSelection = null;
             if (_vbe.ActiveCodePane != null)
             {
-                oldSelection = _vbe.ActiveCodePane.CodeModule.GetQualifiedSelection();
+                using (var codePane = _vbe.ActiveCodePane)
+                {
+                    oldSelection = codePane.GetQualifiedSelection();
+                }
             }
 
             ImplementMissingMembers(_state.GetRewriter(_targetClass));
 
             if (oldSelection.HasValue)
             {
-                var module = oldSelection.Value.QualifiedName.Component.CodeModule;
-                var pane = module.CodePane;
-                pane.Selection = oldSelection.Value.Selection;
+                using (var module = oldSelection.Value.QualifiedName.Component.CodeModule)
+                {
+                    using (var pane = module.CodePane)
+                    {
+                        pane.Selection = oldSelection.Value.Selection;
+                    }
+                }
             }
 
             _state.OnParseRequested(this);

--- a/RetailCoder.VBE/Refactorings/RemoveParameters/RemoveParametersRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/RemoveParameters/RemoveParametersRefactoring.cs
@@ -41,18 +41,22 @@ namespace Rubberduck.Refactorings.RemoveParameters
             }
 
             QualifiedSelection? oldSelection = null;
-            var pane = _vbe.ActiveCodePane;
-            var module = pane.CodeModule;
-            if (!module.IsWrappingNullReference)
+            using (var pane = _vbe.ActiveCodePane)
             {
-                oldSelection = module.GetQualifiedSelection();
-            }
+                using (var module = pane.CodeModule)
+                {
+                    if (!module.IsWrappingNullReference)
+                    {
+                        oldSelection = module.GetQualifiedSelection();
+                    }
+                }
 
-            RemoveParameters();
+                RemoveParameters();
 
-            if (oldSelection.HasValue)
-            {
-                pane.Selection = oldSelection.Value.Selection;
+                if (oldSelection.HasValue)
+                {
+                    pane.Selection = oldSelection.Value.Selection;
+                }
             }
 
             _model.State.OnParseRequested(this);
@@ -116,7 +120,6 @@ namespace Rubberduck.Refactorings.RemoveParameters
         {
             foreach (var reference in references.Where(item => item.Context != method.Context))
             {
-                var module = reference.QualifiedModuleName.Component.CodeModule;
                 VBAParser.ArgumentListContext argumentList = null;
                 var callStmt = ParserRuleContextHelper.GetParent<VBAParser.CallStmtContext>(reference.Context);
                 if (callStmt != null)
@@ -139,7 +142,10 @@ namespace Rubberduck.Refactorings.RemoveParameters
                     continue;
                 }
 
-                RemoveCallArguments(argumentList, module);
+                using (var module = reference.QualifiedModuleName.Component.CodeModule)
+                {
+                    RemoveCallArguments(argumentList, module);
+                }
             }
         }
 

--- a/RetailCoder.VBE/Refactorings/Rename/RenamePresenterFactory.cs
+++ b/RetailCoder.VBE/Refactorings/Rename/RenamePresenterFactory.cs
@@ -21,11 +21,16 @@ namespace Rubberduck.Refactorings.Rename
 
         public RenamePresenter Create()
         {
-            var codePane = _vbe.ActiveCodePane;
-            var qualifiedSelection = codePane.IsWrappingNullReference
-                ? new QualifiedSelection()
-                : new QualifiedSelection(new QualifiedModuleName(codePane.CodeModule.Parent), codePane.Selection);
-
+            QualifiedSelection qualifiedSelection;
+            using (var codePane = _vbe.ActiveCodePane)
+            {
+                using (var codeModule = codePane.CodeModule)
+                {
+                    qualifiedSelection = codePane.IsWrappingNullReference
+                        ? new QualifiedSelection()
+                        : new QualifiedSelection(new QualifiedModuleName(codeModule.Parent), codePane.Selection);
+                }
+            }
             return new RenamePresenter(_view, new RenameModel(_vbe, _state, qualifiedSelection));
         }
     }

--- a/RetailCoder.VBE/Refactorings/Rename/RenameRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/Rename/RenameRefactoring.cs
@@ -210,21 +210,27 @@ namespace Rubberduck.Refactorings.Rename
 
             if (target.DeclarationType.HasFlag(DeclarationType.Control))
             {
-                var module = target.QualifiedName.QualifiedModuleName.Component.CodeModule;
-                var control = module.Parent.Controls.FirstOrDefault(item => item.Name == target.IdentifierName);
-                if (control == null)
+                using (var controls = target.QualifiedName.QualifiedModuleName.Component.Controls)
                 {
-                    PresentRenameErrorMessage($"{BuildDefaultErrorMessage(target)} - Null control reference");
-                    return false;
+                    using (var control = controls.FirstOrDefault(item => item.Name == target.IdentifierName))
+                    {
+                        if (control == null)
+                        {
+                            PresentRenameErrorMessage($"{BuildDefaultErrorMessage(target)} - Null control reference");
+                            return false;
+                        }
+                    }
                 }
             }
             else if (target.DeclarationType.HasFlag(DeclarationType.Module))
             {
-                var module = target.QualifiedName.QualifiedModuleName.Component.CodeModule;
-                if (module.IsWrappingNullReference)
+                using (var module = target.QualifiedName.QualifiedModuleName.Component.CodeModule)
                 {
-                    PresentRenameErrorMessage($"{BuildDefaultErrorMessage(target)} - Null Module reference");
-                    return false;
+                    if (module.IsWrappingNullReference)
+                    {
+                        PresentRenameErrorMessage($"{BuildDefaultErrorMessage(target)} - Null Module reference");
+                        return false;
+                    }
                 }
             }
             return true;
@@ -381,13 +387,17 @@ namespace Rubberduck.Refactorings.Rename
         {
             if (_model.Target.DeclarationType.HasFlag(DeclarationType.Control))
             {
-                var module = _model.Target.QualifiedName.QualifiedModuleName.Component.CodeModule;
-                var control = module.Parent.Controls.SingleOrDefault(item => item.Name == _model.Target.IdentifierName);
-                Debug.Assert(control != null, $"input validation fail: unable to locate '{_model.Target.IdentifierName}' in Controls collection");
+                using (var controls = _model.Target.QualifiedName.QualifiedModuleName.Component.Controls)
+                {
+                    using (var control = controls.SingleOrDefault(item => item.Name == _model.Target.IdentifierName))
+                    {
+                        Debug.Assert(control != null,
+                            $"input validation fail: unable to locate '{_model.Target.IdentifierName}' in Controls collection");
 
-                control.Name = _model.NewName;
+                        control.Name = _model.NewName;
+                    }
+                }
                 RenameReferences(_model.Target, _model.NewName);
-
                 var controlEventHandlers = FindEventHandlersForControl(_model.Target);
                 RenameDefinedFormatMembers(controlEventHandlers, _appendUnderscoreFormat);
             }
@@ -443,8 +453,11 @@ namespace Rubberduck.Refactorings.Rename
             }
             else
             {
-                Debug.Assert(!component.CodeModule.IsWrappingNullReference, "input validation fail: Attempting to rename an ICodeModule wrapping a null reference");
-                component.CodeModule.Name = _model.NewName;
+                using (var codeModule = component.CodeModule)
+                {
+                    Debug.Assert(!codeModule.IsWrappingNullReference, "input validation fail: Attempting to rename an ICodeModule wrapping a null reference");
+                    codeModule.Name = _model.NewName;
+                }
             }
         }
 

--- a/RetailCoder.VBE/Refactorings/ReorderParameters/ReorderParametersRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ReorderParameters/ReorderParametersRefactoring.cs
@@ -41,21 +41,23 @@ namespace Rubberduck.Refactorings.ReorderParameters
                 return;
             }
 
-            var pane = _vbe.ActiveCodePane;
-            if (!pane.IsWrappingNullReference)
+            using (var pane = _vbe.ActiveCodePane)
             {
-                QualifiedSelection? oldSelection;
-                var module = pane.CodeModule;
+                if (!pane.IsWrappingNullReference)
                 {
-                    oldSelection = module.GetQualifiedSelection();
-                }
+                    QualifiedSelection? oldSelection;
+                    using (var module = pane.CodeModule)
+                    {
+                        oldSelection = module.GetQualifiedSelection();
+                    }
 
-                AdjustReferences(_model.TargetDeclaration.References);
-                AdjustSignatures();
+                    AdjustReferences(_model.TargetDeclaration.References);
+                    AdjustSignatures();
 
-                if (oldSelection.HasValue)
-                {
-                    pane.Selection = oldSelection.Value.Selection;
+                    if (oldSelection.HasValue)
+                    {
+                        pane.Selection = oldSelection.Value.Selection;
+                    }
                 }
             }
 
@@ -69,7 +71,7 @@ namespace Rubberduck.Refactorings.ReorderParameters
 
         public void Refactor(QualifiedSelection target)
         {
-            var pane = _vbe.ActiveCodePane;
+            using (var pane = _vbe.ActiveCodePane)
             {
                 pane.Selection = target.Selection;
                 Refactor();
@@ -83,7 +85,7 @@ namespace Rubberduck.Refactorings.ReorderParameters
                 throw new ArgumentException("Invalid declaration type");
             }
 
-            var pane = _vbe.ActiveCodePane;
+            using (var pane = _vbe.ActiveCodePane)
             {
                 pane.Selection = target.QualifiedSelection.Selection;
                 Refactor();

--- a/RetailCoder.VBE/UI/CodeExplorer/Commands/AddComponentCommand.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/Commands/AddComponentCommand.cs
@@ -32,7 +32,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
         {
             using (var components = node != null
                 ? GetDeclaration(node).Project.VBComponents
-                : ComponentsColectionFromActiveProject())
+                : ComponentsCollectionFromActiveProject())
             {
                 var folderAnnotation = $"'@Folder(\"{GetFolder(node)}\")";
 
@@ -46,7 +46,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             }
         }
 
-        private IVBComponents ComponentsColectionFromActiveProject()
+        private IVBComponents ComponentsCollectionFromActiveProject()
         {
             using (var activeProject = _vbe.ActiveVBProject)
             {

--- a/RetailCoder.VBE/UI/CodeExplorer/Commands/AddComponentCommand.cs
+++ b/RetailCoder.VBE/UI/CodeExplorer/Commands/AddComponentCommand.cs
@@ -30,14 +30,28 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         public void AddComponent(CodeExplorerItemViewModel node, ComponentType type)
         {
-            var components = node != null
+            using (var components = node != null
                 ? GetDeclaration(node).Project.VBComponents
-                : _vbe.ActiveVBProject.VBComponents;
+                : ComponentsColectionFromActiveProject())
+            {
+                var folderAnnotation = $"'@Folder(\"{GetFolder(node)}\")";
 
-            var folderAnnotation = $"'@Folder(\"{GetFolder(node)}\")";
+                using (var newComponent = components.Add(type))
+                {
+                    using (var codeModule = newComponent.CodeModule)
+                    {
+                        codeModule.InsertLines(1, folderAnnotation);
+                    }
+                }
+            }
+        }
 
-            var newComponent = components.Add(type);
-            newComponent.CodeModule.InsertLines(1, folderAnnotation);
+        private IVBComponents ComponentsColectionFromActiveProject()
+        {
+            using (var activeProject = _vbe.ActiveVBProject)
+            {
+                return activeProject.VBComponents;
+            }
         }
 
         private Declaration GetDeclaration(CodeExplorerItemViewModel node)

--- a/RetailCoder.VBE/UI/Command/AddTestModuleCommand.cs
+++ b/RetailCoder.VBE/UI/Command/AddTestModuleCommand.cs
@@ -159,61 +159,71 @@ namespace Rubberduck.UI.Command
                 project.EnsureReferenceToAddInLibrary();
             }
 
-            var component = project.VBComponents.Add(ComponentType.StandardModule);
-            var module = component.CodeModule;
-            component.Name = GetNextTestModuleName(project);
-
-            var hasOptionExplicit = false;
-            if (module.CountOfLines > 0 && module.CountOfDeclarationLines > 0)
+            using(var components = project.VBComponents)
             {
-                hasOptionExplicit = module.GetLines(1, module.CountOfDeclarationLines).Contains("Option Explicit");
-            }
-
-            var options = string.Concat(hasOptionExplicit ? string.Empty : "Option Explicit\r\n",
-                "Option Private Module\r\n\r\n");
-
-            if (parameterIsModuleDeclaration)
-            {
-                var moduleCodeBuilder = new StringBuilder();
-                var declarationsToStub = GetDeclarationsToStub((Declaration)parameter);
-
-                foreach (var declaration in declarationsToStub)
+                using (var component = components.Add(ComponentType.StandardModule))
                 {
-                    var name = string.Empty;
-
-                    switch (declaration.DeclarationType)
+                    using (var module = component.CodeModule)
                     {
-                        case DeclarationType.Procedure:
-                        case DeclarationType.Function:
-                            name = declaration.IdentifierName;
-                            break;
-                        case DeclarationType.PropertyGet:
-                            name = $"Get{declaration.IdentifierName}";
-                            break;
-                        case DeclarationType.PropertyLet:
-                            name = $"Let{declaration.IdentifierName}";
-                            break;
-                        case DeclarationType.PropertySet:
-                            name = $"Set{declaration.IdentifierName}";
-                            break;
+                        component.Name = GetNextTestModuleName(project);
+
+                        var hasOptionExplicit = false;
+                        if (module.CountOfLines > 0 && module.CountOfDeclarationLines > 0)
+                        {
+                            hasOptionExplicit = module.GetLines(1, module.CountOfDeclarationLines)
+                                .Contains("Option Explicit");
+                        }
+
+                        var options = string.Concat(hasOptionExplicit ? string.Empty : "Option Explicit\r\n",
+                            "Option Private Module\r\n\r\n");
+
+                        if (parameterIsModuleDeclaration)
+                        {
+                            var moduleCodeBuilder = new StringBuilder();
+                            var declarationsToStub = GetDeclarationsToStub((Declaration) parameter);
+
+                            foreach (var declaration in declarationsToStub)
+                            {
+                                var name = string.Empty;
+
+                                switch (declaration.DeclarationType)
+                                {
+                                    case DeclarationType.Procedure:
+                                    case DeclarationType.Function:
+                                        name = declaration.IdentifierName;
+                                        break;
+                                    case DeclarationType.PropertyGet:
+                                        name = $"Get{declaration.IdentifierName}";
+                                        break;
+                                    case DeclarationType.PropertyLet:
+                                        name = $"Let{declaration.IdentifierName}";
+                                        break;
+                                    case DeclarationType.PropertySet:
+                                        name = $"Set{declaration.IdentifierName}";
+                                        break;
+                                }
+
+                                var stub = AddTestMethodCommand.TestMethodTemplate.Replace(
+                                    AddTestMethodCommand.NamePlaceholder, $"{name}_Test");
+                                moduleCodeBuilder.AppendLine(stub);
+                            }
+
+                            module.AddFromString(options + GetTestModule(settings) + moduleCodeBuilder);
+                        }
+                        else
+                        {
+                            var defaultTestMethod = settings.DefaultTestStubInNewModule
+                                ? AddTestMethodCommand.TestMethodTemplate.Replace(AddTestMethodCommand.NamePlaceholder,
+                                    "TestMethod1")
+                                : string.Empty;
+
+                            module.AddFromString(options + GetTestModule(settings) + defaultTestMethod);
+                        }
                     }
 
-                    var stub = AddTestMethodCommand.TestMethodTemplate.Replace(AddTestMethodCommand.NamePlaceholder, $"{name}_Test");
-                    moduleCodeBuilder.AppendLine(stub);
+                    component.Activate();
                 }
-
-                module.AddFromString(options + GetTestModule(settings) + moduleCodeBuilder);
             }
-            else
-            {
-                var defaultTestMethod = settings.DefaultTestStubInNewModule
-                    ? AddTestMethodCommand.TestMethodTemplate.Replace(AddTestMethodCommand.NamePlaceholder, "TestMethod1")
-                    : string.Empty;
-
-                module.AddFromString(options + GetTestModule(settings) + defaultTestMethod);
-            }
-
-            component.Activate();
             _state.OnParseRequested(this);
         }
 

--- a/RetailCoder.VBE/UI/Command/NavigateCommand.cs
+++ b/RetailCoder.VBE/UI/Command/NavigateCommand.cs
@@ -24,7 +24,13 @@ namespace Rubberduck.UI.Command
 
             try
             {
-                param.QualifiedName.Component.CodeModule.CodePane.Selection = param.Selection;
+                using (var codeModule = param.QualifiedName.Component.CodeModule)
+                {
+                    using (var codePane = codeModule.CodePane)
+                    {
+                        codePane.Selection = param.Selection;
+                    }
+                }
             }
             catch (COMException)
             {

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorReorderParametersCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorReorderParametersCommand.cs
@@ -60,20 +60,26 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override void OnExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
-            var module = pane.CodeModule;
+            using (var pane = Vbe.ActiveCodePane)
             {
                 if (pane.IsWrappingNullReference)
                 {
                     return;
                 }
-                var selection = new QualifiedSelection(new QualifiedModuleName(module.Parent), pane.Selection);
 
-                using (var view = new ReorderParametersDialog(new ReorderParametersViewModel(_state)))
+                using (var module = pane.CodeModule)
                 {
-                    var factory = new ReorderParametersPresenterFactory(Vbe, view, _state, _msgbox);
-                    var refactoring = new ReorderParametersRefactoring(Vbe, factory, _msgbox);
-                    refactoring.Refactor(selection);
+                    using (var component = module.Parent)
+                    {
+                        var selection = new QualifiedSelection(new QualifiedModuleName(component), pane.Selection); //The component does not get passed out. So, it is safe to dispose afterwards.
+
+                        using (var view = new ReorderParametersDialog(new ReorderParametersViewModel(_state)))
+                        {
+                            var factory = new ReorderParametersPresenterFactory(Vbe, view, _state, _msgbox);
+                            var refactoring = new ReorderParametersRefactoring(Vbe, factory, _msgbox);
+                            refactoring.Refactor(selection);
+                        }
+                    }
                 }
             }
         }

--- a/RetailCoder.VBE/UI/IdentifierReferences/IdentifierReferencesListDockablePresenter.cs
+++ b/RetailCoder.VBE/UI/IdentifierReferences/IdentifierReferencesListDockablePresenter.cs
@@ -26,7 +26,13 @@ namespace Rubberduck.UI.IdentifierReferences
 
         public static void OnNavigateIdentifierReference(IdentifierReference reference)
         {
-            reference.QualifiedModuleName.Component.CodeModule.CodePane.Selection = reference.Selection;
+            using (var codeModule = reference.QualifiedModuleName.Component.CodeModule)
+            {
+                using (var codePane = codeModule.CodePane)
+                {
+                    codePane.Selection = reference.Selection;
+                }
+            }
         }
 
         private void ControlNavigate(object sender, ListItemActionEventArgs e)

--- a/RetailCoder.VBE/UI/IdentifierReferences/ImplementationsListDockablePresenter.cs
+++ b/RetailCoder.VBE/UI/IdentifierReferences/ImplementationsListDockablePresenter.cs
@@ -28,7 +28,13 @@ namespace Rubberduck.UI.IdentifierReferences
 
         public static void OnNavigateImplementation(Declaration implementation)
         {
-            implementation.QualifiedName.QualifiedModuleName.Component.CodeModule.CodePane.Selection = implementation.Selection;
+            using (var codeModule = implementation.QualifiedName.QualifiedModuleName.Component.CodeModule)
+            {
+                using (var codePane = codeModule.CodePane)
+                {
+                    codePane.Selection = implementation.Selection;
+                }
+            }
         }
 
         private void ControlNavigate(object sender, ListItemActionEventArgs e)

--- a/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -149,16 +149,16 @@ namespace Rubberduck.UI.ToDoItems
                         return;
                     }
 
-                    var module = _selectedItem.Selection.QualifiedName.Component.CodeModule;
+                    using (var module = _selectedItem.Selection.QualifiedName.Component.CodeModule)
                     {
                         var oldContent = module.GetLines(_selectedItem.Selection.Selection.StartLine, 1);
                         var newContent = oldContent.Remove(_selectedItem.Selection.Selection.StartColumn - 1);
 
                         module.ReplaceLine(_selectedItem.Selection.Selection.StartLine, newContent);
-
-                        RefreshCommand.Execute(null);
                     }
-                });
+                    RefreshCommand.Execute(null);
+                }
+                );
             }
         }
 

--- a/RetailCoder.VBE/UnitTesting/UnitTestUtils.cs
+++ b/RetailCoder.VBE/UnitTesting/UnitTestUtils.cs
@@ -26,8 +26,18 @@ namespace Rubberduck.UnitTesting
 
             // apparently, sometimes it thinks the components are different but knows the modules are the same
             // if the modules are the same, then the component is the same as far as we are concerned
-            return GetAllTests(vbe, state)
-                    .Where(test => test.Declaration.QualifiedName.QualifiedModuleName.Component.CodeModule.Equals(component.CodeModule));
+            return GetAllTests(vbe, state).Where(test => TestCodeModuleEqualsComponentCodeModule(test, component));
+        }
+
+        private static bool TestCodeModuleEqualsComponentCodeModule(TestMethod test, IVBComponent component)
+        {
+            using (var testCodeModule = test.Declaration.QualifiedName.QualifiedModuleName.Component.CodeModule)
+            {
+                using (var componentCodeModule = component.CodeModule)
+                {
+                    return testCodeModule.Equals(componentCodeModule);
+                }
+            }
         }
 
         public static bool IsTestMethod(RubberduckParserState state, Declaration item)

--- a/Rubberduck.Inspections/Concrete/ObsoleteCallStatementInspection.cs
+++ b/Rubberduck.Inspections/Concrete/ObsoleteCallStatementInspection.cs
@@ -29,9 +29,12 @@ namespace Rubberduck.Inspections.Concrete
 
             foreach (var context in Listener.Contexts.Where(context => !IsIgnoringInspectionResultFor(context.ModuleName, context.Context.Start.Line)))
             {
-                var module = context.ModuleName.Component.CodeModule;
-                var lines = module.GetLines(context.Context.Start.Line,
-                    context.Context.Stop.Line - context.Context.Start.Line + 1);
+                string lines;
+                using (var module = context.ModuleName.Component.CodeModule)
+                {
+                    lines = module.GetLines(context.Context.Start.Line,
+                        context.Context.Stop.Line - context.Context.Start.Line + 1);
+                }
 
                 var stringStrippedLines = string.Join(string.Empty, lines).StripStringLiterals();
 

--- a/Rubberduck.Inspections/QuickFixes/IgnoreOnceQuickFix.cs
+++ b/Rubberduck.Inspections/QuickFixes/IgnoreOnceQuickFix.cs
@@ -31,14 +31,17 @@ namespace Rubberduck.Inspections.QuickFixes
         {
             var annotationText = $"'@Ignore {result.Inspection.AnnotationName}";
 
-            var module = result.QualifiedSelection.QualifiedName.Component.CodeModule;
-            var annotationLine = result.QualifiedSelection.Selection.StartLine;
-            while (annotationLine != 1 && module.GetLines(annotationLine - 1, 1).EndsWith(" _"))
+            int annotationLine;
+            string codeLine;
+            using (var module = result.QualifiedSelection.QualifiedName.Component.CodeModule)
             {
-                annotationLine--;
+                annotationLine = result.QualifiedSelection.Selection.StartLine;
+                while (annotationLine != 1 && module.GetLines(annotationLine - 1, 1).EndsWith(" _"))
+                {
+                    annotationLine--;
+                }
+                codeLine = annotationLine == 1 ? string.Empty : module.GetLines(annotationLine - 1, 1);
             }
-            var codeLine = annotationLine == 1 ? string.Empty : module.GetLines(annotationLine - 1, 1);
-
             RuleContext treeRoot = result.Context;
             while (treeRoot.Parent != null)
             {

--- a/Rubberduck.Parsing/Emitter.cs
+++ b/Rubberduck.Parsing/Emitter.cs
@@ -59,10 +59,19 @@ End Function
                 object result;
                 try
                 {
-                    component = project.VBComponents.Add(ComponentType.StandardModule);
-                    component.CodeModule.AddFromString(content);
-                    var host = project.VBE.HostApplication();
-                    result = host.Run(name, args);
+                    using (var components = project.VBComponents)
+                    {
+                        component = components.Add(ComponentType.StandardModule);
+                        using (var codeModule = component.CodeModule)
+                        {
+                            codeModule.AddFromString(content);
+                        }
+                        using (var vbe = project.VBE)
+                        {
+                            var host = vbe.HostApplication();
+                            result = host.Run(name, args);
+                        }
+                    }
                 }
                 catch (COMException)
                 {
@@ -73,7 +82,11 @@ End Function
                 {
                     if (component != null)
                     {
-                        project.VBComponents.Remove(component);
+                        using (var components = project.VBComponents)
+                        {
+                            components.Remove(component);
+                        }
+                        component.Dispose();
                     }
                 }
 

--- a/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
@@ -92,7 +92,11 @@ namespace Rubberduck.Parsing.Symbols
             {
                 return null;
             }
-            var lastDeclarationsSectionLine = _qualifiedModuleName.Component.CodeModule.CountOfDeclarationLines;
+            int lastDeclarationsSectionLine;
+            using (var codeModule = _qualifiedModuleName.Component.CodeModule)
+            {
+                lastDeclarationsSectionLine = codeModule.CountOfDeclarationLines;
+            }
             var annotations = _annotations.Where(annotation => annotation.QualifiedSelection.QualifiedName.Equals(_qualifiedModuleName)
                 && annotation.QualifiedSelection.Selection.EndLine <= lastDeclarationsSectionLine);
             return annotations.ToList();

--- a/Rubberduck.Parsing/VBA/ComponentParseTask.cs
+++ b/Rubberduck.Parsing/VBA/ComponentParseTask.cs
@@ -150,15 +150,19 @@ namespace Rubberduck.Parsing.VBA
             return attributesParseResults;
         }
 
-        private static string GetCode(ICodeModule module)
+        private static string GetCode(IVBComponent component)
         {
-            var lines = module.CountOfLines;
-            if (lines == 0)
+            string codeLines;
+            using (var module = component.CodeModule)
             {
-                return string.Empty;
-            }
+                var lines = module.CountOfLines;
+                if (lines == 0)
+                {
+                    return string.Empty;
+                }
 
-            var codeLines = module.GetLines(1, lines);
+                codeLines = module.GetLines(1, lines);
+            }
             var code = string.Concat(codeLines);
 
             return code;
@@ -166,7 +170,7 @@ namespace Rubberduck.Parsing.VBA
 
         private CommonTokenStream RewriteAndPreprocess(CancellationToken cancellationToken)
         {
-            var code = _rewriter?.GetText() ?? string.Join(Environment.NewLine, GetCode(_module.Component.CodeModule));
+            var code = _rewriter?.GetText() ?? string.Join(Environment.NewLine, GetCode(_module.Component));
             var tokenStreamProvider = new SimpleVBAModuleTokenStreamProvider();
             var tokens = tokenStreamProvider.Tokens(code);
             _preprocessor.PreprocessTokenStream(_module.Name, tokens, new PreprocessorExceptionErrorListener(_module.ComponentName, ParsePass.CodePanePass), cancellationToken);

--- a/Rubberduck.Parsing/VBA/ParseErrorEventArgs.cs
+++ b/Rubberduck.Parsing/VBA/ParseErrorEventArgs.cs
@@ -24,10 +24,12 @@ namespace Rubberduck.Parsing.VBA
         public void Navigate()
         {
             var selection = new Selection(_exception.LineNumber, _exception.Position, _exception.LineNumber, _exception.Position + _exception.OffendingSymbol.Text.Length - 1);
-            var module = _component.CodeModule;
-            var pane = module.CodePane;
+            using (var module = _component.CodeModule)
             {
-                pane.Selection = selection;
+                using (var pane = module.CodePane)
+                {
+                    pane.Selection = selection;
+                }
             }
         }
     }

--- a/Rubberduck.SmartIndenter/Indenter.cs
+++ b/Rubberduck.SmartIndenter/Indenter.cs
@@ -23,28 +23,35 @@ namespace Rubberduck.SmartIndenter
         /// </summary>
         public void IndentCurrentProcedure()
         {
-            var pane = _vbe.ActiveCodePane;
-
-            if (pane == null)
+            using (var pane = _vbe.ActiveCodePane)
             {
-                return;
+                if (pane == null)
+                {
+                    return;
+                }
+
+                using (var module = pane.CodeModule)
+                {
+                    var selection = GetSelection(pane);
+
+                    var procName = module.GetProcOfLine(selection.StartLine);
+                    var procKind = module.GetProcKindOfLine(selection.StartLine);
+
+                    if (string.IsNullOrEmpty(procName))
+                    {
+                        return;
+                    }
+
+                    var startLine = module.GetProcStartLine(procName, procKind);
+                    var endLine = startLine + module.GetProcCountLines(procName, procKind);
+
+                    selection = new Selection(startLine, 1, endLine, 1);
+                    using (var component = module.Parent)
+                    {
+                        Indent(component, selection);
+                    }
+                }
             }
-            var module = pane.CodeModule;
-            var selection = GetSelection(pane);
-
-            var procName = module.GetProcOfLine(selection.StartLine);
-            var procKind = module.GetProcKindOfLine(selection.StartLine);
-
-            if (string.IsNullOrEmpty(procName))
-            {
-                return;
-            }
-
-            var startLine = module.GetProcStartLine(procName, procKind);
-            var endLine = startLine + module.GetProcCountLines(procName, procKind);
-
-            selection = new Selection(startLine, 1, endLine, 1);
-            Indent(module.Parent, selection);
         }
 
         /// <summary>

--- a/Rubberduck.VBEEditor/QualifiedModuleName.cs
+++ b/Rubberduck.VBEEditor/QualifiedModuleName.cs
@@ -49,15 +49,21 @@ namespace Rubberduck.VBEditor
             _componentName = component.IsWrappingNullReference ? string.Empty : component.Name;
 
             ContentHashCode = 0;
-            if (!component.IsWrappingNullReference)
+            if (!Component.IsWrappingNullReference)
             {
-                var module = Component.CodeModule;
-                ContentHashCode = module.CountOfLines > 0
-                    ? module.GetLines(1, module.CountOfLines).GetHashCode()
-                    : 0;
+                using (var module = Component.CodeModule)
+                {
+                    ContentHashCode = module.CountOfLines > 0
+                        ? module.GetLines(1, module.CountOfLines).GetHashCode()
+                        : 0;
+                }
             }
 
-            var project = component.Collection.Parent;
+            IVBProject project;
+            using (var components = component.Collection)
+            {
+                project = components.Parent;
+            }
             _projectName = project == null ? string.Empty : project.Name;
             ProjectPath = string.Empty;
             ProjectId = GetProjectId(project);

--- a/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
+++ b/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Events\VBENativeServices.cs" />
     <Compile Include="Events\WindowChangedEventArgs.cs" />
     <Compile Include="Extensions\MSAccessComponentTypeExtensions.cs" />
+    <Compile Include="SafeComWrappers\Office.Core\Abstract\IUserForm.cs" />
     <Compile Include="SafeComWrappers\Abstract\ISafeComWrapper.cs" />
     <Compile Include="SafeComWrappers\DispatcherEventArgs.cs" />
     <Compile Include="SafeComWrappers\MSAccessComponentType.cs" />
@@ -196,6 +197,7 @@
     <Compile Include="SafeComWrappers\VBA\AddIn.cs" />
     <Compile Include="SafeComWrappers\VBA\AddIns.cs" />
     <Compile Include="SafeComWrappers\VBA\Application.cs" />
+    <Compile Include="SafeComWrappers\VBA\UserForm.cs" />
     <Compile Include="SafeComWrappers\VBA\CodeModule.cs" />
     <Compile Include="SafeComWrappers\VBA\CodePane.cs" />
     <Compile Include="SafeComWrappers\VBA\CodePanes.cs" />

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/Abstract/IUserForm.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/Abstract/IUserForm.cs
@@ -1,0 +1,8 @@
+﻿namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core.Abstract
+{
+    public interface IUserForm
+    {
+        IControls Controls { get; }
+        IControls Selected { get; }
+    }
+}

--- a/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
@@ -149,7 +149,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers
             {
                 _comSafe?.TryRemove(this);
 
-                if (!_rewrapping && !HasBeenReleased)
+                if (!_rewrapping && !IsWrappingNullReference && !HasBeenReleased)
                 {
                     Release();
                 }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/CodePane.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/CodePane.cs
@@ -37,7 +37,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             if (endLine > startLine && endColumn == 1)
             {
                 endLine -= 1;
-                endColumn = CodeModule.GetLines(endLine, 1).Length;
+                using (var codeModule = CodeModule)
+                {
+                    endColumn = codeModule.GetLines(endLine, 1).Length;
+                }
             }
 
             return new Selection(startLine, startColumn, endLine, endColumn);
@@ -62,7 +65,11 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                 return null;
             }
 
-            var component = CodeModule.Parent;
+            IVBComponent component;
+            using (var codeModule = CodeModule)
+            {
+                component = codeModule.Parent;
+            }
             var moduleName = new QualifiedModuleName(component);
             return new QualifiedSelection(moduleName, selection);
         }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBComponent.cs
@@ -104,8 +104,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             // this issue causes forms to always be treated as "modified" in source control, which causes conflicts.
             // we need to remove the extra newline before the file gets written to its output location.
 
-            var visibleCode = CodeModule.Content().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-            var legitEmptyLineCount = visibleCode.TakeWhile(string.IsNullOrWhiteSpace).Count();
+            int legitEmptyLineCount;
+            using (var codeModule = CodeModule)
+            {
+                var visibleCode = codeModule.Content().Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+                legitEmptyLineCount = visibleCode.TakeWhile(string.IsNullOrWhiteSpace).Count();
+            }
 
             var tempFile = ExportToTempFile();
             var contents = File.ReadAllLines(tempFile);
@@ -129,11 +133,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 
         private void ExportDocumentModule(string path)
         {
-            var lineCount = CodeModule.CountOfLines;
-            if (lineCount > 0)
+            using (var codeModule = CodeModule)
             {
-                var text = CodeModule.GetLines(1, lineCount);
-                File.WriteAllText(path, text);
+                var lineCount = codeModule.CountOfLines;
+                if (lineCount > 0)
+                {
+                    var text = codeModule.GetLines(1, lineCount);
+                    File.WriteAllText(path, text);
+                }
             }
         }
 
@@ -143,17 +150,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             Export(path);
             return path;
         }
-        //public override void Release(bool final = false)
-        //{
-        //    if (!IsWrappingNullReference)
-        //    {
-        //        DesignerWindow().Release();
-        //        Controls.Release();
-        //        Properties.Release();
-        //        CodeModule.Release();
-        //        base.Release(final);
-        //    }
-        //}
 
         public override bool Equals(ISafeComWrapper<VB.VBComponent> other)
         {

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBComponents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBComponents.cs
@@ -114,8 +114,11 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                 {
                     throw new IndexOutOfRangeException($"Could not find document component named '{name}'.");
                 }
-                component.CodeModule.Clear();
-                component.CodeModule.AddFromString(codeString);
+                using (var codeModule = component.CodeModule)
+                {
+                    codeModule.Clear();
+                    codeModule.AddFromString(codeString);
+                }
             }
             else if (ext == ComponentTypeExtensions.FormExtension)
             {
@@ -132,8 +135,11 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                 var declarationsStartLine = nonAttributeLines + attributeLines + 1;
                 var correctCodeString = string.Join(Environment.NewLine, codeLines.Skip(declarationsStartLine - 1).ToArray());
 
-                component.CodeModule.Clear();
-                component.CodeModule.AddFromString(correctCodeString);
+                using (var codeModule = component.CodeModule)
+                {
+                    codeModule.Clear();
+                    codeModule.AddFromString(correctCodeString);
+                }
             }
             else if (ext != ComponentTypeExtensions.FormBinaryExtension)
             {
@@ -159,7 +165,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                     break;
                 case ComponentType.ActiveXDesigner:
                 case ComponentType.Document:
-                    component.CodeModule.Clear();
+                    using (var codeModule = component.CodeModule)
+                    {
+                        codeModule.Clear();
+                    }
                     break;
                 default:
                     break;

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodeModule.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodeModule.cs
@@ -63,7 +63,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             {
                 return null;
             }
-            return CodePane.GetQualifiedSelection();
+            using (var codePane = CodePane)
+            {
+                return codePane.GetQualifiedSelection();
+            }
         }
 
         public string Content()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePane.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePane.cs
@@ -45,7 +45,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             if (endLine > startLine && endColumn == 1)
             {
                 endLine -= 1;
-                endColumn = CodeModule.GetLines(endLine, 1).Length;
+                using (var codeModule = CodeModule)
+                {
+                    endColumn = codeModule.GetLines(endLine, 1).Length;
+                }
             }
 
             return new Selection(startLine, startColumn, endLine, endColumn);

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePane.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePane.cs
@@ -75,7 +75,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         private void SetSelection(int startLine, int startColumn, int endLine, int endColumn)
         {
-            if (IsWrappingNullReference) return;
+            if (IsWrappingNullReference)
+            {
+                return;
+            }
             Target.SetSelection(startLine, startColumn, endLine, endColumn);
             ForceFocus();
         }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/UserForm.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/UserForm.cs
@@ -1,0 +1,32 @@
+﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using Rubberduck.VBEditor.SafeComWrappers.Office.Core.Abstract;
+
+namespace Rubberduck.VBEditor.SafeComWrappers.VBA
+{
+    public class UserForm : SafeComWrapper<Microsoft.Vbe.Interop.Forms.UserForm>, IUserForm
+    {
+        public UserForm(Microsoft.Vbe.Interop.Forms.UserForm target, bool rewrapping = false) 
+            : base(target, rewrapping)
+        {
+        }
+
+        public IControls Controls => new Controls(Target.Controls);
+
+        public IControls Selected => new Controls(Target.Selected);
+
+        public override bool Equals(ISafeComWrapper<Microsoft.Vbe.Interop.Forms.UserForm> other)
+        {
+            return IsEqualIfNull(other) || (other != null && ReferenceEquals(other.Target, Target));
+        }
+
+        public bool Equals(IUserForm other)
+        {
+            return Equals(other as SafeComWrapper<Microsoft.Vbe.Interop.Forms.UserForm>);
+        }
+
+        public override int GetHashCode()
+        {
+            return IsWrappingNullReference ? 0 : Target.GetHashCode();
+        }
+    }
+}

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -41,13 +41,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         {
             get
             {
-                var designer = IsWrappingNullReference
+                using (var designer = IsWrappingNullReference
                     ? null
-                    : new UserForm(Target.Designer as VB.Forms.UserForm);
-
-                return designer == null 
-                    ? new Controls(null) 
-                    : designer.Controls;
+                    : new UserForm(Target.Designer as VB.Forms.UserForm))
+                {
+                    return designer == null
+                        ? new Controls(null)
+                        : designer.Controls;
+                }
             }
         }
 
@@ -55,13 +56,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         {
             get
             {
-                var designer = IsWrappingNullReference
+                using (var designer = IsWrappingNullReference
                     ? null
-                    : new UserForm(Target.Designer as VB.Forms.UserForm);
-
-                return designer == null
-                    ? new Controls(null)
-                    : designer.Selected;
+                    : new UserForm(Target.Designer as VB.Forms.UserForm))
+                {
+                    return designer == null
+                        ? new Controls(null)
+                        : designer.Selected;
+                }
             }
         }
         

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -43,11 +43,11 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             {
                 var designer = IsWrappingNullReference
                     ? null
-                    : Target.Designer as VB.Forms.UserForm;
+                    : new UserForm(Target.Designer as VB.Forms.UserForm);
 
                 return designer == null 
                     ? new Controls(null) 
-                    : new Controls(designer.Controls);
+                    : designer.Controls;
             }
         }
 
@@ -57,11 +57,11 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             {
                 var designer = IsWrappingNullReference
                     ? null
-                    : Target.Designer as VB.Forms.UserForm;
+                    : new UserForm(Target.Designer as VB.Forms.UserForm);
 
                 return designer == null
                     ? new Controls(null)
-                    : new Controls(designer.Selected);
+                    : designer.Selected;
             }
         }
         
@@ -73,9 +73,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 {
                     return false;
                 }
-                var designer = Target.Designer;
-                var hasDesigner = designer != null;
-                return hasDesigner;
+                using (var designer = new UserForm(Target.Designer as VB.Forms.UserForm))
+                {
+                    return !designer.IsWrappingNullReference;
+                }
             }
         }
 
@@ -188,17 +189,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             Export(path);
             return path;
         }
-        //public override void Release(bool final = false)
-        //{
-        //    if (!IsWrappingNullReference)
-        //    {
-        //        DesignerWindow().Release();
-        //        Controls.Release();
-        //        Properties.Release();
-        //        CodeModule.Release();
-        //        base.Release(final);
-        //    }
-        //}
 
         public override bool Equals(ISafeComWrapper<VB.VBComponent> other)
         {

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
@@ -142,16 +142,34 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         public static void SetSelection(IVBProject vbProject, Selection selection, string name)
         {
-            var components = vbProject.VBComponents;
-            var component = components.SingleOrDefault(c => c.Name == name);
-            if (component == null || component.IsWrappingNullReference)
+            using (var components = vbProject.VBComponents)
             {
-                return;
-            }
+                using (var component = components.SingleOrDefault(c => ComponentHasName(c, name))) 
+                {
+                    if (component == null || component.IsWrappingNullReference)
+                    {
+                        return;
+                    }
 
-            var module = component.CodeModule;
-            var pane = module.CodePane;
-            pane.Selection = selection;
+                    using (var module = component.CodeModule)
+                    {
+                        using (var pane = module.CodePane)
+                        {
+                            pane.Selection = selection;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool ComponentHasName(IVBComponent c, string name)
+        {
+            var sameName = c.Name == name;
+            if (!sameName)
+            {
+                c.Dispose();
+            }
+            return sameName;
         }
 
 


### PR DESCRIPTION
This PR introduced a wrapper for the `UserForm` class in order to properly release the designer when querying the controls of a component. 

The only methods on the wrapper are those needed to get the controls. If ever the need arises to use the other methods, the interface and the implementation will have to be extended.

In addition to the wrapper, this PR contains some disposal of temporary instances of `ICodeModule`. This should cover all instances outside the main project and the tests. 