### PR TITLE
AssignByValueMakeLocalCopyQuickFix - corrects error when applied on a function 

### DIFF
--- a/Rubberduck.Inspections/QuickFixes/AssignedByValParameterMakeLocalCopyQuickFix.cs
+++ b/Rubberduck.Inspections/QuickFixes/AssignedByValParameterMakeLocalCopyQuickFix.cs
@@ -32,6 +32,9 @@ namespace Rubberduck.Inspections.QuickFixes
 
         public override void Fix(IInspectionResult result)
         {
+            Debug.Assert(result.Target.Context.Parent is ArgListContext);
+            Debug.Assert(null != ParserRuleContextHelper.GetChild<EndOfStatementContext>(result.Target.Context.Parent.Parent));
+
             var forbiddenNames = _parserState.DeclarationFinder.GetDeclarationsWithIdentifiersToAvoid(result.Target).Select(n => n.IdentifierName);
 
             var localIdentifier = PromptForLocalVariableName(result.Target, forbiddenNames.ToList());
@@ -120,10 +123,8 @@ namespace Rubberduck.Inspections.QuickFixes
             var endOfStmtCtxt = ParserRuleContextHelper.GetChild<EndOfStatementContext>(target.Context.Parent.Parent);
             var eosContent = endOfStmtCtxt.GetText();
             var idxLastNewLine = eosContent.LastIndexOf(Environment.NewLine);
-            var comment = eosContent.Substring(0, idxLastNewLine);
-            var endOfStmtNewLineContent = eosContent.Substring(idxLastNewLine);
-
-            Debug.Assert(target.Context.Parent is ArgListContext);
+            var endOfStmtCtxtComment = eosContent.Substring(0, idxLastNewLine);
+            var endOfStmtCtxtEndFormat = eosContent.Substring(idxLastNewLine);
 
             var insertCtxt = (ParserRuleContext)ParserRuleContextHelper.GetChild<AsTypeClauseContext>(target.Context.Parent.Parent);
             if(insertCtxt == null)
@@ -132,7 +133,7 @@ namespace Rubberduck.Inspections.QuickFixes
             }
 
             rewriter.Remove(endOfStmtCtxt);
-            rewriter.InsertAfter(insertCtxt.Stop.TokenIndex, $"{comment}{endOfStmtNewLineContent}{localVariableDeclaration}" + $"{endOfStmtNewLineContent}{localVariableAssignment}{endOfStmtNewLineContent}");
+            rewriter.InsertAfter(insertCtxt.Stop.TokenIndex, $"{endOfStmtCtxtComment}{endOfStmtCtxtEndFormat}{localVariableDeclaration}" + $"{endOfStmtCtxtEndFormat}{localVariableAssignment}{endOfStmtCtxtEndFormat}");
         }
     }
 }

--- a/RubberduckTests/Inspections/AssignedByValParameterInspectionTests.cs
+++ b/RubberduckTests/Inspections/AssignedByValParameterInspectionTests.cs
@@ -15,7 +15,7 @@ namespace RubberduckTests.Inspections
         public void AssignedByValParameter_ReturnsResult_Sub()
         {
             const string inputCode =
-                @"Public Sub Foo(ByVal arg1 As String)
+@"Public Sub Foo(ByVal arg1 As String)
     Let arg1 = ""test""
 End Sub";
 
@@ -35,7 +35,7 @@ End Sub";
         public void AssignedByValParameter_ReturnsResult_Function()
         {
             const string inputCode =
-                @"Function Foo(ByVal arg1 As Integer) As Boolean
+@"Function Foo(ByVal arg1 As Integer) As Boolean
     Let arg1 = 9
 End Function";
 
@@ -55,7 +55,7 @@ End Function";
         public void AssignedByValParameter_ReturnsResult_MultipleParams()
         {
             const string inputCode =
-                @"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
+@"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
     Let arg1 = ""test""
     Let arg2 = 9
 End Sub";
@@ -76,7 +76,7 @@ End Sub";
         public void AssignedByValParameter_DoesNotReturnResult()
         {
             const string inputCode =
-                @"Public Sub Foo(ByVal arg1 As String)
+@"Public Sub Foo(ByVal arg1 As String)
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
@@ -95,7 +95,7 @@ End Sub";
         public void AssignedByValParameter_Ignored_DoesNotReturnResult_Sub()
         {
             const string inputCode =
-                @"'@Ignore AssignedByValParameter
+@"'@Ignore AssignedByValParameter
 Public Sub Foo(ByVal arg1 As String)
     Let arg1 = ""test""
 End Sub";
@@ -116,7 +116,7 @@ End Sub";
         public void AssignedByValParameter_ReturnsResult_SomeAssignedByValParams()
         {
             const string inputCode =
-                @"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
+ @"Public Sub Foo(ByVal arg1 As String, ByVal arg2 As Integer)
     Let arg1 = ""test""
     
     Dim var1 As Integer

--- a/RubberduckTests/QuickFixes/AssignedByValParameterMakeLocalCopyQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AssignedByValParameterMakeLocalCopyQuickFixTests.cs
@@ -16,16 +16,16 @@ namespace RubberduckTests.QuickFixes
     {
         [Test]
         [Category("QuickFixes")]
-        public void AssignedByValParameter_LocalVariableAssignment()
+        public void AssignedByValParameter_LocalVariableAssignment_Sub()
         {
             var inputCode =
-                @"Public Sub Foo(ByVal arg1 As String)
+@"Public Sub Foo(ByVal arg1 As String)
     Let arg1 = ""test""
 End Sub";
             var expectedCode =
-                @"Public Sub Foo(ByVal arg1 As String)
-Dim localArg1 As String
-localArg1 = arg1
+@"Public Sub Foo(ByVal arg1 As String)
+    Dim localArg1 As String
+    localArg1 = arg1
     Let localArg1 = ""test""
 End Sub";
 
@@ -33,6 +33,112 @@ End Sub";
             Assert.AreEqual(expectedCode, quickFixResult);
         }
 
+        [Test]
+        [Category("QuickFixes")]
+        public void AssignedByValParameter_LocalVariableAssignment_SubWithCommentn()
+        {
+            var inputCode =
+@"Public Sub Foo(ByVal arg1 As String)  'Comment is here _
+and here _
+and here
+    Let arg1 = ""test""
+End Sub";
+            var expectedCode =
+@"Public Sub Foo(ByVal arg1 As String)  'Comment is here _
+and here _
+and here
+    Dim localArg1 As String
+    localArg1 = arg1
+    Let localArg1 = ""test""
+End Sub";
+
+            var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
+            Assert.AreEqual(expectedCode, quickFixResult);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void AssignedByValParameter_LocalVariableAssignment_Function()
+        {
+            var inputCode =
+@"Public Function Foo(ByVal arg1 As String) As String
+    arg1 = ""test""
+    Foo = arg1
+End Function";
+            var expectedCode =
+@"Public Function Foo(ByVal arg1 As String) As String
+    Dim localArg1 As String
+    localArg1 = arg1
+    localArg1 = ""test""
+    Foo = localArg1
+End Function";
+
+            var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
+            Assert.AreEqual(expectedCode, quickFixResult);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void AssignedByValParameter_LocalVariableAssignment_FunctionWithComment()
+        {
+            var inputCode =
+@"Public Function Foo(ByVal arg1 As String) As String   'This is a comment
+    arg1 = ""test""
+    Foo = arg1
+End Function";
+            var expectedCode =
+@"Public Function Foo(ByVal arg1 As String) As String   'This is a comment
+    Dim localArg1 As String
+    localArg1 = arg1
+    localArg1 = ""test""
+    Foo = localArg1
+End Function";
+
+            var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
+            Assert.AreEqual(expectedCode, quickFixResult);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void AssignedByValParameter_LocalVariableAssignment_Property()
+        {
+            var inputCode =
+@"
+Option Explicit
+Private mBar as Long
+Public Property Let Foo(ByVal bar As Long)
+    bar = 42
+    bar = bar * 2
+    mBar = bar
+End Property
+
+Public Property Get Foo() As Long
+    Dim bar as Long
+    bar = 12
+    Foo = mBar
+End Property
+";
+            var expectedCode =
+@"
+Option Explicit
+Private mBar as Long
+Public Property Let Foo(ByVal bar As Long)
+    Dim localBar As Long
+    localBar = bar
+    localBar = 42
+    localBar = localBar * 2
+    mBar = localBar
+End Property
+
+Public Property Get Foo() As Long
+    Dim bar as Long
+    bar = 12
+    Foo = mBar
+End Property
+";
+            var quickFixResult = ApplyLocalVariableQuickFixToCodeFragment(inputCode);
+            Assert.AreEqual(expectedCode, quickFixResult);
+        }
         [Test]
         [Category("QuickFixes")]
         public void AssignedByValParameter_LocalVariableAssignment_ComplexFormat()
@@ -56,8 +162,8 @@ End Sub
         bar, _
     ByRef barbecue _
                     )
-Dim localFoo As Long
-localFoo = foo
+    Dim localFoo As Long
+    localFoo = foo
     localFoo = 4
     bar = barbecue * _
                 bar + localFoo / barbecue
@@ -83,8 +189,8 @@ End Sub"
             var expectedCode =
                     @"
 Public Sub Foo(ByVal arg1 As String)
-Dim localArg12 As String
-localArg12 = arg1
+    Dim localArg12 As String
+    localArg12 = arg1
     Dim fooVar, _
         localArg1 As Long
     Let localArg12 = ""test""
@@ -178,8 +284,8 @@ End Sub"
             var expectedCode =
                     @"
 Public Sub Foo(ByVal target As Range)
-Dim localTarget As Range
-Set localTarget = target
+    Dim localTarget As Range
+    Set localTarget = target
     Set localTarget = Selection
 End Sub"
                 ;
@@ -201,8 +307,8 @@ End Sub"
             var expectedCode =
                     @"
 Public Sub Foo(FirstArg As Long, ByVal arg1)
-Dim localArg1 As Variant
-localArg1 = arg1
+    Dim localArg1 As Variant
+    localArg1 = arg1
     localArg1 = Range(""A1: C4"")
 End Sub"
                 ;
@@ -236,8 +342,8 @@ Enum TestEnum
 End Enum
 
 Public Sub Foo(FirstArg As Long, ByVal arg1 As TestEnum)
-Dim localArg1 As TestEnum
-localArg1 = arg1
+    Dim localArg1 As TestEnum
+    localArg1 = arg1
     localArg1 = EnumThree
 End Sub"
                 ;


### PR DESCRIPTION
The AssignByValueMakeLocalCopyQuickFix does not properly handle rewriting the AsTypeContext of a function.  This PR corrects the behavior.  

The current result when this QuickFix is applied to a Function:

Original code:
```vba
Private Function AddTwo(ByVal arg As Long) As Long
  arg = arg + 2
  AddTwo = arg
End Function
```

After the QuickFix makes a local copy of `arg` (Uncompilable):
```vba
Private Function AddTwo(ByVal arg As Long)
  Dim localArg As Long
  localArg = arg As Long  <-- Function's AsTypeContext is pushed to here
  localArg = localArg + 2
  AddTwo = localArg
End Function
```

The PR also enhances the QuickFix to retain any existing comment after the Sub/FunctionStmtContext and match the indentation format of the original code's first line.
  
  