### PR TITLE
Rewite of ComWrapperEnumeration

### DIFF
--- a/Rubberduck.VBEEditor/SafeComWrappers/ComWrapperEnumerator.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/ComWrapperEnumerator.cs
@@ -1,39 +1,143 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
+using System.Runtime.InteropServices;
+using ComTypes = System.Runtime.InteropServices.ComTypes;
 
 namespace Rubberduck.VBEditor.SafeComWrappers
 {
+    // The CLR automagically handles COM enumeration by custom marshalling IEnumVARIANT to a managed class (see EnumeratorToEnumVariantMarshaler)
+    // But as we need explicit control over all COM objects in RD, this is unacceptable.  We need to obtain the explicit IEnumVARIANT interface
+    // and ensure this RCW is destroyed in a timely fashion, using Marshal.ReleaseComObject.
+    // The automatic custom marshalling of the enumeration getter method (DISPID_ENUM) prohibits access to the underlying IEnumVARIANT interface.
+    // To work around it, we must call the IDispatch:::Invoke method directly (instead of using CLRs normal late-bound method calling ability).
+
+    [Guid("00020400-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]        
+    interface IDispatch
+    {
+        [PreserveSig] int GetTypeInfoCount([Out] out uint pctinfo);
+        [PreserveSig] int GetTypeInfo([In] uint iTInfo, [In] uint lcid, [Out] out ComTypes.ITypeInfo pTypeInfo);
+        [PreserveSig] int GetIDsOfNames([In] ref Guid riid, [In] string[] rgszNames, [In] uint cNames, [In] uint lcid, [Out] out int[] rgDispId);
+ 
+        [PreserveSig]
+        int Invoke([In] int dispIdMember,
+            [In] ref Guid riid,
+            [In] uint lcid,
+            [In] uint dwFlags,
+            [In, Out] ref ComTypes.DISPPARAMS pDispParams,
+            [Out] out Object pVarResult,
+            [In, Out] ref ComTypes.EXCEPINFO pExcepInfo,
+            [Out] out uint pArgErr);
+    }
+
+    class IDispatchHelper
+    {
+        public enum StandardDispIds : int
+        {
+            DISPID_ENUM = -4
+        }
+
+        public enum InvokeKind : int
+        {
+            DISPATCH_METHOD = 1,
+            DISPATCH_PROPERTYGET = 2,
+            DISPATCH_PROPERTYPUT = 4,
+            DISPATCH_PROPERTYPUTREF = 8,
+        }
+        
+        public static object PropertyGet_NoArgs(IDispatch obj, int memberId)
+        {
+            var pDispParams = new ComTypes.DISPPARAMS();
+            object pVarResult;
+            var pExcepInfo = new ComTypes.EXCEPINFO();
+            uint ErrArg;
+            Guid guid = new Guid();
+            
+            int hr = obj.Invoke(memberId, ref guid, 0, (uint)(InvokeKind.DISPATCH_METHOD | InvokeKind.DISPATCH_PROPERTYGET), 
+                                    ref pDispParams, out pVarResult, ref pExcepInfo, out ErrArg);
+
+            if (hr < 0)
+            {
+                // could expand this to handle DISP_E_EXCEPTION
+                throw new ArgumentException(string.Format("CallSimpleMethodNoArgs Error invoking DispId {0}:  COM error code is {1}", memberId, hr));
+            }
+
+            return pVarResult;
+        }
+    }
+
+    [Guid("00020404-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IEnumVARIANT
+    {
+        // rgVar is technically an unmanaged array here, but we only ever call with celt=1, so this is compatible.
+        [PreserveSig] int Next([In] uint celt, [Out] out object rgVar, [Out] out uint pceltFetched);
+
+        [PreserveSig] int Skip([In] uint celt);
+        [PreserveSig] int Reset();
+        [PreserveSig] int Clone([Out] out IEnumVARIANT retval);
+    }
+
     public class ComWrapperEnumerator<TWrapperItem> : IEnumerator<TWrapperItem>
         where TWrapperItem : class
     {
         private readonly Func<object, TWrapperItem> _itemWrapper;
-        private readonly IEnumerator _internal;
+        private readonly IEnumVARIANT _enumeratorRCW;
+        private TWrapperItem _currentItem;
 
-        public ComWrapperEnumerator(IEnumerable source, Func<object, TWrapperItem> itemWrapper)
+        public ComWrapperEnumerator(object source, Func<object, TWrapperItem> itemWrapper)
         {
             _itemWrapper = itemWrapper;
-            _internal = source?.GetEnumerator() ?? Enumerable.Empty<TWrapperItem>().GetEnumerator();
+
+            if (source != null)
+            {
+                _enumeratorRCW = (IEnumVARIANT)IDispatchHelper.PropertyGet_NoArgs((IDispatch)source, (int)IDispatchHelper.StandardDispIds.DISPID_ENUM);
+                ((IEnumerator)this).Reset();  // precaution 
+            }
         }
 
         public void Dispose()
         {
-            // nothing to dispose here
+            if (!IsWrappingNullReference) Marshal.ReleaseComObject(_enumeratorRCW);
         }
 
-        public bool MoveNext()
+        void IEnumerator.Reset()
         {
-            return _internal.MoveNext();
+            if (!IsWrappingNullReference)
+            {
+                int hr = _enumeratorRCW.Reset();      
+                if (hr < 0)
+                {
+                    throw new ArgumentException(string.Format("Error invoking IEnumVARIANT::Reset().  COM error code is {0}", hr));
+                }
+            }
         }
+        
+        public bool IsWrappingNullReference => _enumeratorRCW == null;
+        
+        public TWrapperItem Current => _currentItem; 
+        object IEnumerator.Current => _currentItem;
 
-        public void Reset()
+        bool IEnumerator.MoveNext()
         {
-            _internal.Reset();
+            if (IsWrappingNullReference) return false;
+
+            _currentItem = null;
+
+            object currentItemRCW;
+            uint celtFetched;
+            int hr = _enumeratorRCW.Next(1, out currentItemRCW, out celtFetched);
+            // hr == S_FALSE (1) or S_OK (0), or <0 means error
+
+            _currentItem = _itemWrapper.Invoke(currentItemRCW);     // creates a null wrapped reference even on end/error, just as a precaution
+            
+            if (hr < 0)
+            {
+                throw new ArgumentException(string.Format("Error invoking IEnumVARIANT::Next().  COM error code is {0}", hr));
+            }
+           
+            return (celtFetched == 1);      // celtFetched == 0 at end
         }
-
-        public TWrapperItem Current => _itemWrapper.Invoke(_internal.Current);
-
-        object IEnumerator.Current => Current;
     }
 }

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControls.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBarControls.cs
@@ -31,9 +31,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         IEnumerator<ICommandBarControl> IEnumerable<ICommandBarControl>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<ICommandBarControl>(null, o => new CommandBarControl(null))
-                : new ComWrapperEnumerator<ICommandBarControl>(Target,
+            return new ComWrapperEnumerator<ICommandBarControl>(Target,
                     comObject => new CommandBarControl((Microsoft.Office.Core.CommandBarControl) comObject));
         }
 

--- a/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBars.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Office.Core/CommandBars.cs
@@ -57,9 +57,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office.Core
 
         IEnumerator<ICommandBar> IEnumerable<ICommandBar>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<ICommandBar>(null, o => new CommandBar(null))
-                : new ComWrapperEnumerator<ICommandBar>(Target,
+            return new ComWrapperEnumerator<ICommandBar>(Target,
                     comObject => new CommandBar((Microsoft.Office.Core.CommandBar) comObject));
         }
 

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBComponents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBComponents.cs
@@ -69,9 +69,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 
         IEnumerator<IVBComponent> IEnumerable<IVBComponent>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IVBComponent>(null, o => new VBComponent(null))
-                : new ComWrapperEnumerator<IVBComponent>(Target, comObject => new VBComponent((VB.VBComponent)comObject));
+            return new ComWrapperEnumerator<IVBComponent>(Target, comObject => new VBComponent((VB.VBComponent)comObject));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBProjects.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBProjects.cs
@@ -54,9 +54,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 
         IEnumerator<IVBProject> IEnumerable<IVBProject>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IVBProject>(null, o => new VBProject(null))
-                : new ComWrapperEnumerator<IVBProject>(Target, comObject => new VBProject((VB.VBProject)comObject));
+            return new ComWrapperEnumerator<IVBProject>(Target, comObject => new VBProject((VB.VBProject)comObject));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/AddIns.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/AddIns.cs
@@ -48,9 +48,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<IAddIn> IEnumerable<IAddIn>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IAddIn>(null, o => new AddIn(null))
-                : new ComWrapperEnumerator<IAddIn>(Target, comObject => new AddIn((VB.AddIn) comObject));
+            return new ComWrapperEnumerator<IAddIn>(Target, comObject => new AddIn((VB.AddIn) comObject));
         }
     }
 }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePanes.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodePanes.cs
@@ -28,9 +28,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<ICodePane> IEnumerable<ICodePane>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<ICodePane>(null, o => new CodePane(null))
-                : new ComWrapperEnumerator<ICodePane>(Target, comObject => new CodePane((VB.CodePane) comObject));
+            return new ComWrapperEnumerator<ICodePane>(Target, comObject => new CodePane((VB.CodePane) comObject));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Controls.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Controls.cs
@@ -20,9 +20,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         IEnumerator<IControl> IEnumerable<IControl>.GetEnumerator()
         {
             // soft-casting because ImageClass doesn't implement IControl
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IControl>(null, o => new Control(null))
-                : new ComWrapperEnumerator<IControl>(Target, comObject => new Control(comObject as VB.Forms.Control));
+            return new ComWrapperEnumerator<IControl>(Target, comObject => new Control(comObject as VB.Forms.Control));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/LinkedWindows.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/LinkedWindows.cs
@@ -47,9 +47,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<IWindow> IEnumerable<IWindow>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IWindow>(null, o => new Window(null))
-                : new ComWrapperEnumerator<IWindow>(Target, comObject => new Window((VB.Window) comObject));
+            return new ComWrapperEnumerator<IWindow>(Target, comObject => new Window((VB.Window) comObject));
         }
         
         public override bool Equals(ISafeComWrapper<VB.LinkedWindows> other)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Properties.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Properties.cs
@@ -24,9 +24,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<IProperty> IEnumerable<IProperty>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IProperty>(null, o => new Property(null))
-                : new ComWrapperEnumerator<IProperty>(Target, comObject => new Property((VB.Property) comObject));
+            return new ComWrapperEnumerator<IProperty>(Target, comObject => new Property((VB.Property) comObject));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/References.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/References.cs
@@ -96,9 +96,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<IReference> IEnumerable<IReference>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IReference>(null, o => new Reference(null))
-                : new ComWrapperEnumerator<IReference>(Target, comObject => new Reference((VB.Reference) comObject));
+            return new ComWrapperEnumerator<IReference>(Target, comObject => new Reference((VB.Reference) comObject));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponents.cs
@@ -72,9 +72,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<IVBComponent> IEnumerable<IVBComponent>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IVBComponent>(null, o => new VBComponent(null))
-                : new ComWrapperEnumerator<IVBComponent>(Target, comObject => new VBComponent((VB.VBComponent) comObject));
+            return new ComWrapperEnumerator<IVBComponent>(Target, comObject => new VBComponent((VB.VBComponent) comObject));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProjects.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProjects.cs
@@ -60,9 +60,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<IVBProject> IEnumerable<IVBProject>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IVBProject>(null, o => new VBProject(null))
-                : new ComWrapperEnumerator<IVBProject>(Target, comObject => new VBProject((VB.VBProject) comObject));
+            return new ComWrapperEnumerator<IVBProject>(Target, comObject => new VBProject((VB.VBProject) comObject));
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/Windows.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/Windows.cs
@@ -53,9 +53,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
         IEnumerator<IWindow> IEnumerable<IWindow>.GetEnumerator()
         {
-            return IsWrappingNullReference
-                ? new ComWrapperEnumerator<IWindow>(null, o => new Window(null))
-                : new ComWrapperEnumerator<IWindow>(Target, comObject => new Window((VB.Window) comObject));
+            return new ComWrapperEnumerator<IWindow>(Target, comObject => new Window((VB.Window) comObject));
         }
 
         public override bool Equals(ISafeComWrapper<VB.Windows> other)


### PR DESCRIPTION
Rewrite of ComWrapperEnumeration in order to offer control of the underlying IEnumVARIANT RCW, which is sometimes leaking past OnDisconnection due to being GC'd

The CLR automagically handles COM enumeration by custom marshalling IEnumVARIANT to a managed class (see EnumeratorToEnumVariantMarshaler) but as we need explicit control over all COM objects in RD, this is unacceptable.  We need to obtain the explicit IEnumVARIANT interface and ensure this RCW is destroyed in a timely fashion, using Marshal.ReleaseComObject.

The automatic custom marshalling of the enumeration getter method (DISPID_ENUM) prohibits access to the underlying IEnumVARIANT interface, and I can't find a way of turning off the automtic custom marshalling here.  To work around it, we must call the IDispatch:::Invoke method directly (instead of using CLRs normal late-bound method calling ability).