### PR TITLE
Fixes default member logic

### DIFF
--- a/Rubberduck.Inspections/Concrete/ObjectVariableNotSetInspection.cs
+++ b/Rubberduck.Inspections/Concrete/ObjectVariableNotSetInspection.cs
@@ -6,7 +6,6 @@ using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Inspections.Resources;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
-using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace Rubberduck.Inspections.Concrete
 {

--- a/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
+++ b/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
@@ -30,7 +30,7 @@ namespace Rubberduck.Inspections
             var setStmtContext = reference.Context.GetAncestor<VBAParser.SetStmtContext>();
             return setStmtContext == null && RequiresSetAssignment(reference, state);
         }
-
+        
         /// <summary>
         /// Determines whether the 'Set' keyword is required (whether it's present or not) for the specified identifier reference.
         /// </summary>
@@ -116,14 +116,11 @@ namespace Rubberduck.Inspections
 
             var memberRefs = state.DeclarationFinder.IdentifierReferences(reference.ParentScoping.QualifiedName);
             var lastRef = memberRefs.LastOrDefault(r => !Equals(r, reference) && r.Context.GetAncestor<VBAParser.LetStmtContext>() == letStmtContext);
-            if (lastRef?.Declaration.AsTypeDeclaration?.DeclarationType.HasFlag(DeclarationType.ClassModule) ?? false)
+            if (lastRef?.Declaration.IsObject ?? false)
             {
                 // the last reference in the expression is referring to an object type
-                return true;
-            }
-            if (lastRef?.Declaration.AsTypeName == Tokens.Object)
-            {
-                return true;
+                // return true *if* the object doesn't have a default member
+                return !lastRef.Declaration.AsTypeDeclaration?.Attributes.HasDefaultMemberAttribute() ?? false;
             }
 
             var accessibleDeclarations = state.DeclarationFinder.GetAccessibleDeclarations(reference.ParentScoping);

--- a/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
+++ b/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
@@ -74,17 +74,9 @@ namespace Rubberduck.Inspections
 
             if (isObjectVariable)
             {
-                // get the members of the returning type, a default member could make us lie otherwise
                 var classModule = declaration.AsTypeDeclaration as ClassModuleDeclaration;
-                if (HasParameterlessDefaultMember(classModule))
-                {
-                    // assigned declaration has a default parameterless member, which is legally being assigned here.
-                    // might be a good idea to flag that default member assignment though...
-                    return false;
-                }
-
-                // assign declaration is an object without a default parameterless (or with all parameters optional) member - LHS needs a 'Set' keyword.
-                return true;
+                // if assigned declaration is an object without a default parameterless (or with all parameters optional) member, LHS needs a 'Set' keyword.
+                return !HasParameterlessDefaultMember(classModule);
             }
 
             // assigned declaration is a variant. we need to know about the RHS of the assignment.
@@ -115,7 +107,7 @@ namespace Rubberduck.Inspections
             if (lastRef?.Declaration.IsObject ?? false)
             {
                 // the last reference in the expression is referring to an object type
-                // return true *if* the object doesn't have a default member
+                // return true *if* the object doesn't have a parameterless default member
                 var typeDeclaration = lastRef.Declaration.AsTypeDeclaration as ClassModuleDeclaration;
                 return !HasParameterlessDefaultMember(typeDeclaration);
             }

--- a/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
+++ b/Rubberduck.Inspections/VariableRequiresSetAssignmentEvaluator.cs
@@ -38,87 +38,61 @@ namespace Rubberduck.Inspections
         /// <param name="state">The parser state</param>
         public static bool RequiresSetAssignment(IdentifierReference reference, RubberduckParserState state)
         {
-            if (!reference.IsAssignment)
-            {
-                // reference isn't assigning its declaration; not interesting
-                return false;
-            }
+            // reference isn't assigning its declaration
+            if (!reference.IsAssignment) { return false; }
 
+            // Set keyword is already there.
+            // Returning reference.Declaration.IsObject allows flagging redundant Set keyword!
             var setStmtContext = reference.Context.GetAncestor<VBAParser.SetStmtContext>();
-            if (setStmtContext != null)
-            {
-                // don't assume Set keyword is legit...
-                return reference.Declaration.IsObject;
-            }
+            if (setStmtContext != null) { return reference.Declaration.IsObject; }
 
+            // Temporal coupling: LetStmtContext wouldn't be present given a SetStmtContext.
+            // If both SetStmtContext and LetStmtContext are missing, we're not looking at an assignment expression.
             var letStmtContext = reference.Context.GetAncestor<VBAParser.LetStmtContext>();
-            if (letStmtContext == null)
-            {
-                // not an assignment
-                return false;
-            }
+            if (letStmtContext == null) { return false; }
 
             var declaration = reference.Declaration;
+            var isObjectVariable = declaration.IsObject;
             if (declaration.IsArray)
             {
-                // arrays don't need a Set statement... todo figure out if array items are objects
-                return false;
+                // this is an array of object types (explicitly declared as such)
+                return isObjectVariable;
             }
 
-            var isObjectVariable = declaration.IsObject;
-            var isVariant = declaration.IsUndeclared || declaration.AsTypeName == Tokens.Variant;
-            if (!isObjectVariable && !isVariant)
-            {
-                return false;
-            }
-
+            // at this point we need to know if what we're looking at is an object or a variant.
+            // if it's neither, we're done here.
+            // if assigned declaration is an object with no default parameterless member, Set keyword is required (and missing!).
             if (isObjectVariable)
             {
                 var classModule = declaration.AsTypeDeclaration as ClassModuleDeclaration;
-                // if assigned declaration is an object without a default parameterless (or with all parameters optional) member, LHS needs a 'Set' keyword.
                 return !HasParameterlessDefaultMember(classModule);
             }
 
-            // assigned declaration is a variant. we need to know about the RHS of the assignment.
+            // at this point if we're not looking at a variant, we can't say Set keyword is required/missing.
+            var isVariant = declaration.IsUndeclared || declaration.AsTypeName == Tokens.Variant;
+            if (!isVariant) { return false; }
+
+            // the fun begins: we need to infer as much type information as we can from the RHS expression.
 
             var expression = letStmtContext.expression();
-            if (expression == null)
-            {
-                Debug.Assert(false, "RHS expression is empty? What's going on here?");
-            }
+            if (expression == null) { Debug.Assert(false, "RHS expression is empty? What's going on here?"); }
 
-            if (expression is VBAParser.NewExprContext)
-            {
-                // RHS expression is newing up an object reference - LHS needs a 'Set' keyword:
-                return true;
-            }
+            // If RHS is New-ing up an object instance, Set keyword is required & missing.
+            if (expression is VBAParser.NewExprContext) { return true; }
 
+            // If RHS is assigning to Nothing (i.e. an "object literal" identifier), Set keyword is required & missing.
             var literalExpression = expression as VBAParser.LiteralExprContext;
-            if (literalExpression?.literalExpression()?.literalIdentifier()?.objectLiteralIdentifier() != null)
-            {
-                // RHS is a 'Nothing' token - LHS needs a 'Set' keyword:
-                return true;
-            }
+            if (literalExpression?.literalExpression()?.literalIdentifier()?.objectLiteralIdentifier() != null) { return true; }
 
-            // todo resolve expression return type
-
-            var memberRefs = state.DeclarationFinder.IdentifierReferences(reference.ParentScoping.QualifiedName);
-            var lastRef = memberRefs.LastOrDefault(r => !Equals(r, reference) && r.Context.GetAncestor<VBAParser.LetStmtContext>() == letStmtContext);
+            // note: rhsRefs is correct, but the type of rhsRefs.LastOrDefault may not *necessarily* be the type of the expression.
+            // todo: try to *actually* resolve the RHS expression.
+            var rhsRefs = state.DeclarationFinder.IdentifierReferences(reference.ParentScoping.QualifiedName)
+                .Where(r => !Equals(r, reference) && r.Context.GetAncestor<VBAParser.LetStmtContext>() == letStmtContext);
+            var lastRef = rhsRefs.LastOrDefault();
             if (lastRef?.Declaration.IsObject ?? false)
             {
-                // the last reference in the expression is referring to an object type
-                // return true *if* the object doesn't have a parameterless default member
                 var typeDeclaration = lastRef.Declaration.AsTypeDeclaration as ClassModuleDeclaration;
                 return !HasParameterlessDefaultMember(typeDeclaration);
-            }
-
-            var accessibleDeclarations = state.DeclarationFinder.GetAccessibleDeclarations(reference.ParentScoping);
-            foreach (var accessibleDeclaration in accessibleDeclarations.Where(d => d.IdentifierName == expression.GetText()))
-            {
-                if (accessibleDeclaration.DeclarationType.HasFlag(DeclarationType.ClassModule) || accessibleDeclaration.AsTypeName == Tokens.Object)
-                {
-                    return true;
-                }
             }
 
             return false;

--- a/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
+++ b/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
@@ -142,7 +142,7 @@ namespace Rubberduck.Parsing.ComReflection
             {
                 var moduleName = new QualifiedModuleName(_referenceName, _path,
                     module.Type == DeclarationType.Enumeration || module.Type == DeclarationType.UserDefinedType
-                        ? string.Format("_{0}", module.Name)
+                        ? $"_{module.Name}"
                         : module.Name);
 
                 var declaration = CreateModuleDeclaration(module, moduleName, project, GetModuleAttributes(module));
@@ -235,8 +235,9 @@ namespace Rubberduck.Parsing.ComReflection
                     _declarations.AddRange(hasParams.Parameters);
                     memberTree.AddChildren(hasParams.Parameters);
                 }
-                var coClass = memberDeclaration as ClassModuleDeclaration;
-                if (coClass != null && item == defaultMember)
+
+                var coClass = declaration as ClassModuleDeclaration;
+                if (coClass != null && item.IsDefault)
                 {
                     coClass.DefaultMember = memberDeclaration;
                 }
@@ -292,7 +293,7 @@ namespace Rubberduck.Parsing.ComReflection
                 case DeclarationType.PropertyLet:
                     return new PropertyLetDeclaration(member, parent, module, attributes);
                 default:
-                    throw new InvalidEnumArgumentException(string.Format("Unexpected DeclarationType {0} encountered.", member.Type));
+                    throw new InvalidEnumArgumentException($"Unexpected DeclarationType {member.Type} encountered.");
             }
         }
 

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -14,6 +14,34 @@ namespace RubberduckTests.Inspections
     {
         [Test]
         [Category("Inspections")]
+        public void ObjectVariableNotSet_ArrayOfObjects_ReturnsResult()
+        {
+            var expectResultCount = 1;
+            var input =
+                @"
+Dim foo(0 To 9) As Object
+Private Function TestFunction(ByVal target As Range) As String
+    foo(1) = target
+End Function";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel.1.8.xml");
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ObjectVariableNotSet_ArrayOfStrings_ReturnsNoResult()
+        {
+            var expectResultCount = 0;
+            var input =
+                @"
+Dim foo(0 To 9) As String
+Private Function TestFunction(ByVal target As Range) As String
+    foo(1) = target 'implicit default member call here (target._Default -> target.Value)
+End Function";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel.1.8.xml");
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ObjectVariableNotSet_DefaultMemberAssignment_ReturnsNoResult()
         {
             var expectResultCount = 0;

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -14,7 +14,7 @@ namespace RubberduckTests.Inspections
     {
         [Test]
         [Category("Inspections")]
-        public void ObjectVariableNotSet_AlsoAssignedToNothing_ReturnsNoResult()
+        public void ObjectVariableNotSet_DefaultMemberAssignment_ReturnsNoResult()
         {
             var expectResultCount = 0;
             var input =
@@ -28,7 +28,7 @@ End Function";
 
         [Test]
         [Category("Inspections")]
-        public void ObjectVariableNotSet_DefaultMemberAssignment_ReturnsNoResult()
+        public void ObjectVariableNotSet_AlsoAssignedToNothing_ReturnsNoResult()
         {
             var expectResultCount = 0;
             var input =

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -23,7 +23,7 @@ Private Function TestFunction(ByVal target As Range) As String
     Dim myArray As Variant
     myArray = target    ' read range values into an array
 End Function";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel.1.8.xml");
         }
 
         [Test]

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -19,6 +19,20 @@ namespace RubberduckTests.Inspections
             var expectResultCount = 0;
             var input =
                 @"
+Private Function TestFunction(ByVal target As Range) As String
+    Dim myArray As Variant
+    myArray = target    ' read range values into an array
+End Function";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ObjectVariableNotSet_DefaultMemberAssignment_ReturnsNoResult()
+        {
+            var expectResultCount = 0;
+            var input =
+                @"
 Private Sub DoSomething()
     Dim target As Object
     Set target = New Object


### PR DESCRIPTION
COM collector knew about default members, but wasn't assigning the `DefaultMember` property of `ClassModuleDeclaration` instances.

This fixes #3712, confirmed.