### PR TITLE
Attempt to fix code modules and fix for projects not getting removed

### DIFF
--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -886,10 +886,16 @@ namespace Rubberduck.Parsing.VBA
 
         public bool IsNewOrModified(QualifiedModuleName key)
         {
+            //We are doing this up front instead skipping it whenever the module is new
+            //because of some issues with the CodeModule property of the VBComponents
+            //that sometimes surfaces later in the parsing process 
+            //in case they had not been accessed before.
+            var currentModuleContentHash = GetModuleContentHash(key);
+
             if (_moduleStates.TryGetValue(key, out var moduleState))
             {
                 // existing/modified
-                return moduleState.IsNew || GetModuleContentHash(key) != moduleState.ModuleContentHashCode;
+                return moduleState.IsNew || currentModuleContentHash != moduleState.ModuleContentHashCode;
             }
 
             // new

--- a/Rubberduck.VBEEditor/ComManagement/ProjectsRepository.cs
+++ b/Rubberduck.VBEEditor/ComManagement/ProjectsRepository.cs
@@ -46,6 +46,11 @@ namespace Rubberduck.VBEditor.ComManagement
 
         private void EnsureValidProjectId(IVBProject project)
         {
+            if (project.IsWrappingNullReference)
+            {
+                return;
+            }
+
             if (string.IsNullOrEmpty(project.ProjectId) || _projects.Keys.Contains(project.ProjectId))
             {
                 project.AssignProjectId();

--- a/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers
             Target = target;
             _rewrapping = rewrapping;
 
-            if (!rewrapping && target != null)
+            if (!rewrapping && target != null && (this is IVBProject))
             {
                 _comSafe = ComSafeManager.GetCurrentComSafe();
                 _comSafe.Add(this);

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBProject.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBProject.cs
@@ -67,16 +67,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             Target.MakeCompiledFile();
         }
 
-        //public override void Release(bool final = false)
-        //{
-        //    if (!IsWrappingNullReference)
-        //    {
-        //        References.Release();
-        //        VBComponents.Release();
-        //        base.Release(final);
-        //    }
-        //}
-
         public override bool Equals(ISafeComWrapper<VB.VBProject> other)
         {
             return IsEqualIfNull(other) || (other != null && other.Target == Target);
@@ -98,8 +88,16 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             return VBComponents.Select(component => component.Name).ToArray();
         }
 
+        //Assigns a new project id in case none has been saved so far
+        //and the saved one does not exist already.
+        //Otherwise, the saved project id remains unchanged.
         public void AssignProjectId()
         {
+            if (IsWrappingNullReference)
+            {
+                return;
+            }
+
             //assign a hashcode if no helpfile is present
             if (string.IsNullOrEmpty(HelpFile))
             {

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -1,7 +1,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
+using NLog;
 using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.SafeComWrappers.Office.Core.Abstract;
@@ -11,6 +14,16 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 {
     public class VBComponent : SafeComWrapper<VB.VBComponent>, IVBComponent
     {
+        private const int MaxRetryCount = 10;
+
+        private enum ComErrorCodes : uint
+        {
+            E_FAIL = 0x80004005, 
+
+        }
+
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
         public VBComponent(VB.VBComponent target, bool rewrapping = false) 
             : base(target, rewrapping)
         { }
@@ -18,7 +31,32 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public QualifiedModuleName QualifiedModuleName => new QualifiedModuleName(this);
 
         public ComponentType Type => IsWrappingNullReference ? 0 : (ComponentType)Target.Type;
-        public ICodeModule CodeModule => new CodeModule(IsWrappingNullReference ? null : Target.CodeModule);
+
+        //The retry approach is an attempt to deal with the problem that sometimes the code module is not yet ready to get accessed. 
+        public ICodeModule CodeModule => IsWrappingNullReference ? new CodeModule(null) : RetryOnComException(() => new CodeModule(Target.CodeModule), (uint)ComErrorCodes.E_FAIL);
+
+        private T RetryOnComException<T>(Func<T> func, uint retryErrorCode, int maxRetries = MaxRetryCount)
+        {
+            var remainingRetries = maxRetries;
+            while (true)
+            {
+                try
+                {
+                    return func();
+                }
+                catch (COMException exception)
+                {
+                    if ((uint)exception.ErrorCode != retryErrorCode || remainingRetries <= 0)
+                    {
+                        throw;
+                    }
+                    _logger.Debug(exception, "Failed with COM exception. Retrying.");
+                    remainingRetries--;
+                    Thread.Yield();
+                }
+            }
+        }
+
         public IVBE VBE => new VBE(IsWrappingNullReference ? null : Target.VBE);
         public IVBComponents Collection => new VBComponents(IsWrappingNullReference ? null : Target.Collection);
         public IProperties Properties => new Properties(IsWrappingNullReference ? null : Target.Properties);

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBComponent.cs
@@ -16,10 +16,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
     {
         private const int MaxRetryCount = 10;
 
-        private enum ComErrorCodes : uint
+        private enum ComErrorCodes
         {
-            E_FAIL = 0x80004005, 
-
+            E_FAIL = unchecked((int)0x80004005) 
         }
 
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
@@ -33,9 +32,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public ComponentType Type => IsWrappingNullReference ? 0 : (ComponentType)Target.Type;
 
         //The retry approach is an attempt to deal with the problem that sometimes the code module is not yet ready to get accessed. 
-        public ICodeModule CodeModule => IsWrappingNullReference ? new CodeModule(null) : RetryOnComException(() => new CodeModule(Target.CodeModule), (uint)ComErrorCodes.E_FAIL);
+        public ICodeModule CodeModule => IsWrappingNullReference ? new CodeModule(null) : RetryOnComException(() => new CodeModule(Target.CodeModule), (int)ComErrorCodes.E_FAIL);
 
-        private T RetryOnComException<T>(Func<T> func, uint retryErrorCode, int maxRetries = MaxRetryCount)
+        private T RetryOnComException<T>(Func<T> func, int retryErrorCode, int maxRetries = MaxRetryCount)
         {
             var remainingRetries = maxRetries;
             while (true)
@@ -46,7 +45,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 }
                 catch (COMException exception)
                 {
-                    if ((uint)exception.ErrorCode != retryErrorCode || remainingRetries <= 0)
+                    if (exception.ErrorCode != retryErrorCode || remainingRetries <= 0)
                     {
                         throw;
                     }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProject.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBProject.cs
@@ -81,19 +81,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             if (!IsWrappingNullReference) Target.MakeCompiledFile();
         }
 
-        //public override void Release(bool final = false)
-        //{
-        //    if (!IsWrappingNullReference)
-        //    {
-        //        if (Protection == ProjectProtection.Unprotected)
-        //        {
-        //            References.Release();
-        //            VBComponents.Release();
-        //        }
-        //        base.Release(final);
-        //    }
-        //}
-
         public override bool Equals(ISafeComWrapper<VB.VBProject> other)
         {
             return IsEqualIfNull(other) || (other != null && other.Target == Target);
@@ -115,8 +102,17 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             return VBComponents.Select(component => component.Name).ToArray();
         }
 
+
+        //Assigns a new project id in case none has been saved so far
+        //and the saved one does not exist already.
+        //Otherwise, the saved project id remains unchanged.
         public void AssignProjectId()
         {
+            if (IsWrappingNullReference)
+            {
+                return;
+            }
+            
             //assign a hashcode if no helpfile is present
             if (string.IsNullOrEmpty(HelpFile))
             {


### PR DESCRIPTION
This PR tries to deal with issue #3753. Unfortunately, I cannot verify that it fixes the issue because I cannot reproduce the issue reliably myself.

The two attemps made here are the following:

1. I introduced a retry approach for accessing the `CodeModule` property of a `VBComponent`, which sometimes fails for some unknown reason.

2. I made `IsNewOrModified` always compute the content hash, even if the module is clearly new. This is an attempt to access the `CodeModule` property for the first time at the same stage of the parsing process as before the PR that made the issue appear.
