### PR TITLE
Reintroduce content hash on QMNs

### DIFF
--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -898,13 +898,8 @@ namespace Rubberduck.Parsing.VBA
 
         private int GetModuleContentHash(QualifiedModuleName module)
         {
-            using (var codeModule = ProjectsProvider.Component(module).CodeModule)
-            {
-                var code = codeModule?.Content();
-                return string.IsNullOrEmpty(code)
-                        ? 0
-                        : code.GetHashCode();
-            }
+            var component = ProjectsProvider.Component(module);
+            return QualifiedModuleName.GetModuleContentHash(component);
         }
 
         public Declaration FindSelectedDeclaration(ICodePane activeCodePane)

--- a/Rubberduck.VBEEditor/QualifiedModuleName.cs
+++ b/Rubberduck.VBEEditor/QualifiedModuleName.cs
@@ -33,19 +33,35 @@ namespace Rubberduck.VBEditor
             return new QualifiedModuleName(projectName, reference.FullPath, projectName).ProjectId;
         }
 
+        public static int GetModuleContentHash(IVBComponent component)
+        {
+            if (component == null || component.IsWrappingNullReference)
+            {
+                return 0;
+            }
+
+            using (var codeModule = component.CodeModule)
+            {
+                return codeModule?.SimpleContentHash() ?? 0;
+            }
+        }
+
+
         public QualifiedModuleName(IVBProject project)
         {
             _componentName = null;
             ComponentType = ComponentType.Undefined;
             _projectName = project.Name;
             ProjectPath = string.Empty;
-            ProjectId = GetProjectId(project);           
+            ProjectId = GetProjectId(project);
+            ModuleContentHashOnCreation = GetModuleContentHash(null);
         }
 
         public QualifiedModuleName(IVBComponent component)
         {
             ComponentType = component.Type;
             _componentName = component.IsWrappingNullReference ? string.Empty : component.Name;
+            ModuleContentHashOnCreation = GetModuleContentHash(component);
 
             using (var components = component.Collection)
             {
@@ -58,6 +74,7 @@ namespace Rubberduck.VBEditor
             }
         }
 
+
         /// <summary>
         /// Creates a QualifiedModuleName for a built-in declaration.
         /// Do not use this overload for user declarations.
@@ -69,6 +86,7 @@ namespace Rubberduck.VBEditor
             ProjectId = $"{_projectName};{ProjectPath}".GetHashCode().ToString(CultureInfo.InvariantCulture);
             _componentName = componentName;
             ComponentType = ComponentType.ComComponent;
+            ModuleContentHashOnCreation = GetModuleContentHash(null);
         }
 
         public QualifiedMemberName QualifyMemberName(string member)
@@ -89,6 +107,7 @@ namespace Rubberduck.VBEditor
         public string ProjectName => _projectName ?? string.Empty;
 
         public string ProjectPath { get; }
+        public int ModuleContentHashOnCreation { get; }
 
         public override string ToString()
         {

--- a/Rubberduck.VBEEditor/QualifiedModuleName.cs
+++ b/Rubberduck.VBEEditor/QualifiedModuleName.cs
@@ -61,6 +61,13 @@ namespace Rubberduck.VBEditor
         {
             ComponentType = component.Type;
             _componentName = component.IsWrappingNullReference ? string.Empty : component.Name;
+
+            //note: We set this property in order to stabelize the component.
+            //For some reason, components sometimes seem to get removed on the COM side although 
+            //an RCW is still holding a reference. For some reason, opening the CodeModule of a 
+            //component seems to prevent this. 
+            //This is a hack to open the code module on each component for which we get a QMN 
+            //in a way that does not get optimized away.
             ModuleContentHashOnCreation = GetModuleContentHash(component);
 
             using (var components = component.Collection)

--- a/Rubberduck.VBEEditor/SafeComWrappers/Abstract/ICodeModule.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Abstract/ICodeModule.cs
@@ -19,6 +19,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
         string Content();
         void Clear();
         string ContentHash();
+        int SimpleContentHash();
 
         /// <summary>
         /// Adds the specified code to the module. If "require variable declaration" is on, code is added under Option Explicit and an extraneous empty line.

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/CodeModule.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/CodeModule.cs
@@ -160,6 +160,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             }
         }
 
+        public int SimpleContentHash()
+        {
+            var code = Content();
+            return string.IsNullOrEmpty(code)
+                ? 0
+                : code.GetHashCode();
+        }
+
         public bool IsDirty => _previousContentHash.Equals(ContentHash());
 
         public void AddFromString(string content)

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodeModule.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/CodeModule.cs
@@ -110,6 +110,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             }
         }
 
+        public int SimpleContentHash()
+        {
+            var code = Content();
+            return string.IsNullOrEmpty(code)
+                ? 0
+                : code.GetHashCode();
+        }
+
         public bool IsDirty => _previousContentHash.Equals(ContentHash());
 
         public void AddFromString(string content)

--- a/RubberduckTests/Mocks/MockProjectBuilder.cs
+++ b/RubberduckTests/Mocks/MockProjectBuilder.cs
@@ -320,7 +320,11 @@ namespace RubberduckTests.Mocks
                 lines.TakeWhile(line => line.Contains(Tokens.Declare + ' ') || !ModuleBodyTokens.Any(line.Contains)).Count());
 
             codeModule.Setup(m => m.Content()).Returns(() => string.Join(Environment.NewLine, lines));
-            
+
+            codeModule.Setup(m => m.SimpleContentHash()).Returns(() => string.IsNullOrEmpty(codeModule.Object.Content())
+                ? 0
+                : codeModule.Object.Content().GetHashCode());
+
             codeModule.Setup(m => m.GetLines(It.IsAny<Selection>()))
                 .Returns((Selection selection) => string.Join(Environment.NewLine, lines.Skip(selection.StartLine - 1).Take(selection.LineCount)));
             


### PR DESCRIPTION
This PR reintroduces computing the content hash of a component when creating a QMN for it. This is an attempt to deal with issue #3753. Removing the calculation of the content hash is the change from PR #3735 most probably causing the problems.

For some reason, the components acquired from the VBEAPI sometimes get removed by the VBE although our RCW is still holding a reference. This behaviour causes exceptions when later trying to access properties of the component. Apparently, one way to stabelize the component is to access its code module. Exactly this is guaranteed to happen when we compute the content hash of the module and save it to a public property. (This prevents the optimizer from removing the redundant code.)