### PR TITLE
Fix for AttributeNode

### DIFF
--- a/Rubberduck.Parsing/VBA/Attributes.cs
+++ b/Rubberduck.Parsing/VBA/Attributes.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Grammar;
@@ -41,7 +40,7 @@ namespace Rubberduck.Parsing.VBA
 
         public void AddValue(string value)
         {
-            _values.Add(value);
+            _values?.Add(value);
         }
 
         public IReadOnlyList<string> Values
@@ -51,7 +50,7 @@ namespace Rubberduck.Parsing.VBA
 
         public bool HasValue(string value)
         {
-            return _values.Any(item => item.Equals(value, StringComparison.OrdinalIgnoreCase));
+            return Values.Any(item => item.Equals(value, StringComparison.OrdinalIgnoreCase));
         }
 
         public bool Equals(AttributeNode other)

--- a/Rubberduck.Parsing/VBA/Attributes.cs
+++ b/Rubberduck.Parsing/VBA/Attributes.cs
@@ -20,37 +20,35 @@ namespace Rubberduck.Parsing.VBA
 
     public class AttributeNode : IEquatable<AttributeNode>
     {
-        private readonly string _name;
         private readonly IList<string> _values;
 
         public AttributeNode(VBAParser.AttributeStmtContext context)
         {
             Context = context;
+            Name = Context?.attributeName().GetText() ?? String.Empty;
+            _values = Context?.attributeValue().Select(a => a.GetText()).ToList() ?? new List<string>();
         }
 
         public AttributeNode(string name, IEnumerable<string> values)
         {
-            _name = name;
+            Name = name;
             _values = values.ToList();
         }
 
         public VBAParser.AttributeStmtContext Context { get; }
 
-        public string Name => Context?.attributeName().GetText() ?? _name;
-
+        public string Name { get; }
+    
         public void AddValue(string value)
         {
-            _values?.Add(value);
+            _values.Add(value);
         }
 
-        public IReadOnlyList<string> Values
-        {
-            get { return Context?.attributeValue().Select(a => a.GetText()).ToArray() ?? _values.ToArray(); }
-        }
+        public IReadOnlyCollection<string> Values => _values.AsReadOnly();
 
         public bool HasValue(string value)
         {
-            return Values.Any(item => item.Equals(value, StringComparison.OrdinalIgnoreCase));
+            return _values.Any(item => item.Equals(value, StringComparison.OrdinalIgnoreCase));
         }
 
         public bool Equals(AttributeNode other)


### PR DESCRIPTION
Fixes #3772 

The simple most fix for the issue, which is contained in commit one of this PR, is a two character change. (`_values` --> `Values` in `HasValue`)

However, to make `AttributeNodes` less confusing and prone to throw exceptions in case the constructor taking a context is used, I redesigned the class a bit.