### PR TITLE
Detect inappropriate thread access to TypeLib API

### DIFF
--- a/Rubberduck.VBEEditor/ComManagement/TypeLibs/TypeLibsSupport.cs
+++ b/Rubberduck.VBEEditor/ComManagement/TypeLibs/TypeLibsSupport.cs
@@ -561,7 +561,11 @@ namespace Rubberduck.VBEditor.ComManagement.TypeLibsSupport
                 throw new ArgumentException("Expected a COM object");
             }
 
-            var referencesPtr = Marshal.GetIUnknownForObject(comObj);
+            var referencesPtr = Marshal.GetIUnknownForObjectInContext(comObj);
+            if (referencesPtr == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Cannot access the TypeLib API from this thread.  TypeLib API must be accessed from the main thread.");
+            }
             var retVal = StructHelper.ReadStructureSafe<T>(referencesPtr);
             Marshal.Release(referencesPtr);
             return retVal;


### PR DESCRIPTION
Background: the TypeLib API is only safe to access in the main thread, as the VBE maintains the type library in the main thread, and the exposed objects (ITypeLib/ITypeInfo) are not implemented with any built-in thread safety.

This PR replaces GetIUnknownForObject with GetIUnknownForObjectInContext to detect inappropriate threaded access to the TypeLib API, and throws an error in such a case.