### PR TITLE
remove flags from status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,16 +23,6 @@ coverage:
         # allow decrease by up to 5 %
         threshold: 5
         base: auto
-      core:
-        # restrict core decrease to 2%
-        threshold: 2
-        flags: core
-      ui:
-        flags: ui
-      inspections:
-        flags: inspections
-      tools:
-        flags: tools
   
 comment:
   layout: "flags, diff, files"


### PR DESCRIPTION
Status checks for certain areas of the project are a cool idea in theory, the problem is that codecov apparently doesn't correctly report coverage for reports that apply to multiple flags.  
Long story short, this feature would've been nice if it worked, but it doesn't....