### PR TITLE
Enforce ending NEWLINE on commentBody

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -502,8 +502,9 @@ subroutineName : identifier;
 // 5.2.3.3 User Defined Type Declarations
 publicTypeDeclaration : ((GLOBAL | PUBLIC) whiteSpace)? udtDeclaration;
 privateTypeDeclaration : PRIVATE whiteSpace udtDeclaration;
-udtDeclaration : TYPE whiteSpace untypedIdentifier endOfStatement udtMemberList endOfStatement END_TYPE;  
-udtMemberList : udtMember (endOfStatement udtMember)*; 
+// member list includes trailing endOfStatement
+udtDeclaration : TYPE whiteSpace untypedIdentifier endOfStatement udtMemberList END_TYPE;  
+udtMemberList : (udtMember endOfStatement)+; 
 udtMember : reservedNameMemberDeclaration | untypedNameMemberDeclaration;
 untypedNameMemberDeclaration : untypedIdentifier whiteSpace? optionalArrayClause;
 reservedNameMemberDeclaration : unrestrictedIdentifier whiteSpace asTypeClause;
@@ -872,15 +873,16 @@ endOfStatement :
 
 // Annotations must come before comments because of precedence. ANTLR4 matches as much as possible then chooses the one that comes first.
 commentOrAnnotation :
-    annotationList 
+    (annotationList 
     | remComment
-    | comment
+    | comment) 
+	// all comments must end with a logical line. See VBA Language Spec 3.3.1
+	(NEWLINE | EOF)
 ;
 remComment : REM whiteSpace? commentBody;
 comment : SINGLEQUOTE commentBody;
-// commentBody must terminate with a NEWLINE, see VBA Language spec, section 3.3.1 and 3789
-commentBody : (LINE_CONTINUATION | ~NEWLINE)* (NEWLINE | EOF);
-annotationList : SINGLEQUOTE (AT annotation whiteSpace?)+ (whiteSpace? COLON commentBody)?;
+commentBody : (~NEWLINE)*;
+annotationList : SINGLEQUOTE (AT annotation whiteSpace?)+ (COLON commentBody)?;
 annotation : annotationName annotationArgList?;
 annotationName : unrestrictedIdentifier;
 annotationArgList : 

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -864,8 +864,9 @@ endOfLine :
     | whiteSpace? commentOrAnnotation
 ;
 
+// we expect endOfStatement to consume all trailing whitespace
 endOfStatement :
-    (endOfLine | (whiteSpace? COLON whiteSpace?))+
+    (endOfLine whiteSpace? | (whiteSpace? COLON whiteSpace?))+
 	| whiteSpace? EOF
 ;
 
@@ -877,7 +878,8 @@ commentOrAnnotation :
 ;
 remComment : REM whiteSpace? commentBody;
 comment : SINGLEQUOTE commentBody;
-commentBody : (LINE_CONTINUATION | ~NEWLINE)*;
+// commentBody must terminate with a NEWLINE, see VBA Language spec, section 3.3.1 and 3789
+commentBody : (LINE_CONTINUATION | ~NEWLINE)* (NEWLINE | EOF);
 annotationList : SINGLEQUOTE (AT annotation whiteSpace?)+ (whiteSpace? COLON commentBody)?;
 annotation : annotationName annotationArgList?;
 annotationName : unrestrictedIdentifier;

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -440,8 +440,7 @@ END";
         [Test]
         public void TestEmptyComment()
         {
-            string code = @"'
-";
+            string code = @"'";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
@@ -450,8 +449,7 @@ END";
         [Test]
         public void TestEmptyRemComment()
         {
-            string code = @"Rem
-";
+            string code = @"Rem";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//remComment");
         }
@@ -460,8 +458,7 @@ END";
         [Test]
         public void TestOneCharRemComment()
         {
-            string code = @"Rem a
-";
+            string code = @"Rem a";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//remComment");
         }
@@ -470,8 +467,7 @@ END";
         [Test]
         public void TestCommentThatLooksLikeAnnotation()
         {
-            string code = @"'@param foo; the value of something
-";
+            string code = @"'@param foo; the value of something";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
@@ -500,8 +496,7 @@ End Sub";
         [Test]
         public void TestOneCharComment()
         {
-            string code = @"'a
-";
+            string code = @"'a";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
@@ -2183,6 +2178,23 @@ End Sub
 ";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//variableSubStmt", matches => matches.Count == 1);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void UserDefinedType_TreatsFinalCommentAsComment()
+        {
+            // See Issue #3789
+            const string code = @"
+Private Type tX
+    foo As String
+    bar As Long
+    'foobar as shouldNotBeVisible
+End Type
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//udtMember", matches => matches.Count == 2);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//commentOrAnnotation", matches => matches.Count == 1);
         }
 
         private Tuple<VBAParser, ParserRuleContext> Parse(string code, PredictionMode predictionMode = null)

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -440,7 +440,8 @@ END";
         [Test]
         public void TestEmptyComment()
         {
-            string code = @"'";
+            string code = @"'
+";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
@@ -449,7 +450,8 @@ END";
         [Test]
         public void TestEmptyRemComment()
         {
-            string code = @"Rem";
+            string code = @"Rem
+";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//remComment");
         }
@@ -458,7 +460,8 @@ END";
         [Test]
         public void TestOneCharRemComment()
         {
-            string code = @"Rem a";
+            string code = @"Rem a
+";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//remComment");
         }
@@ -467,7 +470,8 @@ END";
         [Test]
         public void TestCommentThatLooksLikeAnnotation()
         {
-            string code = @"'@param foo; the value of something";
+            string code = @"'@param foo; the value of something
+";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
@@ -496,7 +500,8 @@ End Sub";
         [Test]
         public void TestOneCharComment()
         {
-            string code = @"'a";
+            string code = @"'a
+";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }


### PR DESCRIPTION
This requires an additional modification to endOfStatement to keep
consuming any "leading" whitespace for the following statement.
Fixes #3789