### PR TITLE
Some Safety Around the ActiveCodePane

### DIFF
--- a/RetailCoder.VBE/Navigation/RegexSearchReplace/RegexSearchReplace.cs
+++ b/RetailCoder.VBE/Navigation/RegexSearchReplace/RegexSearchReplace.cs
@@ -96,6 +96,11 @@ namespace Rubberduck.Navigation.RegexSearchReplace
         {
             using (var pane = _vbe.ActiveCodePane)
             {
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return new List<RegexSearchResult>();    
+                }
+
                 using (var module = pane.CodeModule)
                 {
                     var results = GetResultsFromModule(module, searchPattern);
@@ -119,21 +124,22 @@ namespace Rubberduck.Navigation.RegexSearchReplace
             var state = _parser.State;
             using (var pane = _vbe.ActiveCodePane)
             {
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return new List<RegexSearchResult>();
+                }
+
                 using (var module = pane.CodeModule)
                 {
                     var results = GetResultsFromModule(module, searchPattern);
 
-                    using (var moduleParent = module.Parent)
-                    {
-                        var qualifiedSelection =
-                            new QualifiedSelection(new QualifiedModuleName(moduleParent), pane.Selection);
-                        dynamic block = state.AllDeclarations.FindTarget(qualifiedSelection, declarationTypes).Context
-                            .Parent;
-                        var selection = new Selection(block.Start.Line, block.Start.Column, block.Stop.Line,
-                            block.Stop.Column);
+                    var qualifiedSelection = pane.GetQualifiedSelection();
+                    dynamic block = state.AllDeclarations.FindTarget(qualifiedSelection.Value, declarationTypes).Context
+                        .Parent;
+                    var selection = new Selection(block.Start.Line, block.Start.Column, block.Stop.Line,
+                        block.Stop.Column);
 
-                        return results.Where(r => selection.Contains(r.Selection)).ToList();
-                    }
+                    return results.Where(r => selection.Contains(r.Selection)).ToList();
                 }
             }
         }
@@ -142,6 +148,11 @@ namespace Rubberduck.Navigation.RegexSearchReplace
         {
             using (var pane = _vbe.ActiveCodePane)
             {
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return new List<RegexSearchResult>();
+                }
+
                 using (var codeModule = pane.CodeModule)
                 {
                     return GetResultsFromModule(codeModule, searchPattern).ToList();

--- a/RetailCoder.VBE/Refactorings/EncapsulateField/EncapsulateFieldPresenterFactory.cs
+++ b/RetailCoder.VBE/Refactorings/EncapsulateField/EncapsulateFieldPresenterFactory.cs
@@ -1,6 +1,7 @@
 ﻿using Rubberduck.Parsing.VBA;
 using Rubberduck.UI.Refactorings;
 using Rubberduck.UI.Refactorings.EncapsulateField;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Refactorings.EncapsulateField
@@ -20,13 +21,9 @@ namespace Rubberduck.Refactorings.EncapsulateField
 
         public EncapsulateFieldPresenter Create()
         {
-            var pane = _vbe.ActiveCodePane;
-            if (pane == null || pane.IsWrappingNullReference)
-            {
-                return null;
-            }
 
-            var selection = pane.GetQualifiedSelection();
+            var selection = _vbe.GetActiveSelection();
+
             if (!selection.HasValue)
             {
                 return null;

--- a/RetailCoder.VBE/Refactorings/EncapsulateField/EncapsulateFieldRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/EncapsulateField/EncapsulateFieldRefactoring.cs
@@ -46,15 +46,28 @@ namespace Rubberduck.Refactorings.EncapsulateField
 
         public void Refactor(QualifiedSelection target)
         {
-            var pane = _vbe.ActiveCodePane;
-            pane.Selection = target.Selection;
+            using (var pane = _vbe.ActiveCodePane)
+            {
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return;
+                }
+                pane.Selection = target.Selection;
+            }
             Refactor();
         }
 
         public void Refactor(Declaration target)
         {
-            var pane = _vbe.ActiveCodePane;
-            pane.Selection = target.QualifiedSelection.Selection;
+            using (var pane = _vbe.ActiveCodePane)
+            {
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return;
+                }
+
+                pane.Selection = target.QualifiedSelection.Selection;
+            }
             Refactor();
         }
 

--- a/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfacePresenterFactory.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfacePresenterFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.UI.Refactorings;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Refactorings.ExtractInterface
@@ -20,12 +21,9 @@ namespace Rubberduck.Refactorings.ExtractInterface
 
         public ExtractInterfacePresenter Create()
         {
-            var pane = _vbe.ActiveCodePane;
-            if (pane == null || pane.IsWrappingNullReference)
-            {
-                return null;
-            }
-            var selection = pane.GetQualifiedSelection();
+
+            var selection = _vbe.GetActiveSelection();
+            
             if (selection == null)
             {
                 return null;

--- a/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ExtractInterface/ExtractInterfaceRefactoring.cs
@@ -39,25 +39,21 @@ namespace Rubberduck.Refactorings.ExtractInterface
                 return;
             }
 
-            var pane = _vbe.ActiveCodePane;
-            QualifiedSelection? oldSelection;
-            if (!pane.IsWrappingNullReference)
+            using (var pane = _vbe.ActiveCodePane)
             {
-                var module = pane.CodeModule;
+                if (pane.IsWrappingNullReference)
                 {
-                    oldSelection = module.GetQualifiedSelection();
+                    return;
                 }
-            }
-            else
-            {
-                return;
-            }
 
-            AddInterface();
+                var oldSelection = pane.GetQualifiedSelection();
 
-            if (oldSelection.HasValue)
-            {
-                pane.Selection = oldSelection.Value.Selection;
+                AddInterface();
+
+                if (oldSelection.HasValue)
+                {
+                    pane.Selection = oldSelection.Value.Selection;
+                }
             }
 
             _model.State.OnParseRequested(this);
@@ -65,7 +61,7 @@ namespace Rubberduck.Refactorings.ExtractInterface
 
         public void Refactor(QualifiedSelection target)
         {
-            var pane = _vbe.ActiveCodePane;
+            using (var pane = _vbe.ActiveCodePane)
             {
                 if (pane.IsWrappingNullReference)
                 {
@@ -78,7 +74,7 @@ namespace Rubberduck.Refactorings.ExtractInterface
 
         public void Refactor(Declaration target)
         {
-            var pane = _vbe.ActiveCodePane;
+            using (var pane = _vbe.ActiveCodePane)
             {
                 if (pane.IsWrappingNullReference)
                 {

--- a/RetailCoder.VBE/Refactorings/ImplementInterface/ImplementInterfaceRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ImplementInterface/ImplementInterfaceRefactoring.cs
@@ -34,19 +34,25 @@ namespace Rubberduck.Refactorings.ImplementInterface
 
         public void Refactor()
         {
-            if (_vbe.ActiveCodePane == null)
+            QualifiedSelection? qualifiedSelection;
+            using (var activePane = _vbe.ActiveCodePane)
             {
-                _messageBox.Show(RubberduckUI.ImplementInterface_InvalidSelectionMessage, RubberduckUI.ImplementInterface_Caption,
-                    System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
-                return;
-            }
+                if (activePane == null || activePane.IsWrappingNullReference)
+                {
+                    _messageBox.Show(RubberduckUI.ImplementInterface_InvalidSelectionMessage,
+                        RubberduckUI.ImplementInterface_Caption,
+                        System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
+                    return;
+                }
 
-            var qualifiedSelection = _vbe.ActiveCodePane.GetQualifiedSelection();
-            if (!qualifiedSelection.HasValue)
-            {
-                _messageBox.Show(RubberduckUI.ImplementInterface_InvalidSelectionMessage, RubberduckUI.ImplementInterface_Caption,
-                    System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
-                return;
+                qualifiedSelection = activePane.GetQualifiedSelection();
+                if (!qualifiedSelection.HasValue)
+                {
+                    _messageBox.Show(RubberduckUI.ImplementInterface_InvalidSelectionMessage,
+                        RubberduckUI.ImplementInterface_Caption,
+                        System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Exclamation);
+                    return;
+                }
             }
 
             Refactor(qualifiedSelection.Value);
@@ -74,14 +80,7 @@ namespace Rubberduck.Refactorings.ImplementInterface
                 return;
             }
 
-            QualifiedSelection? oldSelection = null;
-            if (_vbe.ActiveCodePane != null)
-            {
-                using (var codePane = _vbe.ActiveCodePane)
-                {
-                    oldSelection = codePane.GetQualifiedSelection();
-                }
-            }
+            var oldSelection = _vbe.GetActiveSelection();
 
             ImplementMissingMembers(_state.GetRewriter(_targetClass));
 

--- a/RetailCoder.VBE/Refactorings/IntroduceField/IntroduceFieldRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/IntroduceField/IntroduceFieldRefactoring.cs
@@ -33,7 +33,7 @@ namespace Rubberduck.Refactorings.IntroduceField
 
         public void Refactor()
         {
-            var selection = _vbe.ActiveCodePane.GetQualifiedSelection();
+            var selection = _vbe.GetActiveSelection();
 
             if (!selection.HasValue)
             {
@@ -78,11 +78,7 @@ namespace Rubberduck.Refactorings.IntroduceField
                 return;
             }
 
-            QualifiedSelection? oldSelection = null;
-            if (_vbe.ActiveCodePane != null)
-            {
-                oldSelection = _vbe.ActiveCodePane.CodeModule.GetQualifiedSelection();
-            }
+            var oldSelection = _vbe.GetActiveSelection();
 
             rewriter.Remove(target);
             AddField(rewriter, target);

--- a/RetailCoder.VBE/Refactorings/RemoveParameters/RemoveParametersPresenterFactory.cs
+++ b/RetailCoder.VBE/Refactorings/RemoveParameters/RemoveParametersPresenterFactory.cs
@@ -24,13 +24,8 @@ namespace Rubberduck.Refactorings.RemoveParameters
 
         public RemoveParametersPresenter Create()
         {
-            var pane = _vbe.ActiveCodePane;
-            if (pane == null || pane.IsWrappingNullReference)
-            {
-                return null;
-            }
+            var selection = _vbe.GetActiveSelection();
 
-            var selection = pane.GetQualifiedSelection();
             if (!selection.HasValue)
             {
                 return null;
@@ -38,7 +33,6 @@ namespace Rubberduck.Refactorings.RemoveParameters
 
             var model = new RemoveParametersModel(_state, selection.Value, _messageBox);
             return new RemoveParametersPresenter(_view, model, _messageBox);
-
         }
     }
 }

--- a/RetailCoder.VBE/Refactorings/RemoveParameters/RemoveParametersRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/RemoveParameters/RemoveParametersRefactoring.cs
@@ -51,7 +51,7 @@ namespace Rubberduck.Refactorings.RemoveParameters
 
                 RemoveParameters();
 
-                if (oldSelection.HasValue)
+                if (oldSelection.HasValue && !pane.IsWrappingNullReference)
                 {
                     pane.Selection = oldSelection.Value.Selection;
                 }

--- a/RetailCoder.VBE/Refactorings/Rename/RenamePresenterFactory.cs
+++ b/RetailCoder.VBE/Refactorings/Rename/RenamePresenterFactory.cs
@@ -21,16 +21,8 @@ namespace Rubberduck.Refactorings.Rename
 
         public RenamePresenter Create()
         {
-            QualifiedSelection qualifiedSelection;
-            using (var codePane = _vbe.ActiveCodePane)
-            {
-                using (var codeModule = codePane.CodeModule)
-                {
-                    qualifiedSelection = codePane.IsWrappingNullReference
-                        ? new QualifiedSelection()
-                        : new QualifiedSelection(new QualifiedModuleName(codeModule.Parent), codePane.Selection);
-                }
-            }
+            var activeSelection = _vbe.GetActiveSelection();
+            var qualifiedSelection = activeSelection.HasValue ? activeSelection.Value : new QualifiedSelection(); 
             return new RenamePresenter(_view, new RenameModel(_vbe, _state, qualifiedSelection));
         }
     }

--- a/RetailCoder.VBE/Refactorings/Rename/RenameRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/Rename/RenameRefactoring.cs
@@ -43,7 +43,8 @@ namespace Rubberduck.Refactorings.Rename
             _messageBox = messageBox;
             _state = state;
             _model = null;
-            _initialSelection = new Tuple<ICodePane, Selection>(_vbe.ActiveCodePane, _vbe.ActiveCodePane.IsWrappingNullReference ? Selection.Empty : _vbe.ActiveCodePane.Selection);
+            var activeCodePane = _vbe.ActiveCodePane;
+            _initialSelection = new Tuple<ICodePane, Selection>(activeCodePane, activeCodePane.IsWrappingNullReference ? Selection.Empty : activeCodePane.Selection);
             _modulesToRewrite = new List<QualifiedModuleName>();
             _renameActions = new Dictionary<DeclarationType, Action>
             {

--- a/RetailCoder.VBE/Refactorings/ReorderParameters/ReorderParametersPresenterFactory.cs
+++ b/RetailCoder.VBE/Refactorings/ReorderParameters/ReorderParametersPresenterFactory.cs
@@ -24,14 +24,8 @@ namespace Rubberduck.Refactorings.ReorderParameters
 
         public IReorderParametersPresenter Create()
         {
-            var pane = _vbe.ActiveCodePane;
+            var selection = _vbe.GetActiveSelection();
 
-            if (pane == null || pane.IsWrappingNullReference)
-            {
-                return null;
-            }
-
-            var selection = pane.GetQualifiedSelection();
             if (!selection.HasValue)
             {
                 return null;
@@ -39,7 +33,7 @@ namespace Rubberduck.Refactorings.ReorderParameters
 
             var model = new ReorderParametersModel(_state, selection.Value, _messageBox);
             return new ReorderParametersPresenter(_view, model, _messageBox);
-
+            
         }
     }
 }

--- a/RetailCoder.VBE/Refactorings/ReorderParameters/ReorderParametersRefactoring.cs
+++ b/RetailCoder.VBE/Refactorings/ReorderParameters/ReorderParametersRefactoring.cs
@@ -47,22 +47,20 @@ namespace Rubberduck.Refactorings.ReorderParameters
 
             using (var pane = _vbe.ActiveCodePane)
             {
-                if (!pane.IsWrappingNullReference)
+                if (pane.IsWrappingNullReference)
                 {
-                    QualifiedSelection? oldSelection;
-                    using (var module = pane.CodeModule)
-                    {
-                        oldSelection = module.GetQualifiedSelection();
-                    }
-
-                    AdjustReferences(_model.TargetDeclaration.References);
-                    AdjustSignatures();
-
-                    if (oldSelection.HasValue)
-                    {
-                        pane.Selection = oldSelection.Value.Selection;
-                    }
+                    return;
                 }
+
+                var oldSelection = pane.GetQualifiedSelection();
+
+                AdjustReferences(_model.TargetDeclaration.References);
+                AdjustSignatures();
+
+                if (oldSelection.HasValue && !pane.IsWrappingNullReference)
+                {
+                    pane.Selection = oldSelection.Value.Selection;
+                } 
             }
 
             foreach (var rewriter in _rewriters)
@@ -77,9 +75,14 @@ namespace Rubberduck.Refactorings.ReorderParameters
         {
             using (var pane = _vbe.ActiveCodePane)
             {
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return;
+                }
+
                 pane.Selection = target.Selection;
-                Refactor();
             }
+            Refactor();
         }
 
         public void Refactor(Declaration target)
@@ -91,9 +94,13 @@ namespace Rubberduck.Refactorings.ReorderParameters
 
             using (var pane = _vbe.ActiveCodePane)
             {
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return;
+                }
                 pane.Selection = target.QualifiedSelection.Selection;
-                Refactor();
             }
+            Refactor();
         }
 
         private bool IsValidParamOrder()

--- a/RetailCoder.VBE/UI/Command/AddTestMethodCommand.cs
+++ b/RetailCoder.VBE/UI/Command/AddTestMethodCommand.cs
@@ -47,7 +47,18 @@ namespace Rubberduck.UI.Command
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            if (_state.Status != ParserState.Ready || _vbe.ActiveCodePane == null) { return false; }
+            if (_state.Status != ParserState.Ready)
+            {
+                return false;
+            }
+
+            using (var activePane = _vbe.ActiveCodePane)
+            {
+                if (activePane == null || activePane.IsWrappingNullReference)
+                {
+                    return false;
+                }
+            }
 
             var testModules = _state.AllUserDeclarations.Where(d =>
                         d.DeclarationType == DeclarationType.ProceduralModule &&

--- a/RetailCoder.VBE/UI/Command/AddTestMethodExpectedErrorCommand.cs
+++ b/RetailCoder.VBE/UI/Command/AddTestMethodExpectedErrorCommand.cs
@@ -52,33 +52,32 @@ namespace Rubberduck.UI.Command
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            var pane = _vbe.ActiveCodePane;
+            using (var pane = _vbe.ActiveCodePane)
             {
                 if (_state.Status != ParserState.Ready || pane.IsWrappingNullReference)
                 {
                     return false;
                 }
-
-                var testModules = _state.AllUserDeclarations.Where(d =>
+            }
+            var testModules = _state.AllUserDeclarations.Where(d =>
                             d.DeclarationType == DeclarationType.ProceduralModule &&
                             d.Annotations.Any(a => a.AnnotationType == AnnotationType.TestModule));
 
-                try
+            try
+            {
+                // the code modules consistently match correctly, but the components don't
+                using (var component = _vbe.SelectedVBComponent)
                 {
-                    // the code modules consistently match correctly, but the components don't
-                    using (var component = _vbe.SelectedVBComponent)
+                    using(var selectedModule = component.CodeModule)
                     {
-                        using(var selectedModule = component.CodeModule)
-                        {
-                            return testModules.Any(a => _state.ProjectsProvider.Component(a.QualifiedModuleName).HasEqualCodeModule(selectedModule));
-                        }
+                        return testModules.Any(a => _state.ProjectsProvider.Component(a.QualifiedModuleName).HasEqualCodeModule(selectedModule));
                     }
                 }
-                catch (COMException)
-                {
-                    return false;
-                }
             }
+            catch (COMException)
+            {
+                return false;
+            }      
         }
 
         protected override void OnExecute(object parameter)

--- a/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
@@ -100,15 +100,18 @@ namespace Rubberduck.UI.Command
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            if (_vbe.ActiveCodePane == null || _state.Status != ParserState.Ready)
+            using (var codePane = _vbe.ActiveCodePane)
             {
-                return false;
+                if (codePane == null || codePane.IsWrappingNullReference || _state.Status != ParserState.Ready)
+                {
+                    return false;
+                }
+
+                var target = FindTarget(parameter);
+                var canExecute = target != null;
+
+                return canExecute;
             }
-
-            var target = FindTarget(parameter);
-            var canExecute = target != null;
-
-            return canExecute;
         }
 
         protected override void OnExecute(object parameter)
@@ -180,7 +183,10 @@ namespace Rubberduck.UI.Command
                 return declaration;
             }
 
-            return _state.FindSelectedDeclaration(_vbe.ActiveCodePane);
+            using (var activePane = _vbe.ActiveCodePane)
+            {
+                return _state.FindSelectedDeclaration(activePane);
+            }
         }
 
         private IEnumerable<Declaration> FindImplementations(Declaration target)

--- a/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
@@ -95,12 +95,23 @@ namespace Rubberduck.UI.Command
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            if (_state.Status != ParserState.Ready ||
-                (_vbe.ActiveCodePane == null && !(_vbe.SelectedVBComponent?.HasDesigner ?? false)))
+            if (_state.Status != ParserState.Ready)
             {
                 return false;
             }
-            
+
+            using (var activePane = _vbe.ActiveCodePane)
+            {
+                using (var selectedComponent = _vbe.SelectedVBComponent)
+                {
+                    if ((activePane == null || activePane.IsWrappingNullReference)
+                        && !(selectedComponent?.HasDesigner ?? false))
+                    {
+                        return false;
+                    }
+                }
+            }
+
             var target = FindTarget(parameter);
             var canExecute = target != null;
 
@@ -176,7 +187,17 @@ namespace Rubberduck.UI.Command
                 return declaration;
             }
 
-            return _vbe.ActiveCodePane != null && (_vbe.SelectedVBComponent?.HasDesigner ?? false)
+            bool findDesigner;
+            using (var activePane = _vbe.ActiveCodePane)
+            {
+                using (var selectedComponent = _vbe.SelectedVBComponent)
+                {
+                    findDesigner = activePane != null && !activePane.IsWrappingNullReference 
+                                    && (selectedComponent?.HasDesigner ?? false);
+                }
+            }
+
+            return findDesigner
                 ? FindFormDesignerTarget()
                 : FindCodePaneTarget();
         }

--- a/RetailCoder.VBE/UI/Command/IndentCurrentModuleCommand.cs
+++ b/RetailCoder.VBE/UI/Command/IndentCurrentModuleCommand.cs
@@ -22,7 +22,10 @@ namespace Rubberduck.UI.Command
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            return !_vbe.ActiveCodePane.IsWrappingNullReference;
+            using (var activePane = _vbe.ActiveCodePane)
+            {
+                return activePane != null && !activePane.IsWrappingNullReference;
+            }
         }
 
         protected override void OnExecute(object parameter)

--- a/RetailCoder.VBE/UI/Command/IndentCurrentProcedureCommand.cs
+++ b/RetailCoder.VBE/UI/Command/IndentCurrentProcedureCommand.cs
@@ -23,7 +23,10 @@ namespace Rubberduck.UI.Command
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            return _vbe.ActiveCodePane != null;
+            using (var activePane = _vbe.ActiveCodePane)
+            {
+                return activePane != null || !activePane.IsWrappingNullReference;
+            }
         }
 
         protected override void OnExecute(object parameter)

--- a/RetailCoder.VBE/UI/Command/Refactorings/CodePaneRefactorRenameCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/CodePaneRefactorRenameCommand.cs
@@ -22,27 +22,38 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            if (Vbe.ActiveCodePane == null)
+            Declaration target;
+            using (var activePane = Vbe.ActiveCodePane)
             {
-                return false;
+                if (Vbe.ActiveCodePane == null || activePane.IsWrappingNullReference)
+                {
+                    return false;
+                }
+            
+                target = _state.FindSelectedDeclaration(activePane);
             }
 
-            var target = _state.FindSelectedDeclaration(Vbe.ActiveCodePane);
             return _state.Status == ParserState.Ready && target != null && target.IsUserDefined;
         }
 
         protected override void OnExecute(object parameter)
         {
-            if (Vbe.ActiveCodePane == null) { return; }
-
             Declaration target;
-            if (parameter != null)
+            using (var activePane = Vbe.ActiveCodePane)
             {
-                target = parameter as Declaration;
-            }
-            else
-            {
-                target = _state.FindSelectedDeclaration(Vbe.ActiveCodePane);
+                if (activePane == null || activePane.IsWrappingNullReference)
+                {
+                    return;
+                }
+
+                if (parameter != null)
+                {
+                    target = parameter as Declaration;
+                }
+                else
+                {
+                    target = _state.FindSelectedDeclaration(Vbe.ActiveCodePane);
+                }
             }
 
             if (target == null || !target.IsUserDefined)

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
@@ -2,12 +2,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Antlr4.Runtime;
+using Microsoft.VB6.Interop.VBIDE;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings.ExtractInterface;
 using Rubberduck.UI.Refactorings;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.Command.Refactorings
@@ -34,7 +36,8 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            var selection = Vbe.ActiveCodePane.GetQualifiedSelection();
+            var selection = Vbe.GetActiveSelection();
+
             if (!selection.HasValue)
             {
                 return false;
@@ -69,9 +72,12 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override void OnExecute(object parameter)
         {
-            if (Vbe.ActiveCodePane == null)
+            using(var activePane = Vbe.ActiveCodePane)
             {
-                return;
+                if (activePane == null || activePane.IsWrappingNullReference)
+                {
+                    return;
+                }
             }
 
             using (var view = new ExtractInterfaceDialog(new ExtractInterfaceViewModel()))

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractMethodCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorExtractMethodCommand.cs
@@ -23,33 +23,26 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            if (Vbe.ActiveCodePane == null || _state.Status != ParserState.Ready)
+
+            var qualifiedSelection = Vbe.GetActiveSelection();
+
+            if (!qualifiedSelection.HasValue)
             {
                 return false;
             }
 
-            var pane = Vbe.ActiveCodePane;
-            var module = pane.CodeModule;
-            {
-                var qualifiedSelection = pane.GetQualifiedSelection();
-                if (!qualifiedSelection.HasValue || module.IsWrappingNullReference)
-                {
-                    return false;
-                }
-
-                var allDeclarations = _state.AllDeclarations;
-                var extractMethodValidation = new ExtractMethodSelectionValidation(allDeclarations);
+            var allDeclarations = _state.AllDeclarations;
+            var extractMethodValidation = new ExtractMethodSelectionValidation(allDeclarations);
                 
-                var canExecute = extractMethodValidation.withinSingleProcedure(qualifiedSelection.Value);
+            var canExecute = extractMethodValidation.withinSingleProcedure(qualifiedSelection.Value);
 
-                return canExecute;
-            }
+            return canExecute;
         }
 
         protected override void OnExecute(object parameter)
         {
             var declarations = _state.AllDeclarations;
-            var qualifiedSelection = Vbe.ActiveCodePane.GetQualifiedSelection();
+            var qualifiedSelection = Vbe.GetActiveSelection();
 
             var extractMethodValidation = new ExtractMethodSelectionValidation(declarations);
             var canExecute = extractMethodValidation.withinSingleProcedure(qualifiedSelection.Value);
@@ -58,8 +51,8 @@ namespace Rubberduck.UI.Command.Refactorings
                 return;
             }
 
-            var pane = Vbe.ActiveCodePane;
-            var module = pane.CodeModule;
+            using (var pane = Vbe.ActiveCodePane)
+            using (var module = pane.CodeModule)
             {
                 var extraction = new ExtractMethodExtraction();
                 // bug: access to disposed closure

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorImplementInterfaceCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorImplementInterfaceCommand.cs
@@ -4,6 +4,7 @@ using Rubberduck.Common;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings.ImplementInterface;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.Command.Refactorings
@@ -23,15 +24,10 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
-            {
-                if (_state.Status != ParserState.Ready || pane.IsWrappingNullReference)
-                {
-                    return false;
-                }
+            
+            var selection = Vbe.GetActiveSelection();        
 
-                var selection = pane.GetQualifiedSelection();
-                if (!selection.HasValue)
+            if (!selection.HasValue)
                 {
                     return false;
                 }
@@ -43,21 +39,20 @@ namespace Rubberduck.UI.Command.Refactorings
                     d.QualifiedSelection.QualifiedName.Equals(selection.Value.QualifiedName));
 
                 return targetInterface != null && targetClass != null;
-            }
+            
         }
 
         protected override void OnExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
+            using (var pane = Vbe.ActiveCodePane)
             {
                 if (pane.IsWrappingNullReference)
                 {
                     return;
                 }
-
-                var refactoring = new ImplementInterfaceRefactoring(Vbe, _state, _msgBox);
-                refactoring.Refactor();
             }
+            var refactoring = new ImplementInterfaceRefactoring(Vbe, _state, _msgBox);
+            refactoring.Refactor();
         }
     }
 }

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorIntroduceFieldCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorIntroduceFieldCommand.cs
@@ -2,6 +2,7 @@
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings.IntroduceField;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.Command.Refactorings
@@ -20,43 +21,34 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
+            if (_state.Status != ParserState.Ready)
             {
-                if (_state.Status != ParserState.Ready || pane.IsWrappingNullReference)
-                {
-                    return false;
-                }
-
-                var selection = pane.GetQualifiedSelection();
-                if (!selection.HasValue)
-                {
-                    return false;
-                }
-
-                var target = _state.AllUserDeclarations.FindVariable(selection.Value);
-
-                return target != null && target.ParentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Member);
+                return false;
             }
+
+            var selection = Vbe.GetActiveSelection();
+
+            if (!selection.HasValue)
+            {
+                return false;
+            }
+
+            var target = _state.AllUserDeclarations.FindVariable(selection.Value);
+
+            return target != null && target.ParentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Member);
         }
 
         protected override void OnExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
+            var selection = Vbe.GetActiveSelection();
+
+            if (!selection.HasValue)
             {
-                if (pane.IsWrappingNullReference)
-                {
-                    return;
-                }
-
-                var selection = pane.GetQualifiedSelection();
-                if (!selection.HasValue)
-                {
-                    return;
-                }
-
-                var refactoring = new IntroduceFieldRefactoring(Vbe, _state, _messageBox);
-                refactoring.Refactor(selection.Value);
+                return;
             }
+
+            var refactoring = new IntroduceFieldRefactoring(Vbe, _state, _messageBox);
+            refactoring.Refactor(selection.Value);
         }
     }
 }

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorIntroduceParameterCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorIntroduceParameterCommand.cs
@@ -20,43 +20,34 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
+            if (_state.Status != ParserState.Ready)
             {
-                if (_state.Status != ParserState.Ready || pane.IsWrappingNullReference)
-                {
-                    return false;
-                }
-
-                var selection = pane.GetQualifiedSelection();
-                if (!selection.HasValue)
-                {
-                    return false;
-                }
-
-                var target = _state.AllUserDeclarations.FindVariable(selection.Value);
-
-                return target != null && target.ParentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Member);
+                return false;
             }
+
+            var selection = Vbe.GetActiveSelection();
+
+            if (!selection.HasValue)
+            {
+                return false;
+            }
+
+            var target = _state.AllUserDeclarations.FindVariable(selection.Value);
+
+            return target != null && target.ParentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Member);
         }
 
         protected override void OnExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
+            var selection = Vbe.GetActiveSelection();
+
+            if (!selection.HasValue)
             {
-                if (pane.IsWrappingNullReference)
-                {
-                    return;
-                }
-
-                var selection = pane.GetQualifiedSelection();
-                if (!selection.HasValue)
-                {
-                    return;
-                }
-
-                var refactoring = new IntroduceParameterRefactoring(Vbe, _state, _messageBox);
-                refactoring.Refactor(selection.Value);
+                return;
             }
+
+            var refactoring = new IntroduceParameterRefactoring(Vbe, _state, _messageBox);
+            refactoring.Refactor(selection.Value);
         }
     }
 }

--- a/RetailCoder.VBE/UI/Command/Refactorings/RefactorRemoveParametersCommand.cs
+++ b/RetailCoder.VBE/UI/Command/Refactorings/RefactorRemoveParametersCommand.cs
@@ -5,6 +5,7 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings.RemoveParameters;
 using Rubberduck.UI.Refactorings.RemoveParameters;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.Command.Refactorings
@@ -34,34 +35,38 @@ namespace Rubberduck.UI.Command.Refactorings
 
         protected override bool EvaluateCanExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
-            if (pane.IsWrappingNullReference || _state.Status != ParserState.Ready)
+            if (_state.Status != ParserState.Ready)
             {
                 return false;
             }
 
-            var selection = pane.GetQualifiedSelection();
+            var selection = Vbe.GetActiveSelection();
+
+            if (!selection.HasValue)
+            {
+                return false;
+            }
+
             var member = _state.AllUserDeclarations.FindTarget(selection.Value, ValidDeclarationTypes);
             if (member == null)
             {
                 return false;
             }
 
-            var parameters = _state.AllUserDeclarations.Where(item => item.DeclarationType == DeclarationType.Parameter && member.Equals(item.ParentScopeDeclaration)).ToList();
-            return member.DeclarationType == DeclarationType.PropertyLet || member.DeclarationType == DeclarationType.PropertySet
-                    ? parameters.Count > 1
-                    : parameters.Any();
+            var parameters = _state.DeclarationFinder.UserDeclarations(DeclarationType.Parameter)
+                .Where(item => member.Equals(item.ParentScopeDeclaration))
+                .ToList();
+            return member.DeclarationType == DeclarationType.PropertyLet 
+                    || member.DeclarationType == DeclarationType.PropertySet
+                        ? parameters.Count > 1
+                        : parameters.Any();
+            
         }
 
         protected override void OnExecute(object parameter)
         {
-            var pane = Vbe.ActiveCodePane;
-            if (pane.IsWrappingNullReference)
-            {
-                return;
-            }
+            var selection = Vbe.GetActiveSelection();
 
-            var selection = pane.GetQualifiedSelection();
             using (var view = new RemoveParametersDialog(new RemoveParametersViewModel(_state)))
             {
                 var factory = new RemoveParametersPresenterFactory(Vbe, view, _state, _msgbox);

--- a/Rubberduck.SmartIndenter/Indenter.cs
+++ b/Rubberduck.SmartIndenter/Indenter.cs
@@ -25,7 +25,7 @@ namespace Rubberduck.SmartIndenter
         {
             using (var pane = _vbe.ActiveCodePane)
             {
-                if (pane == null)
+                if (pane == null || pane.IsWrappingNullReference)
                 {
                     return;
                 }
@@ -59,12 +59,14 @@ namespace Rubberduck.SmartIndenter
         /// </summary>
         public void IndentCurrentModule()
         {
-            var pane = _vbe.ActiveCodePane;
-            if (pane == null)
+            using (var pane = _vbe.ActiveCodePane)
             {
-                return;
+                if (pane == null || pane.IsWrappingNullReference)
+                {
+                    return;
+                }
+                Indent(pane.CodeModule.Parent);
             }
-            Indent(pane.CodeModule.Parent);
         }
 
         /// <summary>

--- a/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IVBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IVBE.cs
@@ -22,6 +22,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
         IHostApplication HostApplication();
         IWindow ActiveMDIChild();
 
+        QualifiedSelection? GetActiveSelection();
+
         bool IsInDesignMode { get; }
         int ProjectsCount { get; }
     }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB6/VBE.cs
@@ -166,5 +166,18 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                 }
             }
         }
+
+        public QualifiedSelection? GetActiveSelection()
+        {
+            using (var activePane = ActiveCodePane)
+            {
+                if (activePane == null || activePane.IsWrappingNullReference)
+                {
+                    return null;
+                }
+
+                return activePane.GetQualifiedSelection();
+            }
+        }
     }
 }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VBA/VBE.cs
@@ -390,6 +390,19 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             }
             return false;
         }
+
+        public QualifiedSelection? GetActiveSelection()
+        {
+            using (var activePane = ActiveCodePane)
+            {
+                if (activePane == null || activePane.IsWrappingNullReference)
+                {
+                    return null;
+                }
+
+                return activePane.GetQualifiedSelection();
+            }
+        }
     }
 }
 

--- a/RubberduckTests/Mocks/MockVbeBuilder.cs
+++ b/RubberduckTests/Mocks/MockVbeBuilder.cs
@@ -190,6 +190,7 @@ namespace RubberduckTests.Mocks
             vbe.SetupProperty(m => m.ActiveVBProject);
             
             vbe.SetupGet(m => m.SelectedVBComponent).Returns(() => vbe.Object.ActiveCodePane?.CodeModule?.Parent);
+            vbe.Setup(m => m.GetActiveSelection()).Returns(() => vbe.Object.ActiveCodePane?.GetQualifiedSelection());
             vbe.SetupGet(m => m.ActiveWindow).Returns(() => vbe.Object.ActiveCodePane.Window);
 
             var mainWindow = new Mock<IWindow>();


### PR DESCRIPTION
This is some work around the `ActieCodePane` I did some time ago as part of a failed PR and never got around to actually push. It mostly adds disposal around the `ActieCodePane` and makes accessing the currently active selection more straight forward.