### PR TITLE
Add New ParserStates Started and UnexpectedError

### DIFF
--- a/RetailCoder.VBE/UI/Command/ReparseCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ReparseCommand.cs
@@ -38,7 +38,8 @@ namespace Rubberduck.UI.Command
             return _state.Status == ParserState.Pending
                    || _state.Status == ParserState.Ready
                    || _state.Status == ParserState.Error
-                   || _state.Status == ParserState.ResolverError;
+                   || _state.Status == ParserState.ResolverError
+                   || _state.Status == ParserState.UnexpectedError;
         }
 
         protected override void OnExecute(object parameter)

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -3000,6 +3000,24 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Started.
+        /// </summary>
+        public static string ParserState_Started {
+            get {
+                return ResourceManager.GetString("ParserState_Started", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected Error.
+        /// </summary>
+        public static string ParserState_UnexpectedError {
+            get {
+                return ResourceManager.GetString("ParserState_UnexpectedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parsing project components....
         /// </summary>
         public static string ParseStarted {

--- a/RetailCoder.VBE/UI/RubberduckUI.de.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1727,5 +1727,11 @@ Möchten sie die Einstellungen in Rubberduck importieren?</value>
   </data>
   <data name="CodeMetrics_Nesting" xml:space="preserve">
     <value>Maximale Einrückung</value>
+  </data>
+  <data name="ParserState_Started" xml:space="preserve">
+    <value>Gestartet</value>
+  </data>
+  <data name="ParserState_UnexpectedError" xml:space="preserve">
+    <value>Unerwarteter Fehler</value>
   </data>
 </root>

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -1789,4 +1789,10 @@ Would you like to import them to Rubberduck?</value>
   <data name="GeneralSettings_CompileBeforeParse" xml:space="preserve">
     <value>Compile code before parsing</value>
   </data>
+  <data name="ParserState_Started" xml:space="preserve">
+    <value>Started</value>
+  </data>
+  <data name="ParserState_UnexpectedError" xml:space="preserve">
+    <value>Unexpected Error</value>
+  </data>
 </root>

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -165,7 +165,7 @@ namespace Rubberduck.Parsing.VBA
             toReresolveReferences.UnionWith(toReresolveReferencesInput);
             token.ThrowIfCancellationRequested();
 
-            _parserStateManager.SetModuleStates(toParse, ParserState.Pending, token);
+            _parserStateManager.SetModuleStates(toParse, ParserState.Started, token);
             token.ThrowIfCancellationRequested();
 
             _parserStateManager.SetStatusAndFireStateChanged(this, ParserState.LoadingReference, token);
@@ -320,9 +320,9 @@ namespace Rubberduck.Parsing.VBA
             catch (Exception exception)
             {
                 Logger.Error(exception, "Unexpected exception thrown in parsing run. (thread {0}).", Thread.CurrentThread.ManagedThreadId);
-                if (!(_parserStateManager.OverallParserState >= ParserState.Error))
+                if (_parserStateManager.OverallParserState != ParserState.UnexpectedError)
                 {
-                    _parserStateManager.SetStatusAndFireStateChanged(this, ParserState.Error, token);
+                    _parserStateManager.SetStatusAndFireStateChanged(this, ParserState.UnexpectedError, token);
                 }
             }
             finally
@@ -337,7 +337,7 @@ namespace Rubberduck.Parsing.VBA
         {
             token.ThrowIfCancellationRequested();
 
-            _parserStateManager.SetStatusAndFireStateChanged(requestor, ParserState.Pending, token);
+            _parserStateManager.SetStatusAndFireStateChanged(requestor, ParserState.Started, token);
             token.ThrowIfCancellationRequested();
 
             _projectManager.RefreshProjects();

--- a/Rubberduck.Parsing/VBA/ParserState.cs
+++ b/Rubberduck.Parsing/VBA/ParserState.cs
@@ -4,9 +4,13 @@ namespace Rubberduck.Parsing.VBA
     public enum ParserState
     {
         /// <summary>
-        /// Parse was requested but hasn't started yet.
+        /// Parse has not been requested or has not started yet.
         /// </summary>
         Pending,
+        /// <summary>
+        /// Parse has started and is in the coordination phase.
+        /// </summary>
+        Started,
         /// <summary>
         /// Project references are being loaded into parser state.
         /// </summary>
@@ -43,6 +47,10 @@ namespace Rubberduck.Parsing.VBA
         /// Parsing completed, but identifier references could not be resolved for one or more modules.
         /// </summary>
         ResolverError,
+        /// <summary>
+        /// Unexpected exception has been encountered during a parse.
+        /// </summary>
+        UnexpectedError,
         /// <summary>
         /// This component doesn't need a state.  Use for built-in declarations.
         /// </summary>

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -402,6 +402,10 @@ namespace Rubberduck.Parsing.VBA
             }
 
             // error state takes precedence over every other state
+            if (stateCounts[(int)ParserState.UnexpectedError] > 0)
+            {
+                return ParserState.UnexpectedError;
+            }
             if (stateCounts[(int)ParserState.Error] > 0)
             {
                 return ParserState.Error;


### PR DESCRIPTION
This PR introduces two new values in `ParserState`: `Started` and `UnexpectedError`.

`Started` gets set right after starting a parse, which makes it feel more responsive and prevents the user from requesting multiple parses by rapidly clicking the refresh button. (The `RequestParseCommand` is deactivated in this state.)

`UnexpactedError` gets set only whenever we encounter an unexpected exception while performing a parsing run. This indicates to the user that something has gone wrong they probably cannot do something about. (The `RequestParseCommand` is actiated in this state.)

I hope I did not forget anything that needed to get changed after adding the states. 
The french translation for the states is currenlty missing. 

Closes #3779
Closes #2816