### PR TITLE
Cancel inspections

### DIFF
--- a/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
+++ b/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
@@ -102,7 +102,7 @@ namespace Rubberduck.UI.Inspections
         {            
             if (e.InspectionSettingsChanged)
             {
-                RefreshInspections();
+                RefreshInspections(CancellationToken.None);
             }
             _runInspectionsOnReparse = e.RunInspectionsOnReparse;
         }
@@ -269,7 +269,7 @@ namespace Rubberduck.UI.Inspections
         }
 
         private bool _runInspectionsOnReparse;
-        private void HandleStateChanged(object sender, EventArgs e)
+        private void HandleStateChanged(object sender, ParserStateEventArgs e)
         {
             if(!IsRefreshing && (_state.Status == ParserState.Pending || _state.Status == ParserState.Error || _state.Status == ParserState.ResolverError))
             {
@@ -284,16 +284,27 @@ namespace Rubberduck.UI.Inspections
 
             if (_runInspectionsOnReparse || IsRefreshing)
             {
-                RefreshInspections();
+                RefreshInspections(e.Token);
             }
         }
 
-        private async void RefreshInspections()
+        private async void RefreshInspections(CancellationToken token)
         {
             var stopwatch = Stopwatch.StartNew();
             IsBusy = true;
 
-            var results = (await _inspector.FindIssuesAsync(_state, CancellationToken.None)).ToList();
+            List<IInspectionResult> results;
+            try
+            {
+                var inspectionResults = await _inspector.FindIssuesAsync(_state, token);
+                results = inspectionResults.ToList();
+            }
+            catch (OperationCanceledException)
+            {
+                Logger.Debug("Inspections got canceled.");
+                return; //We throw away the partial results.
+            }
+
             if (GroupByInspectionType)
             {
                 results = results.OrderBy(o => o.Inspection.InspectionType)

--- a/Rubberduck.Inspections/Inspector.cs
+++ b/Rubberduck.Inspections/Inspector.cs
@@ -61,23 +61,27 @@ namespace Rubberduck.Inspections
                 {
                     return new IInspectionResult[] { };
                 }
+                token.ThrowIfCancellationRequested();
 
                 state.OnStatusMessageUpdate(RubberduckUI.CodeInspections_Inspecting);
                 var allIssues = new ConcurrentBag<IInspectionResult>();
+                token.ThrowIfCancellationRequested();
 
                 var config = _configService.LoadConfiguration();
                 UpdateInspectionSeverity(config);
+                token.ThrowIfCancellationRequested();
 
                 var parseTreeInspections = _inspections
                     .Where(inspection => inspection.Severity != CodeInspectionSeverity.DoNotShow)
                     .OfType<IParseTreeInspection>()
                     .ToArray();
+                token.ThrowIfCancellationRequested();
 
-                foreach(var listener in parseTreeInspections.Select(inspection => inspection.Listener))
+                foreach (var listener in parseTreeInspections.Select(inspection => inspection.Listener))
                 {
                     listener.ClearContexts();
                 }
-                
+
                 // Prepare ParseTreeWalker based inspections
                 var passes = Enum.GetValues(typeof (ParsePass)).Cast<ParsePass>();
                 foreach (var parsePass in passes)
@@ -91,8 +95,10 @@ namespace Rubberduck.Inspections
                         LogManager.GetCurrentClassLogger().Warn(e);
                     }
                 }
+                token.ThrowIfCancellationRequested();
 
                 var inspectionsToRun = _inspections.Where(inspection => inspection.Severity != CodeInspectionSeverity.DoNotShow);
+                token.ThrowIfCancellationRequested();
 
                 try
                 {
@@ -102,12 +108,17 @@ namespace Rubberduck.Inspections
                 {
                     if (exception.Flatten().InnerExceptions.All(ex => ex is OperationCanceledException))
                     {
-                        LogManager.GetCurrentClassLogger().Debug("Inspections got canceled.");
+                        //This eliminates the stack trace, but for the cancellation, this is irrelevant.
+                        throw exception.InnerException ?? exception;
                     }
                     else
                     {
                         LogManager.GetCurrentClassLogger().Error(exception);
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {
@@ -137,20 +148,26 @@ namespace Rubberduck.Inspections
 
                 Parallel.ForEach(inspectionsToRun,
                     options,
-                    inspection => RunInspection(inspection, allIssues)
+                    inspection => RunInspection(inspection, allIssues, token)
                 );
             }
 
-            private static void RunInspection(IInspection inspection, ConcurrentBag<IInspectionResult> allIssues)
+            private static void RunInspection(IInspection inspection, ConcurrentBag<IInspectionResult> allIssues, CancellationToken token)
             {
                 try
                 {
                     var inspectionResults = inspection.GetInspectionResults();
 
+                    token.ThrowIfCancellationRequested();
+
                     foreach (var inspectionResult in inspectionResults)
                     {
                         allIssues.Add(inspectionResult);
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {

--- a/Rubberduck.Parsing/IParseResultProvider.cs
+++ b/Rubberduck.Parsing/IParseResultProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor;
 
@@ -6,19 +7,17 @@ namespace Rubberduck.Parsing
 {
     public class ParseProgressEventArgs : EventArgs
     {
-        private readonly QualifiedModuleName _module;
-        private readonly ParserState _state;
-        private readonly ParserState _oldState;
-
-        public ParseProgressEventArgs(QualifiedModuleName module, ParserState state, ParserState oldState)
+        public ParseProgressEventArgs(QualifiedModuleName module, ParserState state, ParserState oldState, CancellationToken token)
         {
-            _module = module;
-            _state = state;
-            _oldState = oldState;
+            Module = module;
+            State = state;
+            OldState = oldState;
+            Token = token;
         }
 
-        public QualifiedModuleName Module { get { return _module; } }
-        public ParserState State { get { return _state; } }
-        public ParserState OldState { get { return _oldState; } }
+        public QualifiedModuleName Module { get; }
+        public ParserState State { get; }
+        public ParserState OldState { get; }
+        public CancellationToken Token { get; }
     }
 }

--- a/Rubberduck.Parsing/VBA/ParserStateManagerBase.cs
+++ b/Rubberduck.Parsing/VBA/ParserStateManagerBase.cs
@@ -38,7 +38,7 @@ namespace Rubberduck.Parsing.VBA
 
         public void EvaluateOverallParserState(CancellationToken token)
         {
-            _state.EvaluateParserState();
+            _state.EvaluateParserState(token);
         }
 
         public void SetModuleState(QualifiedModuleName module, ParserState parserState, CancellationToken token, bool evaluateOverallParserState = true)
@@ -48,7 +48,7 @@ namespace Rubberduck.Parsing.VBA
 
         public void SetStatusAndFireStateChanged(object requestor, ParserState status, CancellationToken token)
         {
-            _state.SetStatusAndFireStateChanged(requestor, status);
+            _state.SetStatusAndFireStateChanged(requestor, status, token);
         }
     }
 }

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -17,6 +17,7 @@ using Rubberduck.Parsing.Symbols.ParsingExceptions;
 using Rubberduck.VBEditor.Application;
 using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
+using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 // ReSharper disable LoopCanBeConvertedToQuery
@@ -697,20 +698,19 @@ namespace Rubberduck.Parsing.VBA
                 foreach (var moduleState in _moduleStates.Where(moduleState => moduleState.Key.ProjectId == projectId))
                 {
                     var qualifiedModuleName = moduleState.Key;
-                    var component = ProjectsProvider.Component(moduleState.Key);
-                    if (component != null)
+                    if (qualifiedModuleName.ComponentType == ComponentType.Undefined && qualifiedModuleName.ComponentType == ComponentType.ComComponent)
                     {
-                        while (!ClearStateCache(qualifiedModuleName))
+                        if (_moduleStates.TryRemove(qualifiedModuleName, out var state))
                         {
-                            // until Hell freezes over?
+                            state.Dispose();
                         }
                     }
                     else
                     {
-                        // store project module name
-                        if (_moduleStates.TryRemove(qualifiedModuleName, out var state))
+                        //This should be a user component.
+                        while (!ClearStateCache(qualifiedModuleName))
                         {
-                            state.Dispose();
+                            // until Hell freezes over?
                         }
                     }
                 }


### PR DESCRIPTION
This PR sets up cancellation of the inspections whenever a new parse is requested before they finish.

I chose to simply discard all partial results. 

In addition, I removed a rather useless use of the `ProjectsRepository` in `RubberduckParserState.ClearStateCache`.