### PR TITLE
fix VBETypeLibsAPI_Object as exposed via AddIns("Rubberduck.Extension").Object

### DIFF
--- a/Rubberduck.VBEEditor/ComManagement/TypeLibs/TypeLibsAPI.cs
+++ b/Rubberduck.VBEEditor/ComManagement/TypeLibs/TypeLibsAPI.cs
@@ -22,13 +22,11 @@ namespace Rubberduck.VBEditor.ComManagement.TypeLibsAPI
         private IVBE _ide;
         private readonly VBETypeLibsAPI _api;
 
-        public VBETypeLibsAPI_Object()
+        public VBETypeLibsAPI_Object(IVBE ide)
         {
+            _ide = ide;
             _api = new VBETypeLibsAPI();
         }
-
-        public VBETypeLibsAPI_Object(IVBE ide) 
-            => _ide = ide;
 
         public bool CompileProject(string projectName) 
             => _api.CompileProject(_ide, projectName);


### PR DESCRIPTION
fix VBETypeLibsAPI_Object as exposed via Application.VBE.AddIns("Rubberduck.Extension").Object

broken since changes in PR #3783