### PR TITLE
Compile before parse fix

### DIFF
--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -501,6 +501,8 @@
     <Compile Include="UnitTesting\Stubs\Beep.cs" />
     <Compile Include="UnitTesting\IStub.cs" />
     <Compile Include="UnitTesting\StubBase.cs" />
+    <Compile Include="VBERuntime\IVBESettings.cs" />
+    <Compile Include="VBERuntime\VBESettings.cs" />
     <Compile Include="VersionCheck\IVersionCheck.cs" />
     <Compile Include="UI\Command\MenuItems\CommandBars\AppCommandBarBase.cs" />
     <Compile Include="UI\Command\MenuItems\CommandBars\ContextSelectionLabelMenuItem.cs" />

--- a/RetailCoder.VBE/Rubberduck.csproj
+++ b/RetailCoder.VBE/Rubberduck.csproj
@@ -501,6 +501,7 @@
     <Compile Include="UnitTesting\Stubs\Beep.cs" />
     <Compile Include="UnitTesting\IStub.cs" />
     <Compile Include="UnitTesting\StubBase.cs" />
+    <Compile Include="VBERuntime\RegistryWrapper.cs" />
     <Compile Include="VBERuntime\IVBESettings.cs" />
     <Compile Include="VBERuntime\VBESettings.cs" />
     <Compile Include="VersionCheck\IVersionCheck.cs" />

--- a/RetailCoder.VBE/UI/Command/ReparseCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ReparseCommand.cs
@@ -54,7 +54,7 @@ namespace Rubberduck.UI.Command
                     return;
                 }
 
-                if (CompileAllProjects(out var failedNames))
+                if (AreAllProjectsCompiled(out var failedNames))
                 {
                     if (!PromptUserToContinue(failedNames))
                     {
@@ -67,8 +67,6 @@ namespace Rubberduck.UI.Command
 
         private bool VerifyCompileOnDemand()
         {
-            //Command_Reparse_CompileOnDemandEnabled
-
             if (_vbeSettings.CompileOnDemand)
             {
                 return DialogResult.Yes == _messageBox.Show(RubberduckUI.Command_Reparse_CompileOnDemandEnabled,
@@ -79,7 +77,7 @@ namespace Rubberduck.UI.Command
             return true;
         }
 
-        private bool CompileAllProjects(out List<string> failedNames)
+        private bool AreAllProjectsCompiled(out List<string> failedNames)
         {
             failedNames = new List<string>();
             using (var projects = _vbe.VBProjects)

--- a/RetailCoder.VBE/UI/Command/SettingsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/SettingsCommand.cs
@@ -12,19 +12,19 @@ namespace Rubberduck.UI.Command
     [ComVisible(false)]
     public class SettingsCommand : CommandBase
     {
-        private readonly IGeneralConfigService _service;
-        private readonly IOperatingSystem _operatingSystem;
-        public SettingsCommand(IGeneralConfigService service, IOperatingSystem operatingSystem) : base(LogManager.GetCurrentClassLogger())
+        private readonly ISettingsFormFactory _settingsFormFactory;
+
+        public SettingsCommand(ISettingsFormFactory settingsFormFactory) : base(LogManager.GetCurrentClassLogger())
         {
-            _service = service;
-            _operatingSystem = operatingSystem;
+            _settingsFormFactory = settingsFormFactory;
         }
 
         protected override void OnExecute(object parameter)
         {
-            using (var window = new SettingsForm(_service, _operatingSystem))
+            using (var window = _settingsFormFactory.Create())
             {
                 window.ShowDialog();
+                _settingsFormFactory.Release(window);
             }
         }
     }

--- a/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
+++ b/RetailCoder.VBE/UI/Inspections/InspectionResultsViewModel.cs
@@ -40,13 +40,13 @@ namespace Rubberduck.UI.Inspections
         private readonly IQuickFixProvider _quickFixProvider;
         private readonly IClipboardWriter _clipboard;
         private readonly IGeneralConfigService _configService;
-        private readonly IOperatingSystem _operatingSystem;
+        private readonly ISettingsFormFactory _settingsFormFactory;
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         public InspectionResultsViewModel(RubberduckParserState state, IInspector inspector, IQuickFixProvider quickFixProvider,
             INavigateCommand navigateCommand, ReparseCommand reparseCommand,
-            IClipboardWriter clipboard, IGeneralConfigService configService, IOperatingSystem operatingSystem)
+            IClipboardWriter clipboard, IGeneralConfigService configService, ISettingsFormFactory settingsFormFactory)
         {
             _state = state;
             _inspector = inspector;
@@ -54,7 +54,7 @@ namespace Rubberduck.UI.Inspections
             NavigateCommand = navigateCommand;
             _clipboard = clipboard;
             _configService = configService;
-            _operatingSystem = operatingSystem;
+            _settingsFormFactory = settingsFormFactory;
             RefreshCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(),
                 o =>
                 {
@@ -238,9 +238,10 @@ namespace Rubberduck.UI.Inspections
 
         private void OpenSettings(object param)
         {
-            using (var window = new SettingsForm(_configService, _operatingSystem, SettingsViews.InspectionSettings))
+            using (var window = _settingsFormFactory.Create())
             {
                 window.ShowDialog();
+                _settingsFormFactory.Release(window);
             }
         }
 

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -1160,6 +1160,24 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The VBEsetting &quot;Compile On Demand&quot; is currently enabled. This is not recommended as this may hide compilation errors and cause problems with parsing. Do you want to parse anyway?.
+        /// </summary>
+        public static string Command_Reparse_CompileOnDemandEnabled {
+            get {
+                return ResourceManager.GetString("Command_Reparse_CompileOnDemandEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Compile On Demand Setting.
+        /// </summary>
+        public static string Command_Reparse_CompileOnDemandEnabled_Caption {
+            get {
+                return ResourceManager.GetString("Command_Reparse_CompileOnDemandEnabled_Caption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Code Explorer.
         /// </summary>
         public static string CommandDescription_CodeExplorerCommand {
@@ -1993,6 +2011,24 @@ namespace Rubberduck.UI {
         public static string GeneralSettings_CompileBeforeParse {
             get {
                 return ResourceManager.GetString("GeneralSettings_CompileBeforeParse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The VBE setting &quot;Compile On Demand&quot; is currently enabled. It is strongly recommended that you disable the setting via the VBE Properties dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?\r\n\r\nNOTE: Restart may be required for setting to take effect..
+        /// </summary>
+        public static string GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled {
+            get {
+                return ResourceManager.GetString("GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Compile On Demand currently enabled.
+        /// </summary>
+        public static string GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption {
+            get {
+                return ResourceManager.GetString("GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption", resourceCulture);
             }
         }
         

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -2017,7 +2017,7 @@ namespace Rubberduck.UI {
         /// <summary>
         ///   Looks up a localized string similar to The VBE setting &quot;Compile On Demand&quot; is currently enabled. It is strongly recommended that you disable the setting via the VBE Options dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?
         ///
-        ///NOTE: Restart may be required for setting to take effect..
+        ///NOTE: Restart is required for the setting to take effect..
         /// </summary>
         public static string GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled {
             get {

--- a/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
+++ b/RetailCoder.VBE/UI/RubberduckUI.Designer.cs
@@ -2015,7 +2015,9 @@ namespace Rubberduck.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The VBE setting &quot;Compile On Demand&quot; is currently enabled. It is strongly recommended that you disable the setting via the VBE Properties dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?\r\n\r\nNOTE: Restart may be required for setting to take effect..
+        ///   Looks up a localized string similar to The VBE setting &quot;Compile On Demand&quot; is currently enabled. It is strongly recommended that you disable the setting via the VBE Options dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?
+        ///
+        ///NOTE: Restart may be required for setting to take effect..
         /// </summary>
         public static string GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled {
             get {

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -1802,7 +1802,9 @@ Would you like to import them to Rubberduck?</value>
     <value>Compile On Demand Setting</value>
   </data>
   <data name="GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled" xml:space="preserve">
-    <value>The VBE setting "Compile On Demand" is currently enabled. It is strongly recommended that you disable the setting via the VBE Properties dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?\r\n\r\nNOTE: Restart may be required for setting to take effect.</value>
+    <value>The VBE setting "Compile On Demand" is currently enabled. It is strongly recommended that you disable the setting via the VBE Options dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?
+
+NOTE: Restart may be required for setting to take effect.</value>
   </data>
   <data name="GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption" xml:space="preserve">
     <value>Compile On Demand currently enabled</value>

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -1795,4 +1795,16 @@ Would you like to import them to Rubberduck?</value>
   <data name="ParserState_UnexpectedError" xml:space="preserve">
     <value>Unexpected Error</value>
   </data>
+  <data name="Command_Reparse_CompileOnDemandEnabled" xml:space="preserve">
+    <value>The VBEsetting "Compile On Demand" is currently enabled. This is not recommended as this may hide compilation errors and cause problems with parsing. Do you want to parse anyway?</value>
+  </data>
+  <data name="Command_Reparse_CompileOnDemandEnabled_Caption" xml:space="preserve">
+    <value>Compile On Demand Setting</value>
+  </data>
+  <data name="GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled" xml:space="preserve">
+    <value>The VBE setting "Compile On Demand" is currently enabled. It is strongly recommended that you disable the setting via the VBE Properties dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?\r\n\r\nNOTE: Restart may be required for setting to take effect.</value>
+  </data>
+  <data name="GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption" xml:space="preserve">
+    <value>Compile On Demand currently enabled</value>
+  </data>
 </root>

--- a/RetailCoder.VBE/UI/RubberduckUI.resx
+++ b/RetailCoder.VBE/UI/RubberduckUI.resx
@@ -1804,7 +1804,7 @@ Would you like to import them to Rubberduck?</value>
   <data name="GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled" xml:space="preserve">
     <value>The VBE setting "Compile On Demand" is currently enabled. It is strongly recommended that you disable the setting via the VBE Options dialog under General tab in order to use the Compile Before Parse feature. Do you want to disable it now?
 
-NOTE: Restart may be required for setting to take effect.</value>
+NOTE: Restart is required for the setting to take effect.</value>
   </data>
   <data name="GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption" xml:space="preserve">
     <value>Compile On Demand currently enabled</value>

--- a/RetailCoder.VBE/UI/Settings/GeneralSettingsViewModel.cs
+++ b/RetailCoder.VBE/UI/Settings/GeneralSettingsViewModel.cs
@@ -133,7 +133,6 @@ namespace Rubberduck.UI.Settings
         }
 
         private bool _compileBeforeParse;
-
         public bool CompileBeforeParse
         {
             get => _compileBeforeParse;
@@ -146,20 +145,31 @@ namespace Rubberduck.UI.Settings
 
                 if (value && _vbeSettings.CompileOnDemand)
                 {
-                    var result = _messageBox.Show(RubberduckUI.GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled,
-                        RubberduckUI.GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption, MessageBoxButtons.YesNo,
-                        MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1);
-                    if(result == DialogResult.No)
+                    if(!SynchronizeVBESettings())
                     {
                         return;
                     }
-
-                    _vbeSettings.CompileOnDemand = false;
                 }
 
                 _compileBeforeParse = value;
                 OnPropertyChanged();
             }
+        }
+
+        private bool SynchronizeVBESettings()
+        {
+            var result = _messageBox.Show(RubberduckUI.GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled,
+                RubberduckUI.GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption, MessageBoxButtons.YesNo,
+                MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1);
+
+            if (result == DialogResult.No)
+            {
+                return false;
+            }
+
+            _vbeSettings.CompileOnDemand = false;
+            _vbeSettings.BackGroundCompile = false;
+            return true;
         }
 
         private int _autoSavePeriod;

--- a/RetailCoder.VBE/UI/Settings/GeneralSettingsViewModel.cs
+++ b/RetailCoder.VBE/UI/Settings/GeneralSettingsViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows.Forms;
 using Rubberduck.Settings;
 using Rubberduck.Common;
 using NLog;
@@ -9,6 +10,7 @@ using Rubberduck.Parsing.Common;
 using Rubberduck.Root;
 using Rubberduck.SettingsProvider;
 using Rubberduck.UI.Command;
+using Rubberduck.VBERuntime;
 
 namespace Rubberduck.UI.Settings
 {
@@ -21,11 +23,17 @@ namespace Rubberduck.UI.Settings
     public class GeneralSettingsViewModel : SettingsViewModelBase, ISettingsViewModel
     {
         private readonly IOperatingSystem _operatingSystem;
+        private readonly IMessageBox _messageBox;
+        private readonly IVBESettings _vbeSettings;
+
         private bool _indenterPrompted;
 
-        public GeneralSettingsViewModel(Configuration config, IOperatingSystem operatingSystem)
+        public GeneralSettingsViewModel(Configuration config, IOperatingSystem operatingSystem, IMessageBox messageBox, IVBESettings vbeSettings)
         {
             _operatingSystem = operatingSystem;
+            _messageBox = messageBox;
+            _vbeSettings = vbeSettings;
+
             Languages = new ObservableCollection<DisplayLanguageSetting>(
                 new[] 
             {
@@ -131,11 +139,26 @@ namespace Rubberduck.UI.Settings
             get => _compileBeforeParse;
             set
             {
-                if (_compileBeforeParse != value)
+                if (_compileBeforeParse == value)
                 {
-                    _compileBeforeParse = value;
-                    OnPropertyChanged();
+                    return;
                 }
+
+                if (value && _vbeSettings.CompileOnDemand)
+                {
+                    var result = _messageBox.Show(RubberduckUI.GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled,
+                        RubberduckUI.GeneralSettings_CompileBeforeParse_WarnCompileOnDemandEnabled_Caption, MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1);
+                    if(result == DialogResult.No)
+                    {
+                        return;
+                    }
+
+                    _vbeSettings.CompileOnDemand = false;
+                }
+
+                _compileBeforeParse = value;
+                OnPropertyChanged();
             }
         }
 

--- a/RetailCoder.VBE/UI/Settings/SettingsForm.cs
+++ b/RetailCoder.VBE/UI/Settings/SettingsForm.cs
@@ -1,9 +1,16 @@
 ﻿using System.Windows.Forms;
 using Rubberduck.Settings;
 using Rubberduck.Common;
+using Rubberduck.VBERuntime;
 
 namespace Rubberduck.UI.Settings
 {
+    public interface ISettingsFormFactory
+    {
+        SettingsForm Create();
+        void Release(SettingsForm form);
+    }
+
     public partial class SettingsForm : Form
     {
         public SettingsForm()
@@ -11,7 +18,7 @@ namespace Rubberduck.UI.Settings
             InitializeComponent();
         }
 
-        public SettingsForm(IGeneralConfigService configService, IOperatingSystem operatingSystem, SettingsViews activeView = SettingsViews.GeneralSettings) : this()
+        public SettingsForm(IGeneralConfigService configService, IOperatingSystem operatingSystem, IMessageBox messageBox, IVBESettings vbeSettings, SettingsViews activeView = SettingsViews.GeneralSettings) : this()
         {
             var config = configService.LoadConfiguration();
 
@@ -19,7 +26,7 @@ namespace Rubberduck.UI.Settings
                 config,
                 new SettingsView
                 {
-                    Control = new GeneralSettings(new GeneralSettingsViewModel(config, operatingSystem)),
+                    Control = new GeneralSettings(new GeneralSettingsViewModel(config, operatingSystem, messageBox, vbeSettings)),
                     View = SettingsViews.GeneralSettings
                 },
                 new SettingsView

--- a/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/RetailCoder.VBE/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -21,13 +21,13 @@ namespace Rubberduck.UI.ToDoItems
     {
         private readonly RubberduckParserState _state;
         private readonly IGeneralConfigService _configService;
-        private readonly IOperatingSystem _operatingSystem;
+        private readonly ISettingsFormFactory _settingsFormFactory;
 
-        public ToDoExplorerViewModel(RubberduckParserState state, IGeneralConfigService configService, IOperatingSystem operatingSystem)
+        public ToDoExplorerViewModel(RubberduckParserState state, IGeneralConfigService configService, ISettingsFormFactory settingsFormFactory)
         {
             _state = state;
             _configService = configService;
-            _operatingSystem = operatingSystem;
+            _settingsFormFactory = settingsFormFactory;
             _state.StateChanged += HandleStateChanged;
 
             SetMarkerGroupingCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), param =>
@@ -222,9 +222,10 @@ namespace Rubberduck.UI.ToDoItems
                 }
                 return _openTodoSettings = new DelegateCommand(LogManager.GetCurrentClassLogger(), _ =>
                 {
-                    using (var window = new SettingsForm(_configService, _operatingSystem, SettingsViews.TodoSettings))
+                    using (var window = _settingsFormFactory.Create())
                     {
                         window.ShowDialog();
+                        _settingsFormFactory.Release(window);
                     }
                 });
             }

--- a/RetailCoder.VBE/UI/UnitTesting/TestExplorerViewModel.cs
+++ b/RetailCoder.VBE/UI/UnitTesting/TestExplorerViewModel.cs
@@ -21,8 +21,9 @@ namespace Rubberduck.UI.UnitTesting
         private readonly RubberduckParserState _state;
         private readonly ITestEngine _testEngine;
         private readonly IClipboardWriter _clipboard;
-        private readonly IGeneralConfigService _configService;
-        private readonly IOperatingSystem _operatingSystem;
+        private readonly ISettingsFormFactory _settingsFormFactory;
+        //private readonly IGeneralConfigService _configService;
+        //private readonly IOperatingSystem _operatingSystem;
 
         public TestExplorerViewModel(IVBE vbe,
              RubberduckParserState state,
@@ -30,7 +31,7 @@ namespace Rubberduck.UI.UnitTesting
              TestExplorerModel model,
              IClipboardWriter clipboard,
              IGeneralConfigService configService,
-             IOperatingSystem operatingSystem)
+             ISettingsFormFactory settingsFormFactory)
         {
             _vbe = vbe;
             _state = state;
@@ -38,8 +39,7 @@ namespace Rubberduck.UI.UnitTesting
             _testEngine.TestCompleted += TestEngineTestCompleted;
             Model = model;
             _clipboard = clipboard;
-            _configService = configService;
-            _operatingSystem = operatingSystem;
+            _settingsFormFactory = settingsFormFactory;
 
             _navigateCommand = new NavigateCommand(_state.ProjectsProvider);
 
@@ -196,9 +196,10 @@ namespace Rubberduck.UI.UnitTesting
 
         private void OpenSettings(object param)
         {
-            using (var window = new SettingsForm(_configService, _operatingSystem, SettingsViews.UnitTestSettings))
+            using (var window = _settingsFormFactory.Create())
             {
                 window.ShowDialog();
+                _settingsFormFactory.Release(window);
             }
         }
 

--- a/RetailCoder.VBE/VBERuntime/IVBESettings.cs
+++ b/RetailCoder.VBE/VBERuntime/IVBESettings.cs
@@ -1,0 +1,9 @@
+﻿namespace Rubberduck.VBERuntime
+{
+    public interface IVBESettings
+    {
+        VBESettings.DllVersion Version { get; }
+        bool CompileOnDemand { get; set; }
+        bool BackGroundCompile { get; set; }
+    }
+}

--- a/RetailCoder.VBE/VBERuntime/RegistryWrapper.cs
+++ b/RetailCoder.VBE/VBERuntime/RegistryWrapper.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Win32;
+
+namespace Rubberduck.VBERuntime
+{
+    public interface IRegistryWrapper
+    {
+        object GetValue(string keyName, string valueName, object defaultValue);
+        void SetValue(string keyName, string valueName, object value, RegistryValueKind valueKind);
+    }
+
+    public class RegistryWrapper : IRegistryWrapper
+    {
+        public object GetValue(string keyName, string valueName, object defaultValue)
+        {
+            return Registry.GetValue(keyName, valueName, defaultValue);
+        }
+
+        public void SetValue(string keyName, string valueName, object value, RegistryValueKind valueKind)
+        {
+            Registry.SetValue(keyName, valueName, value, valueKind);
+        }
+    }
+}

--- a/RetailCoder.VBE/VBERuntime/VBESettings.cs
+++ b/RetailCoder.VBE/VBERuntime/VBESettings.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.Win32;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBERuntime
+{
+    public class VBESettings : IVBESettings
+    {
+        private const string Vbe7SettingPath = @"HKEY_CURRENT_USER\Software\Microsoft\VBA\7.0\Common";
+        private const string Vbe6SettingPath = @"HKEY_CURRENT_USER\Software\Microsoft\VBA\6.0\Common";
+
+        public enum DllVersion
+        {
+            Unknown,
+            Vbe6,
+            Vbe7
+        }
+
+        private readonly string _registryRootPath;
+
+        public VBESettings(IVBE vbe)
+        {
+            try
+            {
+                switch (Convert.ToInt32(decimal.Parse(vbe.Version)))
+                {
+                    case 6:
+                        Version = DllVersion.Vbe6;
+                        _registryRootPath = Vbe6SettingPath;
+                        break;
+                    case 7:
+                        Version = DllVersion.Vbe7;
+                        _registryRootPath = Vbe7SettingPath;
+                        break;
+                    default:
+                        Version = DllVersion.Unknown;
+                        break;
+                }
+            }
+            catch
+            {
+                Version = DllVersion.Unknown;
+                _registryRootPath = null;
+            }
+        }
+
+        public DllVersion Version { get; }
+
+        public bool CompileOnDemand
+        {
+            get => DWordToBooleanConverter(nameof(CompileOnDemand));
+            set => BooleanToDWordConverter(nameof(CompileOnDemand), value);
+        }
+
+        public bool BackGroundCompile
+        {
+            get => DWordToBooleanConverter(nameof(BackGroundCompile));
+            set => BooleanToDWordConverter(nameof(BackGroundCompile), value);
+        }
+
+        private const int DWordTrueValue = 1;
+        private const int DWordFalseValue = 0;
+
+        private bool DWordToBooleanConverter(string keyName)
+        {
+            var result = Registry.GetValue(_registryRootPath, keyName, DWordFalseValue) as int?;
+            return Convert.ToBoolean(result ?? DWordFalseValue);
+        }
+
+        private void BooleanToDWordConverter(string keyName, bool value)
+        {
+            Registry.SetValue(_registryRootPath, keyName, value ? DWordTrueValue : DWordFalseValue, RegistryValueKind.DWord);
+        }
+    }
+}

--- a/RetailCoder.VBE/VBERuntime/VBESettings.cs
+++ b/RetailCoder.VBE/VBERuntime/VBESettings.cs
@@ -16,10 +16,11 @@ namespace Rubberduck.VBERuntime
             Vbe7
         }
 
+        private readonly IRegistryWrapper _registry;
         private readonly string _activeRegistryRootPath;
         private readonly string[] _registryRootPaths = {Vbe7SettingPath, Vbe6SettingPath};
 
-        public VBESettings(IVBE vbe)
+        public VBESettings(IVBE vbe, IRegistryWrapper registry)
         {
             try
             {
@@ -43,6 +44,7 @@ namespace Rubberduck.VBERuntime
                 Version = DllVersion.Unknown;
                 _activeRegistryRootPath = null;
             }
+            _registry = registry;
         }
 
         public DllVersion Version { get; }
@@ -80,14 +82,14 @@ namespace Rubberduck.VBERuntime
 
         private bool? DWordToBooleanConverter(string path, string keyName)
         {
-            return !(Registry.GetValue(path, keyName, DWordFalseValue) is int result)
+            return !(_registry.GetValue(path, keyName, DWordFalseValue) is int result)
                 ? (bool?) null
                 : Convert.ToBoolean(result);
         }
 
         private void BooleanToDWordConverter(string path, string keyName, bool value)
         {
-            Registry.SetValue(path, keyName, value ? DWordTrueValue : DWordFalseValue, RegistryValueKind.DWord);
+            _registry.SetValue(path, keyName, value ? DWordTrueValue : DWordFalseValue, RegistryValueKind.DWord);
         }
     }
 }

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -305,6 +305,7 @@
     <Compile Include="UnitTesting\EngineTests.cs" />
     <Compile Include="UnitTesting\DiscoveryTests.cs" />
     <Compile Include="UnitTesting\ViewModelTests.cs" />
+    <Compile Include="VBE\VBESettingsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/RubberduckTests/Settings/GeneralSettingsTests.cs
+++ b/RubberduckTests/Settings/GeneralSettingsTests.cs
@@ -7,6 +7,7 @@ using GeneralSettings = Rubberduck.Settings.GeneralSettings;
 using Rubberduck.Common;
 using Moq;
 using Rubberduck.UI;
+using Rubberduck.VBERuntime;
 
 namespace RubberduckTests.Settings
 {
@@ -16,6 +17,16 @@ namespace RubberduckTests.Settings
         private Mock<IOperatingSystem> GetOperatingSystemMock()
         {
             return new Mock<IOperatingSystem>();
+        }
+
+        private Mock<IMessageBox> GetMessageBoxMock()
+        {
+            return new Mock<IMessageBox>();
+        }
+
+        private Mock<IVBESettings> GetVBESettingsMock()
+        {
+            return new Mock<IVBESettings>();
         }
 
         private Configuration GetDefaultConfig()
@@ -70,7 +81,7 @@ namespace RubberduckTests.Settings
         public void SaveConfigWorks()
         {
             var customConfig = GetNondefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(customConfig, GetOperatingSystemMock().Object);
+            var viewModel = new GeneralSettingsViewModel(customConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object);
 
             var config = GetDefaultConfig();
             viewModel.UpdateConfig(config);
@@ -88,7 +99,7 @@ namespace RubberduckTests.Settings
         [Test]
         public void SetDefaultsWorks()
         {
-            var viewModel = new GeneralSettingsViewModel(GetNondefaultConfig(), GetOperatingSystemMock().Object);
+            var viewModel = new GeneralSettingsViewModel(GetNondefaultConfig(), GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object);
 
             var defaultConfig = GetDefaultConfig();
             viewModel.SetToDefaults(defaultConfig);
@@ -107,7 +118,7 @@ namespace RubberduckTests.Settings
         public void LanguageIsSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object);
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object);
 
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.Language, viewModel.SelectedLanguage);
         }
@@ -117,7 +128,7 @@ namespace RubberduckTests.Settings
         public void HotkeysAreSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object);
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object);
 
             Assert.IsTrue(defaultConfig.UserSettings.HotkeySettings.Settings.SequenceEqual(viewModel.Hotkeys));
         }
@@ -127,7 +138,7 @@ namespace RubberduckTests.Settings
         public void AutoSaveEnabledIsSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object);
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object);
 
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.IsAutoSaveEnabled, viewModel.AutoSaveEnabled);
         }
@@ -137,7 +148,7 @@ namespace RubberduckTests.Settings
         public void AutoSavePeriodIsSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object);
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object);
 
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.AutoSavePeriod, viewModel.AutoSavePeriod);
         }

--- a/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
+++ b/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
@@ -34,7 +34,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
+                var vm = new ToDoExplorerViewModel(state, cs, null);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -69,7 +69,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
+                var vm = new ToDoExplorerViewModel(state, cs, null);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -104,7 +104,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TO-DO", "N@TE", "BUG " });
-                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
+                var vm = new ToDoExplorerViewModel(state, cs, null);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -138,7 +138,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
+                var vm = new ToDoExplorerViewModel(state, cs, null);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -172,7 +172,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, GetOperatingSystemMock().Object);
+                var vm = new ToDoExplorerViewModel(state, cs, null);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)

--- a/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
+++ b/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
@@ -207,10 +207,5 @@ namespace RubberduckTests.TodoExplorer
             var userSettings = new UserSettings(null, null, todoSettings, null, null, null, null);
             return new Configuration(userSettings);
         }
-
-        private Mock<IOperatingSystem> GetOperatingSystemMock()
-        {
-            return new Mock<IOperatingSystem>();
-        }
     }
 }

--- a/RubberduckTests/VBE/VBESettingsTests.cs
+++ b/RubberduckTests/VBE/VBESettingsTests.cs
@@ -1,0 +1,84 @@
+﻿using NUnit.Framework;
+using Rubberduck.VBERuntime;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.VBE
+{
+    [TestFixture]
+    public class VBESettingsTests
+    {
+        [Category("VBE")]
+        [Test]
+        public void DllVersion_MustBe6()
+        {
+            var vbe = new MockVbeBuilder().Build();
+            vbe.SetupGet(s => s.Version).Returns("6.00");
+            var settings = new VBESettings(vbe.Object);
+
+            Assert.IsTrue(settings.Version == VBESettings.DllVersion.Vbe6);
+        }
+
+        [Category("VBE")]
+        [Test]
+        public void DllVersion_MustBe7()
+        {
+            var vbe = new MockVbeBuilder().Build();
+            vbe.SetupGet(s => s.Version).Returns("7.00");
+            var settings = new VBESettings(vbe.Object);
+
+            Assert.IsTrue(settings.Version == VBESettings.DllVersion.Vbe7);
+        }
+        
+        [Category("VBE")]
+        [Test]
+        public void DllVersion_IsBogus()
+        {
+            var vbe = new MockVbeBuilder().Build();
+            vbe.SetupGet(s => s.Version).Returns("foo");
+            var settings = new VBESettings(vbe.Object);
+
+            Assert.IsTrue(settings.Version == VBESettings.DllVersion.Unknown);
+        }
+
+        [Category("VBE")]
+        [Test]
+        public void DllVersion_IsNull()
+        {
+            var vbe = new MockVbeBuilder().Build();
+            vbe.SetupGet(s => s.Version).Returns((string)null);
+            var settings = new VBESettings(vbe.Object);
+
+            Assert.IsTrue(settings.Version == VBESettings.DllVersion.Unknown);
+        }
+
+        [Category("VBE")]
+        [Test]
+        public void CompileOnDemand_WriteRead()
+        {
+            var vbe = new MockVbeBuilder().Build();
+            vbe.SetupGet(s => s.Version).Returns("7.00");
+            var settings = new VBESettings(vbe.Object);
+
+            settings.CompileOnDemand = true;
+            Assert.IsTrue(settings.CompileOnDemand);
+
+            settings.CompileOnDemand = false;
+            Assert.IsTrue(settings.CompileOnDemand == false);
+        }
+
+        [Category("VBE")]
+        [Test]
+        public void BackGroundCompile_WriteRead()
+        {
+            var vbe = new MockVbeBuilder().Build();
+            vbe.SetupGet(s => s.Version).Returns("7.00");
+            var settings = new VBESettings(vbe.Object);
+
+            settings.BackGroundCompile = true;
+            Assert.IsTrue(settings.BackGroundCompile);
+
+            settings.BackGroundCompile = false;
+            Assert.IsTrue(settings.BackGroundCompile == false);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3807 

Introduces a new `VBESettings` class to provide some access to the VBE settings stored in the registry
Introduces a new `RegistryWrapper` class which aids testability for the registry operations; basically a stripped down version of the `Microsoft.Win32.Registry` static class.

Will now check that `Compile On Demand` is enabled during parsing and warn the user. Additionally, if the user enables the `Compile Before Parse` option via the general settings and the `Compile On Demand` is enabled, the user will be prompted whether they wish to update that. Unfortunately, it is necessary to restart to make the changes effective because in testing, VBE do not re-read the registry settings once it has loaded. As a consequence, a write to the registry will be inconsistent with what is shown in the Options dialog in the same session. For sake of keeping the implementation simple, I felt that was an acceptable trade-off.

Note also that `VBESettings` will attempt to write to all registry path, where they exist to keep the value consistent for different hosts. 

Furthermore, because of new dependencies added to the `GeneralSettingsViewModel` and `SettingsForm`, which required other consumers to know too much, I opted to use CW auto-magic factory for the class, to avoid forcing the other consumers to take on dependencies they do not even need. 