### PR TITLE
Fixed inspections and quick fixes registration in Castle Windsor

### DIFF
--- a/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
+++ b/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
@@ -244,8 +244,7 @@ namespace Rubberduck.Root
                 container.Register(Classes.FromAssembly(assembly)
                     .IncludeNonPublicTypes()
                     .Where(type => type.IsBasedOn(typeof(IQuickFix)) && type.NotDisabledExperimental(_initialSettings))
-                    .WithService.Base()
-                    .WithService.Self()
+                    .WithService.Select(new[] {typeof(IQuickFix)})
                     .LifestyleSingleton());
             }
         }
@@ -257,7 +256,7 @@ namespace Rubberduck.Root
                 container.Register(Classes.FromAssembly(assembly)
                     .IncludeNonPublicTypes()
                     .Where(type => type.IsBasedOn(typeof(IInspection)) && type.NotDisabledExperimental(_initialSettings))
-                    .WithService.Base()
+                    .WithService.Select(new[] { typeof(IInspection) })
                     .LifestyleTransient());
             }
         }
@@ -269,7 +268,6 @@ namespace Rubberduck.Root
                 container.Register(Classes.FromAssembly(assembly)
                     .IncludeNonPublicTypes()
                     .Where(type => type.IsBasedOn(typeof(IParseTreeInspection)) && type.NotDisabledExperimental(_initialSettings))
-                    .WithService.Base()
                     .WithService.Select(new[] { typeof(IInspection) })
                     .LifestyleTransient());
             }


### PR DESCRIPTION
Apparently some PR broke the IoC registration for inspections and quick fixes. Only `ParseTreeInspections` were registered correctly. Other inspections and all quick fixes were not registered at all or registered having service type of `Object`. This PR's purpose is to restore the functionality.