### PR TITLE
Remove user settings deletion

### DIFF
--- a/Rubberduck.Deployment/InnoSetup/Installer Build Script.iss
+++ b/Rubberduck.Deployment/InnoSetup/Installer Build Script.iss
@@ -103,8 +103,11 @@ Source: "{#IncludesDir}Rubberduck.RegisterAddIn.reg"; DestDir: "{app}"; Flags: i
 ; Use [Code] section (RegisterAddIn procedure) to register the entries instead.
 #include <Rubberduck.reg.iss>
 
-[UninstallDelete]
-Type: filesandordirs; Name: "{userappdata}\{#AppName}"
+; Commneted out because we don't want to delete users setting when they are just
+; uninstalling to install another version of Rubberduck. Considered prompting to
+; delete but not for right now. 
+; [UninstallDelete]
+; Type: filesandordirs; Name: "{userappdata}\{#AppName}"
 
 [CustomMessages]
 ; TODO add additional languages here by adding include files in \Includes folder
@@ -1063,5 +1066,8 @@ end;
 ///</remarks>
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
-  if CurUninstallStep = usUninstall then UnregisterAddin();
+  if CurUninstallStep = usUninstall then
+  begin
+    UnregisterAddin();
+  end;
 end;


### PR DESCRIPTION
Closes #3884 

Considered prompting to delete but decided it's too much of a hassle and opted for the KISS route -- the settings will never be deleted. If they don't like it, they can clean it up manually. Besides, with per-machine install, I will never be able to track all users folder, so there's that....