### PR TITLE
3868 comments

### DIFF
--- a/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/ParseTreeExpressionEvaluator.cs
+++ b/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/ParseTreeExpressionEvaluator.cs
@@ -153,10 +153,11 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         private static string _plus;
         private static string _minusSign;
         private static string _exponent;
+        private static string _integerDivide;
 
         public static string MULTIPLY => _multiply ?? LoadSymbols(VBAParser.MULT);
         public static string DIVIDE => _divide ?? LoadSymbols(VBAParser.DIV);
-        public static string INTEGER_DIVIDE => @"\";
+        public static string INTEGER_DIVIDE => _integerDivide ?? LoadSymbols(VBAParser.INTDIV);
         public static string PLUS => _plus ?? LoadSymbols(VBAParser.PLUS);
         public static string MINUS => _minusSign ?? LoadSymbols(VBAParser.MINUS);
         public static string ADDITIVE_INVERSE => MINUS;
@@ -167,6 +168,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         {
             _multiply = VBAParser.DefaultVocabulary.GetLiteralName(VBAParser.MULT).Replace("'", "");
             _divide = VBAParser.DefaultVocabulary.GetLiteralName(VBAParser.DIV).Replace("'", "");
+            _integerDivide = VBAParser.DefaultVocabulary.GetLiteralName(VBAParser.INTDIV).Replace("'", "");
             _plus = VBAParser.DefaultVocabulary.GetLiteralName(VBAParser.PLUS).Replace("'", "");
             _minusSign = VBAParser.DefaultVocabulary.GetLiteralName(VBAParser.MINUS).Replace("'", "");
             _exponent = VBAParser.DefaultVocabulary.GetLiteralName(VBAParser.POW).Replace("'", "");

--- a/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/ParseTreeValueVisitor.cs
+++ b/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/ParseTreeValueVisitor.cs
@@ -241,7 +241,6 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         {
             expressionValue = string.Empty;
             declaredTypeName = string.Empty;
-
             if (lExprContext.TryGetChildContext(out VBAParser.MemberAccessExprContext memberAccess))
             {
                 var member = memberAccess.GetChild<VBAParser.UnrestrictedIdentifierContext>();
@@ -320,11 +319,13 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         {
             var localDeclaration = declaration;
             var iterationGuard = 0;
-            while (!localDeclaration.AsTypeIsBaseType && iterationGuard++ < 5)
+            while (!(localDeclaration is null) 
+                && !localDeclaration.AsTypeIsBaseType 
+                && iterationGuard++ < 5)
             {
                 localDeclaration = localDeclaration.AsTypeDeclaration;
             }
-            return localDeclaration.AsTypeName;
+            return localDeclaration is null ? declaration.AsTypeName : localDeclaration.AsTypeName;
         }
 
         private static bool IsBinaryMathContext<T>(T context)

--- a/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/ParseTreeValueVisitor.cs
+++ b/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/ParseTreeValueVisitor.cs
@@ -279,9 +279,9 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         private bool TryGetIdentifierReferenceForContext(ParserRuleContext context, out IdentifierReference idRef)
         {
             idRef = null;
-            var nameToMatch = context.GetText();
-            var identifierReferences = (_state.DeclarationFinder.MatchName(context.GetText()).Select(dec => dec.References)).SelectMany(rf => rf);
-            if (identifierReferences.Any(rf => rf.Context == context))
+            var identifierReferences = (_state.DeclarationFinder.MatchName(context.GetText()).Select(dec => dec.References)).SelectMany(rf => rf)
+                .Where(rf => rf.Context == context);
+            if (identifierReferences.Count() == 1)
             {
                 idRef = identifierReferences.First();
                 return true;

--- a/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/RangeClauseFilter.cs
+++ b/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/RangeClauseFilter.cs
@@ -156,6 +156,11 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 AddSingleValueImpl(val);
             }
+
+            foreach (var val in newFilter.VariableSingleValues)
+            {
+                VariableSingleValues.Add(val);
+            }
             _descriptorIsDirty = true;
         }
 

--- a/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/RangeClauseFilter.cs
+++ b/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/RangeClauseFilter.cs
@@ -44,6 +44,8 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         private bool _hasExtents;
         private T _minExtent;
         private T _maxExtent;
+        private string _cachedDescriptor;
+        private bool _descriptorIsDirty;
 
         public RangeClauseFilter(string typeName, IParseTreeValueFactory valueFactory, IRangeClauseFilterFactory filterFactory, TryConvertParseTreeValue<T> tConverter)
         {
@@ -61,6 +63,8 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             _falseValue = ConvertToContainedGeneric(false);
             _trueValue = ConvertToContainedGeneric(true);
             TypeName = typeName;
+            _cachedDescriptor = string.Empty;
+            _descriptorIsDirty = true;
         }
 
         private List<Tuple<T, T>> RangeValues => _ranges;
@@ -83,6 +87,10 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         {
             get
             {
+                if (ContainsBooleans && CoversTrueFalse())
+                {
+                    return true;
+                }
 
                 var coversAll = false;
                 var hasLTFilter = TryGetIsLTValue(out T ltValue);
@@ -101,10 +109,6 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
                     coversAll = gt - lt + 1 <= RangesValuesCount() + SingleValues.Count()
                         || gt == lt && RangesFilterValue(ltValue);
                 }
-                else if (ContainsBooleans && !coversAll)
-                {
-                    coversAll = SingleValues.Contains(_trueValue);
-                }
                 return coversAll;
             }
         }
@@ -115,9 +119,9 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 return _ranges.Any() || _variableRanges.Any()
                     || _singleValues.Any() || _variableSingles.Any()
+                    || _relationalOps.Any()
                     || TryGetIsLTValue(out T isLT) && isLT.CompareTo(_minExtent) != 0
-                    || TryGetIsGTValue(out T isGT) && isGT.CompareTo(_maxExtent) != 0
-                    || _relationalOps.Any();
+                    || TryGetIsGTValue(out T isGT) && isGT.CompareTo(_maxExtent) != 0;
             }
         }
 
@@ -152,6 +156,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 AddSingleValueImpl(val);
             }
+            _descriptorIsDirty = true;
         }
 
         public void AddIsClause(IParseTreeValue value, string opSymbol)
@@ -168,6 +173,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 AddRelationalOpImpl(value.ValueText);
             }
+            _descriptorIsDirty = true;
         }
 
         public void AddRelationalOp(IParseTreeValue value)
@@ -184,6 +190,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 AddRelationalOpImpl(value.ValueText);
             }
+            _descriptorIsDirty = true;
         }
 
         public void AddSingleValue(IParseTreeValue value)
@@ -200,6 +207,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 VariableSingleValues.Add(value.ValueText);
             }
+            _descriptorIsDirty = true;
         }
 
         public void AddValueRange(IParseTreeValue inputStartVal, IParseTreeValue inputEndVal)
@@ -225,6 +233,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 AddVariableRangeImpl(inputStartVal.ValueText, inputEndVal.ValueText);
             }
+            _descriptorIsDirty = true;
         }
 
         public IRangeClauseFilter FilterUnreachableClauses(IRangeClauseFilter filter)
@@ -309,6 +318,11 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 
         public override string ToString()
         {
+            if (!_descriptorIsDirty)
+            {
+                return _cachedDescriptor;
+            }
+
             var descriptors = new HashSet<string>
             {
                 GetIsClausesDescriptor(LogicSymbols.LT),
@@ -329,7 +343,9 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
                 }
                 descriptor.Append(descriptors.ElementAt(idx));
             }
-            return descriptor.ToString();
+            _cachedDescriptor = descriptor.ToString();
+            _descriptorIsDirty = false;
+            return _cachedDescriptor;
         }
 
         public override int GetHashCode()
@@ -357,14 +373,19 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             {
                 if (ContainsBooleans)
                 {
-                    return _singleValues.Contains(_trueValue) && _singleValues.Contains(_falseValue)
-                        || RangesFilterValue(_trueValue) && RangesFilterValue(_falseValue);
+                    return CoversTrueFalse();
                 }
                 return _singleValues.Contains(_trueValue) && _singleValues.Contains(_falseValue)
                     || RangesFilterValue(_trueValue) && RangesFilterValue(_falseValue)
                     || IsLTFiltersValue(_trueValue) && IsLTFiltersValue(_falseValue)
                     || IsGTFiltersValue(_trueValue) && IsGTFiltersValue(_falseValue);
             }
+        }
+
+        private bool CoversTrueFalse()
+        {
+            return _singleValues.Contains(_trueValue) && _singleValues.Contains(_falseValue)
+                || RangesFilterValue(_trueValue) && RangesFilterValue(_falseValue);
         }
 
         private void RemoveIsLTClause() => RemoveIsClauseImpl(LogicSymbols.LT);

--- a/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/UnreachableCaseInspection.cs
+++ b/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/UnreachableCaseInspection.cs
@@ -49,6 +49,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
+            InspectionResults = new List<IInspectionResult>();
             var qualifiedSelectCaseStmts = Listener.Contexts
                 .Where(result => !IsIgnoringInspectionResultFor(result.ModuleName, result.Context.Start.Line));
 

--- a/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/UnreachableCaseInspection.cs
+++ b/Rubberduck.Inspections/Concrete/UnreachableCaseInspection/UnreachableCaseInspection.cs
@@ -18,7 +18,6 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         private IParseTreeValueVisitorFactory _parseTreeVisitorFactory;
         private ISelectCaseStmtContextWrapperFactory _selectStmtFactory;
         private IParseTreeValueFactory _valueFactory;
-        private IParseTreeValueVisitor _parseTreeValueVisitor;
         private enum CaseInpectionResult { Unreachable, MismatchType, CaseElse };
 
         private static Dictionary<CaseInpectionResult, string> ResultMessages = new Dictionary<CaseInpectionResult, string>()
@@ -36,8 +35,6 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             _selectStmtFactory = factoriesFactory.CreateISelectStmtContextWrapperFactory();
             _valueFactory = factoriesFactory.CreateIParseTreeValueFactory();
             _parseTreeVisitorFactory = factoriesFactory.CreateIParseTreeValueVisitorFactory();
-
-            _parseTreeValueVisitor = _parseTreeVisitorFactory.Create(State, _valueFactory);
         }
 
         public override IInspectionListener Listener { get; } =
@@ -45,7 +42,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 
         private List<IInspectionResult> InspectionResults { set; get; } = new List<IInspectionResult>();
 
-        private ParseTreeVisitorResults ValueResults { get; } = new ParseTreeVisitorResults();
+        private ParseTreeVisitorResults ValueResults { set; get; } = new ParseTreeVisitorResults();
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
@@ -54,6 +51,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
                 .Where(result => !IsIgnoringInspectionResultFor(result.ModuleName, result.Context.Start.Line));
 
             var parseTreeValueVisitor = _parseTreeVisitorFactory.Create(State, _valueFactory);
+            ValueResults = new ParseTreeVisitorResults();
             parseTreeValueVisitor.OnValueResultCreated += ValueResults.OnNewValueResult;
 
             foreach (var qualifiedSelectCaseStmt in qualifiedSelectCaseStmts)

--- a/RubberduckTests/Inspections/UnreachableCaseInspectionTests.cs
+++ b/RubberduckTests/Inspections/UnreachableCaseInspectionTests.cs
@@ -596,6 +596,7 @@ namespace RubberduckTests.Inspections
             Assert.AreEqual(expected, filteredResults);
         }
 
+        [TestCase("Range:3:55", "Single=x.Item(2)", "Range:3:55,Single=x.Item(2)")]
         [TestCase("Range=3:55", "IsLT=6", "IsLT=6,Range=6:55")]
         [TestCase("Range=3:55", "IsGT=6", "IsGT=6,Range=3:6")]
         [TestCase("IsLT=6", "Range=1:5", "IsLT=6")]
@@ -2542,6 +2543,38 @@ Public Const MY_CONSTANT As <propertyTypeAndAssignment>
             };
 
             CheckActualResultsEqualsExpected(components, unreachable: 1);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void UciFunctional_DuplicateSelectExpressionVariableInModule()
+        {
+            string inputCode =
+@"
+Sub FirstSub(x As Long)
+    Select Case x
+        Case 55
+            MsgBox CStr(x)
+        Case 56
+            MsgBox CStr(x)
+        Case 55
+            MsgBox ""Unreachable""
+    End Select
+End Sub
+
+Sub SecondSub(x As Boolean)
+    Select Case x
+        Case 55
+            MsgBox CStr(x)
+        Case 0
+            MsgBox CStr(x)
+        Case Else
+            MsgBox ""Unreachable""
+    End Select
+End Sub
+";
+
+            CheckActualResultsEqualsExpected(inputCode, unreachable: 1, caseElse: 1);
         }
 
         private static void CheckActualResultsEqualsExpected(string inputCode, int unreachable = 0, int mismatch = 0, int caseElse = 0)

--- a/RubberduckTests/Inspections/UnreachableCaseInspectionTests.cs
+++ b/RubberduckTests/Inspections/UnreachableCaseInspectionTests.cs
@@ -583,7 +583,7 @@ namespace RubberduckTests.Inspections
         [TestCase("IsLT=True, IsGT=True", "RelOp=x > 6", "Single=False,RelOp=Is > True")]
         [TestCase("IsLT=False, IsGT=False", "RelOp=x > 6", "Single=False,RelOp=Is < False")]
         [TestCase("IsGT=False", "RelOp=x > 6", "Single=False")]
-        [TestCase("Single=True, Single=False", "Single=True", "")]
+        [TestCase("Single=True, Single=False", "Single=False,Single=True", "")]
         [Category("Inspections")]
         public void UciUnit_FilterBoolean(string firstCase, string secondCase, string expectedClauses)
         {
@@ -802,7 +802,7 @@ End Sub";
         [TestCase("Dim Hint%\r\nHint% = 1\r\nSelect Case Hint%", "10 To 30,20", "Integer")] //Integer
         [TestCase("Dim Hint&\r\nHint& = 1\r\nSelect Case Hint&", "1000 To 3000,2000", "Long")] //Long
         [Category("Inspections")]
-        public void UciFunctional_SelectExprTypeHint(string typeHintExpr, string firstCase, string expected)
+        public void UciUnit_SelectExprTypeHint(string typeHintExpr, string firstCase, string expected)
         {
             string inputCode =
 @"
@@ -829,7 +829,7 @@ End Sub";
         [TestCase("Dim Hint%", "Hint%", "Integer")] //Integer
         [TestCase("Dim Hint&", "Hint&", "Long")] //Long
         [Category("Inspections")]
-        public void UciFunctional_CaseClauseTypeHint(string typeHintExpr, string firstCase, string expected)
+        public void UciUnit_CaseClauseTypeHint(string typeHintExpr, string firstCase, string expected)
         {
             string inputCode =
 @"
@@ -848,7 +848,7 @@ End Sub";
             inputCode = inputCode.Replace("<typeHintExprAndSelectCase>", typeHintExpr);
             inputCode = inputCode.Replace("<firstCaseVal>", firstCase);
 
-            var result = GetCaseClauseType(inputCode);
+            var result = GetSelectExpressionType(inputCode);
             Assert.AreEqual(expected, result);
         }
 
@@ -859,7 +859,7 @@ End Sub";
         [TestCase("True", "x As Byte", "Boolean")]
         [TestCase("ToString(45)", "x As Byte", "String")]
         [Category("Inspections")]
-        public void UciFunctional_SelectExpressionType(string selectExpr, string argList, string expected)
+        public void UciUnit_SelectExpressionType(string selectExpr, string argList, string expected)
         {
             string inputCode =
 @"
@@ -893,9 +893,9 @@ End Sub";
         [TestCase("ToLong(True) * .0035", "45", "Double")]
         [TestCase("True", "x < 5", "Boolean")]
         [TestCase("1 To 10.0", "55 To 100.0", "Double")]
-        [TestCase("ToString(45)",@"""Bar""","String")]
+        [TestCase("ToString(45)", @"""Bar""", "String")]
         [Category("Inspections")]
-        public void UciFunctional_CaseClauseType(string rangeExpr1, string rangeExpr2, string expected)
+        public void UciUnit_CaseClauseType(string rangeExpr1, string rangeExpr2, string expected)
         {
             string inputCode =
 @"
@@ -920,7 +920,121 @@ End Sub";
 
             inputCode = inputCode.Replace("<rangeExpr1>", rangeExpr1);
             inputCode = inputCode.Replace("<rangeExpr2>", rangeExpr2);
-            var result = GetCaseClauseType(inputCode);
+            var result = GetSelectExpressionType(inputCode);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("45", "55", "Long")]
+        [TestCase("45.6", "55", "Double")]
+        [TestCase(@"""Test""", @"""55""", "String")]
+        [TestCase("True", "y < 6", "Boolean")]
+        [Category("Inspections")]
+        public void UciUnit_CaseClauseTypeUnrecognizedSelectExpressionType(string rangeExpr1, string rangeExpr2, string expected)
+        {
+            string inputCode =
+@"
+        Sub Foo(x As Collection)
+            Dim y As Long
+            y = 8
+            Select Case x(1)
+                Case <rangeExpr1>
+                'OK
+                Case <rangeExpr2>
+                'OK
+                Case Else
+                'OK
+            End Select
+
+        End Sub";
+
+            inputCode = inputCode.Replace("<rangeExpr1>", rangeExpr1);
+            inputCode = inputCode.Replace("<rangeExpr2>", rangeExpr2);
+            var result = GetSelectExpressionType(inputCode);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("x.Item(2)", "55", "Long")]
+        [TestCase("x.Item(2)", "45.6", "Double")]
+        [TestCase("x.Item(2)", @"""Test""", "String")]
+        [TestCase("x.Item(2)", "False", "Boolean")]
+        [Category("Inspections")]
+        public void UciUnit_CaseClauseTypeUnrecognizedCaseExpressionType(string rangeExpr1, string rangeExpr2, string expected)
+        {
+            string inputCode =
+@"
+        Sub Foo(x As Collection)
+            Select Case x(3)
+                Case <rangeExpr1>
+                'OK
+                Case <rangeExpr2>
+                'OK
+                Case <rangeExpr2>
+                'OK
+                Case Else
+                'OK
+            End Select
+
+        End Sub";
+
+            inputCode = inputCode.Replace("<rangeExpr1>", rangeExpr1);
+            inputCode = inputCode.Replace("<rangeExpr2>", rangeExpr2);
+            var result = GetSelectExpressionType(inputCode);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("x.Item(2)", "True", false)]
+        [TestCase("x.Item(2)", "True, False", true)]
+        [Category("Inspections")]
+        public void UciFunctional_CaseClauseTypeUnrecognizedCaseExpressionType2(string rangeExpr1, string rangeExpr2, bool triggersCaseElse)
+        {
+            string inputCode =
+@"
+        Sub Foo(x As Collection)
+            Select Case x(3)
+                Case <rangeExpr1>
+                'OK
+                Case <rangeExpr2>
+                'OK
+                Case <rangeExpr2>
+                'unreachable
+                Case Else
+                'Depends on flag
+            End Select
+
+        End Sub";
+
+            inputCode = inputCode.Replace("<rangeExpr1>", rangeExpr1);
+            inputCode = inputCode.Replace("<rangeExpr2>", rangeExpr2);
+            CheckActualResultsEqualsExpected(inputCode, unreachable: 1, caseElse: triggersCaseElse ? 1 : 0);
+        }
+
+        [TestCase("95", "55", "Long")]
+        [TestCase("23.2", "45.6", "Double")]
+        [TestCase(@"""Foo""", @"""Test""", "String")]
+        [TestCase("x < 6", "x > 9", "Boolean")]
+        [TestCase("95.7", "55", "Double")]
+        [Category("Inspections")]
+        public void UciUnit_CaseClauseTypeVariantSelectExpression(string rangeExpr1, string rangeExpr2, string expected)
+        {
+            string inputCode =
+@"
+        Sub Foo(x As Variant)
+            Select Case x
+                Case <rangeExpr1>
+                'OK
+                Case <rangeExpr2>
+                'OK
+                Case <rangeExpr2>
+                'OK
+                Case Else
+                'OK
+            End Select
+
+        End Sub";
+
+            inputCode = inputCode.Replace("<rangeExpr1>", rangeExpr1);
+            inputCode = inputCode.Replace("<rangeExpr2>", rangeExpr2);
+            var result = GetSelectExpressionType(inputCode);
             Assert.AreEqual(expected, result);
         }
 
@@ -1395,7 +1509,7 @@ Select Case x
         }
 
         [TestCase("True", "Is <= False", 2)]
-        [TestCase("Is >= True", "False", 2)]
+        [TestCase("Is >= True", "False", 1)]
         [Category("Inspections")]
         public void UciFunctional_BooleanRelationalOps(string firstCase, string secondCase, int expected)
         {
@@ -2503,13 +2617,6 @@ Public Const MY_CONSTANT As <propertyTypeAndAssignment>
         {
             var selectStmtValueResults = GetParseTreeValueResults(inputCode, out VBAParser.SelectCaseStmtContext selectStmt);
             var iSelectStmt = InspectionSelectStmtFactory.Create(selectStmt, selectStmtValueResults);
-            return iSelectStmt.EvaluationTypeName;
-        }
-
-        private string GetCaseClauseType(string inputCode)
-        {
-            var valueResults = GetParseTreeValueResults(inputCode, out VBAParser.SelectCaseStmtContext selectStmt);
-            var iSelectStmt = InspectionSelectStmtFactory.Create(selectStmt, valueResults);
             return iSelectStmt.EvaluationTypeName;
         }
 


### PR DESCRIPTION
Follow-up work for remaining comments for merge  #3868 

1. Strengthened `SelectExpression `type evaluations. e.g., allows inspection of `SelectExpression `Type `Variant ` or other non-base-types if the CaseStatement Types represent a consistent inspectable type.
2. Added dirty-flag/caching to make `ToString()`/`GetHashCode` a more performant.
3. Retrieving integer division symbol from `VBAParser.DefaultVocabulary`.
4. Fixes bug: using the same variable name for different Select Case constructs, within the same module was not resolved properly.
5.  Fixes bug: `ParseTreeValueResults` were not cleared prior to additional invocations of the inspection.

There is more follow-up work to be done after v2.2.  Thought #1,4,5 above would be good to get into v2.2.