### PR TITLE
Tighten down the requirement for elevation to only admins, not power users

### DIFF
--- a/Rubberduck.Deployment/InnoSetup/Installer Build Script.iss
+++ b/Rubberduck.Deployment/InnoSetup/Installer Build Script.iss
@@ -236,7 +236,7 @@ function ShellExecute(hwnd: HWND; lpOperation: string; lpFile: string;
 ///</remarks>
 function IsElevated: Boolean;
 begin
-  Result := IsAdminLoggedOn or IsPowerUserLoggedOn;
+  Result := IsAdminLoggedOn;
 end;
 
 ///<remarks>
@@ -775,6 +775,7 @@ end;
 procedure InitializeWizard();
 begin
   HasElevateSwitch := CmdLineParamExists('/ELEVATE');
+
   Log(Format('HasElevateSwitch: %d', [HasElevateSwitch]));
   Log(Format('IsElevated: %d', [IsElevated()]));
 


### PR DESCRIPTION
Fixes #3916 

I considered adding a `/override` but decided against it as this means one more combination to test for what is already difficult to test project. Hopefully, simply checking for the admin is sufficient for the scenarios we need to support. 