### PR TITLE
Fixing indexed default members

### DIFF
--- a/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
+++ b/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
@@ -235,7 +235,8 @@ namespace Rubberduck.Parsing.ComReflection
                     _declarations.AddRange(hasParams.Parameters);
                     memberTree.AddChildren(hasParams.Parameters);
                 }
-                var coClass = memberDeclaration as ClassModuleDeclaration;
+
+                var coClass = memberDeclaration.ParentDeclaration as ClassModuleDeclaration;
                 if (coClass != null && item == defaultMember)
                 {
                     coClass.DefaultMember = memberDeclaration;

--- a/RubberduckTests/Binding/IndexDefaultBindingTests.cs
+++ b/RubberduckTests/Binding/IndexDefaultBindingTests.cs
@@ -10,6 +10,7 @@ using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace RubberduckTests.Binding
 {
+
     [TestFixture]
     public class IndexDefaultBindingTests
     {
@@ -17,6 +18,90 @@ namespace RubberduckTests.Binding
         private const string BINDING_TARGET_UNRESTRICTEDNAME = "UnrestrictedName";
         private const string TEST_CLASS_NAME = "TestClass";
         private const string REFERENCED_PROJECT_FILEPATH = @"C:\Temp\ReferencedProjectA";
+
+        [Category("Binding")]
+        [Test]
+        public void IndexedDefaultMember()
+        {
+            string callerModule = @"
+Public Property Get Ok() As Klasse2
+End Property
+
+Public Sub Test()
+    Call Ok(1)
+End Sub
+";
+
+            string defaultMemberClass = @"
+Public Property Get Test2(a As Integer)
+Attribute Test2.VB_UserMemId = 0
+    Test2 = 2
+End Property
+";
+
+            var builder = new MockVbeBuilder();
+            var enclosingProjectBuilder = builder.ProjectBuilder("Any Project", ProjectProtection.Unprotected);
+            enclosingProjectBuilder.AddComponent("AnyModule1", ComponentType.StandardModule, callerModule);
+            enclosingProjectBuilder.AddComponent("Klasse2", ComponentType.ClassModule, defaultMemberClass);
+            var enclosingProject = enclosingProjectBuilder.Build();
+            builder.AddProject(enclosingProject);
+            var vbe = builder.Build();
+            using (var state = Parse(vbe))
+            {
+                var declaration =
+                    state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
+                                                          d.IdentifierName == "Test2");
+
+                //One for the assignment in the property itself and one for the default member access.
+                Assert.AreEqual(2, declaration.References.Count());
+            }
+        }
+
+        [Category("Binding")]
+        [Test]
+        public void IndexedDefaultMemberMemberAccess()
+        {
+            string callerModule = @"
+Public Property Get Ok() As Klasse2
+End Property
+
+Public Sub Test()
+    Dim bar As Long
+    bar = Ok(1).Test3
+End Sub
+";
+
+            string defaultMemberClass = @"
+Public Property Get Test2(a As Integer) As Klasse3
+Attribute Test2.VB_UserMemId = 0
+    Set Test2 = New Klasse3
+End Property
+";
+            string defaultMemberTargetClass = @"
+Public Property Get Test3() As Long
+Attribute Test3.VB_UserMemId = 0
+    Test3 = 3
+End Property
+";
+
+            var builder = new MockVbeBuilder();
+            var enclosingProjectBuilder = builder.ProjectBuilder("Any Project", ProjectProtection.Unprotected);
+            enclosingProjectBuilder.AddComponent("AnyModule1", ComponentType.StandardModule, callerModule);
+            enclosingProjectBuilder.AddComponent("Klasse2", ComponentType.ClassModule, defaultMemberClass);
+            enclosingProjectBuilder.AddComponent("Klasse3", ComponentType.ClassModule, defaultMemberTargetClass);
+            var enclosingProject = enclosingProjectBuilder.Build();
+            builder.AddProject(enclosingProject);
+            var vbe = builder.Build();
+            using (var state = Parse(vbe))
+            {
+                var declaration =
+                    state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
+                                                          d.IdentifierName == "Test3");
+
+                //One for the assignment in the property itself and one for the access via the default member.
+                Assert.AreEqual(2, declaration.References.Count());
+            }
+        }
 
         [Category("Binding")]
         [Test]
@@ -33,11 +118,13 @@ End Sub
 
             string middleman = @"
 Public Property Get Test1() As Klasse2
+Attribute Test1.VB_UserMemId = 0
 End Property
 ";
 
             string defaultMemberClass = @"
 Public Property Get Test2(a As Integer)
+    Attribute Test2.VB_UserMemId = 0
     Test2 = 2
 End Property
 ";
@@ -45,8 +132,8 @@ End Property
             var builder = new MockVbeBuilder();
             var enclosingProjectBuilder = builder.ProjectBuilder("Any Project", ProjectProtection.Unprotected);
             enclosingProjectBuilder.AddComponent("AnyModule1", ComponentType.StandardModule, callerModule);
-            enclosingProjectBuilder.AddComponent("AnyClass", ComponentType.ClassModule, middleman);
-            enclosingProjectBuilder.AddComponent("AnyClass2", ComponentType.ClassModule, defaultMemberClass);
+            enclosingProjectBuilder.AddComponent("Klasse1", ComponentType.ClassModule, middleman);
+            enclosingProjectBuilder.AddComponent("Klasse2", ComponentType.ClassModule, defaultMemberClass);
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
             var vbe = builder.Build();
@@ -56,7 +143,165 @@ End Property
                     state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
                                                           d.IdentifierName == "Test2");
 
-                Assert.AreEqual(1, declaration.References.Count());
+                //One for the assignment in the property itself and one for the default member access.
+                Assert.AreEqual(2, declaration.References.Count());
+            }
+        }
+
+        [Category("Binding")]
+        [Test]
+        public void RecursiveDefaultMemberMemberAccess()
+        {
+            string callerModule = @"
+Public Property Get Ok() As Klasse1
+End Property
+
+Private Function Foo(a As Integer)
+    Foo = 5
+End Function
+
+Public Sub Test()
+    Dim bar As Long
+    bar = Foo(Ok(1).Test3)
+End Sub
+";
+
+            string middleman = @"
+Public Property Get Test1() As Klasse2
+Attribute Test1.VB_UserMemId = 0
+End Property
+";
+
+            string defaultMemberClass = @"
+Public Property Get Test2(a As Integer) As Klasse3
+Attribute Test2.VB_UserMemId = 0
+    Set Test2 = New Klasse3
+End Property
+";
+            string defaultMemberTargetClass = @"
+Public Property Get Test3() As Long
+Attribute Test3.VB_UserMemId = 0
+    Test3 = 3
+End Property
+";
+
+            var builder = new MockVbeBuilder();
+            var enclosingProjectBuilder = builder.ProjectBuilder("Any Project", ProjectProtection.Unprotected);
+            enclosingProjectBuilder.AddComponent("AnyModule1", ComponentType.StandardModule, callerModule);
+            enclosingProjectBuilder.AddComponent("Klasse1", ComponentType.ClassModule, middleman);
+            enclosingProjectBuilder.AddComponent("Klasse2", ComponentType.ClassModule, defaultMemberClass);
+            enclosingProjectBuilder.AddComponent("Klasse3", ComponentType.ClassModule, defaultMemberTargetClass);
+            var enclosingProject = enclosingProjectBuilder.Build();
+            builder.AddProject(enclosingProject);
+            var vbe = builder.Build();
+            using (var state = Parse(vbe))
+            {
+                var declaration =
+                    state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
+                                                          d.IdentifierName == "Test3");
+
+                //One for the assignment in the property itself and one for the access via the default member.
+                Assert.AreEqual(2, declaration.References.Count());
+            }
+        }
+
+        [Category("Binding")]
+        [Test]
+        public void RecursiveIndexedDefaultMember()
+        {
+            string callerModule = @"
+Public Property Get Ok() As Klasse1
+End Property
+
+Public Sub Test()
+    Call Ok(1)(2)
+End Sub
+";
+
+            string middleman = @"
+Public Property Get Test1(bar As Long) As Klasse2
+Attribute Test1.VB_UserMemId = 0
+End Property
+";
+
+            string defaultMemberClass = @"
+Public Property Get Test2(a As Integer)
+    Attribute Test2.VB_UserMemId = 0
+    Test2 = 2
+End Property
+";
+
+            var builder = new MockVbeBuilder();
+            var enclosingProjectBuilder = builder.ProjectBuilder("Any Project", ProjectProtection.Unprotected);
+            enclosingProjectBuilder.AddComponent("AnyModule1", ComponentType.StandardModule, callerModule);
+            enclosingProjectBuilder.AddComponent("Klasse1", ComponentType.ClassModule, middleman);
+            enclosingProjectBuilder.AddComponent("Klasse2", ComponentType.ClassModule, defaultMemberClass);
+            var enclosingProject = enclosingProjectBuilder.Build();
+            builder.AddProject(enclosingProject);
+            var vbe = builder.Build();
+            using (var state = Parse(vbe))
+            {
+                var declaration =
+                    state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
+                                                          d.IdentifierName == "Test2");
+
+                //One for the assignment in the property itself and one for the default member access.
+                Assert.AreEqual(2, declaration.References.Count());
+            }
+        }
+
+        [Category("Binding")]
+        [Test]
+        public void RecursiveIndexedDefaultMemberMemberAccess()
+        {
+            string callerModule = @"
+Public Property Get Ok() As Klasse1
+End Property
+
+Private Sub DoIt(a As Long)
+End Sub
+
+Public Sub Test()
+    DoIt Ok(1)(2).Test3
+End Sub
+";
+
+            string middleman = @"
+Public Property Get Test1(bar As Long) As Klasse2
+Attribute Test1.VB_UserMemId = 0
+End Property
+";
+
+            string defaultMemberClass = @"
+Public Property Get Test2(a As Integer) As Klasse3
+Attribute Test2.VB_UserMemId = 0
+    Set Test2 = New Klasse3
+End Property
+";
+            string defaultMemberTargetClass = @"
+Public Property Get Test3() As Long
+Attribute Test3.VB_UserMemId = 0
+    Test3 = 3
+End Property
+";
+
+            var builder = new MockVbeBuilder();
+            var enclosingProjectBuilder = builder.ProjectBuilder("Any Project", ProjectProtection.Unprotected);
+            enclosingProjectBuilder.AddComponent("AnyModule1", ComponentType.StandardModule, callerModule);
+            enclosingProjectBuilder.AddComponent("Klasse1", ComponentType.ClassModule, middleman);
+            enclosingProjectBuilder.AddComponent("Klasse2", ComponentType.ClassModule, defaultMemberClass);
+            enclosingProjectBuilder.AddComponent("Klasse3", ComponentType.ClassModule, defaultMemberTargetClass);
+            var enclosingProject = enclosingProjectBuilder.Build();
+            builder.AddProject(enclosingProject);
+            var vbe = builder.Build();
+            using (var state = Parse(vbe))
+            {
+                var declaration =
+                    state.AllUserDeclarations.Single(d => d.DeclarationType == DeclarationType.PropertyGet &&
+                                                          d.IdentifierName == "Test3");
+
+                //One for the assignment in the property itself and one for the access via the default member.
+                Assert.AreEqual(2, declaration.References.Count());
             }
         }
 


### PR DESCRIPTION
This PR closes #3153

This PR deals with two issues regarding (indexed) default members:

1. We have not been able to resolve indexed default members accessed on index bindings, i.e. on results of function/property get calls, array accesses, or other indexed default members. This was covered up by wrong assumptions in the tests, which also had other problems in their setup. I corrected the tests, added new ones and amended the `IndexDefaultBinding` to make them all pass.
2. The `ReferencedDeclarationsCollector` had a tiny bug with the effect that the default members for classes from referenced libraries were never added to the corresponding class module declarations. I corrected that. Unfortunately this is untestable right now, since the `ReferencedDeclarationsCollector` is one big blob using external function calls. (A refactoring will be due when making it ready to take the type lib from the type lib API.) 

Please note that the fixed bug from point 2 means that all our serialized references for testing lack all default members.