### PR TITLE
Inject a concrete factory for the FakesProvider

### DIFF
--- a/Rubberduck.Core/UnitTesting/IFakes.cs
+++ b/Rubberduck.Core/UnitTesting/IFakes.cs
@@ -9,6 +9,5 @@
     public interface IFakesFactory
     {
         IFakes Create();
-        void Release(IFakes fakes);
     }
 }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProviderFactory.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProviderFactory.cs
@@ -1,0 +1,12 @@
+﻿using Rubberduck.UnitTesting;
+
+namespace Rubberduck.ComClientLibrary.UnitTesting
+{
+    public class FakesProviderFactory : IFakesFactory 
+    {
+        public IFakes Create()
+        {
+            return new FakesProvider();
+        }
+    }
+}

--- a/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
+++ b/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
@@ -10,6 +10,7 @@ using Castle.MicroKernel.Registration;
 using Castle.MicroKernel.Resolvers.SpecializedResolvers;
 using Castle.MicroKernel.SubSystems.Configuration;
 using Castle.Windsor;
+using Rubberduck.ComClientLibrary.UnitTesting;
 using Rubberduck.Common;
 using Rubberduck.Common.Hotkeys;
 using Rubberduck.Navigation.CodeExplorer;
@@ -159,11 +160,8 @@ namespace Rubberduck.Root
         private void RegisterUnitTestingComSide(IWindsorContainer container)
         {
             container.Register(Component.For<IFakesFactory>()
-                .AsFactory()
+                .ImplementedBy<FakesProviderFactory>()
                 .LifestyleSingleton());
-            container.Register(Component.For<IFakes>()
-                .ImplementedBy<FakesProvider>()
-                .LifestyleTransient());
         }
 
         // note: settings namespace classes are injected in singleton scope
@@ -212,6 +210,7 @@ namespace Rubberduck.Root
                             && !type.Name.Equals("SelectionChangeService")
                             && !type.Name.EndsWith("Factory")
                             && !type.Name.EndsWith("ConfigProvider")
+                            && !type.Name.EndsWith("FakesProvider")
                             && !type.GetInterfaces().Contains(typeof(IInspection))
                             && type.NotDisabledExperimental(_initialSettings))
                     .WithService.DefaultInterfaces()
@@ -226,7 +225,10 @@ namespace Rubberduck.Root
             {
                 container.Register(Types.FromAssembly(assembly)
                     .IncludeNonPublicTypes()
-                    .Where(type => type.IsInterface && type.Name.EndsWith("Factory") && type.NotDisabledExperimental(_initialSettings))
+                    .Where(type => type.IsInterface 
+                                   && type.Name.EndsWith("Factory") 
+                                   && !type.Name.Equals("IFakesFactory")
+                                   && type.NotDisabledExperimental(_initialSettings))
                     .WithService.Self()
                     .Configure(c => c.AsFactory())
                     .LifestyleSingleton());

--- a/Rubberduck.Main/Rubberduck.Main.csproj
+++ b/Rubberduck.Main/Rubberduck.Main.csproj
@@ -235,6 +235,7 @@
   <ItemGroup>
     <Compile Include="ComClientLibrary\UI\DockableWindowHost.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\AssertClass.cs" />
+    <Compile Include="ComClientLibrary\UnitTesting\FakesProviderFactory.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\FakesProvider.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IAssert.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IFake.cs" />

--- a/Rubberduck.VBEEditor/Utility/DisposalActionContainer.cs
+++ b/Rubberduck.VBEEditor/Utility/DisposalActionContainer.cs
@@ -10,9 +10,9 @@ namespace Rubberduck.VBEditor.Utility
     internal sealed class DisposalActionContainer<T> : IDisposalActionContainer<T>
     {
         public T Value { get; }
-        private readonly Action _disposalAction;
+        private readonly Action<T> _disposalAction;
 
-        public DisposalActionContainer(T value, Action disposalAction)
+        public DisposalActionContainer(T value, Action<T> disposalAction)
         {
             Value = value;
             _disposalAction = disposalAction;
@@ -31,13 +31,13 @@ namespace Rubberduck.VBEditor.Utility
                 _isDisposed = true;
             }
 
-            _disposalAction.Invoke();
+            _disposalAction.Invoke(Value);
         }
     }
 
     public static class DisposalActionContainer
     {
-        public static IDisposalActionContainer<T> Create<T>(T value, Action disposalAction)
+        public static IDisposalActionContainer<T> Create<T>(T value, Action<T> disposalAction)
         {
             return new DisposalActionContainer<T>(value, disposalAction);
         }

--- a/RubberduckTests/VBEditor/Utility/DisposalActionContainerTests.cs
+++ b/RubberduckTests/VBEditor/Utility/DisposalActionContainerTests.cs
@@ -10,7 +10,7 @@ namespace RubberduckTests.VBEditor.Utility
         public void ValueReturnsValuePassedIn()
         {
             var testValue = 42;
-            var dac = DisposalActionContainer.Create(testValue, () => { });
+            var dac = DisposalActionContainer.Create(testValue, (a) => { });
             var returnedValue = dac.Value;
 
             Assert.AreEqual(testValue, returnedValue);
@@ -20,7 +20,7 @@ namespace RubberduckTests.VBEditor.Utility
         public void FirstDisposeTriggersActionPassedIn()
         {
             var useCount = 0;
-            var dac = DisposalActionContainer.Create(42, () => useCount++);
+            var dac = DisposalActionContainer.Create(42, (a) => useCount++);
             dac.Dispose();
             var expectedUseCount = 1;
 
@@ -31,7 +31,7 @@ namespace RubberduckTests.VBEditor.Utility
         public void MultipleCallsOfDisposeTriggerTheActionPassedInOnce()
         {
             var useCount = 0;
-            var dac = DisposalActionContainer.Create(42, () => useCount++);
+            var dac = DisposalActionContainer.Create(42, (a) => useCount++);
             dac.Dispose();
             dac.Dispose();
             dac.Dispose();
@@ -41,6 +41,17 @@ namespace RubberduckTests.VBEditor.Utility
             var expectedUseCount = 1;
 
             Assert.AreEqual(expectedUseCount, useCount);
+        }
+
+        [Test()]
+        public void ArgumentForActionPassedInIsTheValuePassedIn()
+        {
+            var actualArgumentValue = 0;
+            var dac = DisposalActionContainer.Create(42, (a) => actualArgumentValue = a);
+            dac.Dispose();
+            var expectedArgumentValue = 42;
+
+            Assert.AreEqual(expectedArgumentValue, actualArgumentValue);
         }
     }
 }


### PR DESCRIPTION
This fixed part of the shutdown issue for me. However, there are two caveats.

1. I had to reset my settings in order to get a clean exit. So, there is probably something wrong with the new default settings loading, which did not work for me anyways. (I could not find the Case not reachable inspection in the inspections settings.)
2. After changing the inspections severity for one inspection in the settings window, I got an eternally hanging processes on shutdown in the debugger; no parse required. With this I mean that I had to kill VS to make it respond again to anything.  

The two points above require further investigation, but I think this PR is a step in the right direction.
