### PR TITLE
Parsing vb forms

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBALexer.g4
+++ b/Rubberduck.Parsing/Grammar/VBALexer.g4
@@ -71,6 +71,7 @@ AND : A N D;
 ATTRIBUTE : A T T R I B U T E;
 APPEND : A P P E N D;
 AS : A S;
+BEGINPROPERTY : B E G I N P R O P E R T Y; //Used in module configurations.
 BEGIN : B E G I N;
 BINARY : B I N A R Y;
 BOOLEAN : B O O L E A N;
@@ -110,6 +111,7 @@ END_ENUM : E N D WS+ E N U M;
 END_FUNCTION : E N D (WS | LINE_CONTINUATION)+ F U N C T I O N;
 // We allow "EndIf" without the whitespace as well for the preprocessor.
 END_IF : E N D (WS | LINE_CONTINUATION)* I F;
+ENDPROPERTY : E N D P R O P E R T Y; //Used in module configurations.
 END_PROPERTY : E N D (WS | LINE_CONTINUATION)+ P R O P E R T Y;
 END_SELECT : E N D (WS | LINE_CONTINUATION)+ S E L E C T;
 END_SUB : E N D (WS | LINE_CONTINUATION)+ S U B;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -30,7 +30,7 @@ module :
     moduleAttributes
     moduleHeader?
     moduleAttributes
-	moduleConfigReferences?
+    moduleConfigReferences?
     moduleConfig?
     moduleAttributes
     moduleDeclarations

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -44,12 +44,18 @@ moduleHeader : VERSION whiteSpace numberLiteral whiteSpace? CLASS? endOfStatemen
 
 moduleConfig :
     BEGIN (whiteSpace (GUIDLITERAL | expression) whiteSpace unrestrictedIdentifier whiteSpace?)? endOfStatement
-    (moduleConfig | moduleConfigElement)+
+        (moduleConfig | moduleConfigProperty | moduleConfigElement)+
     END endOfStatement
 ;
 
+moduleConfigProperty :
+    BEGINPROPERTY whiteSpace unrestrictedIdentifier (whiteSpace GUIDLITERAL)? endOfStatement
+        (moduleConfigProperty | moduleConfigElement)+
+    ENDPROPERTY endOfStatement
+;
+
 moduleConfigElement :
-    unrestrictedIdentifier whiteSpace* EQ whiteSpace* expression (COLON numberLiteral)? endOfStatement
+    unrestrictedIdentifier whiteSpace? EQ whiteSpace? expression (COLON numberLiteral)? endOfStatement
 ;
 
 moduleAttributes : (attributeStmt endOfStatement)*;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -26,7 +26,7 @@ options { tokenVocab = VBALexer; }
 startRule : module EOF;
 
 module :
-	endOfStatement?
+    endOfStatement?
     moduleAttributes
     moduleHeader?
     moduleAttributes
@@ -45,7 +45,9 @@ moduleHeader : VERSION whiteSpace numberLiteral whiteSpace? CLASS? endOfStatemen
 
 moduleConfigReferences: moduleConfigReferenceElement+;
 
-moduleConfigReferenceElement: unrestrictedIdentifier whiteSpace? EQ whiteSpace? STRINGLITERAL whiteSpace? SEMICOLON whiteSpace? STRINGLITERAL endOfStatement;
+moduleConfigReferenceElement: 
+    OBJECT whiteSpace? EQ whiteSpace? STRINGLITERAL whiteSpace? SEMICOLON whiteSpace? STRINGLITERAL endOfStatement
+;
 
 moduleConfig :
     BEGIN (whiteSpace (GUIDLITERAL | expression) whiteSpace unrestrictedIdentifier whiteSpace?)? endOfStatement
@@ -71,10 +73,10 @@ attributeValue : expression;
 moduleDeclarations : (moduleDeclarationsElement endOfStatement)*;
 
 moduleOption : 
-    OPTION_BASE whiteSpace numberLiteral                     # optionBaseStmt
+    OPTION_BASE whiteSpace numberLiteral                       # optionBaseStmt
     | OPTION_COMPARE whiteSpace (BINARY | TEXT | DATABASE)     # optionCompareStmt
-    | OPTION_EXPLICIT                                         # optionExplicitStmt
-    | OPTION_PRIVATE_MODULE                                 # optionPrivateModuleStmt
+    | OPTION_EXPLICIT                                          # optionExplicitStmt
+    | OPTION_PRIVATE_MODULE                                    # optionPrivateModuleStmt
 ;
 
 moduleDeclarationsElement :
@@ -294,9 +296,9 @@ argDefaultValue : EQ whiteSpace? expression;
 // 5.2.2 Implicit Definition Directives
 defDirective : defType whiteSpace letterSpec (whiteSpace? COMMA whiteSpace? letterSpec)*;
 defType :
-        DEFBOOL | DEFBYTE | DEFINT | DEFLNG | DEFLNGLNG | DEFLNGPTR | DEFCUR |
-        DEFSNG | DEFDBL | DEFDATE | 
-        DEFSTR | DEFOBJ | DEFVAR
+    DEFBOOL | DEFBYTE | DEFINT | DEFLNG | DEFLNGLNG | DEFLNGPTR | DEFCUR |
+    DEFSNG | DEFDBL | DEFDATE | 
+    DEFSTR | DEFOBJ | DEFVAR
 ;
 // universalLetterRange must appear before letterRange because they both match the same amount in the case of A-Z but we prefer the universalLetterRange.
 // singleLetter must appear at the end to prevent premature bailout
@@ -366,7 +368,7 @@ functionStmt :
     (visibility whiteSpace)? (STATIC whiteSpace)? FUNCTION whiteSpace? functionName (whiteSpace? argList)? (whiteSpace? asTypeClause)? endOfStatement
     block
     statementLabelDefinition? whiteSpace? END_FUNCTION
-	(endOfLine attributeStmt)*
+    (endOfLine attributeStmt)*
 ;
 functionName : identifier;
 
@@ -376,18 +378,18 @@ goToStmt : GOTO whiteSpace expression;
 
 // 5.4.2.8 If Statement
 ifStmt :
-     IF whiteSpace booleanExpression whiteSpace THEN endOfStatement
-     block
-     (statementLabelDefinition? whiteSpace? elseIfBlock)*
-     (statementLabelDefinition? whiteSpace? elseBlock?)
-     statementLabelDefinition? whiteSpace? END_IF
+    IF whiteSpace booleanExpression whiteSpace THEN endOfStatement
+    block
+    (statementLabelDefinition? whiteSpace? elseIfBlock)*
+    (statementLabelDefinition? whiteSpace? elseBlock?)
+    statementLabelDefinition? whiteSpace? END_IF
 ;
 elseIfBlock : 
-     ELSEIF whiteSpace booleanExpression whiteSpace THEN endOfStatement block
-     | ELSEIF whiteSpace booleanExpression whiteSpace THEN whiteSpace? block
+    ELSEIF whiteSpace booleanExpression whiteSpace THEN endOfStatement block
+    | ELSEIF whiteSpace booleanExpression whiteSpace THEN whiteSpace? block
 ;
 elseBlock :
-     ELSE endOfStatement block
+    ELSE endOfStatement block
 ;
 
 // 5.4.2.9 Single-line If Statement
@@ -423,21 +425,21 @@ propertyGetStmt :
     (visibility whiteSpace)? (STATIC whiteSpace)? PROPERTY_GET whiteSpace functionName (whiteSpace? argList)? (whiteSpace asTypeClause)? endOfStatement 
     block 
     statementLabelDefinition? whiteSpace? END_PROPERTY
-	(endOfLine attributeStmt)*
+    (endOfLine attributeStmt)*
 ;
 
 propertySetStmt : 
     (visibility whiteSpace)? (STATIC whiteSpace)? PROPERTY_SET whiteSpace subroutineName (whiteSpace? argList)? endOfStatement 
     block 
     statementLabelDefinition? whiteSpace? END_PROPERTY
-	(endOfLine attributeStmt)*
+    (endOfLine attributeStmt)*
 ;
 
 propertyLetStmt : 
     (visibility whiteSpace)? (STATIC whiteSpace)? PROPERTY_LET whiteSpace subroutineName (whiteSpace? argList)? endOfStatement 
     block 
     statementLabelDefinition? whiteSpace? END_PROPERTY
-	(endOfLine attributeStmt)*
+    (endOfLine attributeStmt)*
 ;
 
 // 5.4.2.20 RaiseEvent Statement
@@ -455,11 +457,11 @@ redimVariableDeclaration : expression (whiteSpace asTypeClause)?;
 // 5.4.3.5 Mid/MidB/Mid$/MidB$ Statement
 // This needs to be explicitly defined to distinguish between Mid as a function and Mid as a keyword.
 midStatement : modeSpecifier 
-	LPAREN whiteSpace? 
-	lExpression whiteSpace? COMMA whiteSpace? lExpression whiteSpace? (COMMA whiteSpace? lExpression whiteSpace?)? 
-	RPAREN 
-	whiteSpace? ASSIGN whiteSpace? 
-	expression;
+    LPAREN whiteSpace? 
+    lExpression whiteSpace? COMMA whiteSpace? lExpression whiteSpace? (COMMA whiteSpace? lExpression whiteSpace?)? 
+    RPAREN 
+    whiteSpace? ASSIGN whiteSpace? 
+    expression;
 modeSpecifier :	(MID | MIDB) DOLLAR? ;
 
 integerExpression : expression;
@@ -494,7 +496,7 @@ caseClause :
 caseElseClause : CASE whiteSpace? ELSE endOfStatement block;
 rangeClause :
     (IS whiteSpace?)? comparisonOperator whiteSpace? expression
-	| selectStartValue whiteSpace TO whiteSpace selectEndValue 
+    | selectStartValue whiteSpace TO whiteSpace selectEndValue 
     | expression
 ;
 selectStartValue : expression;
@@ -506,7 +508,7 @@ subStmt :
     (visibility whiteSpace)? (STATIC whiteSpace)? SUB whiteSpace? subroutineName (whiteSpace? argList)? endOfStatement
     block 
     statementLabelDefinition? whiteSpace? END_SUB
-	(endOfLine attributeStmt)*
+    (endOfLine attributeStmt)*
 ;
 subroutineName : identifier;
 
@@ -589,8 +591,8 @@ fieldLength : MULT whiteSpace? (numberLiteral | identifierValue);
 statementLabelDefinition : {_input.La(-1) == NEWLINE}? (combinedLabels | identifierStatementLabel | standaloneLineNumberLabel);
 identifierStatementLabel : legalLabelIdentifier whiteSpace? COLON;
 standaloneLineNumberLabel : 
-	lineNumberLabel whiteSpace? COLON
-	| lineNumberLabel;
+    lineNumberLabel whiteSpace? COLON
+    | lineNumberLabel;
 combinedLabels : lineNumberLabel whiteSpace identifierStatementLabel;
 lineNumberLabel : numberLiteral;
 
@@ -604,28 +606,28 @@ visibility : PRIVATE | PUBLIC | FRIEND | GLOBAL;
 
 // 5.6 Expressions
 expression :
-	// Literal Expression has to come before lExpression, otherwise it'll be classified as simple name expression instead.
-	whiteSpace? LPAREN whiteSpace? expression whiteSpace? RPAREN									# parenthesizedExpr
-	| TYPEOF whiteSpace expression																	# typeofexpr // To make the grammar SLL, the type-of-is-expression is actually the child of an IS relational op.
-	| HASH expression																				# markedFileNumberExpr // Added to support special forms such as Input(file1, #file1)
-	| NEW whiteSpace expression																		# newExpr
-	| expression whiteSpace? POW whiteSpace? expression												# powOp
-	| MINUS whiteSpace? expression																	# unaryMinusOp
-	| expression whiteSpace? (MULT | DIV) whiteSpace? expression									# multOp
-	| expression whiteSpace? INTDIV whiteSpace? expression											# intDivOp
-	| expression whiteSpace? MOD whiteSpace? expression												# modOp
-	| expression whiteSpace? (PLUS | MINUS) whiteSpace? expression									# addOp
-	| expression whiteSpace? AMPERSAND whiteSpace? expression										# concatOp
-	| expression whiteSpace? (EQ | NEQ | LT | GT | LEQ | GEQ | LIKE | IS) whiteSpace? expression	# relationalOp
-	| NOT whiteSpace? expression																	# logicalNotOp
-	| expression whiteSpace? AND whiteSpace? expression												# logicalAndOp
-	| expression whiteSpace? OR whiteSpace? expression												# logicalOrOp
-	| expression whiteSpace? XOR whiteSpace? expression												# logicalXorOp
-	| expression whiteSpace? EQV whiteSpace? expression												# logicalEqvOp
-	| expression whiteSpace? IMP whiteSpace? expression												# logicalImpOp
-	| literalExpression																				# literalExpr
-	| lExpression																					# lExpr
-	| builtInType																					# builtInTypeExpr
+    // Literal Expression has to come before lExpression, otherwise it'll be classified as simple name expression instead.
+    whiteSpace? LPAREN whiteSpace? expression whiteSpace? RPAREN                                    # parenthesizedExpr
+    | TYPEOF whiteSpace expression                                                                  # typeofexpr // To make the grammar SLL, the type-of-is-expression is actually the child of an IS relational op.
+    | HASH expression                                                                               # markedFileNumberExpr // Added to support special forms such as Input(file1, #file1)
+    | NEW whiteSpace expression                                                                     # newExpr
+    | expression whiteSpace? POW whiteSpace? expression                                             # powOp
+    | MINUS whiteSpace? expression                                                                  # unaryMinusOp
+    | expression whiteSpace? (MULT | DIV) whiteSpace? expression                                    # multOp
+    | expression whiteSpace? INTDIV whiteSpace? expression                                          # intDivOp
+    | expression whiteSpace? MOD whiteSpace? expression                                             # modOp
+    | expression whiteSpace? (PLUS | MINUS) whiteSpace? expression                                  # addOp
+    | expression whiteSpace? AMPERSAND whiteSpace? expression                                       # concatOp
+    | expression whiteSpace? (EQ | NEQ | LT | GT | LEQ | GEQ | LIKE | IS) whiteSpace? expression    # relationalOp
+    | NOT whiteSpace? expression                                                                    # logicalNotOp
+    | expression whiteSpace? AND whiteSpace? expression                                             # logicalAndOp
+    | expression whiteSpace? OR whiteSpace? expression                                              # logicalOrOp
+    | expression whiteSpace? XOR whiteSpace? expression                                             # logicalXorOp
+    | expression whiteSpace? EQV whiteSpace? expression                                             # logicalEqvOp
+    | expression whiteSpace? IMP whiteSpace? expression                                             # logicalImpOp
+    | literalExpression                                                                             # literalExpr
+    | lExpression                                                                                   # lExpr
+    | builtInType                                                                                   # builtInTypeExpr
 ;
 
 // 5.6.5 Literal Expressions
@@ -649,7 +651,7 @@ lExpression :
     | identifier                                                                                                    # simpleNameExpr
     | DOT mandatoryLineContinuation? unrestrictedIdentifier                                                         # withMemberAccessExpr
     | EXCLAMATIONPOINT mandatoryLineContinuation? unrestrictedIdentifier                                            # withDictionaryAccessExpr
-	| lExpression mandatoryLineContinuation whiteSpace? LPAREN whiteSpace? argumentList? whiteSpace? RPAREN			# whitespaceIndexExpr
+    | lExpression mandatoryLineContinuation whiteSpace? LPAREN whiteSpace? argumentList? whiteSpace? RPAREN         # whitespaceIndexExpr
 ;
 
 // 3.3.5.3 Special Identifier Forms
@@ -669,7 +671,7 @@ requiredArgument : argument;
 argument :
     positionalArgument
     | namedArgument
-	| missingArgument
+    | missingArgument
 ;
 
 positionalArgument : argumentExpression;
@@ -690,122 +692,122 @@ upperBoundArgumentExpression : expression;
 addressOfExpression : ADDRESSOF whiteSpace expression;
 
 keyword : 
-       ABS
-     | ADDRESSOF
-     | ALIAS
-     | AND
-     | ANY
-     | ARRAY
-     | ATTRIBUTE
-     | BEGIN
-	 | BEGINPROPERTY
-     | BOOLEAN
-     | BYREF
-     | BYTE
-     | BYVAL
-     | CBOOL
-     | CBYTE
-     | CCUR
-     | CDATE
-     | CDBL
-     | CDEC
-     | CINT
-     | CLASS
-     | CLNG
-     | CLNGLNG
-     | CLNGPTR
-     | CSNG
-     | CSTR
-     | CURRENCY
-     | CVAR
-     | CVERR
-     | DATABASE
-     | DATE
-     | DEBUG
-     | DOEVENTS
-     | DOUBLE
-     | END
-	 | ENDPROPERTY
-     | EQV
-     | FALSE
-     | FIX
-     | IMP
-     | IN
-     | INPUTB
-     | INT
-     | INTEGER
-     | IS
-     | LBOUND
-     | LEN
-     | LEN
-     | LENB
-     | LIB
-     | LIKE
-     | LONG
-     | LONGLONG
-     | LONGPTR
-     | ME
-     | MID
-     | MIDB
-     | MOD
-     | NEW
-     | NOT
-     | NOTHING
-     | NULL
-     | OBJECT
-     | OPTIONAL
-     | OR
-     | PARAMARRAY
-     | PRESERVE
-     | PSET
-     | PTRSAFE
-     | REM
-     | SGN
-     | SINGLE
-     | SPC
-     | STRING
-     | TAB
-     | TEXT
-     | THEN
-     | TO
-     | TRUE
-     | TYPEOF
-     | UBOUND
-     | UNTIL
-     | VARIANT
-     | VERSION
-     | WITHEVENTS
-     | XOR
-     | STEP
-     | ON_ERROR
-     | ERROR
-     | APPEND
-     | BINARY
-     | OUTPUT
-     | RANDOM
-	 | RANDOMIZE
-     | ACCESS
-     | READ
-     | WRITE
-     | READ_WRITE
-     | SHARED
-     | LOCK_READ
-     | LOCK_WRITE
-     | LOCK_READ_WRITE
-     | LINE_INPUT    
-     | RESET
-     | WIDTH
-     | PRINT
-     | GET
-     | PUT
-     | CLOSE
-     | INPUT
-     | LOCK
-     | OPEN
-     | SEEK
-     | UNLOCK
-     | WRITE
-	 | NAME
+      ABS
+    | ADDRESSOF
+    | ALIAS
+    | AND
+    | ANY
+    | ARRAY
+    | ATTRIBUTE
+    | BEGIN
+    | BEGINPROPERTY
+    | BOOLEAN
+    | BYREF
+    | BYTE
+    | BYVAL
+    | CBOOL
+    | CBYTE
+    | CCUR
+    | CDATE
+    | CDBL
+    | CDEC
+    | CINT
+    | CLASS
+    | CLNG
+    | CLNGLNG
+    | CLNGPTR
+    | CSNG
+    | CSTR
+    | CURRENCY
+    | CVAR
+    | CVERR
+    | DATABASE
+    | DATE
+    | DEBUG
+    | DOEVENTS
+    | DOUBLE
+    | END
+    | ENDPROPERTY
+    | EQV
+    | FALSE
+    | FIX
+    | IMP
+    | IN
+    | INPUTB
+    | INT
+    | INTEGER
+    | IS
+    | LBOUND
+    | LEN
+    | LEN
+    | LENB
+    | LIB
+    | LIKE
+    | LONG
+    | LONGLONG
+    | LONGPTR
+    | ME
+    | MID
+    | MIDB
+    | MOD
+    | NEW
+    | NOT
+    | NOTHING
+    | NULL
+    | OBJECT
+    | OPTIONAL
+    | OR
+    | PARAMARRAY
+    | PRESERVE
+    | PSET
+    | PTRSAFE
+    | REM
+    | SGN
+    | SINGLE
+    | SPC
+    | STRING
+    | TAB
+    | TEXT
+    | THEN
+    | TO
+    | TRUE
+    | TYPEOF
+    | UBOUND
+    | UNTIL
+    | VARIANT
+    | VERSION
+    | WITHEVENTS
+    | XOR
+    | STEP
+    | ON_ERROR
+    | ERROR
+    | APPEND
+    | BINARY
+    | OUTPUT
+    | RANDOM
+    | RANDOMIZE
+    | ACCESS
+    | READ
+    | WRITE
+    | READ_WRITE
+    | SHARED
+    | LOCK_READ
+    | LOCK_WRITE
+    | LOCK_READ_WRITE
+    | LINE_INPUT    
+    | RESET
+    | WIDTH
+    | PRINT
+    | GET
+    | PUT
+    | CLOSE
+    | INPUT
+    | LOCK
+    | OPEN
+    | SEEK
+    | UNLOCK
+    | WRITE
+    | NAME
 ;
 
 markerKeyword : AS;
@@ -883,7 +885,7 @@ endOfLine :
 // we expect endOfStatement to consume all trailing whitespace
 endOfStatement :
     (endOfLine whiteSpace? | (whiteSpace? COLON whiteSpace?))+
-	| whiteSpace? EOF
+    | whiteSpace? EOF
 ;
 
 // Annotations must come before comments because of precedence. ANTLR4 matches as much as possible then chooses the one that comes first.
@@ -891,8 +893,8 @@ commentOrAnnotation :
     (annotationList 
     | remComment
     | comment) 
-	// all comments must end with a logical line. See VBA Language Spec 3.3.1
-	(NEWLINE | EOF)
+    // all comments must end with a logical line. See VBA Language Spec 3.3.1
+    (NEWLINE | EOF)
 ;
 remComment : REM whiteSpace? commentBody;
 comment : SINGLEQUOTE commentBody;
@@ -901,11 +903,11 @@ annotationList : SINGLEQUOTE (AT annotation whiteSpace?)+ (COLON commentBody)?;
 annotation : annotationName annotationArgList?;
 annotationName : unrestrictedIdentifier;
 annotationArgList : 
-     whiteSpace annotationArg
-     | whiteSpace annotationArg (whiteSpace? COMMA whiteSpace? annotationArg)+
-     | whiteSpace? LPAREN whiteSpace? RPAREN
-     | whiteSpace? LPAREN whiteSpace? annotationArg whiteSpace? RPAREN
-     | whiteSpace? LPAREN annotationArg (whiteSpace? COMMA whiteSpace? annotationArg)+ whiteSpace? RPAREN;
+    whiteSpace annotationArg
+    | whiteSpace annotationArg (whiteSpace? COMMA whiteSpace? annotationArg)+
+    | whiteSpace? LPAREN whiteSpace? RPAREN
+    | whiteSpace? LPAREN whiteSpace? annotationArg whiteSpace? RPAREN
+    | whiteSpace? LPAREN annotationArg (whiteSpace? COMMA whiteSpace? annotationArg)+ whiteSpace? RPAREN;
 annotationArg : expression;
 
 mandatoryLineContinuation : LINE_CONTINUATION WS*;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -43,8 +43,8 @@ module :
 moduleHeader : VERSION whiteSpace numberLiteral whiteSpace? CLASS? endOfStatement;
 
 moduleConfig :
-    BEGIN (whiteSpace GUIDLITERAL whiteSpace unrestrictedIdentifier whiteSpace?)? endOfStatement
-    moduleConfigElement+
+    BEGIN (whiteSpace (GUIDLITERAL | expression) whiteSpace unrestrictedIdentifier whiteSpace?)? endOfStatement
+    (moduleConfig | moduleConfigElement)+
     END endOfStatement
 ;
 

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -698,6 +698,7 @@ keyword :
      | ARRAY
      | ATTRIBUTE
      | BEGIN
+	 | BEGINPROPERTY
      | BOOLEAN
      | BYREF
      | BYTE
@@ -724,6 +725,7 @@ keyword :
      | DOEVENTS
      | DOUBLE
      | END
+	 | ENDPROPERTY
      | EQV
      | FALSE
      | FIX

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -30,6 +30,7 @@ module :
     moduleAttributes
     moduleHeader?
     moduleAttributes
+	moduleConfigReferences?
     moduleConfig?
     moduleAttributes
     moduleDeclarations
@@ -41,6 +42,10 @@ module :
 ;
 
 moduleHeader : VERSION whiteSpace numberLiteral whiteSpace? CLASS? endOfStatement;
+
+moduleConfigReferences: moduleConfigReferenceElement+;
+
+moduleConfigReferenceElement: unrestrictedIdentifier whiteSpace? EQ whiteSpace? STRINGLITERAL whiteSpace? SEMICOLON whiteSpace? STRINGLITERAL endOfStatement;
 
 moduleConfig :
     BEGIN (whiteSpace (GUIDLITERAL | expression) whiteSpace unrestrictedIdentifier whiteSpace?)? endOfStatement

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -845,7 +845,7 @@ Begin VB.Form Form1
       RowHeight = 15
       AllowAddNew = -1  'True
       BeginProperty HeadFont {0BE35203-8F91-11CE-9DE3-00AA004BB851}
-            Name = ""MS Sans Serif""
+         Name = ""MS Sans Serif""
          Size = 8.25
          Charset = 0
          Weight = 400
@@ -861,6 +861,55 @@ Begin VB.Form Form1
          Underline = 0   'False
          Italic = 0   'False
          Strikethrough = 0   'False
+      EndProperty
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 2);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void TestNestedVbFormModuleConfigWithNestedProperties()
+        {
+            string code = @"
+VERSION 5.00
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin MSDataGridLib.DataGrid DataGrid1
+      Bindings = ""frmMain.frx"":0000
+      Height = 2055
+      Left = 2520
+      TabIndex = 0
+      Top = 120
+      Width = 5655
+      _ExtentX = 9975
+      _ExtentY = 3625
+      _Version = 393216
+      HeadLines = 1
+      RowHeight = 15
+      AllowAddNew = -1  'True
+      BeginProperty Column00 
+         DataField       =   """"
+         Caption         =   """"
+         BeginProperty DataFormat {6D835690-900B-11D0-9484-00A0C91110ED} 
+            Type            =   0
+            Format          =   """"
+            HaveTrueFalseNull=   0
+            FirstDayOfWeek  =   0
+            FirstWeekOfYear =   0
+            LCID            =   1033
+            SubFormatType   =   0
+         EndProperty
       EndProperty
    End
 End

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -470,6 +470,7 @@ Private this As TProgressIndicator
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
+
         [Category("Parser")]
         [Test]
         public void TestAttributeInsideModuleDeclarations()
@@ -643,6 +644,229 @@ BEGIN
 END";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigElement");
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void TestVBFormModuleConfig()
+        {
+            string code = @"
+Begin VB.Form Form1 
+   Caption         =   ""Form1""
+   ClientHeight    =   2640
+   ClientLeft      =   45
+   ClientTop       =   375
+   ClientWidth     =   4710
+   OleObjectBlob   =   ""Form1.frx"":0000
+   StartUpPosition =   1  'CenterOwner
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void TestNestedVbFormModuleConfig()
+        {
+            string code = @"
+VERSION 5.00
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin VB.CommandButton cmdDelete
+      Caption = ""Delete""
+      Height = 495
+      Left = 1320
+      TabIndex = 9
+      Top = 2280
+      Width = 1215
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 2);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void TestNestedVbFormModuleConfigWithObjectDeclarations()
+        {
+            string code = @"
+VERSION 5.00
+Object = ""{67397AA1-7FB1-11D0-B148-00A0C922E820}#6.0#0""; ""MSADODC.OCX""
+Object = ""{CDE57A40-8B86-11D0-B3C6-00A0C90AEA82}#1.0#0""; ""MSDATGRD.OCX""
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin VB.CommandButton cmdDelete
+      Caption = ""Delete""
+      Height = 495
+      Left = 1320
+      TabIndex = 9
+      Top = 2280
+      Width = 1215
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 2);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void TestNestedVbFormModuleConfigWithMultipleChildren()
+        {
+            string code = @"
+VERSION 5.00
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin VB.CommandButton cmdDelete
+      Caption = ""Delete""
+      Height = 495
+      Left = 1320
+      TabIndex = 9
+      Top = 2280
+      Width = 1215
+   End
+   Begin MSDataGridLib.DataGrid DataGrid1
+      Bindings = ""frmMain.frx"":0000
+      Height = 2055
+      Left = 2520
+      TabIndex = 0
+      Top = 120
+      Width = 5655
+      _ExtentX = 9975
+      _ExtentY = 3625
+      _Version = 393216
+      HeadLines = 1
+      RowHeight = 15
+      AllowAddNew = -1  'True
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 3);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void TestNestedVbFormModuleConfigWithProperty()
+        {
+            string code = @"
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin MSDataGridLib.DataGrid DataGrid1
+      Bindings = ""frmMain.frx"":0000
+      Height = 2055
+      Left = 2520
+      TabIndex = 0
+      Top = 120
+      Width = 5655
+      _ExtentX = 9975
+      _ExtentY = 3625
+      _Version = 393216
+      HeadLines = 1
+      RowHeight = 15
+      AllowAddNew = -1  'True
+      BeginProperty HeadFont {0BE35203-8F91-11CE-9DE3-00AA004BB851}
+            Name = ""MS Sans Serif""
+         Size = 8.25
+         Charset = 0
+         Weight = 400
+         Underline = 0   'False
+         Italic = 0   'False
+         Strikethrough = 0   'False
+      EndProperty
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 1);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void TestNestedVbFormModuleConfigWithMultipleProperties()
+        {
+            string code = @"
+VERSION 5.00
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin MSDataGridLib.DataGrid DataGrid1
+      Bindings = ""frmMain.frx"":0000
+      Height = 2055
+      Left = 2520
+      TabIndex = 0
+      Top = 120
+      Width = 5655
+      _ExtentX = 9975
+      _ExtentY = 3625
+      _Version = 393216
+      HeadLines = 1
+      RowHeight = 15
+      AllowAddNew = -1  'True
+      BeginProperty HeadFont {0BE35203-8F91-11CE-9DE3-00AA004BB851}
+            Name = ""MS Sans Serif""
+         Size = 8.25
+         Charset = 0
+         Weight = 400
+         Underline = 0   'False
+         Italic = 0   'False
+         Strikethrough = 0   'False
+      EndProperty
+      BeginProperty Font {0BE35203-8F91-11CE-9DE3-00AA004BB851} 
+         Name = ""MS Sans Serif""
+         Size = 8.25
+         Charset = 0
+         Weight = 400
+         Underline = 0   'False
+         Italic = 0   'False
+         Strikethrough = 0   'False
+      EndProperty
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 2);
         }
 
         [Category("Parser")]


### PR DESCRIPTION
This PR changes the parser and lexer to enable us to parse VB6 forms.

If there are more constructs that have to be added, we can add them once we find an example we cannot parse.