### PR TITLE
Remove the restrictions on the admin elevation

### DIFF
--- a/Rubberduck.Deployment/InnoSetup/Installer Build Script.iss
+++ b/Rubberduck.Deployment/InnoSetup/Installer Build Script.iss
@@ -514,18 +514,19 @@ end;
 
 ///<remarks>
 ///Called after successfully installing, including via the elevated installer
-///to register the VBE addin. Should be never run under elevated context
-///or the registration may not work as expected.
+///to register the VBE addin.
 ///</remarks>
 procedure RegisterAddin();
 begin
-  if not IsElevated() then
-  begin
-    RegisterAddinForIDE(HKCU32, 'Software\Microsoft\VBA\VBE\6.0\Addins', '{#AddinProgId}');
-
     if IsWin64() then 
+    begin
+      RegisterAddinForIDE(HKCU32, 'Software\Microsoft\VBA\VBE\6.0\Addins', '{#AddinProgId}');
       RegisterAddinForIDE(HKCU64, 'Software\Microsoft\VBA\VBE\6.0\Addins64', '{#AddinProgId}');
-  end;
+    end
+      else
+    begin
+      RegisterAddinForIDE(HKCU, 'Software\Microsoft\VBA\VBE\6.0\Addins', '{#AddinProgId}');
+    end;
 end;
 
 ///<remarks>
@@ -816,11 +817,10 @@ begin
       ExpandConstant('{cm:RegisterAddInCaption}'),
       ExpandConstant('{cm:RegisterAddInMessage}'),
       ExpandConstant('{cm:RegisterAddInDescription}'),
-      False, False);
+      false, false);
 
   RegisterAddInOptionPage.Add(ExpandConstant('{cm:RegisterAddInButtonCaption}'));
-  RegisterAddInOptionPage.CheckListBox.ItemEnabled[0] := not IsElevated();
-  RegisterAddInOptionPage.Values[0] := not IsElevated();
+  RegisterAddInOptionPage.Values[0] := true;
 end;
 
 ///<remarks>
@@ -845,14 +845,6 @@ begin
   begin
     Log('PageSkipped set to true now');
     PagesSkipped := True;
-  end;
-
-  // If the installer is elevated, we cannot register the addin so we must skip the
-  // custom page.
-  if (PageID = RegisterAddInOptionPage.ID) and IsElevated() then
-  begin
-    Log('RegisterAddInOptionPage skipped because we are running elevated.');
-    Result := true;
   end;
 
   // We don't need to show the users finished panel from the elevated installer
@@ -998,14 +990,14 @@ begin
     // custom page we should run RegisterAdd()
     else if CurPageID = RegisterAddInOptionPage.ID then
   begin
-    if not IsElevated() and RegisterAddInOptionPage.Values[0] then
+    if RegisterAddInOptionPage.Values[0] then
     begin
       Log('Addin registration was requested and will be performed');
       RegisterAddIn();
     end
       else
     begin
-      Log('Addin registration was declined because either we are elevated or the user unchecked the checkbox');
+      Log('Addin registration was declined because the user unchecked the checkbox');
     end;
   end;
 


### PR DESCRIPTION
Closes #3921 

I made some changes to the `RegisterAddIn()` function and in testing, the bug that was previously observed no longer exhibits and I am able to install as an admin and thus register the IDE for myself. However, I would appreciate others testing to verify it's not "just my computer" symptoms.

Pending: Update the messaging around admin not being able to register as they should no longer apply. Will remove after tests.