### PR TITLE
Move closer refactoring indent fix

### DIFF
--- a/Rubberduck.Core/Refactorings/MoveCloserToUsage/MoveCloserToUsageRefactoring.cs
+++ b/Rubberduck.Core/Refactorings/MoveCloserToUsage/MoveCloserToUsageRefactoring.cs
@@ -125,6 +125,7 @@ namespace Rubberduck.Refactorings.MoveCloserToUsage
             {
                 rewriter.Rewrite();
             }
+            Reparse();
         }
 
         private void UpdateOtherModules()
@@ -207,6 +208,11 @@ namespace Rubberduck.Refactorings.MoveCloserToUsage
 
                 _rewriters.Add(rewriter);
             }
+        }
+
+        private void Reparse()
+        {
+            _state.OnParseRequested(this);
         }
     }
 }

--- a/Rubberduck.Core/Refactorings/MoveCloserToUsage/MoveCloserToUsageRefactoring.cs
+++ b/Rubberduck.Core/Refactorings/MoveCloserToUsage/MoveCloserToUsageRefactoring.cs
@@ -169,8 +169,15 @@ namespace Rubberduck.Refactorings.MoveCloserToUsage
             }
 
             var insertionIndex = (expression as ParserRuleContext).Start.TokenIndex;
-            var firstReferenceLine = _vbe.ActiveCodePane.CodeModule.GetLines((expression as ParserRuleContext).Start.Line, 1);
-            var indentLength = firstReferenceLine.Length - firstReferenceLine.TrimStart().Length;
+            int indentLength;
+            using (var pane = _vbe.ActiveCodePane)
+            {
+                using (var codeModule = pane.CodeModule)
+                {
+                    var firstReferenceLine = codeModule.GetLines((expression as ParserRuleContext).Start.Line, 1);
+                    indentLength = firstReferenceLine.Length - firstReferenceLine.TrimStart().Length;
+                }
+            }
             var padding = new string(' ', indentLength);
 
             var rewriter = _state.GetRewriter(firstReference.QualifiedModuleName);

--- a/Rubberduck.Core/Refactorings/MoveCloserToUsage/MoveCloserToUsageRefactoring.cs
+++ b/Rubberduck.Core/Refactorings/MoveCloserToUsage/MoveCloserToUsageRefactoring.cs
@@ -168,9 +168,12 @@ namespace Rubberduck.Refactorings.MoveCloserToUsage
             }
 
             var insertionIndex = (expression as ParserRuleContext).Start.TokenIndex;
+            var firstReferenceLine = _vbe.ActiveCodePane.CodeModule.GetLines((expression as ParserRuleContext).Start.Line, 1);
+            var indentLength = firstReferenceLine.Length - firstReferenceLine.TrimStart().Length;
+            var padding = new string(' ', indentLength);
 
             var rewriter = _state.GetRewriter(firstReference.QualifiedModuleName);
-            rewriter.InsertBefore(insertionIndex, newVariable);
+            rewriter.InsertBefore(insertionIndex, newVariable + padding);
 
             _rewriters.Add(rewriter);
         }

--- a/RubberduckTests/QuickFixes/MoveFieldCloserToUsageQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/MoveFieldCloserToUsageQuickFixTests.cs
@@ -25,7 +25,7 @@ End Sub";
             const string expectedCode =
                 @"Public Sub Foo()
     Dim bar As String
-bar = ""test""
+    bar = ""test""
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);

--- a/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
+++ b/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
@@ -52,6 +52,40 @@ End Sub";
         [Test]
         [Category("Refactorings")]
         [Category("Move Closer")]
+        public void MoveCloserToUsageRefactoring_LineNumbers()
+        {
+            //Input
+            const string inputCode =
+                @"Private bar As Boolean
+Private Sub Foo()
+100 bar = True
+End Sub";
+            var selection = new Selection(1, 1);
+
+            //Expectation
+            const string expectedCode =
+                @"Private Sub Foo()
+Dim bar As Boolean
+100 bar = True
+End Sub";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [Category("Move Closer")]
         public void MoveCloserToUsageRefactoring_Field_MultipleLines()
         {
             //Input

--- a/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
+++ b/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
@@ -32,7 +32,7 @@ End Sub";
             const string expectedCode =
                 @"Private Sub Foo()
     Dim bar As Boolean
-bar = True
+    bar = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -69,7 +69,7 @@ End Sub";
             const string expectedCode =
                 @"Private Sub Foo()
     Dim bar As Boolean
-bar = True
+    bar = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -155,7 +155,7 @@ End Sub";
                 @"Private Sub Foo()
     Dim bat As Integer
     Dim bar As Boolean
-bar = True
+    bar = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -194,7 +194,7 @@ End Sub";
                 @"Private Sub Foo()
     Dim bat As Integer
     Dim bar As Boolean
-bar = True
+    bar = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -234,7 +234,7 @@ Private bay As Date
 
 Private Sub Foo()
     Dim bat As Boolean
-bat = True
+    bat = True
 End Sub";
             
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -274,7 +274,7 @@ End Sub";
 
 Private Sub Foo()
     Dim bar As Integer
-bar = 3
+    bar = 3
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -314,7 +314,7 @@ End Sub";
 
 Private Sub Foo()
     Dim bat As Boolean
-bat = True
+    bat = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -354,7 +354,7 @@ End Sub";
 
 Private Sub Foo()
     Dim bay As Date
-bay = #1/13/2004#
+    bay = #1/13/2004#
 End Sub";
             
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -396,7 +396,7 @@ End Sub";
 
     bat = True
     Dim bar As Integer
-bar = 3
+    bar = 3
 End Sub";
             
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -438,7 +438,7 @@ End Sub";
 
     bar = 1
     Dim bat As Boolean
-bat = True
+    bat = True
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -480,7 +480,7 @@ End Sub";
 
     bar = 4
     Dim bay As Date
-bay = #1/13/2004#
+    bay = #1/13/2004#
 End Sub";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
@@ -583,7 +583,7 @@ End Sub";
             const string expectedCode =
                 @"Private Sub Foo(ByRef bat As Boolean)
     Dim bar As Boolean
-bat = bar
+    bat = bar
 End Sub";
             var selection = new Selection(1, 1);
 
@@ -618,7 +618,7 @@ End Sub";
             const string expectedCode =
                 @"Private Sub Foo()
     Dim bar As Boolean
-Baz bar
+    Baz bar
 End Sub
 Sub Baz(ByVal bat As Boolean)
 End Sub";
@@ -657,7 +657,7 @@ End Sub";
             const string expectedCode =
                 @"Private Sub Foo()
     Dim bar As Boolean
-Baz True, _
+    Baz True, _
         True, _
         bar
 End Sub
@@ -735,7 +735,7 @@ End Sub";
                 @"
 Public Sub Test()
     Dim foo As Long
-SomeSub someParam:=foo
+    SomeSub someParam:=foo
 End Sub
 
 Public Sub SomeSub(ByVal someParam As Long)
@@ -906,7 +906,7 @@ End Sub";
     Debug.Print ""Some statements between""
     Debug.Print ""Declaration and first usage!""
     Dim foo As Class1
-Set foo = new Class1
+    Set foo = new Class1
     foo.Name = ""FooName""
     foo.OtherProperty = 1626
 End Sub";


### PR DESCRIPTION
Fixes #3964 

First line after insertion was given no indentation. This PR checks the indentation of the line prior to the insertion and adds padding so that the same indentation is preserved.

A reparse is also requested after the refactoring has completed.