### PR TITLE
Fixed null parameter names when collecting reference VB6.OLB

### DIFF
--- a/Rubberduck.Parsing/ComReflection/ComMember.cs
+++ b/Rubberduck.Parsing/ComReflection/ComMember.cs
@@ -91,7 +91,7 @@ namespace Rubberduck.Parsing.ComReflection
             {
                 var paramPtr = new IntPtr(funcDesc.lprgelemdescParam.ToInt64() + Marshal.SizeOf(typeof(ELEMDESC)) * index);
                 var elemDesc = (ELEMDESC)Marshal.PtrToStructure(paramPtr, typeof(ELEMDESC));
-                var param = new ComParameter(elemDesc, info, names[index + 1]);
+                var param = new ComParameter(elemDesc, info, names[index + 1] ?? string.Empty);
                 Parameters.Add(param);
             }
             if (Parameters.Any() && funcDesc.cParamsOpt == -1)

--- a/Rubberduck.Parsing/ComReflection/ComParameter.cs
+++ b/Rubberduck.Parsing/ComReflection/ComParameter.cs
@@ -56,6 +56,8 @@ namespace Rubberduck.Parsing.ComReflection
 
         public ComParameter(ELEMDESC elemDesc, ITypeInfo info, string name)
         {
+            Debug.Assert(name != null, "Parameter name is null");
+
             Name = name;
             var paramDesc = elemDesc.desc.paramdesc;
             GetParameterType(elemDesc.tdesc, info);

--- a/Rubberduck.Parsing/VBA/COMReferenceSynchronizerBase.cs
+++ b/Rubberduck.Parsing/VBA/COMReferenceSynchronizerBase.cs
@@ -175,7 +175,12 @@ namespace Rubberduck.Parsing.VBA
 
         protected void LoadReference(IReference localReference, ConcurrentBag<IReference> unmapped)
         {
-            Logger.Trace(string.Format("Loading referenced type '{0}'.", localReference.Name));
+            if (Thread.CurrentThread.IsBackground && Thread.CurrentThread.Name == null)
+            {
+                Thread.CurrentThread.Name = $"LoadReference '{localReference.Name}'";
+            }
+
+            Logger.Trace(string.Format("Loading referenced type '{0}'.", localReference.Name));            
             var comReflector = new ReferencedDeclarationsCollector(_state, localReference, _serializedDeclarationsPath);
             try
             {


### PR DESCRIPTION
Closes #3951 

Root cause was that this line:
https://github.com/rubberduck-vba/Rubberduck/blob/f43b2b172c120d143750e9a7f8ca5feb06515b4d/Rubberduck.Parsing/ComReflection/ComMember.cs#L88

was returning null values for all array values, but a non-zero count. From this I infer that not all parameter names in the type library are named.

This PR also adds an Assert in the parameter name, and names the background threads which are collecting the references. Happy to remove these if not wanted, but I think they could be helpful for debugging in future.