### PR TITLE
UnitTests: Pass IVBProject rather than ambiguous project name to the TypeLib API

### DIFF
--- a/Rubberduck.Core/UnitTesting/TestMethod.cs
+++ b/Rubberduck.Core/UnitTesting/TestMethod.cs
@@ -22,12 +22,12 @@ namespace Rubberduck.UnitTesting
         private readonly IVBETypeLibsAPI _typeLibApi;
         private readonly RubberduckParserState _state;
 
-        public TestMethod(Declaration declaration, IVBE vbe, IVBETypeLibsAPI typeLibApi, RubberduckParserState state)
+        public TestMethod(RubberduckParserState state, Declaration declaration, IVBE vbe, IVBETypeLibsAPI typeLibApi)
         {
+            _state = state;
             _declaration = declaration;
             _vbe = vbe;
             _typeLibApi = typeLibApi;
-            _state = state;
         }
 
         private Declaration _declaration;

--- a/Rubberduck.Core/UnitTesting/TestMethod.cs
+++ b/Rubberduck.Core/UnitTesting/TestMethod.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
 using Rubberduck.UI;
 using Rubberduck.UI.Controls;
 using Rubberduck.VBEditor;
@@ -19,12 +20,14 @@ namespace Rubberduck.UnitTesting
         private readonly ICollection<AssertCompletedEventArgs> _assertResults = new List<AssertCompletedEventArgs>();
         private readonly IVBE _vbe;
         private readonly IVBETypeLibsAPI _typeLibApi;
+        private readonly RubberduckParserState _state;
 
-        public TestMethod(Declaration declaration, IVBE vbe, IVBETypeLibsAPI typeLibApi)
+        public TestMethod(Declaration declaration, IVBE vbe, IVBETypeLibsAPI typeLibApi, RubberduckParserState state)
         {
             _declaration = declaration;
             _vbe = vbe;
             _typeLibApi = typeLibApi;
+            _state = state;
         }
 
         private Declaration _declaration;
@@ -46,7 +49,8 @@ namespace Rubberduck.UnitTesting
             try
             {
                 AssertHandler.OnAssertCompleted += HandleAssertCompleted;
-                _typeLibApi.ExecuteCode(_vbe, Declaration.ProjectName, Declaration.QualifiedModuleName.ComponentName,
+                var project = _state.ProjectsProvider.Project(Declaration.ProjectId);
+                _typeLibApi.ExecuteCode(project, Declaration.QualifiedModuleName.ComponentName,
                     Declaration.QualifiedName.MemberName);
                 AssertHandler.OnAssertCompleted -= HandleAssertCompleted;
                 

--- a/Rubberduck.Core/UnitTesting/UnitTestUtils.cs
+++ b/Rubberduck.Core/UnitTesting/UnitTestUtils.cs
@@ -17,7 +17,7 @@ namespace Rubberduck.UnitTesting
         {
             return GetTestModuleProcedures(state)
                     .Where(item => IsTestMethod(state, item))
-                    .Select(item => new TestMethod(item, vbe, new VBETypeLibsAPI()));
+                    .Select(item => new TestMethod(item, vbe, new VBETypeLibsAPI(), state));
         }
 
         public static IEnumerable<TestMethod> GetTests(this IVBComponent component, IVBE vbe, RubberduckParserState state)

--- a/Rubberduck.Core/UnitTesting/UnitTestUtils.cs
+++ b/Rubberduck.Core/UnitTesting/UnitTestUtils.cs
@@ -17,7 +17,7 @@ namespace Rubberduck.UnitTesting
         {
             return GetTestModuleProcedures(state)
                     .Where(item => IsTestMethod(state, item))
-                    .Select(item => new TestMethod(item, vbe, new VBETypeLibsAPI(), state));
+                    .Select(item => new TestMethod(state, item, vbe, new VBETypeLibsAPI()));
         }
 
         public static IEnumerable<TestMethod> GetTests(this IVBComponent component, IVBE vbe, RubberduckParserState state)


### PR DESCRIPTION
As above, should be a simple change to avoid using the VBA project name to identify the project when delving into the TypeLib API.