### PR TITLE
Stop removing new line when removing an expression with a line number

### DIFF
--- a/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
+++ b/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
@@ -175,6 +175,43 @@ End Sub";
         [Test]
         [Category("Refactorings")]
         [Category("Move Closer")]
+        public void MoveCloserToUsageRefactoring_VariableWithLineNumbers()
+        {
+            //Input
+            const string inputCode =
+                @"Private Sub Foo()
+1   Dim bar As Boolean
+2   Dim bat As Integer
+3   bar = True
+End Sub";
+            var selection = new Selection(4, 6, 4, 8);
+
+            //Expectation
+            const string expectedCode =
+                @"Private Sub Foo()
+1   
+2   Dim bat As Integer
+Dim bar As Boolean
+3   bar = True
+End Sub";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component, selection);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var qualifiedSelection = new QualifiedSelection(new QualifiedModuleName(component), selection);
+
+                var refactoring = new MoveCloserToUsageRefactoring(vbe.Object, state, null);
+                refactoring.Refactor(qualifiedSelection);
+
+                var rewriter = state.GetRewriter(component);
+                Assert.AreEqual(expectedCode, rewriter.GetText());
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [Category("Move Closer")]
         public void MoveCloserToUsageRefactoring_Variable_MultipleLines()
         {
             //Input


### PR DESCRIPTION
Fixes #3974 

Add special case where a variable declaration has a line number. Normally the declaration and following new line (end of statement) are removed which helps avoid a blank line being left behind. However, with a line number on the declaration the brings the code from the following line to the line with a line number. This can cause invalid code e.g. when the following line has a line number itself.

Incidentally, I can see unreachable code in the file VariableRewriterInfoFinder. The condition `if (blockStmtIndex == containingBlock.ChildCount)` doesn't make sense because it is comparing the (zero-based) index of an item to the number of items and it must always be less?