### PR TITLE
Fixed assembly loading on fall back in deployment.

### DIFF
--- a/Rubberduck.Deployment/BuildRegistryScript.ps1
+++ b/Rubberduck.Deployment/BuildRegistryScript.ps1
@@ -99,10 +99,11 @@ try
 		# For simplicity, the arguments are pass in literally.
 		# & "C:\GitHub\Rubberduck\Rubberduck\Rubberduck.Deployment\echoargs.exe" ""$sourceDll"" /win32 /out:""$sourceTlb"";
 		
+		[System.Reflection.Assembly]::LoadFrom($builderAssemblyPath);
+
 		$devPath = Resolve-Path -Path "C:\Program Files*\Microsoft Visual Studio\*\*\Common*\Tools\VsDevCmd.bat";
 		if($devPath)
 		{
-			[System.Reflection.Assembly]::LoadFrom($builderAssemblyPath);
 			$idlGenerator = New-Object Rubberduck.Deployment.IdlGeneration.IdlGenerator;
 		
 			$idl = $idlGenerator.GenerateIdl($sourceDll);


### PR DESCRIPTION
Fixes build error when building without the C++ build toll installed.