### PR TITLE
Simplify the ExecutionPolicy configuration in deployment

### DIFF
--- a/Rubberduck.Deployment/Rubberduck.Deployment.csproj
+++ b/Rubberduck.Deployment/Rubberduck.Deployment.csproj
@@ -120,9 +120,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -command "$(ProjectDir)BuildRegistryScript.ps1 -config '$(ConfigurationName)' -builderAssemblyPath '$(TargetPath)' -netToolsDir '$(FrameworkSDKDir)bin\NETFX 4.6.1 Tools\' -wixToolsDir '$(ProjectDir)WixToolset\' -sourceDir '$(TargetDir)' -targetDir '$(TargetDir)' -projectDir '$(ProjectDir)' -includeDir '$(ProjectDir)InnoSetup\Includes\' -filesToExtract 'Rubberduck.dll|Rubberduck.API.dll'"</PostBuildEvent>
+    <PostBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command "$(ProjectDir)BuildRegistryScript.ps1 -config '$(ConfigurationName)' -builderAssemblyPath '$(TargetPath)' -netToolsDir '$(FrameworkSDKDir)bin\NETFX 4.6.1 Tools\' -wixToolsDir '$(ProjectDir)WixToolset\' -sourceDir '$(TargetDir)' -targetDir '$(TargetDir)' -projectDir '$(ProjectDir)' -includeDir '$(ProjectDir)InnoSetup\Includes\' -filesToExtract 'Rubberduck.dll|Rubberduck.API.dll'"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -command "$(ProjectDir)PreInnoSetupConfiguration.ps1 -WorkingDir $(ProjectDir)</PreBuildEvent>
+    <PreBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command "$(ProjectDir)PreInnoSetupConfiguration.ps1 -WorkingDir $(ProjectDir)</PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Thanks to @Hosch250  for the nudge - the contributors no longer need to manually set the ExecutionPolicy just to build the deployment, removing a common build error and thus simplifying the setup for contributors. 