### PR TITLE
Fix rename of UDTs

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyModuleInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyModuleInspection.cs
@@ -89,8 +89,7 @@ namespace Rubberduck.Inspections.Concrete
             return context.variableStmt() == null
                    && context.constStmt() == null
                    && context.enumerationStmt() == null
-                   && context.privateTypeDeclaration() == null
-                   && context.publicTypeDeclaration() == null
+                   && context.udtDeclaration() == null
                    && context.eventStmt() == null
                    && context.implementsStmt() == null
                    && context.declareStmt() == null;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -90,8 +90,7 @@ moduleDeclarationsElement :
     | implementsStmt
     | variableStmt
     | moduleOption
-    | publicTypeDeclaration
-    | privateTypeDeclaration)
+    | udtDeclaration)
 ;
 
 moduleBody : 
@@ -518,10 +517,8 @@ subStmt :
 subroutineName : identifier;
 
 // 5.2.3.3 User Defined Type Declarations
-publicTypeDeclaration : ((GLOBAL | PUBLIC) whiteSpace)? udtDeclaration;
-privateTypeDeclaration : PRIVATE whiteSpace udtDeclaration;
 // member list includes trailing endOfStatement
-udtDeclaration : TYPE whiteSpace untypedIdentifier endOfStatement udtMemberList END_TYPE;  
+udtDeclaration : (visibility whiteSpace)? TYPE whiteSpace untypedIdentifier endOfStatement udtMemberList END_TYPE;  
 udtMemberList : (udtMember endOfStatement)+; 
 udtMember : reservedNameMemberDeclaration | untypedNameMemberDeclaration;
 untypedNameMemberDeclaration : untypedIdentifier whiteSpace? optionalArrayClause;

--- a/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationSymbolsListener.cs
@@ -751,30 +751,21 @@ namespace Rubberduck.Parsing.Symbols
             AddDeclaration(declaration);
         }
 
-        public override void EnterPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
+        public override void EnterUdtDeclaration(VBAParser.UdtDeclarationContext context)
         {
-            AddUdtDeclaration(context.udtDeclaration(), Accessibility.Public, context);
+            AddUdtDeclaration(context);
         }
 
-        public override void ExitPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
+        public override void ExitUdtDeclaration(VBAParser.UdtDeclarationContext context)
         {
             _parentDeclaration = _moduleDeclaration;
         }
 
-        public override void EnterPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
+        private void AddUdtDeclaration(VBAParser.UdtDeclarationContext context)
         {
-            AddUdtDeclaration(context.udtDeclaration(), Accessibility.Private, context);
-        }
-
-        public override void ExitPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
-        {
-            _parentDeclaration = _moduleDeclaration;
-        }
-
-        private void AddUdtDeclaration(VBAParser.UdtDeclarationContext udtDeclaration, Accessibility accessibility, ParserRuleContext context)
-        {
-            var identifier = Identifier.GetName(udtDeclaration.untypedIdentifier());
-            var identifierSelection = Identifier.GetNameSelection(udtDeclaration.untypedIdentifier());
+            var identifier = Identifier.GetName(context.untypedIdentifier());
+            var identifierSelection = Identifier.GetNameSelection(context.untypedIdentifier());
+            var accessibility = context.visibility()?.PRIVATE() != null ? Accessibility.Private : Accessibility.Public; 
             var declaration = CreateDeclaration(
                 identifier,
                 null,

--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceListener.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceListener.cs
@@ -86,22 +86,12 @@ namespace Rubberduck.Parsing.Symbols
             SetCurrentScope();
         }
 
-        public override void EnterPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
+        public override void EnterUdtDeclaration(VBAParser.UdtDeclarationContext context)
         {
-            SetCurrentScope(Identifier.GetName(context.udtDeclaration().untypedIdentifier()), DeclarationType.UserDefinedType);
+            SetCurrentScope(Identifier.GetName(context.untypedIdentifier()), DeclarationType.UserDefinedType);
         }
 
-        public override void ExitPublicTypeDeclaration(VBAParser.PublicTypeDeclarationContext context)
-        {
-            SetCurrentScope();
-        }
-
-        public override void EnterPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
-        {
-            SetCurrentScope(Identifier.GetName(context.udtDeclaration().untypedIdentifier()), DeclarationType.UserDefinedType);
-        }
-
-        public override void ExitPrivateTypeDeclaration(VBAParser.PrivateTypeDeclarationContext context)
+        public override void ExitUdtDeclaration(VBAParser.UdtDeclarationContext context)
         {
             SetCurrentScope();
         }

--- a/Rubberduck.Parsing/VBA/COMReferenceSynchronizerBase.cs
+++ b/Rubberduck.Parsing/VBA/COMReferenceSynchronizerBase.cs
@@ -89,7 +89,7 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        private IEnumerable<IReference> GetReferencesToLoadAndSaveReferencePriority(IReadOnlyList<IVBProject> projects)
+        private ICollection<IReference> GetReferencesToLoadAndSaveReferencePriority(IReadOnlyList<IVBProject> projects)
         {
             var referencesToLoad = new List<IReference>();
 

--- a/Rubberduck.VBEEditor/Events/VBENativeServices.cs
+++ b/Rubberduck.VBEEditor/Events/VBENativeServices.cs
@@ -209,16 +209,27 @@ namespace Rubberduck.VBEditor.Events
                 var caption = hwnd.GetWindowText();
                 using (var panes = _vbe.CodePanes)
                 {
+                    var foundIt = false;
                     foreach (var pane in panes)
                     {
-                        using (var window = pane.Window)
+                        try
                         {
-                            if (window.Caption.Equals(caption))
+                            using (var window = pane.Window)
                             {
-                                return pane;
+                                if (window.Caption.Equals(caption))
+                                {
+                                    foundIt = true;
+                                    return pane;
+                                }
                             }
                         }
-                        pane.Dispose();
+                        finally
+                        {
+                            if(!foundIt)
+                            {
+                                pane.Dispose();
+                            }
+                        }
                     }
 
                     return null;
@@ -243,13 +254,25 @@ namespace Rubberduck.VBEditor.Events
             var caption = hwnd.GetWindowText();
             using (var windows = _vbe.Windows)
             {
+                var foundIt = false;
                 foreach (var window in windows)
                 {
-                    if (window.Caption.Equals(caption))
+                    try
                     {
-                        return window;
+                        if (window.Caption.Equals(caption))
+                        {
+                            foundIt = true;
+                            return window;
+                        }
+
                     }
-                    window.Dispose();
+                    finally
+                    {
+                        if (!foundIt)
+                        {
+                            window.Dispose();
+                        }
+                    }
                 }
                 return null;
             }

--- a/RubberduckTests/Refactoring/RenameTests.cs
+++ b/RubberduckTests/Refactoring/RenameTests.cs
@@ -1767,6 +1767,123 @@ End Sub"
         }
 
         #endregion
+        #region Rename UDT Tests
+
+        [Test]
+        [Category("Refactorings")]
+        [Category("Rename")]
+        public void RenameRefactoring_RenamePublicUDT()
+        {
+            var tdo = new RenameTestsDataObject(selection: "UserType", newName: "NewUserType");
+            var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
+            {
+                Input =
+                    @"Option Explicit
+
+Public Type UserType|
+    foo As String
+    bar As Long
+End Type
+
+
+Private Sub DoSomething(baz As UserType)
+    MsgBox CStr(baz.bar)
+End Sub",
+                Expected =
+                    @"Option Explicit
+
+Public Type NewUserType
+    foo As String
+    bar As Long
+End Type
+
+
+Private Sub DoSomething(baz As NewUserType)
+    MsgBox CStr(baz.bar)
+End Sub"
+            };
+            PerformExpectedVersusActualRenameTests(tdo, inputOutput);
+
+            tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [Category("Rename")]
+        public void RenameRefactoring_RenamePrivateUDT()
+        {
+            var tdo = new RenameTestsDataObject(selection: "UserType", newName: "NewUserType");
+            var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
+            {
+                Input =
+                    @"Option Explicit
+
+Public Type UserType|
+    foo As String
+    bar As Long
+End Type
+
+
+Private Sub DoSomething(baz As UserType)
+    MsgBox CStr(baz.bar)
+End Sub",
+                Expected =
+                    @"Option Explicit
+
+Public Type NewUserType
+    foo As String
+    bar As Long
+End Type
+
+
+Private Sub DoSomething(baz As NewUserType)
+    MsgBox CStr(baz.bar)
+End Sub"
+            };
+            PerformExpectedVersusActualRenameTests(tdo, inputOutput);
+
+            tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [Category("Rename")]
+        public void RenameRefactoring_RenameUDTMember()
+        {
+            var tdo = new RenameTestsDataObject(selection: "bar", newName: "fooBar");
+            var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
+            {
+                Input =
+                    @"Option Explicit
+
+Private Type UserType
+    foo As String
+    bar| As Long
+End Type
+
+
+Private Sub DoSomething(baz As UserType)
+    MsgBox CStr(baz.bar)
+End Sub",
+                Expected =
+                    @"Option Explicit
+
+Private Type UserType
+    foo As String
+    fooBar As Long
+End Type
+
+
+Private Sub DoSomething(baz As UserType)
+    MsgBox CStr(baz.fooBar)
+End Sub"
+            };
+            PerformExpectedVersusActualRenameTests(tdo, inputOutput);
+
+            tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        #endregion
         #region Rename Label Tests
         [Test]
         [Category("Refactorings")]
@@ -2253,7 +2370,9 @@ End Property";
                 if (inputOutput.CheckExpectedEqualsActual)
                 {
                     var rewriter = tdo.ParserState.GetRewriter(RetrieveComponent(tdo, inputOutput.ModuleName).CodeModule.Parent);
-                    Assert.AreEqual(inputOutput.Expected, rewriter.GetText());
+                    var expected = inputOutput.Expected;
+                    var actual = rewriter.GetText();
+                    Assert.AreEqual(expected, actual);
                 }
             }
         }

--- a/RubberduckTests/Refactoring/RenameTests.cs
+++ b/RubberduckTests/Refactoring/RenameTests.cs
@@ -1883,6 +1883,95 @@ End Sub"
             tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
+        [Test]
+        [Category("Refactorings")]
+        [Category("Rename")]
+        public void RenameRefactoring_RenamePublicUDT_ReferenceInDifferentModule()
+        {
+            var tdo = new RenameTestsDataObject(selection: "UserType", newName: "NewUserType");
+            var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
+            {
+                Input =
+                    @"Option Explicit
+
+Public Type UserType|
+    foo As String
+    bar As Long
+End Type",
+
+                Expected =
+                    @"Option Explicit
+
+Public Type NewUserType
+    foo As String
+    bar As Long
+End Type"
+            };
+
+            var otherModule = new RenameTestModuleDefinition("Module2", ComponentType.StandardModule)
+            {
+                Input =
+                    @"Option Explicit
+
+Private Sub DoSomething(baz As UserType)
+    MsgBox CStr(baz.bar)
+End Sub",
+                Expected =
+                    @"Option Explicit
+
+Private Sub DoSomething(baz As NewUserType)
+    MsgBox CStr(baz.bar)
+End Sub"
+            };
+            PerformExpectedVersusActualRenameTests(tdo, inputOutput, otherModule);
+
+            tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [Category("Rename")]
+        public void RenameRefactoring_RenamePublicUDTMember_ReferenceInDifferentModule()
+        {
+            var tdo = new RenameTestsDataObject(selection: "bar", newName: "fooBar");
+            var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
+            {
+                Input =
+                    @"Option Explicit
+
+Public Type UserType
+    foo As String
+    bar| As Long
+End Type",
+                Expected =
+                    @"Option Explicit
+
+Public Type UserType
+    foo As String
+    fooBar As Long
+End Type"
+            };
+
+            var otherModule = new RenameTestModuleDefinition("Module2", ComponentType.StandardModule)
+            {
+                Input =
+                    @"Option Explicit
+
+Private Sub DoSomething(baz As UserType)
+    MsgBox CStr(baz.bar)
+End Sub",
+                Expected =
+                    @"Option Explicit
+
+Private Sub DoSomething(baz As UserType)
+    MsgBox CStr(baz.fooBar)
+End Sub"
+            };
+            PerformExpectedVersusActualRenameTests(tdo, inputOutput, otherModule);
+
+            tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
         #endregion
         #region Rename Label Tests
         [Test]


### PR DESCRIPTION
This PR closes #4056 

I took the third option outlined in the issue and it was much more straight forward than expected. Apparently, nothing was really using the separate contextx for the visibility.

I also improved the handling of com wrappers in `VBENativeServices`, which was leaking tons of wrappers. This had a positive effect on the com issues at the shutdown of RD, as far as I could judge in the debugger.