### PR TITLE
Grammar - fix MID statement

### DIFF
--- a/Rubberduck.Parsing/Binding/Bindings/SimpleNameDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/SimpleNameDefaultBinding.cs
@@ -1,7 +1,6 @@
 ﻿using Antlr4.Runtime;
 using Rubberduck.Parsing.Symbols;
 using System.Linq;
-using Rubberduck.Parsing.Grammar;
 
 namespace Rubberduck.Parsing.Binding
 {
@@ -75,14 +74,9 @@ namespace Rubberduck.Parsing.Binding
                 var bracketedExpression = _declarationFinder.OnBracketedExpression(_context.GetText(), _context);
                 return new SimpleNameExpression(bracketedExpression, ExpressionClassification.Unbound, _context);
             }
-            //TODO - this is a complete and total hack to prevent `Mid` and `Mid$` from creating undeclared variables
-            //pending an actual fix to the grammar.  See #2618
-            else if (!_name.Equals("Mid") && !_name.Equals("Mid$"))
-            {
-                var undeclaredLocal = _declarationFinder.OnUndeclaredVariable(_parent, _name, _context);
-                return new SimpleNameExpression(undeclaredLocal, ExpressionClassification.Variable, _context);
-            }
-            return new ResolutionFailedExpression();
+            
+            var undeclaredLocal = _declarationFinder.OnUndeclaredVariable(_parent, _name, _context);
+            return new SimpleNameExpression(undeclaredLocal, ExpressionClassification.Variable, _context);            
         }
 
         private IBoundExpression ResolveProcedureNamespace()

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -130,6 +130,7 @@ mainBlockStmt :
     | ifStmt
     | singleLineIfStmt
     | implementsStmt
+    | midStatement
     | letStmt
     | lsetStmt
     | onErrorStmt
@@ -462,9 +463,9 @@ redimVariableDeclaration : expression (whiteSpace asTypeClause)?;
 // This needs to be explicitly defined to distinguish between Mid as a function and Mid as a keyword.
 midStatement : modeSpecifier 
     LPAREN whiteSpace? 
-    lExpression whiteSpace? COMMA whiteSpace? lExpression whiteSpace? (COMMA whiteSpace? lExpression whiteSpace?)? 
+    lExpression whiteSpace? COMMA whiteSpace? expression whiteSpace? (COMMA whiteSpace? expression whiteSpace?)? 
     RPAREN 
-    whiteSpace? ASSIGN whiteSpace? 
+    whiteSpace? EQ whiteSpace? 
     expression;
 modeSpecifier :	(MID | MIDB) DOLLAR? ;
 

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -2873,7 +2873,118 @@ End Sub
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
         }
-        
+
+        [Category("Parser")]
+        [Test]
+        public void MidDollarStatement()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    Mid$(TestString, 5, 3) = ""fox""
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
+        }
+
+        public void MidBStatement()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    MidB(TestString, 5, 3) = ""fox""
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void MidBDollarStatement()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    MidB$(TestString, 5, 3) = ""fox""
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void MidFunction()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    If Mid(TestString, 5, 3) = ""fox"" Then
+        MsgBox ""Found""
+    End If
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void MidDollarFunction()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    If Mid$(TestString, 5, 3) = ""fox"" Then
+        MsgBox ""Found""
+    End If
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void MidBFunction()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    If MidB(TestString, 5, 3) = ""fox"" Then
+        MsgBox ""Found""
+    End If
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
+        }
+
+        [Category("Parser")]
+        [Test]
+        public void MidBDollarFunction()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    If MidB$(TestString, 5, 3) = ""fox"" Then
+        MsgBox ""Found""
+    End If
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
+        }
+
         private Tuple<VBAParser, ParserRuleContext> Parse(string code, PredictionMode predictionMode = null)
         {
             var stream = new AntlrInputStream(code);

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -2859,6 +2859,21 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//commentOrAnnotation", matches => matches.Count == 1);
         }
 
+        [Category("Parser")]
+        [Test]
+        public void MidStatement()
+        {
+            const string code = @"
+Public Sub Test()
+    Dim TestString As String
+    TestString = ""The dog jumps""
+    Mid(TestString, 5, 3) = ""fox""
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
+        }
+        
         private Tuple<VBAParser, ParserRuleContext> Parse(string code, PredictionMode predictionMode = null)
         {
             var stream = new AntlrInputStream(code);


### PR DESCRIPTION
Closes #4111 

There were a few issues:

1. Was using `ASSIGN` instead of `EQ`
2. Was using `lExpression` instead of `expression`
3. Was not referenced from `mainBlockStmt`
4. No tests