### PR TITLE
Add fakes for Now, Time and Date functions

### DIFF
--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
@@ -67,5 +67,9 @@ namespace Rubberduck.UnitTesting
         [DispId(14)]
         [Description("Configures VBA.FileSystem.CurDir calls.")]
         IFake CurDir { get; }
+
+        [DispId(15)]
+        [Description("Configures VBA.DateTime.Now calls.")]
+        IFake Now { get; }
     }
 }

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
@@ -71,5 +71,9 @@ namespace Rubberduck.UnitTesting
         [DispId(15)]
         [Description("Configures VBA.DateTime.Now calls.")]
         IFake Now { get; }
+
+        [DispId(16)]
+        [Description("Configures VBA.DateTime.Time calls.")]
+        IFake Time { get; }
     }
 }

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
@@ -75,5 +75,9 @@ namespace Rubberduck.UnitTesting
         [DispId(16)]
         [Description("Configures VBA.DateTime.Time calls.")]
         IFake Time { get; }
+
+        [DispId(17)]
+        [Description("Configures VBA.DateTime.Date calls.")]
+        IFake Date { get; }
     }
 }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
@@ -41,7 +41,7 @@ namespace Rubberduck.UnitTesting
             SuppressesCall = false;
         }
 
-        private bool TrySetReturnValue(string parameter, object value, bool any = false)
+        protected bool TrySetReturnValue(string parameter, object value, bool any = false)
         {
             var returnInfo =
                 ReturnValues.Where(r => r.Invocation == (any ? FakesProvider.AllInvocations : (int) InvocationCount) &&
@@ -56,7 +56,7 @@ namespace Rubberduck.UnitTesting
             return true;
         }
 
-        private bool TrySetReturnValue(bool any = false)
+        protected bool TrySetReturnValue(bool any = false)
         {
             var returnInfo =
                 ReturnValues.Where(r => r.Invocation == (any ? FakesProvider.AllInvocations : (int) InvocationCount))

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Rubberduck.UnitTesting.Fakes
+{
+    internal class Date : FakeBase
+    {
+        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcGetDateVar");
+
+        public Date()
+        {
+            InjectDelegate(new DateDelegate(DateCallback), ProcessAddress);
+        }
+
+        [DllImport(TargetLibrary, SetLastError = true)]
+        private static extern void rtcGetDateVar(out object retVal);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
+        private delegate void DateDelegate(IntPtr retVal);
+
+        public void DateCallback(IntPtr retVal)
+        {
+            OnCallBack(true);
+            if (!TrySetReturnValue())                          // specific invocation
+            {
+                TrySetReturnValue(true);                       // any invocation
+            }
+            if (PassThrough)
+            {
+                object result;
+                rtcGetDateVar(out result);
+                Marshal.GetNativeVariantForObject(result, retVal);
+                return;
+            }
+            Marshal.GetNativeVariantForObject(ReturnValue ?? 0, retVal);
+        }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Now.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Now.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Rubberduck.UnitTesting.Fakes
+{
+    internal class Now : FakeBase
+    {
+        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcGetPresentDate");
+
+        public Now()
+        {
+            InjectDelegate(new NowDelegate(NowCallback), ProcessAddress);
+        }
+
+        private readonly ValueTypeConverter<float> _converter = new ValueTypeConverter<float>();
+        public override void Returns(object value, int invocation = FakesProvider.AllInvocations)
+        {
+            _converter.Value = value;
+            base.Returns((float)_converter.Value, invocation);
+        }
+
+        [DllImport(TargetLibrary, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.R4)]
+        private static extern void rtcGetPresentDate();
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
+        private delegate void NowDelegate(IntPtr retVal);
+
+        public void NowCallback(IntPtr retVal)
+        {
+            OnCallBack(true);
+
+            if (PassThrough)
+            {
+                //TODO - get passthrough working with byref call
+                Marshal.GetNativeVariantForObject(0, retVal); // rtcGetPresentDate();
+            }
+            Marshal.GetNativeVariantForObject(ReturnValue ?? 0, retVal);
+        }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Rubberduck.UnitTesting.Fakes
+{
+    internal class Time : FakeBase
+    {
+        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcGetTimeVar");
+
+        public Time()
+        {
+            InjectDelegate(new TimeDelegate(TimeCallback), ProcessAddress);
+        }
+
+        [DllImport(TargetLibrary, SetLastError = true)]
+        private static extern void rtcGetTimeVar(out object retVal);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
+        private delegate void TimeDelegate(IntPtr retVal);
+
+        public void TimeCallback(IntPtr retVal)
+        {
+            OnCallBack(true);
+            if (!TrySetReturnValue())                          // specific invocation
+            {
+                TrySetReturnValue(true);                       // any invocation
+            }
+            if (PassThrough)
+            {
+                object result;
+                rtcGetTimeVar(out result);
+                Marshal.GetNativeVariantForObject(result, retVal);
+                return;
+            }
+            Marshal.GetNativeVariantForObject(ReturnValue ?? 0, retVal);
+        }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
@@ -73,6 +73,7 @@ namespace Rubberduck.UnitTesting
         public IStub ChDir => RetrieveOrCreateFunction<IStub>(typeof(ChDir));
         public IStub ChDrive => RetrieveOrCreateFunction<IStub>(typeof(ChDrive));
         public IFake CurDir => RetrieveOrCreateFunction<IFake>(typeof(CurDir));
+        public IFake Now => RetrieveOrCreateFunction<IFake>(typeof(Now));
 
 
         #endregion

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
@@ -75,6 +75,7 @@ namespace Rubberduck.UnitTesting
         public IFake CurDir => RetrieveOrCreateFunction<IFake>(typeof(CurDir));
         public IFake Now => RetrieveOrCreateFunction<IFake>(typeof(Now));
         public IFake Time => RetrieveOrCreateFunction<IFake>(typeof(Time));
+        public IFake Date => RetrieveOrCreateFunction<IFake>(typeof(Date));
 
 
         #endregion

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
@@ -74,6 +74,7 @@ namespace Rubberduck.UnitTesting
         public IStub ChDrive => RetrieveOrCreateFunction<IStub>(typeof(ChDrive));
         public IFake CurDir => RetrieveOrCreateFunction<IFake>(typeof(CurDir));
         public IFake Now => RetrieveOrCreateFunction<IFake>(typeof(Now));
+        public IFake Time => RetrieveOrCreateFunction<IFake>(typeof(Time));
 
 
         #endregion

--- a/Rubberduck.Main/Rubberduck.Main.csproj
+++ b/Rubberduck.Main/Rubberduck.Main.csproj
@@ -243,6 +243,7 @@
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IFakesProvider.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IStub.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IVerify.cs" />
+    <Compile Include="ComClientLibrary\UnitTesting\Fakes\Now.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\PermissiveAssertClass.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\FakeBase.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\Fakes\CurDir.cs" />

--- a/Rubberduck.Main/Rubberduck.Main.csproj
+++ b/Rubberduck.Main/Rubberduck.Main.csproj
@@ -243,6 +243,7 @@
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IFakesProvider.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IStub.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IVerify.cs" />
+    <Compile Include="ComClientLibrary\UnitTesting\Fakes\Time.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\Fakes\Now.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\PermissiveAssertClass.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\FakeBase.cs" />

--- a/Rubberduck.Main/Rubberduck.Main.csproj
+++ b/Rubberduck.Main/Rubberduck.Main.csproj
@@ -243,6 +243,7 @@
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IFakesProvider.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IStub.cs" />
     <Compile Include="ComClientLibrary\Abstract\UnitTesting\IVerify.cs" />
+    <Compile Include="ComClientLibrary\UnitTesting\Fakes\Date.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\Fakes\Time.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\Fakes\Now.cs" />
     <Compile Include="ComClientLibrary\UnitTesting\PermissiveAssertClass.cs" />

--- a/RubberduckTests/IntegrationTests/FakeTests.bas
+++ b/RubberduckTests/IntegrationTests/FakeTests.bas
@@ -272,3 +272,34 @@ TestFail:
     Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
 End Sub
 
+'@TestMethod
+Public Sub TimeFakeWorks()
+    On Error GoTo TestFail
+
+    With Fakes.Time
+        .Returns #9:00:00 AM#
+        Assert.IsTrue Time = #9:00:00 AM#
+        .Verify.Once
+    End With
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub
+
+'@TestMethod
+Public Sub TimeFakePassThroughWorks()
+    On Error GoTo TestFail
+
+    With Fakes.Time
+        .Returns #9:00:00 AM#
+        .Passthrough = True
+        Assert.IsTrue Time <> #9:00:00 AM#
+        .Verify.Once
+    End With
+
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub

--- a/RubberduckTests/IntegrationTests/FakeTests.bas
+++ b/RubberduckTests/IntegrationTests/FakeTests.bas
@@ -325,7 +325,7 @@ Public Sub DateFakePassThroughWorks()
     On Error GoTo TestFail
 
     With Fakes.Date
-        .Returns #9:00:00 AM#
+        .Returns #1/1/1993#
         .Passthrough = True
         Assert.IsTrue Date <> #1/1/1993#
         .Verify.Once

--- a/RubberduckTests/IntegrationTests/FakeTests.bas
+++ b/RubberduckTests/IntegrationTests/FakeTests.bas
@@ -303,3 +303,35 @@ TestExit:
 TestFail:
     Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
 End Sub
+
+'@TestMethod
+Public Sub DateFakeWorks()
+    On Error GoTo TestFail
+
+    With Fakes.Date
+        .Returns #1/1/1993#
+        Assert.IsTrue Date = #1/1/1993#
+        .Verify.Once
+    End With
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub
+
+
+'@TestMethod
+Public Sub DateFakePassThroughWorks()
+    On Error GoTo TestFail
+
+    With Fakes.Date
+        .Returns #9:00:00 AM#
+        .Passthrough = True
+        Assert.IsTrue Date <> #1/1/1993#
+        .Verify.Once
+    End With
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub

--- a/RubberduckTests/IntegrationTests/FakeTests.bas
+++ b/RubberduckTests/IntegrationTests/FakeTests.bas
@@ -238,3 +238,37 @@ TestExit:
 TestFail:
     Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
 End Sub
+
+'@TestMethod
+Public Sub NowFakeWorks()
+    On Error GoTo TestFail
+
+    With Fakes.Now
+        .Returns #1/1/2018 9:00:00 AM#
+        Assert.IsTrue Now = #1/1/2018 9:00:00 AM#
+        .Verify.Once
+    End With
+
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub
+
+'@TestMethod
+Public Sub NowFakePassThroughWorks()
+    On Error GoTo TestFail
+
+    With Fakes.Now
+        .Returns #1/1/2018 9:00:00 AM#
+        .Passthrough = True
+        Assert.IsTrue Now <> #1/1/2018 9:00:00 AM#
+        .Verify.Once
+    End With
+
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub
+


### PR DESCRIPTION
Adds fakes for the Now, Time and Date functions. Issue #2891 tracks the addition of each item.

Minor issue that integration test for passthrough of Time function could fail for 1 second out of every 24 hours (86 400 seconds). Not considered important enough to add complex logic to avoid this but let me know if this is needed.