### PR TITLE
Fix for 3720

### DIFF
--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
@@ -59,8 +59,9 @@ namespace Rubberduck.UnitTesting
         protected bool TrySetReturnValue(bool any = false)
         {
             var returnInfo =
-                ReturnValues.Where(r => r.Invocation == (any ? FakesProvider.AllInvocations : (int) InvocationCount))
-                    .ToList();
+                ReturnValues.Where(r => r.Invocation == (any ? FakesProvider.AllInvocations : (int) InvocationCount) &&
+                                   r.Argument != null &&
+                                   r.Argument == string.Empty).ToList();
 
             if (returnInfo.Count <= 0)
             {

--- a/RubberduckTests/IntegrationTests/FakeTests.bas
+++ b/RubberduckTests/IntegrationTests/FakeTests.bas
@@ -335,3 +335,43 @@ TestExit:
 TestFail:
     Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
 End Sub
+
+'@TestMethod
+Public Sub MsgBoxAfterInputBoxAnyInvocationFakeWorks()
+    On Error GoTo TestFail
+
+    Dim userInput As String
+
+    Fakes.InputBox.ReturnsWhen "Prompt", "Second", "User entry 2"
+    Fakes.MsgBox.Returns vbOK
+
+    Dim msgBoxRetVal As Integer
+    msgBoxRetVal = MsgBox("This is faked", Title:="My Title")
+
+    Assert.IsTrue msgBoxRetVal = vbOK
+    Fakes.MsgBox.Verify.Once
+
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub
+
+'@TestMethod
+Public Sub InputBoxFakeReturnsWhenWorks()
+    On Error GoTo TestFail
+
+    Dim userInput As String
+    Fakes.InputBox.ReturnsWhen "prompt", "Dummy1", "dummy1 user input"
+    Fakes.InputBox.ReturnsWhen "prompt", "Expected", "expected user input"
+    Fakes.InputBox.ReturnsWhen "prompt", "Dummy2", "dummy2 user input"
+
+    userInput = InputBox(prompt:="Expected")
+
+    Assert.AreEqual "expected user input", userInput
+
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub


### PR DESCRIPTION
Fixes #3720. Also seems to close #3721 

Using the ReturnsWhen method creates a ReturnValueInfo record with a Parameter set to a specific Argument. When calling TrackUsage with the actual arguments passed into the fake, it first calls TrySetReturnValue matching the specific parameter/argument combination. If that doesn't get a match, it then calls the other TrySetReturnValue method just to pick up any ReturnValueInfo record with the right invocation. However, that will pick up ReturnValueInfo records created with a ReturnsWhen call, even though the parameter is not matching.

To get around this, the second TrySetReturnValue method checks the ReturnValueInfo records for a Argument == string.Empty because that is how the Returns method creates the ReturnValueInfo record.

I'm unsure of using string.Empty. Would it be better to set the Parameter and Argument fields to null for a Returns method call? The probably only false positive would be if someone used empty strings for calling ReturnsWhen instead of just using Returns. They shouldn't do that of course but it could happen and null seems to get around this.

Integration tests added using the failing examples given in issues 3720 and 3721. They both now pass (having failed before this change). I don't quite follow exactly why but @Vogel612 did suggest they had the same root cause.