### PR TITLE
implemented smart-concat

### DIFF
--- a/Rubberduck.Core/AutoComplete/AutoCompleteService.cs
+++ b/Rubberduck.Core/AutoComplete/AutoCompleteService.cs
@@ -65,7 +65,7 @@ namespace Rubberduck.AutoComplete
             }
 
             var currentContent = module.GetLines(pSelection);
-            if (e.Keys == Keys.Enter && IsInsideStringLiteral(pSelection, ref currentContent))
+            if (e.Keys == Keys.Enter && _settings.EnableSmartConcat && IsInsideStringLiteral(pSelection, ref currentContent))
             {
                 var indent = currentContent.NthIndexOf('"', 1);
                 var whitespace = new string(' ', indent);

--- a/Rubberduck.Core/Properties/Settings.Designer.cs
+++ b/Rubberduck.Core/Properties/Settings.Designer.cs
@@ -431,7 +431,7 @@ namespace Rubberduck.Properties {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
-<AutoCompleteSettings xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" CompleteBlockOnTab=""true"" CompleteBlockOnEnter=""true"">
+<AutoCompleteSettings xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" CompleteBlockOnTab=""true"" CompleteBlockOnEnter=""true"" EnableSmartConcat=""true"">
   <AutoCompletes>
     <AutoComplete Key=""AutoCompleteClosingBrace"" IsEnabled=""true"" />
     <AutoComplete Key=""AutoCompleteClosingBracket"" IsEnabled=""true"" />

--- a/Rubberduck.Core/Properties/Settings.settings
+++ b/Rubberduck.Core/Properties/Settings.settings
@@ -259,7 +259,7 @@
     </Setting>
     <Setting Name="AutoCompleteSettings" Type="Rubberduck.Settings.AutoCompleteSettings" Scope="Application">
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;AutoCompleteSettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" CompleteBlockOnTab="true" CompleteBlockOnEnter="true"&gt;
+&lt;AutoCompleteSettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" CompleteBlockOnTab="true" CompleteBlockOnEnter="true" EnableSmartConcat="true"&gt;
   &lt;AutoCompletes&gt;
     &lt;AutoComplete Key="AutoCompleteClosingBrace" IsEnabled="true" /&gt;
     &lt;AutoComplete Key="AutoCompleteClosingBracket" IsEnabled="true" /&gt;

--- a/Rubberduck.Core/Settings/AutoCompleteSettings.cs
+++ b/Rubberduck.Core/Settings/AutoCompleteSettings.cs
@@ -26,6 +26,9 @@ namespace Rubberduck.Settings
         [XmlAttribute]
         public bool CompleteBlockOnEnter { get; set; }
 
+        [XmlAttribute]
+        public bool EnableSmartConcat { get; set; }
+
         public AutoCompleteSettings() : this(Enumerable.Empty<AutoCompleteSetting>())
         {
             /* default constructor required for XML serialization */

--- a/Rubberduck.Core/UI/Settings/AutoCompleteSettings.xaml
+++ b/Rubberduck.Core/UI/Settings/AutoCompleteSettings.xaml
@@ -84,10 +84,11 @@
                         </StackPanel>
                     </DockPanel>
                 </Label>
-                <DockPanel HorizontalAlignment="Stretch">
+                <WrapPanel HorizontalAlignment="Center">
                     <CheckBox Margin="10,10" IsChecked="{Binding CompleteBlockOnTab}" HorizontalAlignment="Center" Content="{Resx ResxName=Rubberduck.Resources.Settings.AutoCompletesPage, Key=HandleTabKey}" />
                     <CheckBox Margin="10,10" IsChecked="{Binding CompleteBlockOnEnter}" HorizontalAlignment="Center" Content="{Resx ResxName=Rubberduck.Resources.Settings.AutoCompletesPage, Key=HandleEnterKey}" />
-                </DockPanel>
+                    <CheckBox Margin="10,10" IsChecked="{Binding EnableSmartConcat}" HorizontalAlignment="Center" Content="{Resx ResxName=Rubberduck.Resources.Settings.AutoCompletesPage, Key=EnableSmartConcat}" />
+                </WrapPanel>
                 <Border BorderBrush="DarkGray" BorderThickness="1" CornerRadius="2">
                     <DataGrid Name="AutoCompleteSettingsGrid"
                               ItemsSource="{Binding Settings}"

--- a/Rubberduck.Core/UI/Settings/AutoCompleteSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/AutoCompleteSettingsViewModel.cs
@@ -17,6 +17,7 @@ namespace Rubberduck.UI.Settings
             Settings = new ObservableCollection<AutoCompleteSetting>(config.UserSettings.AutoCompleteSettings.AutoCompletes);
             CompleteBlockOnEnter = config.UserSettings.AutoCompleteSettings.CompleteBlockOnEnter;
             CompleteBlockOnTab = config.UserSettings.AutoCompleteSettings.CompleteBlockOnTab;
+            EnableSmartConcat = config.UserSettings.AutoCompleteSettings.EnableSmartConcat;
 
             ExportButtonCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), _ => ExportSettings());
             ImportButtonCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), _ => ImportSettings());
@@ -45,6 +46,7 @@ namespace Rubberduck.UI.Settings
         {
             config.UserSettings.AutoCompleteSettings.CompleteBlockOnTab = CompleteBlockOnTab;
             config.UserSettings.AutoCompleteSettings.CompleteBlockOnEnter = CompleteBlockOnEnter;
+            config.UserSettings.AutoCompleteSettings.EnableSmartConcat = EnableSmartConcat;
             config.UserSettings.AutoCompleteSettings.AutoCompletes = new HashSet<AutoCompleteSetting>(_settings);
         }
 
@@ -52,6 +54,7 @@ namespace Rubberduck.UI.Settings
         {
             CompleteBlockOnTab = toLoad.CompleteBlockOnTab;
             CompleteBlockOnEnter = toLoad.CompleteBlockOnEnter;
+            EnableSmartConcat = toLoad.EnableSmartConcat;
             Settings = new ObservableCollection<AutoCompleteSetting>(toLoad.AutoCompletes);
         }
 
@@ -73,7 +76,21 @@ namespace Rubberduck.UI.Settings
                 }
             }
         }
-        
+
+        private bool _enableSmartConcat;
+        public bool EnableSmartConcat
+        {
+            get { return _enableSmartConcat; }
+            set
+            {
+                if (_enableSmartConcat != value)
+                {
+                    _enableSmartConcat = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         private bool _completeBlockOnEnter;
         public bool CompleteBlockOnEnter
         {

--- a/Rubberduck.Core/app.config
+++ b/Rubberduck.Core/app.config
@@ -378,7 +378,8 @@
       <setting name="AutoCompleteSettings" serializeAs="Xml">
         <value>
           <AutoCompleteSettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema" CompleteBlockOnTab="true" CompleteBlockOnEnter="true">
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema" CompleteBlockOnTab="true"
+            CompleteBlockOnEnter="true" EnableSmartConcat="true">
             <AutoCompletes>
               <AutoComplete Key="AutoCompleteClosingBrace" IsEnabled="true" />
               <AutoComplete Key="AutoCompleteClosingBracket" IsEnabled="true" />

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
@@ -124,6 +124,15 @@ namespace Rubberduck.Resources.Settings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Override &apos;Function&apos; member block completion.
+        /// </summary>
+        public static string AutoCompleteFunctionBlockDescription {
+            get {
+                return ResourceManager.GetString("AutoCompleteFunctionBlockDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Close &apos;If&apos; blocks.
         /// </summary>
         public static string AutoCompleteIfBlockDescription {
@@ -151,11 +160,29 @@ namespace Rubberduck.Resources.Settings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Override &apos;Property&apos; member block completion.
+        /// </summary>
+        public static string AutoCompletePropertyBlockDescription {
+            get {
+                return ResourceManager.GetString("AutoCompletePropertyBlockDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Close &apos;Select&apos; blocks.
         /// </summary>
         public static string AutoCompleteSelectBlockDescription {
             get {
                 return ResourceManager.GetString("AutoCompleteSelectBlockDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Override &apos;Sub&apos; member block completion.
+        /// </summary>
+        public static string AutoCompleteSubBlockDescription {
+            get {
+                return ResourceManager.GetString("AutoCompleteSubBlockDescription", resourceCulture);
             }
         }
         
@@ -183,6 +210,24 @@ namespace Rubberduck.Resources.Settings {
         public static string AutoCompleteWithBlockDescription {
             get {
                 return ResourceManager.GetString("AutoCompleteWithBlockDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable smart concatenation.
+        /// </summary>
+        public static string EnableSmartConcat {
+            get {
+                return ResourceManager.GetString("EnableSmartConcat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Autocomplete blocks on ENTER.
+        /// </summary>
+        public static string HandleEnterKey {
+            get {
+                return ResourceManager.GetString("HandleEnterKey", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.cs.resx
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.cs.resx
@@ -180,4 +180,7 @@
   <data name="PageInstructions" xml:space="preserve">
     <value>Configure which Rubberduck autocompletions are enabled.</value>
   </data>
+  <data name="EnableSmartConcat" xml:space="preserve">
+    <value>Enable smart concatenation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.de.resx
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.de.resx
@@ -180,4 +180,7 @@
   <data name="PageInstructions" xml:space="preserve">
     <value>Configure which Rubberduck autocompletions are enabled.</value>
   </data>
+  <data name="EnableSmartConcat" xml:space="preserve">
+    <value>Enable smart concatenation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.fr.resx
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.fr.resx
@@ -180,4 +180,7 @@
   <data name="PageInstructions" xml:space="preserve">
     <value>Configure which Rubberduck autocompletions are enabled.</value>
   </data>
+  <data name="EnableSmartConcat" xml:space="preserve">
+    <value>Activer la concaténation intelligente</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.resx
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.resx
@@ -180,4 +180,7 @@
   <data name="PageInstructions" xml:space="preserve">
     <value>Configure which Rubberduck autocompletions are enabled.</value>
   </data>
+  <data name="EnableSmartConcat" xml:space="preserve">
+    <value>Enable smart concatenation</value>
+  </data>
 </root>

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/CodeModule.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/CodeModule.cs
@@ -153,7 +153,11 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             }
             else
             {
-                Target.ReplaceLine(line, content);
+                try
+                {
+                    Target.ReplaceLine(line, content);
+                }
+                catch { /* "too many line continuations" is one possible cause */ }
             }
         }
 


### PR DESCRIPTION
When ENTER is pressed and the caret is inside a string literal, e.g.:

    sql = "SELECT Foo, Bar |"

Vanilla VBE does this:

    sql = "SELECT Foo, Bar "
    |"

Rubberduck does this:

    sql = "SELECT Foo, Bar " & _
          "|"

