### PR TITLE
Introduce CodeStringParser

### DIFF
--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -408,6 +408,7 @@
     <Compile Include="VBA\ParseCoordinator.cs" />
     <Compile Include="VBA\RubberduckParserState.cs" />
     <Compile Include="VBA\StringExtensions.cs" />
+    <Compile Include="VBA\VBACodeStringParser.cs" />
     <Compile Include="VBA\VBALikePatternParser.cs" />
     <Compile Include="VBA\VBADateLiteralParser.cs" />
     <Compile Include="VBA\VBAExpressionParser.cs" />

--- a/Rubberduck.Parsing/VBA/VBACodeStringParser.cs
+++ b/Rubberduck.Parsing/VBA/VBACodeStringParser.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Atn;
+using Antlr4.Runtime.Tree;
+using NLog;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Symbols.ParsingExceptions;
+
+namespace Rubberduck.Parsing.VBA
+{
+    /// <summary>
+    /// The class is meant to be used for where we need to do rewriting without actually
+    /// rewriting an existing module in a VBA project. The result is completely free-floating
+    /// and it is the caller's responsibility to persist the finalized results into one of
+    /// actual code. This is useful for creating a code preview for refactoring.
+    /// </summary>
+    public class VBACodeStringParser
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        private readonly CommonTokenStream _tokenStream;
+        public TokenStreamRewriter Rewriter => new TokenStreamRewriter(_tokenStream);
+        public IParseTree ParseTree { get; }
+
+        /// <summary>
+        /// Parse a given string representing a module code. The code passed in must be
+        /// a valid module body, containing valid declarations or complete procedures. 
+        /// Code snippets are not valid. 
+        /// </summary>
+        /// <param name="moduleName">For logging purpose, provide descritpive name for where the virtual module is used</param>
+        /// <param name="moduleCodeString">A string containing valid module body.</param>
+        public VBACodeStringParser(string moduleName, string moduleCodeString)
+        {
+            var tokenStreamProvider = new SimpleVBAModuleTokenStreamProvider();
+            _tokenStream = tokenStreamProvider.Tokens(moduleCodeString);
+            var parser = new VBAParser(_tokenStream);
+            parser.AddErrorListener(new MainParseExceptionErrorListener(moduleName, ParsePass.CodePanePass));
+            try
+            {
+                parser.Interpreter.PredictionMode = PredictionMode.Sll;
+                ParseTree = parser.startRule();
+            }
+            catch (ParsePassSyntaxErrorException syntaxErrorException)
+            {
+                var parsePassText = syntaxErrorException.ParsePass == ParsePass.CodePanePass
+                    ? "code pane"
+                    : "exported";
+                Logger.Warn($"SLL mode failed while parsing the {parsePassText} version of module {moduleName} at symbol {syntaxErrorException.OffendingSymbol.Text} at L{syntaxErrorException.LineNumber}C{syntaxErrorException.Position}. Retrying using LL.");
+                Logger.Debug(syntaxErrorException, "SLL mode exception");
+                _tokenStream.Reset();
+                parser.Reset();
+                parser.Interpreter.PredictionMode = PredictionMode.Ll;
+                ParseTree = parser.startRule();
+            }
+            catch (Exception exception)
+            {
+                Logger.Warn($"SLL mode failed while parsing module {moduleName}. Retrying using LL.");
+                Logger.Debug(exception, "SLL mode exception");
+                _tokenStream.Reset();
+                parser.Reset();
+                parser.Interpreter.PredictionMode = PredictionMode.Ll;
+                ParseTree = parser.startRule();
+            }
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/VBACodeStringParser.cs
+++ b/Rubberduck.Parsing/VBA/VBACodeStringParser.cs
@@ -16,8 +16,17 @@ namespace Rubberduck.Parsing.VBA
     /// </summary>
     public class VBACodeStringParser
     {
+        public enum ParserMode
+        {
+            Default,
+            Sll,
+            Ll
+        }
+
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         private readonly CommonTokenStream _tokenStream;
+        private readonly VBAParser _parser;
+
         public TokenStreamRewriter Rewriter => new TokenStreamRewriter(_tokenStream);
         public IParseTree ParseTree { get; }
 
@@ -28,38 +37,74 @@ namespace Rubberduck.Parsing.VBA
         /// </summary>
         /// <param name="moduleName">For logging purpose, provide descritpive name for where the virtual module is used</param>
         /// <param name="moduleCodeString">A string containing valid module body.</param>
-        public VBACodeStringParser(string moduleName, string moduleCodeString)
+        /// <param name="mode">Indicates what parser mode to use. By default we use SLL fallbacking to LL. When mode is explicitly specified, only that mode will be used with no fallback.</param>
+        public VBACodeStringParser(string moduleName, string moduleCodeString, ParserMode mode = ParserMode.Default) :
+            this(moduleName,
+                moduleCodeString)
+        {
+            ParseTree = mode == ParserMode.Default ? ParseInternal(moduleName) : ParseInternal(mode);
+        }
+
+        private VBACodeStringParser(string moduleName, string moduleCodeString)
         {
             var tokenStreamProvider = new SimpleVBAModuleTokenStreamProvider();
             _tokenStream = tokenStreamProvider.Tokens(moduleCodeString);
-            var parser = new VBAParser(_tokenStream);
-            parser.AddErrorListener(new MainParseExceptionErrorListener(moduleName, ParsePass.CodePanePass));
+            _parser = new VBAParser(_tokenStream);
+            _parser.AddErrorListener(new MainParseExceptionErrorListener(moduleName, ParsePass.CodePanePass));
+        }
+
+        private IParseTree ParseInternal(string moduleName)
+        {
             try
             {
-                parser.Interpreter.PredictionMode = PredictionMode.Sll;
-                ParseTree = parser.startRule();
+                return ParseInternal(ParserMode.Sll);
             }
             catch (ParsePassSyntaxErrorException syntaxErrorException)
             {
                 var parsePassText = syntaxErrorException.ParsePass == ParsePass.CodePanePass
                     ? "code pane"
                     : "exported";
-                Logger.Warn($"SLL mode failed while parsing the {parsePassText} version of module {moduleName} at symbol {syntaxErrorException.OffendingSymbol.Text} at L{syntaxErrorException.LineNumber}C{syntaxErrorException.Position}. Retrying using LL.");
-                Logger.Debug(syntaxErrorException, "SLL mode exception");
-                _tokenStream.Reset();
-                parser.Reset();
-                parser.Interpreter.PredictionMode = PredictionMode.Ll;
-                ParseTree = parser.startRule();
+                var message = $"SLL mode failed while parsing the {parsePassText} version of module {moduleName} at symbol {syntaxErrorException.OffendingSymbol.Text} at L{syntaxErrorException.LineNumber}C{syntaxErrorException.Position}. Retrying using LL.";
+                LogAndReset(message, syntaxErrorException);
+                return ParseInternal(ParserMode.Ll);
             }
             catch (Exception exception)
             {
-                Logger.Warn($"SLL mode failed while parsing module {moduleName}. Retrying using LL.");
-                Logger.Debug(exception, "SLL mode exception");
-                _tokenStream.Reset();
-                parser.Reset();
-                parser.Interpreter.PredictionMode = PredictionMode.Ll;
-                ParseTree = parser.startRule();
+                var message = $"SLL mode failed while parsing module {moduleName}. Retrying using LL.";
+                LogAndReset(message, exception);
+                return ParseInternal(ParserMode.Ll);
             }
+        }
+
+        private IParseTree ParseInternal(ParserMode mode)
+        {
+            if (mode == ParserMode.Ll)
+            {
+                _parser.Interpreter.PredictionMode = PredictionMode.Ll;
+            }
+            else
+            {
+                _parser.Interpreter.PredictionMode = PredictionMode.Sll;
+            }
+            return _parser.startRule();
+        }
+
+        private void LogAndReset(string logWarnMessage, Exception exception)
+        {
+            Logger.Warn(logWarnMessage);
+            var message = "Unknown exception";
+            if (_parser.Interpreter.PredictionMode == PredictionMode.Sll)
+            {
+                message = "SLL mode exception";
+            }
+            else if (_parser.Interpreter.PredictionMode == PredictionMode.Ll)
+            {
+                message = "LL mode exception";
+            }
+
+            Logger.Debug(exception, message);
+            _tokenStream.Reset();
+            _parser.Reset();
         }
     }
 }

--- a/RubberduckTests/Parsing/VBACodeStringParserTests.cs
+++ b/RubberduckTests/Parsing/VBACodeStringParserTests.cs
@@ -1,7 +1,6 @@
 ﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using NUnit.Framework;
-using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.Symbols.ParsingExceptions;
 using Rubberduck.Parsing.VBA;
 
@@ -73,6 +72,32 @@ End Sub";
             var parser = new VBACodeStringParser("test", inputCode);
             
             Assert.IsInstanceOf<TokenStreamRewriter>(parser.Rewriter);
+        }
+
+        [Test]
+        [Category("VBACodeStringParser_Tests")]
+        public void Parse_ExplicitSll()
+        {
+            const string inputCode = @"
+Public Sub Foo
+    MsgBox ""hi""
+End Sub";
+            var parser = new VBACodeStringParser("test", inputCode, VBACodeStringParser.ParserMode.Sll);
+
+            Assert.IsInstanceOf<IParseTree>(parser.ParseTree);
+        }
+
+        [Test]
+        [Category("VBACodeStringParser_Tests")]
+        public void Parse_ExplicitLl()
+        {
+            const string inputCode = @"
+Public Sub Foo
+    MsgBox ""hi""
+End Sub";
+            var parser = new VBACodeStringParser("test", inputCode, VBACodeStringParser.ParserMode.Ll);
+
+            Assert.IsInstanceOf<IParseTree>(parser.ParseTree);
         }
     }
 }

--- a/RubberduckTests/Parsing/VBACodeStringParserTests.cs
+++ b/RubberduckTests/Parsing/VBACodeStringParserTests.cs
@@ -18,7 +18,7 @@ Public Sub Foo
     MsgBox ""hi""
 End Sub";
             var parser = new VBACodeStringParser("test", inputCode);
-            Assert.IsInstanceOf<IParseTree>(parser.ParseTree);
+            Assert.IsInstanceOf<IParseTree>(parser.Parse().parseTree);
         }
 
         [Test]
@@ -32,6 +32,7 @@ Public Sub Foo
             Assert.Throws<MainParseSyntaxErrorException>(() =>
             {
                 var parser = new VBACodeStringParser("test", inputCode);
+                parser.Parse();
             });
         }
 
@@ -44,6 +45,7 @@ Public Sub Foo
             Assert.Throws<MainParseSyntaxErrorException>(() =>
             {
                 var parser = new VBACodeStringParser("test", inputCode);
+                parser.Parse();
             });
         }
 
@@ -56,7 +58,7 @@ Public Sub Foo
     MsgBox ""hi""
 End Sub";
             var parser = new VBACodeStringParser("test", inputCode);
-            var tree = parser.ParseTree;
+            var tree = parser.Parse().parseTree;
 
             Assert.AreEqual(inputCode + "<EOF>", tree.GetChild(0).GetText());
         }
@@ -71,7 +73,7 @@ Public Sub Foo
 End Sub";
             var parser = new VBACodeStringParser("test", inputCode);
             
-            Assert.IsInstanceOf<TokenStreamRewriter>(parser.Rewriter);
+            Assert.IsInstanceOf<TokenStreamRewriter>(parser.Parse().rewriter);
         }
 
         [Test]
@@ -84,7 +86,7 @@ Public Sub Foo
 End Sub";
             var parser = new VBACodeStringParser("test", inputCode, VBACodeStringParser.ParserMode.Sll);
 
-            Assert.IsInstanceOf<IParseTree>(parser.ParseTree);
+            Assert.IsInstanceOf<IParseTree>(parser.Parse().parseTree);
         }
 
         [Test]
@@ -97,7 +99,7 @@ Public Sub Foo
 End Sub";
             var parser = new VBACodeStringParser("test", inputCode, VBACodeStringParser.ParserMode.Ll);
 
-            Assert.IsInstanceOf<IParseTree>(parser.ParseTree);
+            Assert.IsInstanceOf<IParseTree>(parser.Parse().parseTree);
         }
     }
 }

--- a/RubberduckTests/Parsing/VBACodeStringParserTests.cs
+++ b/RubberduckTests/Parsing/VBACodeStringParserTests.cs
@@ -1,0 +1,78 @@
+﻿using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using NUnit.Framework;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols.ParsingExceptions;
+using Rubberduck.Parsing.VBA;
+
+namespace RubberduckTests.Parsing
+{
+    [TestFixture]
+    public class VBACodeStringParserTests
+    {
+        [Test]
+        [Category("VBACodeStringParser_Tests")]
+        public void CanParse()
+        {
+            const string inputCode = @"
+Public Sub Foo
+    MsgBox ""hi""
+End Sub";
+            var parser = new VBACodeStringParser("test", inputCode);
+            Assert.IsInstanceOf<IParseTree>(parser.ParseTree);
+        }
+
+        [Test]
+        [Category("VBACodeStringParser_Tests")]
+        public void CannotParse()
+        {
+            const string inputCode = @"
+Public Sub Foo
+    MsgBox ""hi""";
+
+            Assert.Throws<MainParseSyntaxErrorException>(() =>
+            {
+                var parser = new VBACodeStringParser("test", inputCode);
+            });
+        }
+
+        [Test]
+        [Category("VBACodeStringParser_Tests")]
+        public void CannotParse_CodeSnippet()
+        {
+            const string inputCode = @"MsgBox ""hi""";
+
+            Assert.Throws<MainParseSyntaxErrorException>(() =>
+            {
+                var parser = new VBACodeStringParser("test", inputCode);
+            });
+        }
+
+        [Test]
+        [Category("VBACodeStringParser_Tests")]
+        public void ParseTreeIsValid()
+        {
+            const string inputCode = @"
+Public Sub Foo
+    MsgBox ""hi""
+End Sub";
+            var parser = new VBACodeStringParser("test", inputCode);
+            var tree = parser.ParseTree;
+
+            Assert.AreEqual(inputCode + "<EOF>", tree.GetChild(0).GetText());
+        }
+
+        [Test]
+        [Category("VBACodeStringParser_Tests")]
+        public void GetRewriter()
+        {
+            const string inputCode = @"
+Public Sub Foo
+    MsgBox ""hi""
+End Sub";
+            var parser = new VBACodeStringParser("test", inputCode);
+            
+            Assert.IsInstanceOf<TokenStreamRewriter>(parser.Rewriter);
+        }
+    }
+}

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="CodeExplorer\CodeExplorerTests.cs" />
     <Compile Include="Mocks\MockVbeEvents.cs" />
     <Compile Include="Inspections\SheetAccessedUsingStringInspectionTests.cs" />
+    <Compile Include="Parsing\VBACodeStringParserTests.cs" />
     <Compile Include="QuickFixes\AccessSheetUsingCodeNameQuickFixTests.cs" />
     <Compile Include="Settings\AutoCompleteSettingsTests.cs" />
     <Compile Include="Settings\CodeInspectionConfigProviderTests.cs" />


### PR DESCRIPTION
The parser is meant to support scenarios where we need to work with code that are still up in the air. The parser is totally disconnected from the main parser and takes in a `string` that only needs to represent a minimally valid code module body and builds a valid parse tree. 

This can be used for example, in code preview, so that rewriting can be handled using the rewriter API for example. 