### PR TITLE
Fixes ComReflection regression

### DIFF
--- a/Rubberduck.Parsing/ComReflection/ComAlias.cs
+++ b/Rubberduck.Parsing/ComReflection/ComAlias.cs
@@ -8,9 +8,9 @@ namespace Rubberduck.Parsing.ComReflection
     [DebuggerDisplay("{Name} As {TypeName}")]
     public class ComAlias : ComBase
     {
-        public string TypeName { get; private set; }
-        public bool IsHidden { get; private set; }
-        public bool IsRestricted { get; private set; }
+        public string TypeName { get; }
+        public bool IsHidden { get; }
+        public bool IsRestricted { get; }
 
         public ComAlias(ITypeLib typeLib, ITypeInfo info, int index, TYPEATTR attributes) : base(typeLib, index)
         {

--- a/Rubberduck.Parsing/ComReflection/ComBase.cs
+++ b/Rubberduck.Parsing/ComReflection/ComBase.cs
@@ -20,10 +20,7 @@ namespace Rubberduck.Parsing.ComReflection
         public Guid Guid { get; protected set; }
         public int Index { get; protected set; }
         public ComDocumentation Documentation { get; protected set; }
-        public string Name
-        {
-            get { return Documentation == null ? string.Empty : Documentation.Name; }
-        }
+        public string Name => Documentation == null ? string.Empty : Documentation.Name;
 
         public DeclarationType Type { get; protected set; }
 
@@ -35,9 +32,7 @@ namespace Rubberduck.Parsing.ComReflection
 
         protected ComBase(ITypeInfo info)
         {
-            ITypeLib typeLib;
-            int index;
-            info.GetContainingTypeLib(out typeLib, out index);
+            info.GetContainingTypeLib(out ITypeLib typeLib, out int index);
             Index = index;
             Debug.Assert(typeLib != null);
             Documentation = new ComDocumentation(typeLib, index);

--- a/Rubberduck.Parsing/ComReflection/ComCoClass.cs
+++ b/Rubberduck.Parsing/ComReflection/ComCoClass.cs
@@ -18,46 +18,23 @@ namespace Rubberduck.Parsing.ComReflection
 
         public bool IsControl { get; private set; }
 
-        public bool IsExtensible
-        {
-            get { return _interfaces.Keys.Any(i => i.IsExtensible); }
-        }
+        public bool IsExtensible => _interfaces.Keys.Any(i => i.IsExtensible);
 
         public ComInterface DefaultInterface { get; private set; }
 
-        public IEnumerable<ComInterface> EventInterfaces
-        {
-            get { return _events; }
-        }
-        public IEnumerable<ComInterface> ImplementedInterfaces
-        {
-            get { return _interfaces.Keys; }
-        }
+        public IEnumerable<ComInterface> EventInterfaces => _events;
 
-        public IEnumerable<ComInterface> VisibleInterfaces
-        {
-            get { return _interfaces.Where(i => !i.Value).Select(i => i.Key); }
-        }
+        public IEnumerable<ComInterface> ImplementedInterfaces => _interfaces.Keys;
 
-        public IEnumerable<ComMember> Members
-        {
-            get { return ImplementedInterfaces.Where(x => !_events.Contains(x)).SelectMany(i => i.Members); }
-        }
+        public IEnumerable<ComInterface> VisibleInterfaces => _interfaces.Where(i => !i.Value).Select(i => i.Key);
 
-        public ComMember DefaultMember
-        {
-            get { return DefaultInterface.DefaultMember; }
-        }
+        public IEnumerable<ComMember> Members => ImplementedInterfaces.Where(x => !_events.Contains(x)).SelectMany(i => i.Members);
 
-        public IEnumerable<ComMember> SourceMembers
-        {
-            get { return _events.SelectMany(i => i.Members); }
-        }
+        public ComMember DefaultMember => DefaultInterface.DefaultMember;
 
-        public bool WithEvents
-        {
-            get { return _events.Count > 0; }
-        }
+        public IEnumerable<ComMember> SourceMembers => _events.SelectMany(i => i.Members);
+
+        public bool WithEvents => _events.Count > 0;
 
         public void AddInterface(ComInterface intrface, bool restricted = false)
         {
@@ -79,19 +56,15 @@ namespace Rubberduck.Parsing.ComReflection
         {
             for (var implIndex = 0; implIndex < typeAttr.cImplTypes; implIndex++)
             {
-                int href;
-                info.GetRefTypeOfImplType(implIndex, out href);
+                info.GetRefTypeOfImplType(implIndex, out int href);
+                info.GetRefTypeInfo(href, out ITypeInfo implemented);
 
-                ITypeInfo implemented;
-                info.GetRefTypeInfo(href, out implemented);
-
-                IntPtr attribPtr;
-                implemented.GetTypeAttr(out attribPtr);
+                implemented.GetTypeAttr(out IntPtr attribPtr);
                 var attribs = (TYPEATTR)Marshal.PtrToStructure(attribPtr, typeof(TYPEATTR));
 
-                ComType inherited;
-                ComProject.KnownTypes.TryGetValue(attribs.guid, out inherited);
-                var intface = inherited as ComInterface ?? new ComInterface(implemented, attribs);                
+                ComProject.KnownTypes.TryGetValue(attribs.guid,  out ComType inherited);
+                var intface = inherited as ComInterface ?? new ComInterface(implemented, attribs);
+                
                 ComProject.KnownTypes.TryAdd(attribs.guid, intface);
 
                 IMPLTYPEFLAGS flags = 0;

--- a/Rubberduck.Parsing/ComReflection/ComCoClass.cs
+++ b/Rubberduck.Parsing/ComReflection/ComCoClass.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.Parsing.ComReflection
         private readonly Dictionary<ComInterface, bool> _interfaces = new Dictionary<ComInterface, bool>();
         private readonly List<ComInterface> _events = new List<ComInterface>();
 
-        public bool IsControl { get; private set; }
+        public bool IsControl { get; }
 
         public bool IsExtensible => _interfaces.Keys.Any(i => i.IsExtensible);
 
@@ -38,6 +38,7 @@ namespace Rubberduck.Parsing.ComReflection
 
         public void AddInterface(ComInterface intrface, bool restricted = false)
         {
+            Debug.Assert(intrface != null);
             if (!_interfaces.ContainsKey(intrface))
             {
                 _interfaces.Add(intrface, restricted);

--- a/Rubberduck.Parsing/ComReflection/ComDocumentation.cs
+++ b/Rubberduck.Parsing/ComReflection/ComDocumentation.cs
@@ -4,42 +4,27 @@ namespace Rubberduck.Parsing.ComReflection
 {
     public class ComDocumentation
     {
-        public string Name { get; private set; }
-        public string DocString { get; private set; }
-        public string HelpFile { get; private set; }
-        public int HelpContext { get; private set; }
+        public string Name { get; }
+        public string DocString { get; }
+        public string HelpFile { get; }
+        public int HelpContext { get; }
 
         public ComDocumentation(ITypeLib typeLib, int index)
         {
-            LoadDocumentation(typeLib, null, index);
+            typeLib.GetDocumentation(index, out string name, out string docString, out int helpContext, out string helpFile);
+            Name = name;
+            DocString = docString;
+            HelpContext = helpContext;
+            HelpFile = helpFile;
         }
 
         public ComDocumentation(ITypeInfo info, int index)
         {
-            LoadDocumentation(null, info, index);
-        }
-
-        private void LoadDocumentation(ITypeLib typeLib, ITypeInfo info, int index)
-        {
-            string name;
-            string docString;
-            int helpContext;
-            string helpFile;
-
-            if (info == null)
-            {
-                typeLib.GetDocumentation(index, out name, out docString, out helpContext, out helpFile);
-            }
-            else
-            {
-                info.GetDocumentation(index, out name, out docString, out helpContext, out helpFile);
-            }
-
-            //See http://chat.stackexchange.com/transcript/message/30119269#30119269
+            info.GetDocumentation(index, out string name, out string docString, out int helpContext, out string helpFile);
             Name = name;
             DocString = docString;
             HelpContext = helpContext;
-            HelpFile = helpFile;            
+            HelpFile = helpFile;
         }
     }
 }

--- a/Rubberduck.Parsing/ComReflection/ComEnumeration.cs
+++ b/Rubberduck.Parsing/ComReflection/ComEnumeration.cs
@@ -10,7 +10,7 @@ namespace Rubberduck.Parsing.ComReflection
 {
     public class ComEnumeration : ComType
     {
-        public List<ComEnumerationMember> Members { get; set; } 
+        public List<ComEnumerationMember> Members { get; } 
 
         public ComEnumeration(ITypeLib typeLib, ITypeInfo info, TYPEATTR attrib, int index) : base(typeLib, attrib, index)
         {            
@@ -25,8 +25,7 @@ namespace Rubberduck.Parsing.ComReflection
             var count = attrib.cVars;
             for (var index = 0; index < count; index++)
             {
-                IntPtr varPtr;
-                info.GetVarDesc(index, out varPtr);
+                info.GetVarDesc(index, out IntPtr varPtr);
                 var desc = (VARDESC)Marshal.PtrToStructure(varPtr, typeof(VARDESC));
                 Members.Add(new ComEnumerationMember(info, desc));
                 info.ReleaseVarDesc(varPtr);

--- a/Rubberduck.Parsing/ComReflection/ComEnumerationMember.cs
+++ b/Rubberduck.Parsing/ComReflection/ComEnumerationMember.cs
@@ -19,8 +19,7 @@ namespace Rubberduck.Parsing.ComReflection
             ValueType = value.VariantType;
 
             var names = new string[1];
-            int count;
-            info.GetNames(varDesc.memid, names, names.Length, out count);
+            info.GetNames(varDesc.memid, names, names.Length, out int count);
             Debug.Assert(count == 1);
             Name = names[0];
         }

--- a/Rubberduck.Parsing/ComReflection/ComEnumerationMember.cs
+++ b/Rubberduck.Parsing/ComReflection/ComEnumerationMember.cs
@@ -8,9 +8,9 @@ namespace Rubberduck.Parsing.ComReflection
     [DebuggerDisplay("{Name} = {Value} ({ValueType})")]
     public class ComEnumerationMember
     {
-        public string Name { get; private set; }
-        public int Value { get; private set; }
-        public VarEnum ValueType { get; private set; }
+        public string Name { get; }
+        public int Value { get; }
+        public VarEnum ValueType { get; }
 
         public ComEnumerationMember(ITypeInfo info, VARDESC varDesc)
         {

--- a/Rubberduck.Parsing/ComReflection/ComField.cs
+++ b/Rubberduck.Parsing/ComReflection/ComField.cs
@@ -10,12 +10,12 @@ namespace Rubberduck.Parsing.ComReflection
     [DebuggerDisplay("{Name}")]
     public class ComField
     {
-        public string Name { get; private set; }
-        public int Index { get; private set; }
-        public DeclarationType Type { get; private set; }
-        public object DefaultValue { get; set; }
-        public string ValueType { get; set; }
-        public VARFLAGS Flags { get; set; }
+        public string Name { get; }
+        public int Index { get; }
+        public DeclarationType Type { get; }
+        public object DefaultValue { get; }
+        public string ValueType { get; }
+        public VARFLAGS Flags { get; }
 
         public ComField(string name, VARDESC varDesc, int index, DeclarationType type)
         {
@@ -29,14 +29,12 @@ namespace Rubberduck.Parsing.ComReflection
             {
                 var value = new ComVariant(varDesc.desc.lpvarValue);
                 DefaultValue = value.Value;
-                string typeName;
-                ValueType = ComVariant.TypeNames.TryGetValue(value.VariantType, out typeName) ? typeName : "Object";
+                ValueType = ComVariant.TypeNames.TryGetValue(value.VariantType, out string typeName) ? typeName : "Object";
             }
             else
             {
                 Debug.Assert(varDesc.varkind == VARKIND.VAR_PERINSTANCE);
-                string typeName;
-                ValueType = ComVariant.TypeNames.TryGetValue((VarEnum)varDesc.elemdescVar.tdesc.vt, out typeName) ? typeName : "Object";                
+                ValueType = ComVariant.TypeNames.TryGetValue((VarEnum)varDesc.elemdescVar.tdesc.vt, out string typeName) ? typeName : "Object";
             }
         }
     }

--- a/Rubberduck.Parsing/ComReflection/ComMember.cs
+++ b/Rubberduck.Parsing/ComReflection/ComMember.cs
@@ -27,15 +27,17 @@ namespace Rubberduck.Parsing.ComReflection
     [DebuggerDisplay("{MemberDeclaration}")]
     public class ComMember : ComBase
     {
-        public bool IsHidden { get; private set; }
-        public bool IsRestricted { get; private set; }
-        public bool ReturnsWithEventsObject { get; private set; }
-        public bool IsDefault { get; private set; }
-        public bool IsEnumerator { get; private set; }
+        public bool IsHidden { get; }
+        public bool IsRestricted { get; }
+        public bool ReturnsWithEventsObject { get; }
+        public bool IsDefault { get; }
+        public bool IsEnumerator { get; }
         //This member is called on an interface when a bracketed expression is dereferenced.
-        public bool IsEvaluateFunction { get; private set; }
+        public bool IsEvaluateFunction { get; }
         public ComParameter ReturnType { get; private set; }
-        public List<ComParameter> Parameters { get; set; }
+
+        private List<ComParameter> _parameters = new List<ComParameter>();
+        public IEnumerable<ComParameter> Parameters => _parameters;
 
         public ComMember(ITypeInfo info, FUNCDESC funcDesc) : base(info, funcDesc)
         {                      
@@ -55,7 +57,6 @@ namespace Rubberduck.Parsing.ComReflection
             if (funcDesc.invkind.HasFlag(INVOKEKIND.INVOKE_PROPERTYGET))
             {
                 Type = DeclarationType.PropertyGet;
-
             }
             else if (funcDesc.invkind.HasFlag(INVOKEKIND.INVOKE_PROPERTYPUT))
             {
@@ -82,17 +83,15 @@ namespace Rubberduck.Parsing.ComReflection
 
         private void LoadParameters(FUNCDESC funcDesc, ITypeInfo info)
         {
-            Parameters = new List<ComParameter>();
             var names = new string[255];
-            int count;
-            info.GetNames(Index, names, names.Length, out count);
+            info.GetNames(Index, names, names.Length, out int count);
 
             for (var index = 0; index < count - 1; index++)
             {
                 var paramPtr = new IntPtr(funcDesc.lprgelemdescParam.ToInt64() + Marshal.SizeOf(typeof(ELEMDESC)) * index);
                 var elemDesc = (ELEMDESC)Marshal.PtrToStructure(paramPtr, typeof(ELEMDESC));
                 var param = new ComParameter(elemDesc, info, names[index + 1] ?? $"{index}unnamedParameter");
-                Parameters.Add(param);
+                _parameters.Add(param);
             }
             if (Parameters.Any() && funcDesc.cParamsOpt == -1)
             {
@@ -127,12 +126,7 @@ namespace Rubberduck.Parsing.ComReflection
                         type = "Event";
                         break;
                 }
-                return string.Format("{0} {1} {2}{3}{4}",
-                    IsHidden || IsRestricted ? "Private" : "Public",
-                    type,
-                    Name,
-                    ReturnType == null ? string.Empty : " As ",
-                    ReturnType == null ? string.Empty : ReturnType.TypeName);
+                return $"{(IsHidden || IsRestricted ? "Private" : "Public")} {type} {Name}{(ReturnType == null ? string.Empty : $" As {ReturnType.TypeName}")}";
             }
         }
     }

--- a/Rubberduck.Parsing/ComReflection/ComModule.cs
+++ b/Rubberduck.Parsing/ComReflection/ComModule.cs
@@ -14,26 +14,14 @@ namespace Rubberduck.Parsing.ComReflection
     public class ComModule : ComType, IComTypeWithMembers, IComTypeWithFields
     {
         private readonly List<ComMember> _members = new List<ComMember>();
-        public IEnumerable<ComMember> Members
-        {
-            get { return _members; }
-        }
+        public IEnumerable<ComMember> Members => _members;
 
-        public ComMember DefaultMember
-        {
-            get { return null; }
-        }
+        public ComMember DefaultMember => null;
 
-        public bool IsExtensible
-        {
-            get { return false; }
-        }
+        public bool IsExtensible => false;
 
         private readonly List<ComField> _fields = new List<ComField>();
-        public IEnumerable<ComField> Fields
-        {
-            get { return _fields; }
-        }
+        public IEnumerable<ComField> Fields => _fields;
 
         public ComModule(ITypeLib typeLib, ITypeInfo info, TYPEATTR attrib, int index) : base(typeLib, attrib, index)
         {
@@ -55,11 +43,9 @@ namespace Rubberduck.Parsing.ComReflection
             var names = new string[1];
             for (var index = 0; index < attrib.cVars; index++)
             {
-                IntPtr varPtr;
-                info.GetVarDesc(index, out varPtr);
+                info.GetVarDesc(index, out IntPtr varPtr);
                 var desc = (VARDESC)Marshal.PtrToStructure(varPtr, typeof(VARDESC));
-                int length;
-                info.GetNames(desc.memid, names, names.Length, out length);
+                info.GetNames(desc.memid, names, names.Length, out int length);
                 Debug.Assert(length == 1);
 
                 _fields.Add(new ComField(names[0], desc, index, DeclarationType.Constant));
@@ -71,8 +57,7 @@ namespace Rubberduck.Parsing.ComReflection
         {
             for (var index = 0; index < attrib.cFuncs; index++)
             {
-                IntPtr memberPtr;
-                info.GetFuncDesc(index, out memberPtr);
+                info.GetFuncDesc(index, out IntPtr memberPtr);
                 var member = (FUNCDESC)Marshal.PtrToStructure(memberPtr, typeof(FUNCDESC));
                 if (member.callconv != CALLCONV.CC_STDCALL)
                 {

--- a/Rubberduck.Parsing/ComReflection/ComParameter.cs
+++ b/Rubberduck.Parsing/ComReflection/ComParameter.cs
@@ -38,21 +38,13 @@ namespace Rubberduck.Parsing.ComReflection
         public bool IsParamArray { get; set; }
 
         private Guid _enumGuid = Guid.Empty;
-        public bool IsEnumMember
-        {
-            get { return !_enumGuid.Equals(Guid.Empty); }
-        }
-        public object DefaultValue { get; private set; }
-        public string DefaultAsEnum { get; private set; }
+        public bool IsEnumMember => !_enumGuid.Equals(Guid.Empty);
+
+        public object DefaultValue { get; }
+        public string DefaultAsEnum { get; }
 
         private string _type = "Object";
-        public string TypeName
-        {
-            get
-            {
-                return IsArray ? _type + "()" : _type;
-            }
-        }
+        public string TypeName => IsArray ? $"{_type}()" : _type;
 
         public ComParameter(ELEMDESC elemDesc, ITypeInfo info, string name)
         {
@@ -73,8 +65,7 @@ namespace Rubberduck.Parsing.ComReflection
             var defValue = new ComVariant(paramDesc.lpVarValue + Marshal.SizeOf(typeof(ulong)));
             DefaultValue = defValue.Value;
 
-            ComEnumeration enumType;
-            if (!IsEnumMember || !ComProject.KnownEnumerations.TryGetValue(_enumGuid, out enumType))
+            if (!IsEnumMember || !ComProject.KnownEnumerations.TryGetValue(_enumGuid, out ComEnumeration enumType))
             {
                 return;
             }
@@ -108,11 +99,9 @@ namespace Rubberduck.Parsing.ComReflection
                     }
                     try
                     {
-                        ITypeInfo refTypeInfo;
-                        info.GetRefTypeInfo(href, out refTypeInfo);
+                        info.GetRefTypeInfo(href, out ITypeInfo refTypeInfo);
 
-                        IntPtr attribPtr;
-                        refTypeInfo.GetTypeAttr(out attribPtr);
+                        refTypeInfo.GetTypeAttr(out IntPtr attribPtr);
                         var attribs = (TYPEATTR)Marshal.PtrToStructure(attribPtr, typeof(TYPEATTR));
                         if (attribs.typekind == TYPEKIND.TKIND_ENUM)
                         {
@@ -131,8 +120,7 @@ namespace Rubberduck.Parsing.ComReflection
                     IsArray = true;
                     break;
                 default:
-                    string result;
-                    if (ComVariant.TypeNames.TryGetValue(vt, out result))
+                    if (ComVariant.TypeNames.TryGetValue(vt, out string result))
                     {
                         _type = result;
                     }

--- a/Rubberduck.Parsing/ComReflection/ComProject.cs
+++ b/Rubberduck.Parsing/ComReflection/ComProject.cs
@@ -17,49 +17,31 @@ namespace Rubberduck.Parsing.ComReflection
         public static readonly ConcurrentDictionary<Guid, ComType> KnownTypes = new ConcurrentDictionary<Guid, ComType>();
         public static readonly ConcurrentDictionary<Guid, ComEnumeration> KnownEnumerations = new ConcurrentDictionary<Guid, ComEnumeration>(); 
 
-        public string Path { get; set; }
-        public long MajorVersion { get; private set; }
-        public long MinorVersion { get; private set; }
+        public string Path { get; }
+        public long MajorVersion { get; }
+        public long MinorVersion { get; }
 
         // YGNI...
         // ReSharper disable once NotAccessedField.Local
         private TypeLibTypeFlags _flags;
 
         private readonly List<ComAlias> _aliases = new List<ComAlias>();
-        public IEnumerable<ComAlias> Aliases
-        {
-            get { return _aliases; }
-        }
+        public IEnumerable<ComAlias> Aliases => _aliases;
 
         private readonly List<ComInterface> _interfaces = new List<ComInterface>();
-        public IEnumerable<ComInterface> Interfaces
-        {
-            get { return _interfaces; }
-        }
+        public IEnumerable<ComInterface> Interfaces => _interfaces;
 
         private readonly List<ComEnumeration> _enumerations = new List<ComEnumeration>();
-        public IEnumerable<ComEnumeration> Enumerations
-        {
-            get { return _enumerations; }
-        }
+        public IEnumerable<ComEnumeration> Enumerations => _enumerations;
 
         private readonly List<ComCoClass> _classes = new List<ComCoClass>();
-        public IEnumerable<ComCoClass> CoClasses
-        {
-            get { return _classes; }
-        }
+        public IEnumerable<ComCoClass> CoClasses => _classes;
 
         private readonly List<ComModule> _modules = new List<ComModule>();
-        public IEnumerable<ComModule> Modules
-        {
-            get { return _modules; }
-        }
+        public IEnumerable<ComModule> Modules => _modules;
 
         private readonly List<ComStruct> _structs = new List<ComStruct>();
-        public IEnumerable<ComStruct> Structs
-        {
-            get { return _structs; }
-        }
+        public IEnumerable<ComStruct> Structs => _structs;
 
         public IEnumerable<IComType> Members
         {
@@ -75,18 +57,12 @@ namespace Rubberduck.Parsing.ComReflection
             }
         } 
 
-        public ComProject(ITypeLib typeLibrary) : base(typeLibrary, -1)
-        {   
-            ProcessLibraryAttributes(typeLibrary);
-            LoadModules(typeLibrary);
-        }
-
-        private void ProcessLibraryAttributes(ITypeLib typeLibrary)
+        public ComProject(ITypeLib typeLibrary, string path) : base(typeLibrary, -1)
         {
+            Path = path;
             try
             {
-                IntPtr attribPtr;
-                typeLibrary.GetLibAttr(out attribPtr);
+                typeLibrary.GetLibAttr(out IntPtr attribPtr);
                 var typeAttr = (TYPELIBATTR)Marshal.PtrToStructure(attribPtr, typeof(TYPELIBATTR));
 
                 MajorVersion = typeAttr.wMajorVerNum;
@@ -97,6 +73,7 @@ namespace Rubberduck.Parsing.ComReflection
                 typeLibrary.ReleaseTLibAttr(attribPtr);
             }
             catch (COMException) { }
+            LoadModules(typeLibrary);
         }
 
         private void LoadModules(ITypeLib typeLibrary)
@@ -106,8 +83,7 @@ namespace Rubberduck.Parsing.ComReflection
             {                
                 try
                 {
-                    ITypeInfo info;
-                    typeLibrary.GetTypeInfo(index, out info);
+                    typeLibrary.GetTypeInfo(index, out ITypeInfo info);
                     info.GetTypeAttr(out var typeAttributesPointer);
                     var typeAttributes = (TYPEATTR)Marshal.PtrToStructure(typeAttributesPointer, typeof(TYPEATTR));
 

--- a/Rubberduck.Parsing/ComReflection/ComProject.cs
+++ b/Rubberduck.Parsing/ComReflection/ComProject.cs
@@ -93,14 +93,16 @@ namespace Rubberduck.Parsing.ComReflection
                     {
                         case TYPEKIND.TKIND_ENUM:
                             var enumeration = type ?? new ComEnumeration(typeLibrary, info, typeAttributes, index);
+                            Debug.Assert(enumeration is ComEnumeration);
                             _enumerations.Add(enumeration as ComEnumeration);
-                            if (type == null)
+                            if (type == null && !enumeration.Guid.Equals(Guid.Empty))
                             {
                                 KnownTypes.TryAdd(typeAttributes.guid, enumeration);
                             }
                             break;
                         case TYPEKIND.TKIND_COCLASS:
                             var coclass = type ?? new ComCoClass(typeLibrary, info, typeAttributes, index);
+                            Debug.Assert(coclass is ComCoClass && !coclass.Guid.Equals(Guid.Empty));
                             _classes.Add(coclass as ComCoClass);
                             if (type == null)
                             {
@@ -110,6 +112,7 @@ namespace Rubberduck.Parsing.ComReflection
                         case TYPEKIND.TKIND_DISPATCH:
                         case TYPEKIND.TKIND_INTERFACE:
                             var intface = type ?? new ComInterface(typeLibrary, info, typeAttributes, index);
+                            Debug.Assert(intface is ComInterface && !intface.Guid.Equals(Guid.Empty));
                             _interfaces.Add(intface as ComInterface);
                             if (type == null)
                             {
@@ -122,8 +125,9 @@ namespace Rubberduck.Parsing.ComReflection
                             break;
                         case TYPEKIND.TKIND_MODULE:
                             var module = type ?? new ComModule(typeLibrary, info, typeAttributes, index);
+                            Debug.Assert(module is ComModule);
                             _modules.Add(module as ComModule);
-                            if (type == null)
+                            if (type == null && !module.Guid.Equals(Guid.Empty))
                             {
                                 KnownTypes.TryAdd(typeAttributes.guid, module);
                             }

--- a/Rubberduck.Parsing/ComReflection/ComStruct.cs
+++ b/Rubberduck.Parsing/ComReflection/ComStruct.cs
@@ -12,15 +12,11 @@ namespace Rubberduck.Parsing.ComReflection
     public class ComStruct : ComType, IComTypeWithFields
     {
         private readonly List<ComField> _fields = new List<ComField>();
-        public IEnumerable<ComField> Fields
-        {
-            get { return _fields; }
-        }
+        public IEnumerable<ComField> Fields => _fields;
 
         public ComStruct(ITypeLib typeLib, ITypeInfo info, TYPEATTR attrib, int index)
             : base(typeLib, attrib, index)
         {
-            _fields = new List<ComField>();
             Type = DeclarationType.UserDefinedType;          
             GetFields(info, attrib);
         }
@@ -30,11 +26,9 @@ namespace Rubberduck.Parsing.ComReflection
             var names = new string[1];
             for (var index = 0; index < attrib.cVars; index++)
             {
-                IntPtr varPtr;
-                info.GetVarDesc(index, out varPtr);
+                info.GetVarDesc(index, out IntPtr varPtr);
                 var desc = (VARDESC)Marshal.PtrToStructure(varPtr, typeof(VARDESC));
-                int length;
-                info.GetNames(desc.memid, names, names.Length, out length);
+                info.GetNames(desc.memid, names, names.Length, out int length);
                 Debug.Assert(length == 1);
 
                 _fields.Add(new ComField(names[0], desc, index, DeclarationType.UserDefinedTypeMember));

--- a/Rubberduck.Parsing/ComReflection/ComType.cs
+++ b/Rubberduck.Parsing/ComReflection/ComType.cs
@@ -27,31 +27,30 @@ namespace Rubberduck.Parsing.ComReflection
     [DebuggerDisplay("{Name}")]
     public abstract class ComType : ComBase, IComType
     {
-        public bool IsAppObject { get; private set; }
-        public bool IsPreDeclared { get; private set; }
-        public bool IsHidden { get; private set; }
-        public bool IsRestricted { get; private set; }
+        public bool IsAppObject { get; }
+        public bool IsPreDeclared { get; }
+        public bool IsHidden { get; }
+        public bool IsRestricted { get; }
         
         protected ComType(ITypeInfo info, TYPEATTR attrib)
             : base(info)
         {
-            SetFlagsFromTypeAttr(attrib);
+            Guid = attrib.guid;
+            IsAppObject = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FAPPOBJECT);
+            IsPreDeclared = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FPREDECLID);
+            IsHidden = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN);
+            IsRestricted = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED);
         }
 
         protected ComType(ITypeLib typeLib, TYPEATTR attrib, int index)
             : base(typeLib, index)
         {
             Index = index;
-            SetFlagsFromTypeAttr(attrib);
-        }
-
-        private void SetFlagsFromTypeAttr(TYPEATTR attrib)
-        {
             Guid = attrib.guid;
             IsAppObject = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FAPPOBJECT);
             IsPreDeclared = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FPREDECLID);
             IsHidden = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN);
-            IsRestricted = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED);           
+            IsRestricted = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED);
         }
     }
 }

--- a/Rubberduck.Parsing/ComReflection/ComVariant.cs
+++ b/Rubberduck.Parsing/ComReflection/ComVariant.cs
@@ -73,8 +73,14 @@ namespace Rubberduck.Parsing.ComReflection
 
         public bool Equals(ComVariant other)
         {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
+            if (other is null)
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
             return VariantType == other.VariantType && Equals(Value, other.Value);
         }
 

--- a/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
+++ b/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
@@ -125,7 +125,7 @@ namespace Rubberduck.Parsing.ComReflection
                 return _declarations;
             }
 
-            var type = new ComProject(typeLibrary) { Path = _path };
+            var type = new ComProject(typeLibrary, _path);
 
             var projectName = new QualifiedModuleName(type.Name, _path, type.Name);
             var project = new ProjectDeclaration(type, projectName);

--- a/Rubberduck.Parsing/ComReflection/XmlPersistableDeclarations.cs
+++ b/Rubberduck.Parsing/ComReflection/XmlPersistableDeclarations.cs
@@ -17,7 +17,9 @@ namespace Rubberduck.Parsing.ComReflection
             {
                 NamespaceHandling = NamespaceHandling.OmitDuplicates,
                 Encoding = Encoding.UTF8,
-                //Indent = true
+#if PRETTY_XML
+                Indent = true
+#endif
             };
 
             using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write))


### PR DESCRIPTION
I don't have VB6 installed yet, so this is untested there. If anything this would fix things and not break them though.

For future reference, the problem is that when caching was added to more types it was under the assumption that everything would have a Guid. This **_should only be assumed to be true of interfaces and coclasses_** (required, I believe), and I'm not 100% sure about the coclasses.