### PR TITLE
Mandatory Major and Minor Version when addin References in Tests

### DIFF
--- a/RubberduckTests/Binding/MemberAccessTypeBindingTests.cs
+++ b/RubberduckTests/Binding/MemberAccessTypeBindingTests.cs
@@ -106,7 +106,7 @@ namespace RubberduckTests.Binding
 
             var enclosingProject = builder
                 .ProjectBuilder("AnyProjectName", ProjectProtection.Unprotected)
-                .AddReference(referencedProjectName, ReferencedProjectFilepath)
+                .AddReference(referencedProjectName, ReferencedProjectFilepath, 0, 0)
                 .AddComponent(TestClassName, ComponentType.ClassModule, code)
                 .Build();
             builder.AddProject(enclosingProject);

--- a/RubberduckTests/Binding/SimpleNameDefaultBindingTests.cs
+++ b/RubberduckTests/Binding/SimpleNameDefaultBindingTests.cs
@@ -92,7 +92,7 @@ End Sub", BindingTargetName);
             builder.AddProject(referencedProject);
 
             var enclosingProjectBuilder = builder.ProjectBuilder("AnyProjectName", ProjectProtection.Unprotected);
-            enclosingProjectBuilder.AddReference(referencedProjectName, ReferencedProjectFilepath);
+            enclosingProjectBuilder.AddReference(referencedProjectName, ReferencedProjectFilepath, 0, 0);
             enclosingProjectBuilder.AddComponent(TestClassName, ComponentType.ClassModule, CreateTestProcedure(BindingTargetName));
             enclosingProjectBuilder.AddComponent("AnyModule", ComponentType.StandardModule, CreateEnumType(BindingTargetName));
             var enclosingProject = enclosingProjectBuilder.Build();
@@ -123,7 +123,7 @@ End Sub", BindingTargetName);
 
             var enclosingProject = builder
                 .ProjectBuilder("AnyProjectName", ProjectProtection.Unprotected)
-                .AddReference(referencedProjectName, ReferencedProjectFilepath)
+                .AddReference(referencedProjectName, ReferencedProjectFilepath, 0, 0)
                 .AddComponent(TestClassName, ComponentType.ClassModule, CreateTestProcedure(BindingTargetName))
                 .Build();
             builder.AddProject(enclosingProject);
@@ -151,7 +151,7 @@ End Sub", BindingTargetName);
             builder.AddProject(referencedProject);
 
             var enclosingProjectBuilder = builder.ProjectBuilder("AnyProjectName", ProjectProtection.Unprotected);
-            enclosingProjectBuilder.AddReference(referencedProjectName, ReferencedProjectFilepath);
+            enclosingProjectBuilder.AddReference(referencedProjectName, ReferencedProjectFilepath, 0, 0);
             enclosingProjectBuilder.AddComponent(TestClassName, ComponentType.ClassModule, CreateTestProcedure(BindingTargetName));
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);

--- a/RubberduckTests/Binding/SimpleNameTypeBindingTests.cs
+++ b/RubberduckTests/Binding/SimpleNameTypeBindingTests.cs
@@ -72,7 +72,7 @@ namespace RubberduckTests.Binding
             builder.AddProject(referencedProject);
 
             var enclosingProjectBuilder = builder.ProjectBuilder("AnyProjectName", ProjectProtection.Unprotected);
-            enclosingProjectBuilder.AddReference(REFERENCED_PROJECT_NAME, ReferencedProjectFilepath);
+            enclosingProjectBuilder.AddReference(REFERENCED_PROJECT_NAME, ReferencedProjectFilepath, 0, 0);
             enclosingProjectBuilder.AddComponent(TEST_CLASS_NAME, ComponentType.ClassModule, "Public WithEvents anything As " + BINDING_TARGET_NAME);
             enclosingProjectBuilder.AddComponent("AnyModule", ComponentType.StandardModule, CreateEnumType(BINDING_TARGET_NAME));
             var enclosingProject = enclosingProjectBuilder.Build();
@@ -101,7 +101,7 @@ namespace RubberduckTests.Binding
             builder.AddProject(referencedProject);
 
             var enclosingProjectBuilder = builder.ProjectBuilder("AnyProjectName", ProjectProtection.Unprotected);
-            enclosingProjectBuilder.AddReference(REFERENCED_PROJECT_NAME, ReferencedProjectFilepath);
+            enclosingProjectBuilder.AddReference(REFERENCED_PROJECT_NAME, ReferencedProjectFilepath, 0, 0);
             enclosingProjectBuilder.AddComponent(TEST_CLASS_NAME, ComponentType.ClassModule, "Public WithEvents anything As " + BINDING_TARGET_NAME);
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);
@@ -132,7 +132,7 @@ namespace RubberduckTests.Binding
             builder.AddProject(referencedProject);
 
             var enclosingProjectBuilder = builder.ProjectBuilder("Enclosing", ProjectProtection.Unprotected);
-            enclosingProjectBuilder.AddReference(referencedProjectName, ReferencedProjectFilepath);
+            enclosingProjectBuilder.AddReference(referencedProjectName, ReferencedProjectFilepath, 0, 0);
             enclosingProjectBuilder.AddComponent(TEST_CLASS_NAME, ComponentType.ClassModule, enclosingCode);
             var enclosingProject = enclosingProjectBuilder.Build();
             builder.AddProject(enclosingProject);

--- a/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
+++ b/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
@@ -290,7 +290,7 @@ End Sub
             projectBuilder.MockUserFormBuilder("UserForm1", userForm1Code).AddFormToProjectBuilder()
                 .AddComponent("ReferencingModule", ComponentType.StandardModule, analyzedCode)
                 //.AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel)
-                .AddReference("MSForms", MockVbeBuilder.LibraryPathMsForms);
+                .AddReference("MSForms", MockVbeBuilder.LibraryPathMsForms, 2, 0);
 
             mockVbe.AddProject(projectBuilder.Build());
 

--- a/RubberduckTests/Inspections/ShadowedDeclarationInspectionTests.cs
+++ b/RubberduckTests/Inspections/ShadowedDeclarationInspectionTests.cs
@@ -134,10 +134,10 @@ End Property";
             foreach (var expectedResultCount in expectedResultCountsByDeclarationIdentifierName)
             {
                 var referencedProject = builder.ProjectBuilder(expectedResultCount.Key, ProjectProtection.Unprotected)
-                    .AddComponent("Foo" + expectedResultCount.Key, ComponentType.StandardModule, "")
+                    .AddComponent("Foo" + expectedResultCount.Key, ComponentType.StandardModule, string.Empty)
                     .Build();
                 builder.AddProject(referencedProject);
-                userProjectBuilder = userProjectBuilder.AddReference(expectedResultCount.Key, "");
+                userProjectBuilder = userProjectBuilder.AddReference(expectedResultCount.Key, string.Empty, 0, 0);
             }
 
             var userProject = userProjectBuilder.Build();
@@ -5046,7 +5046,7 @@ End Function");
             builder.AddProject(referencedProject);
             var userProject = builder.ProjectBuilder("Baz", ProjectProtection.Unprotected)
                 .AddComponent("Qux", ComponentType.ClassModule, $"Public Event E ({sameName} As String)")
-                .AddReference("Foo", "")
+                .AddReference("Foo", string.Empty, 0, 0)
                 .Build();
             builder.AddProject(userProject);
 
@@ -5125,7 +5125,7 @@ End Sub";
             builder.AddProject(referencedProject);
             var userProject = builder.ProjectBuilder("Baz", ProjectProtection.Unprotected)
                 .AddComponent("Qux", ComponentType.StandardModule, ignoredDeclarationCode)
-                .AddReference("Foo", string.Empty)
+                .AddReference("Foo", string.Empty, 0, 0)
                 .Build();
             builder.AddProject(userProject);
 
@@ -5198,7 +5198,7 @@ End Sub";
             }
             var referencedProject = referencedProjectBuilder.Build();
             builder.AddProject(referencedProject);
-            var userProject = CreateUserProject(builder, userProjectName).AddReference(referencedProjectName, string.Empty).Build();
+            var userProject = CreateUserProject(builder, userProjectName).AddReference(referencedProjectName, string.Empty, 0, 0).Build();
             builder.AddProject(userProject);
 
             return builder;
@@ -5233,7 +5233,7 @@ End Sub";
             referencedProjectBuilder.AddComponent(referencedComponentName, referencedComponentComponentType, referencedComponentCode);
             var referencedProject = referencedProjectBuilder.Build();
             builder.AddProject(referencedProject);
-            var userProject = CreateUserProject(builder, userProjectName).AddReference(referencedProjectName, string.Empty).Build();
+            var userProject = CreateUserProject(builder, userProjectName).AddReference(referencedProjectName, string.Empty, 0, 0).Build();
             builder.AddProject(userProject);
 
             return builder;

--- a/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
+++ b/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
@@ -171,7 +171,7 @@ End Sub";
                         CreateVBComponentPropertyMock("Name", "Sheet1").Object,
                         CreateVBComponentPropertyMock("CodeName", "Sheet1").Object
                     })
-                .AddReference("ReferencedProject", "")
+                .AddReference("ReferencedProject", string.Empty, 0, 0)
                 .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
                 .Build();
 

--- a/RubberduckTests/Mocks/MockProjectBuilder.cs
+++ b/RubberduckTests/Mocks/MockProjectBuilder.cs
@@ -106,7 +106,7 @@ namespace RubberduckTests.Mocks
         /// <param name="filePath">The path to the referenced library.</param>
         /// <param name="isBuiltIn">Indicates whether the reference is a built-in reference.</param>
         /// <returns>Returns the <see cref="MockProjectBuilder"/> instance.</returns>
-        public MockProjectBuilder AddReference(string name, string filePath, int major = 0, int minor = 0, bool isBuiltIn = false)
+        public MockProjectBuilder AddReference(string name, string filePath, int major, int minor, bool isBuiltIn = false)
         {
             var reference = CreateReferenceMock(name, filePath, major, minor, isBuiltIn);
             _references.Add(reference.Object);

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -1224,7 +1224,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestModule", ComponentType.StandardModule, code, new Selection(5, 16))
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel)
+                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -1235,6 +1235,7 @@ End Sub";
 
             Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);
         }
+
         [Category("Resolver")]
         [Test]
         [Ignore("Need to fix the default member access for function calls; see case #3937")]
@@ -1252,7 +1253,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestModule", ComponentType.StandardModule, code, new Selection(6, 22))
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel)
+                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8)
                 .AddProjectToVbeBuilder()
                 .Build();
 


### PR DESCRIPTION
I made the major and minor reference mandatory in `MockProjectBuilder.AddReference`. 

The problem with this is that it is not abvious that you have to provide them when referencing a library in tests. In paricular, there have been two tests referencing the Excel object model, where the major version `1` and minor version `8` had not been provided.

Before, the versions simply defaulted to `0`, which is not too helpful.

I would like to add that I am not too happy with the current design since it is possible to reference other projects that do not have a version number, e.g. other Excel workbooks.