### PR TITLE
Deployment bug fixes & Analyzer for new projects

### DIFF
--- a/Rubberduck.Deployment/Rubberduck.Deployment.csproj
+++ b/Rubberduck.Deployment/Rubberduck.Deployment.csproj
@@ -116,9 +116,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command "$(ProjectDir)BuildRegistryScript.ps1 -config '$(ConfigurationName)' -builderAssemblyPath '$(TargetPath)' -netToolsDir '$(FrameworkSDKDir)bin\NETFX 4.6.1 Tools\' -wixToolsDir '$(ProjectDir)WixToolset\' -sourceDir '$(TargetDir)' -targetDir '$(TargetDir)' -projectDir '$(ProjectDir)' -includeDir '$(ProjectDir)InnoSetup\Includes\' -filesToExtract 'Rubberduck.dll|Rubberduck.API.dll'"</PostBuildEvent>
+    <PostBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command "&amp; '$(ProjectDir)BuildRegistryScript.ps1' -config '$(ConfigurationName)' -builderAssemblyPath '$(TargetPath)' -netToolsDir '$(FrameworkSDKDir)bin\NETFX 4.6.1 Tools\' -wixToolsDir '$(ProjectDir)WixToolset\' -sourceDir '$(TargetDir)' -targetDir '$(TargetDir)' -projectDir '$(ProjectDir)' -includeDir '$(ProjectDir)InnoSetup\Includes\' -filesToExtract 'Rubberduck.dll|Rubberduck.API.dll'"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command "$(ProjectDir)PreInnoSetupConfiguration.ps1 -WorkingDir $(ProjectDir)</PreBuildEvent>
+    <PreBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command "&amp; '$(ProjectDir)PreInnoSetupConfiguration.ps1' -WorkingDir '$(ProjectDir)'"</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Rubberduck.Interaction/Rubberduck.Interaction.csproj
+++ b/Rubberduck.Interaction/Rubberduck.Interaction.csproj
@@ -46,5 +46,8 @@
     <Compile Include="IMessageBox.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\RubberduckCodeAnalysis\bin\Release\RubberduckCodeAnalysis.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Rubberduck.Refactorings/Rubberduck.Refactorings.csproj
+++ b/Rubberduck.Refactorings/Rubberduck.Refactorings.csproj
@@ -104,5 +104,8 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\RubberduckCodeAnalysis\bin\Release\RubberduckCodeAnalysis.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -622,7 +622,6 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <Resource Include="Icons\Fugue\application-resize.png" />
   </ItemGroup>
@@ -872,6 +871,9 @@
     <Resource Include="Icons\Fugue\blue-folder-horizontal-open.png" />
     <Resource Include="Icons\Fugue\arrow1.png" />
     <Content Include="Icons\Fugue\arrow_circle_double_mask.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\RubberduckCodeAnalysis\bin\Release\RubberduckCodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Thanks to @rkapka for the assistance - there is an issue with space in the path for powershell script. This PR fixes the issue and also fixes the issue with MIDL which is uh, *weird* about backslash in the path (and it doesn't want to take a full path but a directory and file name separately). 

Since I was mucking in the script, I took liberty of adding auto-deletions of previous debug registration scripts with hard-coded for 10 files. 

I also noticed that newer project did not have the analyzer referenced so I added them as well.