### PR TITLE
Adds Add Predeclared Class Module Command

### DIFF
--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -78,6 +78,8 @@ namespace Rubberduck.Navigation.CodeExplorer
             AddClassModuleCommand = commands.OfType<AddClassModuleCommand>().SingleOrDefault();
             AddUserFormCommand = commands.OfType<AddUserFormCommand>().SingleOrDefault();
 
+            AddPredeclaredClassModuleCommand = commands.OfType<AddPredeclaredClassModuleCommand>().SingleOrDefault();
+
             OpenProjectPropertiesCommand = commands.OfType<OpenProjectPropertiesCommand>().SingleOrDefault();
             RenameCommand = commands.OfType<RenameCommand>().SingleOrDefault();
             IndenterCommand = commands.OfType<IndentCommand>().SingleOrDefault();
@@ -516,6 +518,8 @@ namespace Rubberduck.Navigation.CodeExplorer
         public CommandBase AddStdModuleCommand { get; }
         public CommandBase AddClassModuleCommand { get; }
         public CommandBase AddUserFormCommand { get; }
+
+        public CommandBase AddPredeclaredClassModuleCommand { get; }
 
         public CommandBase OpenDesignerCommand { get; }
         public CommandBase OpenProjectPropertiesCommand { get; }

--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -395,6 +395,8 @@
     <Compile Include="AutoComplete\AutoCompleteClosingParenthese.cs" />
     <Compile Include="AutoComplete\AutoCompleteClosingString.cs" />
     <Compile Include="AutoComplete\AutoCompleteService.cs" />
+    <Compile Include="UI\CodeExplorer\Commands\AddClassModuleCommand.cs" />
+    <Compile Include="UI\CodeExplorer\Commands\AddPredeclaredClassModuleCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\AddTestModuleWithStubsCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\CodeExplorerCommandAttribute.cs" />
     <Compile Include="UI\CodeExplorer\Commands\AddUserFormCommand.cs" />
@@ -426,7 +428,6 @@
     <Compile Include="UI\CodeExplorer\Commands\ImportCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\PrintCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\OpenDesignerCommand.cs" />
-    <Compile Include="UI\CodeExplorer\Commands\AddClassModuleCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\AddStdModuleCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\AddTestModuleCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\AddComponentCommand.cs" />

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -397,6 +397,14 @@
                                 <Image Height="16" Source="{StaticResource AddUserFormImage}" />
                             </MenuItem.Icon>
                         </MenuItem>
+                        <Separator />
+                        <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_AddPredeclaredClassModuleText}"
+                                  Command="{Binding AddPredeclaredClassModuleCommand}"
+                                  CommandParameter="{Binding SelectedItem}">
+                            <MenuItem.Icon>
+                                <Image Height="16" Source="{StaticResource AddClassModuleImage}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
                     </MenuItem>
                 </Menu>
 

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -193,6 +193,14 @@
                                         <Image Height="16" Source="{StaticResource AddUserFormImage}" />
                                     </MenuItem.Icon>
                                 </MenuItem>
+                                <Separator />
+                                <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_AddPredeclaredClassModuleText}"
+                                  Command="{Binding AddPredeclaredClassModuleCommand}"
+                                  CommandParameter="{Binding SelectedItem}">
+                                    <MenuItem.Icon>
+                                        <Image Height="16" Source="{StaticResource AddClassModuleImage}" />
+                                    </MenuItem.Icon>
+                                </MenuItem>
                             </MenuItem>
                             <MenuItem Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Find}">
                                 <MenuItem.Icon>

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
@@ -51,6 +51,30 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             }
         }
 
+        public void AddComponent(CodeExplorerItemViewModel node, string fileName)
+        {
+            var nodeProject = GetDeclaration(node)?.Project;
+            if (node != null && nodeProject == null)
+            {
+                return; //The project is not available.
+            }
+
+            using (var components = node != null
+                ? nodeProject.VBComponents
+                : ComponentsCollectionFromActiveProject())
+            {
+                var folderAnnotation = $"'@Folder(\"{GetFolder(node)}\")";
+
+                using (var newComponent = components.Import(fileName))
+                {
+                    using (var codeModule = newComponent.CodeModule)
+                    {
+                        codeModule.InsertLines(1, folderAnnotation);
+                    }
+                }
+            }
+        }
+
         private IVBComponents ComponentsCollectionFromActiveProject()
         {
             using (var activeProject = _vbe.ActiveVBProject)

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
@@ -64,7 +64,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             string optionCompare = string.Empty;
             using (IHostApplication hostApp = _vbe.HostApplication())
             {
-                optionCompare = hostApp.ApplicationName == "Microsoft Access" ? "Option Compare Database" :
+                optionCompare = hostApp.ApplicationName == "Access" ? "Option Compare Database" :
                     string.Empty;
             }
 
@@ -79,10 +79,19 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 {
                     using (var codeModule = newComponent.CodeModule)
                     {
-                        var delarationLines = string.Concat(folderAnnotation, optionCompare);
-                        codeModule.InsertLines(1, delarationLines);
+                        var delarationLines = string.Concat(folderAnnotation,  optionCompare);
+                        if (optionCompare.Length > 0)
+                        {
+                            codeModule.InsertLines(1, optionCompare);
+                        }
+                        if (folderAnnotation.Length > 0)
+                        {
+                            codeModule.InsertLines(1, folderAnnotation);
+                        }
+                        codeModule.CodePane.Show();
                     }
                 }
+                File.Delete(fileName);
             }
         }
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddPredeclaredClassModuleCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddPredeclaredClassModuleCommand.cs
@@ -29,6 +29,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         private string CreatePreclaredClassModule()
         {
+            //module text intentionally omits a VB_Name attribute so that the name is automatically assigned by the VBE.
             string moduleText = @"
 VERSION 1.0 CLASS
 BEGIN

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddPredeclaredClassModuleCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddPredeclaredClassModuleCommand.cs
@@ -1,0 +1,28 @@
+using NLog;
+using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.UI.Command;
+using Rubberduck.VBEditor.SafeComWrappers;
+
+namespace Rubberduck.UI.CodeExplorer.Commands
+{
+    [CodeExplorerCommand]
+    public class AddPredeclaredClassModuleCommand : CommandBase
+    {
+        private readonly AddComponentCommand _addComponentCommand;
+
+        public AddPredeclaredClassModuleCommand(AddComponentCommand addComponentCommand) : base(LogManager.GetCurrentClassLogger())
+        {
+            _addComponentCommand = addComponentCommand;
+        }
+
+        protected override bool EvaluateCanExecute(object parameter)
+        {
+            return _addComponentCommand.CanAddComponent(parameter as CodeExplorerItemViewModel);
+        }
+
+        protected override void OnExecute(object parameter)
+        {
+            _addComponentCommand.AddComponent(parameter as CodeExplorerItemViewModel, ComponentType.ClassModule);
+        }
+    }
+}

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddPredeclaredClassModuleCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddPredeclaredClassModuleCommand.cs
@@ -2,6 +2,7 @@ using NLog;
 using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers;
+using System.IO;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
 {
@@ -22,7 +23,25 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         protected override void OnExecute(object parameter)
         {
-            _addComponentCommand.AddComponent(parameter as CodeExplorerItemViewModel, ComponentType.ClassModule);
+            string moduleText = CreatePreclaredClassModule();
+            _addComponentCommand.AddComponent(parameter as CodeExplorerItemViewModel, moduleText);
+        }
+
+        private string CreatePreclaredClassModule()
+        {
+            string moduleText = @"
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = True
+Attribute VB_Exposed = False
+Attribute VB_Ext_KEY = ""Rubberduck"",""Predeclared Class Module""
+Option Explicit
+";
+            return moduleText;
         }
     }
 }

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
@@ -97,6 +97,15 @@ namespace Rubberduck.Resources.CodeExplorer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Predeclared Class module (.cls).
+        /// </summary>
+        public static string CodeExplorer_AddPredeclaredClassModuleText {
+            get {
+                return ResourceManager.GetString("CodeExplorer_AddPredeclaredClassModuleText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Standard module (.bas).
         /// </summary>
         public static string CodeExplorer_AddStdModuleText {

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
@@ -355,4 +355,7 @@
   <data name="ExportBeforeRemove_Prompt" xml:space="preserve">
     <value>Do you want to export '{0}' before removing?</value>
   </data>
+  <data name="CodeExplorer_AddPredeclaredClassModuleText" xml:space="preserve">
+    <value>Predeclared Class module (.cls)</value>
+  </data>
 </root>


### PR DESCRIPTION
This is a WIP, as I've yet to test with VB6, so do not merge. It only occurred to me afterwards that VB6 handles imports differently, so I'll probably need to push the import module from text methods into the `IVbComponents` implementations.

Closes #4183 

This PR is only for adding new Predeclared Classes. I'm undecided about how to go about implementing toggling the attribute: a dedicated UI, like the (somewhat poor) one in VB6, or waiting for AvalonEdit codepanes, and editing in place.

The implementation is aware of whether the host is Microsoft Access, and if it is, adds an `Option Compare Database` statement. It is unaware of the VBE's `Require Variable Declaration` setting, and will always add `Option Explicit`.

It also adds a VB_EXT attribute for identifying the creator of the module.