### PR TITLE
Fix issue 3655

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MultilineParameterInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MultilineParameterInspection.cs
@@ -30,7 +30,7 @@ namespace Rubberduck.Inspections.Concrete
                 .Select(context => new QualifiedContextInspectionResult(this,
                                                   string.Format(context.Context.GetSelection().LineCount > 3
                                                         ? RubberduckUI.EasterEgg_Continuator
-                                                        : Resources.Inspections.InspectionResults.MultilineParameterInspection, ((VBAParser.ArgContext)context.Context).unrestrictedIdentifier().ToString()),
+                                                        : Resources.Inspections.InspectionResults.MultilineParameterInspection, ((VBAParser.ArgContext)context.Context).unrestrictedIdentifier().GetText()),
                                                   context));
         }
 


### PR DESCRIPTION
Closes #3655 

Use GetText method instead of ToString so that the parameter name is picked up correctly.