### PR TITLE
Fix loading serialized declarations from non standard path

### DIFF
--- a/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
+++ b/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
@@ -101,8 +101,9 @@ namespace Rubberduck.Parsing.ComReflection
 
         public List<Declaration> LoadDeclarationsFromXml()
         {
-            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Rubberduck", "Declarations");
-            var file = Path.Combine(path, string.Format("{0}.{1}.{2}", _referenceName, _referenceMajor, _referenceMinor) + ".xml");
+            var path = _serializedDeclarationsPath;
+            var filename = $"{_referenceName}.{_referenceMajor}.{_referenceMinor}.xml";
+            var file = Path.Combine(path, filename);
             var reader = new XmlPersistableDeclarations();
             var deserialized = reader.Load(file);
 

--- a/RubberduckTests/Inspections/ApplicationWorksheetFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/ApplicationWorksheetFunctionInspectionTests.cs
@@ -21,17 +21,7 @@ namespace RubberduckTests.Inspections
 
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-
-            parser.State.AddTestLibrary("Excel.1.8.xml");
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error)
-            {
-                Assert.Inconclusive("Parser Error");
-            }
-
-            return parser.State;
+            return MockParser.CreateAndParse(vbe.Object); ;
         }
 
         [Test]

--- a/RubberduckTests/Inspections/HostSpecificExpressionInspectionTests.cs
+++ b/RubberduckTests/Inspections/HostSpecificExpressionInspectionTests.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using NUnit.Framework;
 using Moq;
 using Rubberduck.Inspections.Concrete;
-using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using RubberduckTests.Mocks;
@@ -26,24 +25,15 @@ End Sub
             var project = builder.ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, code)
                 .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 7, true)
+                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
                 .Build();
             var vbe = builder.AddProject(project).Build();
             var mockHost = new Mock<IHostApplication>();
             mockHost.SetupGet(m => m.ApplicationName).Returns("Excel");
             vbe.Setup(m => m.HostApplication()).Returns(() => mockHost.Object);
 
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                state.AddTestLibrary("VBA.4.2.xml");
-                state.AddTestLibrary("Excel.1.8.xml");
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new HostSpecificExpressionInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 

--- a/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
@@ -32,8 +32,6 @@ End Sub
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
                 {
@@ -67,17 +65,8 @@ End Sub
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new ImplicitActiveSheetReferenceInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 

--- a/RubberduckTests/Inspections/ImplicitActiveWorkbookReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitActiveWorkbookReferenceInspectionTests.cs
@@ -29,17 +29,8 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new ImplicitActiveWorkbookReferenceInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 
@@ -67,17 +58,9 @@ End Sub";
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new ImplicitActiveWorkbookReferenceInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 

--- a/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
+++ b/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
@@ -26,17 +26,7 @@ namespace RubberduckTests.Inspections
 
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-
-            //parser.State.AddTestLibrary(library.Equals("Scripting") ? "Scripting.1.0.xml" : "Excel.1.8.xml");
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error)
-            {
-                Assert.Inconclusive("Parser Error");
-            }
-
-            return parser.State;
+            return MockParser.CreateAndParse(vbe.Object);
         }
 
         [Test]
@@ -349,7 +339,6 @@ End Sub
             var projectBuilder = vbeBuilder.ProjectBuilder("testproject", ProjectProtection.Unprotected);
             projectBuilder.MockUserFormBuilder("UserForm1", userForm1Code).AddFormToProjectBuilder()
                 .AddComponent("ReferencingModule", ComponentType.StandardModule, analyzedCode)
-                //.AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel)
                 .AddReference("MSForms", MockVbeBuilder.LibraryPathMsForms, 2, 0);
 
             vbeBuilder.AddProject(projectBuilder.Build());

--- a/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
+++ b/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
@@ -28,7 +28,7 @@ namespace RubberduckTests.Inspections
 
             var parser = MockParser.Create(vbe.Object);
 
-            parser.State.AddTestLibrary(library.Equals("Scripting") ? "Scripting.1.0.xml" : "Excel.1.8.xml");
+            //parser.State.AddTestLibrary(library.Equals("Scripting") ? "Scripting.1.0.xml" : "Excel.1.8.xml");
 
             parser.Parse(new CancellationTokenSource());
             if (parser.State.Status >= ParserState.Error)
@@ -345,28 +345,17 @@ Sub FizzBuzz()
 
 End Sub
 ";
-            var mockVbe = new MockVbeBuilder();
-            var projectBuilder = mockVbe.ProjectBuilder("testproject", ProjectProtection.Unprotected);
+            var vbeBuilder = new MockVbeBuilder();
+            var projectBuilder = vbeBuilder.ProjectBuilder("testproject", ProjectProtection.Unprotected);
             projectBuilder.MockUserFormBuilder("UserForm1", userForm1Code).AddFormToProjectBuilder()
                 .AddComponent("ReferencingModule", ComponentType.StandardModule, analyzedCode)
                 //.AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel)
                 .AddReference("MSForms", MockVbeBuilder.LibraryPathMsForms, 2, 0);
 
-            mockVbe.AddProject(projectBuilder.Build());
+            vbeBuilder.AddProject(projectBuilder.Build());
+            var vbe = vbeBuilder.Build();
 
-
-            var parser = MockParser.Create(mockVbe.Build().Object);
-
-            //parser.State.AddTestLibrary("Excel.1.8.xml");
-            parser.State.AddTestLibrary("MSForms.2.0.xml");
-
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error)
-            {
-                Assert.Inconclusive("Parser Error");
-            }
-
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
                 var inspection = new MemberNotOnInterfaceInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);

--- a/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
+++ b/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
@@ -177,16 +177,7 @@ End Sub";
 
             var vbe = builder.AddProject(referencedProject).AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-            parser.State.AddTestLibrary("Excel.1.8.xml");
-            parser.Parse(new CancellationTokenSource());
-
-            if (parser.State.Status >= ParserState.Error)
-            {
-                Assert.Inconclusive("Parser Error");
-            }
-
-            return parser.State;
+            return MockParser.CreateAndParse(vbe.Object);
         }
 
         private static Mock<IProperty> CreateVBComponentPropertyMock(string propertyName, string propertyValue)

--- a/RubberduckTests/Mocks/MockParser.cs
+++ b/RubberduckTests/Mocks/MockParser.cs
@@ -113,37 +113,14 @@ namespace RubberduckTests.Mocks
                 parserStateManager,
                 true);
         }
-        
-        public static RubberduckParserState CreateAndParse(IVBE vbe, IInspectionListener listener, IEnumerable<string> testLibraries = null)
-        {
-            var parser = CreateWithLibraries(vbe, testLibraries: testLibraries);
-            parser.Parse(new CancellationTokenSource());
-            if (parser.State.Status >= ParserState.Error)
-            { Assert.Inconclusive("Parser Error"); }
 
-            return parser.State;
-        }
-
-        public static RubberduckParserState CreateAndParse(IVBE vbe, string serializedDeclarationsPath = null, IEnumerable<string> testLibraries = null)
+        public static RubberduckParserState CreateAndParse(IVBE vbe, string serializedDeclarationsPath = null)
         {
-            var parser = CreateWithLibraries(vbe, serializedDeclarationsPath, testLibraries);
+            var parser = Create(vbe, serializedDeclarationsPath);
             parser.Parse(new CancellationTokenSource());
             if (parser.State.Status >= ParserState.Error) { Assert.Inconclusive("Parser Error"); }
 
             return parser.State;
-        }
-
-        private static ParseCoordinator CreateWithLibraries(IVBE vbe, string serializedDeclarationsPath = null, IEnumerable<string> testLibraries = null)
-        {
-            var parser = Create(vbe, serializedDeclarationsPath);
-            if (testLibraries != null)
-            {
-                foreach (var lib in testLibraries)
-                {
-                    parser.State.AddTestLibrary(lib);
-                }
-            }
-            return parser;
         }
 
         private static readonly HashSet<DeclarationType> ProceduralTypes =
@@ -152,16 +129,6 @@ namespace RubberduckTests.Mocks
                 DeclarationType.Procedure, DeclarationType.Function, DeclarationType.PropertyGet,
                 DeclarationType.PropertyLet, DeclarationType.PropertySet
             });
-
-        public static void AddTestLibrary(this RubberduckParserState state, string serialized)
-        {
-            var reader = new XmlPersistableDeclarations();
-            var basePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            basePath = Directory.GetParent(basePath).Parent.FullName;
-            var path = Path.Combine(basePath, "Testfiles\\Resolver", serialized);
-            var deserialized = reader.Load(path);
-            AddTestLibrary(state, deserialized);
-        }
 
         // ReSharper disable once UnusedMember.Global; used by RubberduckWeb to load serialized declarations.
         public static void AddTestLibrary(this RubberduckParserState state, Stream stream)

--- a/RubberduckTests/Mocks/MockVbeBuilder.cs
+++ b/RubberduckTests/Mocks/MockVbeBuilder.cs
@@ -35,6 +35,22 @@ namespace RubberduckTests.Mocks
         public static readonly string LibraryPathAdoDb = @"C:\Program Files\Common Files\System\ado\msado15.dll";
         public static readonly string LibraryPathAdoRecordset = @"C:\Program Files\Common Files\System\ado\msador15.dll";
 
+        public static readonly Dictionary<string, string> LibraryPaths = new Dictionary<string, string>
+        {
+            ["VBA"] = LibraryPathVBA,
+            ["Excel"] = LibraryPathMsExcel,
+            ["Office"] = LibraryPathMsOffice,
+            ["stdole"] = LibraryPathStdOle,
+            ["MSForms"] = LibraryPathMsForms,
+            ["VBIDE"] = LibraryPathVBIDE,
+            ["Scripting"] = LibraryPathScripting,
+            ["VBScript_RegExp_55"] = LibraryPathRegex,
+            ["MSXML2"] = LibraryPathMsXml,
+            ["SHDocVw"] = LibraryPathShDoc,
+            ["ADODB"] = LibraryPathAdoDb,
+            ["ADOR"] = LibraryPathAdoRecordset
+        };
+
         //private Mock<IWindows> _vbWindows;
         private readonly Windows _windows = new Windows();
 

--- a/RubberduckTests/QuickFixes/AccessSheetUsingCodeNameQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AccessSheetUsingCodeNameQuickFixTests.cs
@@ -300,16 +300,7 @@ End Sub";
 
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-            parser.State.AddTestLibrary("Excel.1.8.xml");
-            parser.Parse(new CancellationTokenSource());
-
-            if (parser.State.Status >= ParserState.Error)
-            {
-                Assert.Inconclusive("Parser Error");
-            }
-
-            return parser.State;
+            return MockParser.CreateAndParse(vbe.Object);
         }
 
         private static Mock<IProperty> CreateVBComponentPropertyMock(string propertyName, string propertyValue)

--- a/RubberduckTests/QuickFixes/ApplicationWorksheetFunctionQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ApplicationWorksheetFunctionQuickFixTests.cs
@@ -41,8 +41,6 @@ End Sub
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
                 {
@@ -90,8 +88,6 @@ End Sub
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
                 {
@@ -132,17 +128,8 @@ End Sub
 
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new ApplicationWorksheetFunctionInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 

--- a/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
@@ -40,17 +40,8 @@ End Sub";
             var vbe = builder.AddProject(project).Build();
             var component = vbe.Object.SelectedVBComponent;
 
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                //state.AddTestLibrary("Excel.1.8.xml");
-
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new ApplicationWorksheetFunctionInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 
@@ -257,17 +248,8 @@ End Sub";
             var component = project.Object.VBComponents[0];
             var vbe = builder.AddProject(project).Build();
 
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                //state.AddTestLibrary("Excel.1.8.xml");
-
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new ImplicitActiveSheetReferenceInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 

--- a/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
@@ -43,7 +43,7 @@ End Sub";
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                state.AddTestLibrary("Excel.1.8.xml");
+                //state.AddTestLibrary("Excel.1.8.xml");
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -260,7 +260,7 @@ End Sub";
             var parser = MockParser.Create(vbe.Object);
             using (var state = parser.State)
             {
-                state.AddTestLibrary("Excel.1.8.xml");
+                //state.AddTestLibrary("Excel.1.8.xml");
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -303,18 +303,8 @@ End Sub";
             var component = project.Object.VBComponents[0];
             var vbe = builder.AddProject(project).Build();
 
-
-            var parser = MockParser.Create(vbe.Object);
-            using (var state = parser.State)
+            using (var state = MockParser.CreateAndParse(vbe.Object))
             {
-                state.AddTestLibrary("Excel.1.8.xml");
-
-                parser.Parse(new CancellationTokenSource());
-                if (state.Status >= ParserState.Error)
-                {
-                    Assert.Inconclusive("Parser Error");
-                }
-
                 var inspection = new ImplicitActiveWorkbookReferenceInspection(state);
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 

--- a/RubberduckTests/Refactoring/RenameTests.cs
+++ b/RubberduckTests/Refactoring/RenameTests.cs
@@ -2082,7 +2082,7 @@ End Sub
                 SelectionModuleName = "MyClass",
                 ProjectName = projectName
             };
-            PerformExpectedVersusActualRenameTests(tdo, classInputOutput, usageInputOutput, testLibraries: new[] { "VBA.4.2.xml" });
+            PerformExpectedVersusActualRenameTests(tdo, classInputOutput, usageInputOutput);
             tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
         #endregion
@@ -2305,12 +2305,11 @@ End Property";
             , RenameTestModuleDefinition? inputOutput1
             , RenameTestModuleDefinition? inputOutput2 = null
             , RenameTestModuleDefinition? inputOutput3 = null
-            , RenameTestModuleDefinition? inputOutput4 = null
-            , IEnumerable<string> testLibraries = null)
+            , RenameTestModuleDefinition? inputOutput4 = null)
         {
             try
             {
-                InitializeTestDataObject(tdo, inputOutput1, inputOutput2, inputOutput3, inputOutput4, testLibraries);
+                InitializeTestDataObject(tdo, inputOutput1, inputOutput2, inputOutput3, inputOutput4);
                 RunRenameRefactorScenario(tdo);
                 CheckRenameRefactorTestResults(tdo);
             }
@@ -2324,8 +2323,7 @@ End Property";
             , RenameTestModuleDefinition? inputOutput1
             , RenameTestModuleDefinition? inputOutput2 = null
             , RenameTestModuleDefinition? inputOutput3 = null
-            , RenameTestModuleDefinition? inputOutput4 = null
-            , IEnumerable<string> testLibraries = null)
+            , RenameTestModuleDefinition? inputOutput4 = null)
         {
             var renameTMDs = new List<RenameTestModuleDefinition>();
             bool cursorFound = false;
@@ -2366,7 +2364,7 @@ End Property";
             tdo.MsgBox.Setup(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(tdo.MsgBoxReturn == DialogResult.Yes);
 
             tdo.VBE = tdo.VBE ?? BuildProject(tdo.ProjectName, tdo.ModuleTestSetupDefs);
-            tdo.ParserState = MockParser.CreateAndParse(tdo.VBE, testLibraries: testLibraries);
+            tdo.ParserState = MockParser.CreateAndParse(tdo.VBE);
 
             CreateQualifiedSelectionForTestCase(tdo);
             tdo.RenameModel = new RenameModel(tdo.VBE, tdo.ParserState, tdo.QualifiedSelection) { NewName = tdo.NewName };

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -1225,16 +1225,17 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestModule", ComponentType.StandardModule, code, new Selection(5, 16))
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8)
+                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
                 .AddProjectToVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object, serializedDeclarationsPath: null, testLibraries:new[] { "Excel.1.8.xml" });
-            
-            var expected = state.DeclarationFinder.DeclarationsWithType(DeclarationType.Parameter).Single(p => !p.IsUserDefined && p.IdentifierName=="Link" && p.ParentScope == "EXCEL.EXE;Excel.Worksheet.Paste");
-            var actual = state.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var expected = state.DeclarationFinder.DeclarationsWithType(DeclarationType.Parameter).Single(p => !p.IsUserDefined && p.IdentifierName == "Link" && p.ParentScope == "EXCEL.EXE;Excel.Worksheet.Paste");
+                var actual = state.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
 
-            Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);
+                Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);
+            }
         }
 
         [Category("Resolver")]
@@ -1254,16 +1255,20 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestModule", ComponentType.StandardModule, code, new Selection(6, 22))
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8)
+                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
                 .AddProjectToVbeBuilder()
                 .Build();
 
-            var state = MockParser.CreateAndParse(vbe.Object, serializedDeclarationsPath: null, testLibraries: new[] { "Excel.1.8.xml" });
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var expected = state.DeclarationFinder.DeclarationsWithType(DeclarationType.Parameter).Single(p =>
+                    !p.IsUserDefined && p.IdentifierName == "ColumnIndex" &&
+                    p.ParentScope == "EXCEL.EXE;Excel.Range._Default");
+                var actual = state.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
 
-            var expected = state.DeclarationFinder.DeclarationsWithType(DeclarationType.Parameter).Single(p => !p.IsUserDefined && p.IdentifierName == "ColumnIndex" && p.ParentScope == "EXCEL.EXE;Excel.Range._Default");
-            var actual = state.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
-
-            Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);
+                Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType,
+                    actual.DeclarationType);
+            }
         }
 
         [Category("Resolver")]


### PR DESCRIPTION
This PR closes #4182 

Moreover, the fix makes `MockParser.AddTestLibrary` obsolete since the parsing process will pick up all serialized declarations from referenced projects. Acordingly, I removed it along with all uses.
This had a good effect on test execution times.