### PR TITLE
More safety around handling the temp files in the parser

### DIFF
--- a/Rubberduck.API/VBA/Parser.cs
+++ b/Rubberduck.API/VBA/Parser.cs
@@ -97,7 +97,7 @@ namespace Rubberduck.API.VBA
             _state = new RubberduckParserState(_vbe, projectRepository, declarationFinderFactory, _vbeEvents);
             _state.StateChanged += _state_StateChanged;
 
-            var sourceFileHandler = _vbe.SourceFileHandler;
+            var sourceFileHandler = _vbe.TempSourceFileHandler;
             var vbeVersion = double.Parse(_vbe.Version, CultureInfo.InvariantCulture);
             var predefinedCompilationConstants = new VBAPredefinedCompilationConstants(vbeVersion);
             var typeLibProvider = new TypeLibWrapperProvider(projectRepository);

--- a/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
+++ b/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
@@ -886,7 +886,7 @@ namespace Rubberduck.Root
             container.Register(Component.For<ICommandBars>().Instance(_vbe.CommandBars));
             container.Register(Component.For<IUiContextProvider>().Instance(UiContextProvider.Instance()).LifestyleSingleton());
             container.Register(Component.For<IVBEEvents>().Instance(VBEEvents.Initialize(_vbe)).LifestyleSingleton());
-            container.Register(Component.For<ISourceFileHandler>().Instance(_vbe.SourceFileHandler));
+            container.Register(Component.For<ITempSourceFileHandler>().Instance(_vbe.TempSourceFileHandler));
         }
 
         private void RegisterHotkeyFactory(IWindsorContainer container)

--- a/Rubberduck.Parsing/VBA/Parsing/ModuleParser.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/ModuleParser.cs
@@ -99,7 +99,7 @@ namespace Rubberduck.Parsing.VBA.Parsing
 
             Logger.Trace($"ParseTaskID {taskId} begins attributes pass.");
             var (attributesParseTree, attributesTokenStream) = AttributesPassResults(module, cancellationToken);
-            var attributesRewriter = _moduleRewriterFactory.AttributesRewriter(module, attributesTokenStream ?? codePaneTokenStream);
+            var attributesRewriter = _moduleRewriterFactory.AttributesRewriter(module, attributesTokenStream);
             Logger.Trace($"ParseTaskID {taskId} finished attributes pass.");
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -153,7 +153,7 @@ namespace Rubberduck.Parsing.VBA.Parsing
         private (IParseTree tree, ITokenStream tokenStream) AttributesPassResults(QualifiedModuleName module, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
-            var code = _attributesSourceCodeProvider.SourceCode(module) ?? string.Empty;
+            var code = _attributesSourceCodeProvider.SourceCode(module);
             token.ThrowIfCancellationRequested();
             var attributesParseResults = _parser.Parse(module.ComponentName, module.ProjectId, code, token, CodeKind.AttributesCode);
             return attributesParseResults;

--- a/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
+++ b/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
@@ -82,7 +82,7 @@
     <Compile Include="SourceCodeHandling\CodePaneSourceCodeHandler.cs" />
     <Compile Include="SourceCodeHandling\ISourceCodeHandler.cs" />
     <Compile Include="SourceCodeHandling\ISourceCodeProvider.cs" />
-    <Compile Include="SourceCodeHandling\ISourceFileHandler.cs" />
+    <Compile Include="SourceCodeHandling\ITempSourceFileHandler.cs" />
     <Compile Include="CommandBarLocation.cs" />
     <Compile Include="SafeComWrappers\Abstract\HostApplicationBase.cs" />
     <Compile Include="SafeComWrappers\Abstract\ISafeComWrapper.cs" />

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBComponent.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBComponent.cs
@@ -20,7 +20,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
         IWindow DesignerWindow();
         void Activate();
         void Export(string path);
-        string ExportAsSourceFile(string folder, bool tempFile = false);
+        string ExportAsSourceFile(string folder, bool tempFile = false, bool specialCaseDocumentModules = true);
         int FileCount { get; }
         string GetFileName(short index);
         IVBProject ParentProject { get; }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBE.cs
@@ -25,6 +25,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
 
         bool IsInDesignMode { get; }
         int ProjectsCount { get; }
-        ISourceFileHandler SourceFileHandler { get; }
+        ITempSourceFileHandler TempSourceFileHandler { get; }
     }
 }

--- a/Rubberduck.VBEEditor/SourceCodeHandling/CodePaneSourceCodeHandler.cs
+++ b/Rubberduck.VBEEditor/SourceCodeHandling/CodePaneSourceCodeHandler.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.VBEditor.SourceCodeHandling
 
             using (var codeModule = component.CodeModule)
             {
-                return codeModule.Content();
+                return codeModule.Content() ?? string.Empty;
             }
         }
 

--- a/Rubberduck.VBEEditor/SourceCodeHandling/ITempSourceFileHandler.cs
+++ b/Rubberduck.VBEEditor/SourceCodeHandling/ITempSourceFileHandler.cs
@@ -2,10 +2,10 @@ using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.VBEditor.SourceCodeHandling
 {
-    public interface ISourceFileHandler
+    public interface ITempSourceFileHandler
     {
         string Export(IVBComponent component);
-        void Import(IVBComponent component, string fileName);
+        void ImportAndCleanUp(IVBComponent component, string fileName);
 
         string Read(IVBComponent component);
     }

--- a/Rubberduck.VBEditor.VB6/ExternalFileTempSourceFileHandlerEmulator.cs
+++ b/Rubberduck.VBEditor.VB6/ExternalFileTempSourceFileHandlerEmulator.cs
@@ -5,7 +5,7 @@ using Rubberduck.VBEditor.SourceCodeHandling;
 
 namespace Rubberduck.VBEditor.VB6
 {
-    public class TempSourceFileHandler : ITempSourceFileHandler
+    public class ExternalFileTempSourceFileHandlerEmulator : ITempSourceFileHandler
     {
         public string Export(IVBComponent component)
         {

--- a/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
+++ b/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
@@ -62,6 +62,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExternalFileTempSourceFileHandlerEmulator.cs" />
     <Compile Include="Providers\VB6AddInProvider.cs" />
     <Compile Include="SafeComWrappers\Office\CommandBar.cs" />
     <Compile Include="SafeComWrappers\Office\CommandBarButton.cs" />
@@ -93,7 +94,6 @@
     <Compile Include="SafeComWrappers\VB\VBProjects.cs" />
     <Compile Include="SafeComWrappers\VB\Window.cs" />
     <Compile Include="SafeComWrappers\VB\Windows.cs" />
-    <Compile Include="TempSourceFileHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rubberduck.VBEEditor\Rubberduck.VBEditor.csproj">

--- a/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
+++ b/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
@@ -93,7 +93,7 @@
     <Compile Include="SafeComWrappers\VB\VBProjects.cs" />
     <Compile Include="SafeComWrappers\VB\Window.cs" />
     <Compile Include="SafeComWrappers\VB\Windows.cs" />
-    <Compile Include="SourceFileHandler.cs" />
+    <Compile Include="TempSourceFileHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rubberduck.VBEEditor\Rubberduck.VBEditor.csproj">

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBComponent.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBComponent.cs
@@ -124,7 +124,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         /// </summary>
         /// <param name="folder">Destination folder for the resulting source file.</param>
         /// <param name="tempFile">True if a unique temp file name should be generated. WARNING: filenames generated with this flag are not persisted.</param>
-        public string ExportAsSourceFile(string folder, bool tempFile = false)
+        /// <param name="specialCaseDocumentModules">If reimpot of a document file is required later, it has to receive special treatment.</param>
+        public string ExportAsSourceFile(string folder, bool tempFile = false, bool specialCaseDocumentModules = true)
         {
             throw new NotSupportedException("Export as source file is not supported in VB6");
         }

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBE.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBE.cs
@@ -17,12 +17,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         public VBE(VB.VBE target, bool rewrapping = false)
             : base(target, rewrapping)
         {
-            SourceFileHandler = new SourceFileHandler();
+            TempSourceFileHandler = new TempSourceFileHandler();
         }
 
         public VBEKind Kind => VBEKind.Standalone;
         public object HardReference => Target;
-        public ISourceFileHandler SourceFileHandler { get; }
+        public ITempSourceFileHandler TempSourceFileHandler { get; }
 
         public string Version => IsWrappingNullReference ? string.Empty : Target.Version;
 

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBE.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBE.cs
@@ -17,7 +17,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         public VBE(VB.VBE target, bool rewrapping = false)
             : base(target, rewrapping)
         {
-            TempSourceFileHandler = new TempSourceFileHandler();
+            TempSourceFileHandler = new ExternalFileTempSourceFileHandlerEmulator();
         }
 
         public VBEKind Kind => VBEKind.Standalone;

--- a/Rubberduck.VBEditor.VB6/TempSourceFileHandler.cs
+++ b/Rubberduck.VBEditor.VB6/TempSourceFileHandler.cs
@@ -1,12 +1,11 @@
 ﻿using System.IO;
 using System.Text;
-using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.SourceCodeHandling;
 
 namespace Rubberduck.VBEditor.VB6
 {
-    public class SourceFileHandler : ISourceFileHandler
+    public class TempSourceFileHandler : ITempSourceFileHandler
     {
         public string Export(IVBComponent component)
         {
@@ -14,7 +13,7 @@ namespace Rubberduck.VBEditor.VB6
             return component.GetFileName(1);            
         }
 
-        public void Import(IVBComponent component, string fileName)
+        public void ImportAndCleanUp(IVBComponent component, string fileName)
         {
             // VB6 source code can be written directly in-place, without needing to import it, hence no-op.
         }
@@ -22,16 +21,12 @@ namespace Rubberduck.VBEditor.VB6
         public string Read(IVBComponent component)
         {
             var fileName = Export(component);
-            if (fileName == null)
+            if (fileName == null || !File.Exists(fileName))
             {
                 return null;
             }
 
-            var encoding = component.QualifiedModuleName.ComponentType == ComponentType.Document
-                ? Encoding.UTF8
-                : Encoding.Default;
-
-            return File.ReadAllText(fileName, encoding);
+            return File.ReadAllText(fileName, Encoding.Default);
         }        
     }
 }

--- a/Rubberduck.VBEditor.VBA/Rubberduck.VBEditor.VBA.csproj
+++ b/Rubberduck.VBEditor.VBA/Rubberduck.VBEditor.VBA.csproj
@@ -174,7 +174,7 @@
     <Compile Include="SafeComWrappers\VB\VBProjects.cs" />
     <Compile Include="SafeComWrappers\VB\Window.cs" />
     <Compile Include="SafeComWrappers\VB\Windows.cs" />
-    <Compile Include="SourceFileHandler.cs" />
+    <Compile Include="TempSourceFileHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rubberduck.Resources\Rubberduck.Resources.csproj">

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBComponent.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBComponent.cs
@@ -96,7 +96,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         /// </summary>
         /// <param name="folder">Destination folder for the resulting source file.</param>
         /// <param name="tempFile">True if a unique temp file name should be generated. WARNING: filenames generated with this flag are not persisted.</param>
-        public string ExportAsSourceFile(string folder, bool tempFile = false)
+        /// <param name="specialCaseDocumentModules">If reimpot of a document file is required later, it has to receive special treatment.</param>
+        public string ExportAsSourceFile(string folder, bool tempFile = false, bool specialCaseDocumentModules = true)
         {
             var fullPath = tempFile
                 ? Path.Combine(folder, Path.GetRandomFileName())
@@ -107,7 +108,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                     ExportUserFormModule(fullPath);
                     break;
                 case ComponentType.Document:
-                    ExportDocumentModule(fullPath);
+                    if(specialCaseDocumentModules)
+                    {
+                        ExportDocumentModule(fullPath);
+                    }
+                    else
+                    {
+                        Export(fullPath);
+                    }
                     break;
                 default:
                     Export(fullPath);

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
@@ -19,12 +19,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public VBE(VB.VBE target, bool rewrapping = false)
             : base(target, rewrapping)
         {
-            SourceFileHandler = new SourceFileHandler();
+            TempSourceFileHandler = new TempSourceFileHandler();
         }
 
         public VBEKind Kind => VBEKind.Hosted;
         public object HardReference => Target;
-        public ISourceFileHandler SourceFileHandler { get; }
+        public ITempSourceFileHandler TempSourceFileHandler { get; }
 
         public string Version => IsWrappingNullReference ? string.Empty : Target.Version;
 

--- a/RubberduckTests/IoCContainer/IoCRegistrationTests.cs
+++ b/RubberduckTests/IoCContainer/IoCRegistrationTests.cs
@@ -18,8 +18,8 @@ namespace RubberduckTests.IoCContainer
         {
             var vbeBuilder = new MockVbeBuilder();
             var ideMock = vbeBuilder.Build();
-            var sourceFileHandler = new Mock<ISourceFileHandler>().Object;
-            ideMock.Setup(m => m.SourceFileHandler).Returns(() => sourceFileHandler);
+            var sourceFileHandler = new Mock<ITempSourceFileHandler>().Object;
+            ideMock.Setup(m => m.TempSourceFileHandler).Returns(() => sourceFileHandler);
             var ide = ideMock.Object;
             var addInBuilder = new MockAddInBuilder();
             var addin = addInBuilder.Build().Object;
@@ -46,8 +46,8 @@ namespace RubberduckTests.IoCContainer
         {
             var vbeBuilder = new MockVbeBuilder();
             var ideMock = vbeBuilder.Build();
-            var sourceFileHandler = new Mock<ISourceFileHandler>().Object;
-            ideMock.Setup(m => m.SourceFileHandler).Returns(() => sourceFileHandler);
+            var sourceFileHandler = new Mock<ITempSourceFileHandler>().Object;
+            ideMock.Setup(m => m.TempSourceFileHandler).Returns(() => sourceFileHandler);
             var ide = ideMock.Object;
             var addInBuilder = new MockAddInBuilder();
             var addin = addInBuilder.Build().Object;

--- a/RubberduckTests/IoCContainer/IoCResolvingTests.cs
+++ b/RubberduckTests/IoCContainer/IoCResolvingTests.cs
@@ -22,8 +22,8 @@ namespace RubberduckTests.IoCContainer
         {
             var vbeBuilder = new MockVbeBuilder();
             var ideMock = vbeBuilder.Build();
-            var sourceFileHandler = new Mock<ISourceFileHandler>().Object;
-            ideMock.Setup(m => m.SourceFileHandler).Returns(() => sourceFileHandler);
+            var sourceFileHandler = new Mock<ITempSourceFileHandler>().Object;
+            ideMock.Setup(m => m.TempSourceFileHandler).Returns(() => sourceFileHandler);
             var ide = ideMock.Object;
             var addInBuilder = new MockAddInBuilder();
             var addin = addInBuilder.Build().Object;
@@ -63,8 +63,8 @@ namespace RubberduckTests.IoCContainer
         {
             var vbeBuilder = new MockVbeBuilder();
             var ideMock = vbeBuilder.Build();
-            var sourceFileHandler = new Mock<ISourceFileHandler>().Object;
-            ideMock.Setup(m => m.SourceFileHandler).Returns(() => sourceFileHandler);
+            var sourceFileHandler = new Mock<ITempSourceFileHandler>().Object;
+            ideMock.Setup(m => m.TempSourceFileHandler).Returns(() => sourceFileHandler);
             var ide = ideMock.Object;
             var addInBuilder = new MockAddInBuilder();
             var addin = addInBuilder.Build().Object;


### PR DESCRIPTION
This PR adds some more safety in the `ISourceFileHandler` (now `ITempSourceFileHandler`) around reading the files. I chose to rename the interface and the implementations to convey that they are not to be used to handle permanent exports and imports. 

I also ensured that the `ISourceCodeHandler` implementations never retun `null` and made the attributes passs use the file exported by the VBE or documant modules in order to allow getting the attributes. 