### PR TITLE
Fix the leaky (event) sink!

### DIFF
--- a/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
+++ b/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
@@ -78,6 +78,11 @@
     <Compile Include="Factories\ISafeComWrapperProvider.cs" />
     <Compile Include="Factories\VBEFactory.cs" />
     <Compile Include="HashCode.cs" />
+    <Compile Include="SafeComWrappers\Abstract\IComIndexedProperty.cs" />
+    <Compile Include="SafeComWrappers\Abstract\IEventSource.cs" />
+    <Compile Include="SafeComWrappers\VB\Abstract\ICommandBarButtonEvents.cs" />
+    <Compile Include="SafeComWrappers\VB\Abstract\ICommandBarEvents.cs" />
+    <Compile Include="SafeComWrappers\VB\Abstract\IEvents.cs" />
     <Compile Include="SourceCodeHandling\SourceFileHandlerSourceCodeHandlerAdapter.cs" />
     <Compile Include="SourceCodeHandling\CodePaneSourceCodeHandler.cs" />
     <Compile Include="SourceCodeHandling\ISourceCodeHandler.cs" />

--- a/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IComIndexedProperty.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IComIndexedProperty.cs
@@ -1,0 +1,7 @@
+namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
+{
+    public interface IComIndexedProperty<out TItem>
+    {
+        TItem this[object index] { get; }
+    }
+}

--- a/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IEventSource.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IEventSource.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
+﻿namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
 {
     public interface IEventSource<out TEventSource>
     {

--- a/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IEventSource.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/Abstract/IEventSource.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
+{
+    public interface IEventSource<out TEventSource>
+    {
+        TEventSource EventSource { get; }
+    }
+}

--- a/Rubberduck.VBEEditor/SafeComWrappers/SafeRedirectedEventedComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/SafeRedirectedEventedComWrapper.cs
@@ -35,15 +35,18 @@ namespace Rubberduck.VBEditor.SafeComWrappers
             if (eventSource == null || eventSink == null)
             {
                 return;
-            }
-
-            // Only one event source and one event sink supported at any given time
-            DetachEvents();
+            }            
 
             lock (_lock)
             {
                 if (IsWrappingNullReference)
                 {
+                    return;
+                }
+                
+                // Check that events not already attached
+                if (_eventSource != null || _eventSink != null)
+                {                   
                     return;
                 }
 

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/ICommandBarButtonEvents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/ICommandBarButtonEvents.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
+{
+    public interface ICommandBarButtonEvents : ISafeComWrapper, IEquatable<ICommandBarButtonEvents>
+    {
+    }
+}

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/ICommandBarEvents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/ICommandBarEvents.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
+{
+    public interface ICommandBarEvents : ISafeComWrapper, IComIndexedProperty<ICommandBarButtonEvents>, IEquatable<ICommandBarEvents>
+    {
+    }
+}

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IEvents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IEvents.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
+{
+    public interface IEvents : ISafeComWrapper, IEquatable<IEvents>
+    {
+        ICommandBarEvents CommandBarEvents { get; }
+    }
+}

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IEvents.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IEvents.cs
@@ -2,6 +2,8 @@
 
 namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
 {
+    // This interface is not included on IVBE, as it is only safe in VB6
+    // https://stackoverflow.com/questions/41055765/whats-the-difference-between-commandbarevents-click-and-commandbarbutton-click/41066408#41066408
     public interface IEvents : ISafeComWrapper, IEquatable<IEvents>
     {
         ICommandBarEvents CommandBarEvents { get; }

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBE.cs
@@ -19,7 +19,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
         ICodePanes CodePanes { get; }
         ICommandBars CommandBars { get; }
         IWindows Windows { get; }
-        IEvents Events { get; }
         IHostApplication HostApplication();
         IWindow ActiveMDIChild();
         QualifiedSelection? GetActiveSelection();

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBE.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBE.cs
@@ -19,6 +19,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
         ICodePanes CodePanes { get; }
         ICommandBars CommandBars { get; }
         IWindows Windows { get; }
+        IEvents Events { get; }
         IHostApplication HostApplication();
         IWindow ActiveMDIChild();
         QualifiedSelection? GetActiveSelection();

--- a/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
+++ b/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
@@ -78,6 +78,9 @@
     <Compile Include="SafeComWrappers\VB\CodeModule.cs" />
     <Compile Include="SafeComWrappers\VB\CodePane.cs" />
     <Compile Include="SafeComWrappers\VB\CodePanes.cs" />
+    <Compile Include="SafeComWrappers\VB\CommandBarButtonEvents.cs" />
+    <Compile Include="SafeComWrappers\VB\CommandBarEvents.cs" />
+    <Compile Include="SafeComWrappers\VB\Events.cs" />
     <Compile Include="SafeComWrappers\VB\LinkedWindows.cs" />
     <Compile Include="SafeComWrappers\VB\Properties.cs" />
     <Compile Include="SafeComWrappers\VB\Property.cs" />

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
@@ -297,9 +297,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office8
         {
             // Cast to VB6 VBE SafeComWrapper as  events are not exposed on IVBE as they are only safe to use in VB6
             using (var events = ((VB6.VBE)_vbe).Events)
+            using (var commandBarEvents = events.CommandBarEvents)
             {
                 // Disposal of buttonEvents is handled by the base class
-                var buttonEvents = events.CommandBarEvents[Target] as IEventSource<VB.CommandBarEvents>;
+                var buttonEvents = commandBarEvents[Target] as IEventSource<VB.CommandBarEvents>;
                 AttachEvents(buttonEvents, this);
             }
         }

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
@@ -295,9 +295,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office8
 
         public override void AttachEvents()
         {
-            using (var events = _vbe.Events)
+            // Cast to VB6 VBE SafeComWrapper as  events are not exposed on IVBE as they are only safe to use in VB6
+            using (var events = ((VB6.VBE)_vbe).Events)
             {
-                // Note - disposal of buttonEvents is handled by the base class
+                // Disposal of buttonEvents is handled by the base class
                 var buttonEvents = events.CommandBarEvents[Target] as IEventSource<VB.CommandBarEvents>;
                 AttachEvents(buttonEvents, this);
             }

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
@@ -248,8 +248,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office8
                 lock (_eventLock)
                 {
                     _click += value;
-                    if (_click != null && _click.GetInvocationList().Length != 0)
+                    if (_click != null && _click.GetInvocationList().Length == 1)
                     {
+                        // First subscriber attached - attach COM events
                         AttachEvents();
                     }
                 }
@@ -261,6 +262,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office8
                     _click -= value;
                     if (_click == null || _click.GetInvocationList().Length == 0)
                     {
+                        // Last subscriber detached - detach COM events 
                         DetachEvents();
                     }
                 }

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarButtonEvents.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarButtonEvents.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using VB = Microsoft.Vbe.Interop.VB6;
+
+namespace Rubberduck.VBEditor.SafeComWrappers.VB6
+{
+    public class CommandBarButtonEvents : SafeComWrapper<VB.CommandBarEvents>, ICommandBarButtonEvents, IEventSource<VB.CommandBarEvents>
+    {
+        public CommandBarButtonEvents(VB.CommandBarEvents target, bool rewrapping = false)
+            : base(target, rewrapping)
+        {            
+        }
+
+        public VB.CommandBarEvents EventSource => Target;
+
+        public override bool Equals(ISafeComWrapper<VB.CommandBarEvents> other)
+        {
+            return IsEqualIfNull(other) || (other != null && ReferenceEquals(other.Target, Target));
+        }
+
+        public bool Equals(ICommandBarButtonEvents other)
+        {
+            return Equals(other as SafeComWrapper<VB.CommandBarEvents>);
+        }
+
+        public override int GetHashCode()
+        {
+            return IsWrappingNullReference ? 0 : Target.GetHashCode();
+        }
+    }
+}

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarButtonEvents.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarButtonEvents.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using VB = Microsoft.Vbe.Interop.VB6;
 
 namespace Rubberduck.VBEditor.SafeComWrappers.VB6
@@ -11,7 +10,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         {            
         }
 
-        public VB.CommandBarEvents EventSource => Target;
+        // Explicit implementation as usage should only be from within a SafeComWrapper
+        VB.CommandBarEvents IEventSource<VB.CommandBarEvents>.EventSource => Target;
 
         public override bool Equals(ISafeComWrapper<VB.CommandBarEvents> other)
         {

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarEvents.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarEvents.cs
@@ -1,0 +1,31 @@
+﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using VB = Microsoft.Vbe.Interop.VB6;
+
+// ReSharper disable once CheckNamespace - Special dispensation due to conflicting file vs namespace priorities
+namespace Rubberduck.VBEditor.SafeComWrappers.VB6
+{
+    public class CommandBarEvents : SafeComWrapper<VB.Events>, ICommandBarEvents
+    {
+        public CommandBarEvents(VB.Events target, bool rewrapping = false)
+            : base(target, rewrapping)
+        {
+        }
+
+        public ICommandBarButtonEvents this[object button] => IsWrappingNullReference ? new CommandBarButtonEvents(null) : new CommandBarButtonEvents(Target.CommandBarEvents[button]);
+
+        public override bool Equals(ISafeComWrapper<VB.Events> other)
+        {
+            return IsEqualIfNull(other) || (other != null && ReferenceEquals(other.Target, Target));
+        }
+
+        public bool Equals(ICommandBarEvents other)
+        {
+            return Equals(other as SafeComWrapper<VB.Events>);
+        }
+
+        public override int GetHashCode()
+        {
+            return IsWrappingNullReference ? 0 : Target.GetHashCode();
+        }
+    }
+}

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarEvents.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CommandBarEvents.cs
@@ -11,7 +11,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         {
         }
 
-        public ICommandBarButtonEvents this[object button] => IsWrappingNullReference ? new CommandBarButtonEvents(null) : new CommandBarButtonEvents(Target.CommandBarEvents[button]);
+        public ICommandBarButtonEvents this[object button] => new CommandBarButtonEvents(IsWrappingNullReference ? null : Target.CommandBarEvents[button]);
 
         public override bool Equals(ISafeComWrapper<VB.Events> other)
         {

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/Events.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/Events.cs
@@ -1,0 +1,31 @@
+﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using VB = Microsoft.Vbe.Interop.VB6;
+
+// ReSharper disable once CheckNamespace - Special dispensation due to conflicting file vs namespace priorities
+namespace Rubberduck.VBEditor.SafeComWrappers.VB6
+{
+    public class Events : SafeComWrapper<VB.Events>, IEvents
+    {
+        public Events(VB.Events target, bool rewrapping = false)
+            : base(target, rewrapping)
+        {
+        }
+
+        public ICommandBarEvents CommandBarEvents => new CommandBarEvents(Target);
+
+        public override bool Equals(ISafeComWrapper<VB.Events> other)
+        {
+            return IsEqualIfNull(other) || (other != null && ReferenceEquals(other.Target, Target));
+        }
+
+        public bool Equals(IEvents other)
+        {
+            return Equals(other as SafeComWrapper<VB.Events>);
+        }
+
+        public override int GetHashCode()
+        {
+            return IsWrappingNullReference ? 0 : Target.GetHashCode();
+        }
+    }
+}

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/Events.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/Events.cs
@@ -11,7 +11,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         {
         }
 
-        public ICommandBarEvents CommandBarEvents => new CommandBarEvents(Target);
+        public ICommandBarEvents CommandBarEvents => new CommandBarEvents(IsWrappingNullReference ? null : Target);
 
         public override bool Equals(ISafeComWrapper<VB.Events> other)
         {

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/Events.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/Events.cs
@@ -11,7 +11,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         {
         }
 
-        public ICommandBarEvents CommandBarEvents => new CommandBarEvents(IsWrappingNullReference ? null : Target);
+        public ICommandBarEvents CommandBarEvents => new CommandBarEvents(IsWrappingNullReference ? null : Target, true);
 
         public override bool Equals(ISafeComWrapper<VB.Events> other)
         {

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBE.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBE.cs
@@ -78,6 +78,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         public IVBProjects VBProjects => new VBProjects(IsWrappingNullReference ? null : Target.VBProjects);
 
         public IWindows Windows => new Windows(IsWrappingNullReference ? null : Target.Windows);
+
+        public IEvents Events => new Events(IsWrappingNullReference ? null : Target.Events);
         
         public override bool Equals(ISafeComWrapper<VB.VBE> other)
         {

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/Office/CommandBarButton.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/Office/CommandBarButton.cs
@@ -291,8 +291,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
                 lock (_eventLock)
                 {
                     _click += value;
-                    if (_click != null && _click.GetInvocationList().Length != 0)
+                    if (_click != null && _click.GetInvocationList().Length == 1)
                     {
+                        // First subscriber attached - attach COM events
                         AttachEvents();
                     }
                 }
@@ -304,6 +305,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
                     _click -= value;
                     if (_click == null || _click.GetInvocationList().Length == 0)
                     {
+                        // Last subscriber detached - detach COM events
                         DetachEvents();
                     };
                 }

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
@@ -80,6 +80,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public IVBProjects VBProjects => new VBProjects(IsWrappingNullReference ? null : Target.VBProjects);
 
         public IWindows Windows => new Windows(IsWrappingNullReference ? null : Target.Windows);
+
+        public IEvents Events => throw new NotSupportedException("Accessing the VBE.Events collection is not supported for VBA");
         
         public override bool Equals(ISafeComWrapper<VB.VBE> other)
         {

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
@@ -80,9 +80,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         public IVBProjects VBProjects => new VBProjects(IsWrappingNullReference ? null : Target.VBProjects);
 
         public IWindows Windows => new Windows(IsWrappingNullReference ? null : Target.Windows);
-
-        public IEvents Events => throw new NotSupportedException("Accessing the VBE.Events collection is not supported for VBA");
-        
+       
         public override bool Equals(ISafeComWrapper<VB.VBE> other)
         {
             return IsEqualIfNull(other) || (other != null && other.Target.Version == Version);


### PR DESCRIPTION
Closes #3949 

OK, so technically it's an event *source* that was (perhaps) leaking... but I just couldn't resist that PR title.

This PR addresses an item of technical debt spotted during PR #3935. For expediency at the time, VB6 events for CommandBarButtons were hooked up using chained access to raw RCW objects. This was entirely due to the unpleasant way that older Office libraries (such as the v8 that VB6 uses) modelled button click events.

To remediate, I've created some new SafeComWrappers for CommandBarEvents. These are then used to safely pass the correct RCW into a refactored SafeRedirectedEventComWrapper base class. ~~Note that as we have no need for any of this on the VBA side, the relevant property just throws NotSupportedException. I think this is valid, as its something that could potentially be added later, just that there's no current need.~~ Edit: per chat, VBE.Events must not be used in 64-bit VBA for Office 2000 and up, as it will crash the host. 

One oddity was the need to have one RCW wrapped at two levels (CommandBarEvents and CommandBarButtonEvents) - this is due to the COM OM using indexed properties here - this is the first time we've had to wrap them AFAICT.