### PR TITLE
Quick hack to fix VB6 crash on certain project types

### DIFF
--- a/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
+++ b/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
@@ -337,7 +337,11 @@ namespace Rubberduck.Root
 
         private void RegisterRubberduckMenu(IWindsorContainer container)
         {
-            var location = _addin.CommandBarLocations[CommandBarSite.MenuBar];
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.MenuBar, out var location))
+            {
+                return;
+            }
+
             var controls = MainCommandBarControls(location.ParentId);
             var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
             var menuItemTypes = RubberduckMenuItems();
@@ -403,7 +407,11 @@ namespace Rubberduck.Root
 
         private void RegisterCodePaneContextMenu(IWindsorContainer container)
         {
-            var location = _addin.CommandBarLocations[CommandBarSite.CodeWindow];
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.CodeWindow, out var location))
+            {
+                return;
+            }
+
             var controls = MainCommandBarControls(location.ParentId);
             var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
             var menuItemTypes = CodePaneContextMenuItems();
@@ -424,7 +432,11 @@ namespace Rubberduck.Root
 
         private void RegisterFormDesignerContextMenu(IWindsorContainer container)
         {
-            var location = _addin.CommandBarLocations[CommandBarSite.MsForm];
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.MsForm, out var location))
+            {
+                return;
+            }
+
             var controls = MainCommandBarControls(location.ParentId);
             var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
             var menuItemTypes = FormDesignerContextMenuItems();
@@ -442,7 +454,11 @@ namespace Rubberduck.Root
 
         private void RegisterFormDesignerControlContextMenu(IWindsorContainer container)
         {
-            var location = _addin.CommandBarLocations[CommandBarSite.MsFormControl];
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.MsFormControl, out var location))
+            {
+                return;
+            }
+
             var controls = MainCommandBarControls(location.ParentId);
             var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
             var menuItemTypes = FormDesignerContextMenuItems();
@@ -451,7 +467,11 @@ namespace Rubberduck.Root
 
         private void RegisterProjectExplorerContextMenu(IWindsorContainer container)
         {
-            var location = _addin.CommandBarLocations[CommandBarSite.ProjectExplorer];
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.ProjectExplorer, out var location))
+            {
+                return;
+            }
+
             var controls = MainCommandBarControls(location.ParentId);
             var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
             var menuItemTypes = ProjectWindowContextMenuItems();

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
@@ -30,7 +30,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                 {CommandBarSite.MenuBar, new CommandBarLocation(MenuBar, WindowMenu)},
                 {CommandBarSite.CodeWindow, new CommandBarLocation(CodeWindow, ListProperties)},
                 {CommandBarSite.ProjectExplorer, new CommandBarLocation(ProjectExplorer, ProjectProperties)},
-                {CommandBarSite.MsForm, new CommandBarLocation(MsForm, UpdateUserControls)},
+                // {CommandBarSite.MsForm, new CommandBarLocation(MsForm, UpdateUserControls)}, // FIXME - quick hack for #4280
                 {CommandBarSite.MsFormControl, new CommandBarLocation(MsFormControl, ViewCode)}
             });
         }


### PR DESCRIPTION
Closes #4280.

This is just a quick hack to remove the Forms context menu from VB6 RD. I'll open another issue to put back the menu, which will need some thought as to how best to hook the form designer load event and attach the menu at the right time.

F5'd in VB6 and VBA to make sure no other menus affected. Tested all project types and tried cancelling the dialog - all work now.