### PR TITLE
VB6: Set as start up project

### DIFF
--- a/Rubberduck.Core/CodeAnalysis/CodeMetrics/CodeMetricsViewModel.cs
+++ b/Rubberduck.Core/CodeAnalysis/CodeMetrics/CodeMetricsViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using Rubberduck.Navigation.CodeExplorer;
 using System.Windows;
 using Rubberduck.Navigation.Folders;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.CodeAnalysis.CodeMetrics
 {
@@ -16,13 +17,15 @@ namespace Rubberduck.CodeAnalysis.CodeMetrics
         private readonly RubberduckParserState _state;
         private readonly ICodeMetricsAnalyst _analyst;
         private readonly FolderHelper _folderHelper;
+        private readonly IVBE _vbe;
 
-        public CodeMetricsViewModel(RubberduckParserState state, ICodeMetricsAnalyst analyst, FolderHelper folderHelper)
+        public CodeMetricsViewModel(RubberduckParserState state, ICodeMetricsAnalyst analyst, FolderHelper folderHelper, IVBE vbe)
         {
             _state = state;
             _analyst = analyst;
             _folderHelper = folderHelper;
             _state.StateChanged += OnStateChanged;
+            _vbe = vbe;
         }
         
         private void OnStateChanged(object sender, ParserStateEventArgs e)
@@ -71,7 +74,8 @@ namespace Rubberduck.CodeAnalysis.CodeMetrics
             var newProjects = userDeclarations.Select(grouping =>
                 new CodeExplorerProjectViewModel(_folderHelper,
                     grouping.SingleOrDefault(declaration => declaration.DeclarationType == DeclarationType.Project),
-                    grouping)).ToList();
+                    grouping,
+                    _vbe)).ToList();
 
             UpdateNodes(Projects, newProjects);
 

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerItemViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerItemViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows;
 using System.Windows.Media.Imaging;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.UI;
@@ -202,6 +203,8 @@ namespace Rubberduck.Navigation.CodeExplorer
         public abstract BitmapImage CollapsedIcon { get; }
         public abstract BitmapImage ExpandedIcon { get; }
         public abstract CodeExplorerItemViewModel Parent { get; }
+
+        public virtual FontWeight FontWeight => FontWeights.Normal;
 
         public abstract QualifiedSelection? QualifiedSelection { get; }
 

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows;
 using System.Windows.Media.Imaging;
 using Rubberduck.Navigation.Folders;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using resx = Rubberduck.Resources.CodeExplorer.CodeExplorerUI;
 
 namespace Rubberduck.Navigation.CodeExplorer
@@ -15,6 +17,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         public Declaration Declaration { get; }
 
         private readonly CodeExplorerCustomFolderViewModel _folderTree;
+        private readonly IVBE _vbe;
 
         private static readonly DeclarationType[] ComponentTypes =
         {
@@ -24,12 +27,13 @@ namespace Rubberduck.Navigation.CodeExplorer
             DeclarationType.UserForm, 
         };
 
-        public CodeExplorerProjectViewModel(FolderHelper folderHelper, Declaration declaration, IEnumerable<Declaration> declarations)
+        public CodeExplorerProjectViewModel(FolderHelper folderHelper, Declaration declaration, IEnumerable<Declaration> declarations, IVBE vbe)
         {
             Declaration = declaration;
             _name = Declaration.IdentifierName;
             IsExpanded = true;
             _folderTree = folderHelper.GetFolderTree(declaration);
+            _vbe = vbe;
 
             try
             {
@@ -94,6 +98,27 @@ namespace Rubberduck.Navigation.CodeExplorer
         private readonly BitmapImage _icon;
         public override BitmapImage CollapsedIcon => _icon;
         public override BitmapImage ExpandedIcon => _icon;
+
+        public override FontWeight FontWeight
+        {
+            get
+            {
+                if (_vbe.Kind == VBEKind.Hosted || Declaration.Project == null)
+                {
+                    return base.FontWeight;
+                }
+
+                using (var vbProjects = _vbe.VBProjects)
+                {
+                    if (Declaration.Project.Equals(vbProjects.StartProject))
+                    {
+                        return FontWeights.Bold;
+                    }
+
+                    return base.FontWeight;
+                }
+            }
+        }
 
         // projects are always at the top of the tree
         public override CodeExplorerItemViewModel Parent => null;

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -34,7 +34,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         private readonly GeneralSettings _generalSettings;
         private readonly WindowSettings _windowSettings;
         private readonly IUiDispatcher _uiDispatcher;
-        private readonly VBEKind _vbeKind;
+        private readonly IVBE _vbe;
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -53,7 +53,7 @@ namespace Rubberduck.Navigation.CodeExplorer
             _state.ModuleStateChanged += ParserState_ModuleStateChanged;
             _windowSettingsProvider = windowSettingsProvider;
             _uiDispatcher = uiDispatcher;
-            _vbeKind = vbe.Kind;
+            _vbe = vbe;
 
             if (generalSettingsProvider != null)
             {
@@ -84,8 +84,9 @@ namespace Rubberduck.Navigation.CodeExplorer
             AddPropertyPageCommand = commands.OfType<AddPropertyPageCommand>().SingleOrDefault();
             AddUserDocumentCommand = commands.OfType<AddUserDocumentCommand>().SingleOrDefault();
             AddTestModuleCommand = commands.OfType<UI.CodeExplorer.Commands.AddTestModuleCommand>().SingleOrDefault();
-            AddTestModuleWithStubsCommand = commands.OfType<AddTestModuleWithStubsCommand>().SingleOrDefault();            
+            AddTestModuleWithStubsCommand = commands.OfType<AddTestModuleWithStubsCommand>().SingleOrDefault();
 
+            SetAsStartupProjectCommand = commands.OfType<SetAsStartupProjectCommand>().SingleOrDefault();
             OpenProjectPropertiesCommand = commands.OfType<OpenProjectPropertiesCommand>().SingleOrDefault();
             RenameCommand = commands.OfType<RenameCommand>().SingleOrDefault();
             IndenterCommand = commands.OfType<IndentCommand>().SingleOrDefault();
@@ -334,7 +335,8 @@ namespace Rubberduck.Navigation.CodeExplorer
             var newProjects = userDeclarations.Select(grouping =>
                 new CodeExplorerProjectViewModel(_folderHelper,
                     grouping.SingleOrDefault(declaration => declaration.DeclarationType == DeclarationType.Project),
-                    grouping)).ToList();
+                    grouping,
+                    _vbe)).ToList();
 
             UpdateNodes(Projects, newProjects);
             
@@ -532,6 +534,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         public CommandBase AddTestModuleWithStubsCommand { get; }
 
         public CommandBase OpenDesignerCommand { get; }
+        public CommandBase SetAsStartupProjectCommand { get; }
         public CommandBase OpenProjectPropertiesCommand { get; }
 
         public CommandBase RenameCommand { get; }
@@ -566,7 +569,7 @@ namespace Rubberduck.Navigation.CodeExplorer
 
         private bool CanExecuteExportAllCommand => ExportAllCommand.CanExecute(SelectedItem);
 
-        public Visibility ExportVisibility => _vbeKind == VBEKind.Standalone || CanExecuteExportAllCommand ? Visibility.Collapsed : Visibility.Visible;
+        public Visibility ExportVisibility => _vbe.Kind == VBEKind.Standalone || CanExecuteExportAllCommand ? Visibility.Collapsed : Visibility.Visible;
 
         public Visibility ExportAllVisibility => CanExecuteExportAllCommand ? Visibility.Visible : Visibility.Collapsed;
 
@@ -574,9 +577,9 @@ namespace Rubberduck.Navigation.CodeExplorer
 
         public Visibility EmptyUIRefreshMessageVisibility => _isBusy ? Visibility.Hidden : Visibility.Visible;
 
-        public Visibility VB6Visibility => _vbeKind == VBEKind.Standalone ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility VB6Visibility => _vbe.Kind == VBEKind.Standalone ? Visibility.Visible : Visibility.Collapsed;
 
-        public Visibility VBAVisibility => _vbeKind == VBEKind.Hosted ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility VBAVisibility => _vbe.Kind == VBEKind.Hosted ? Visibility.Visible : Visibility.Collapsed;
 
         public void FilterByName(IEnumerable<CodeExplorerItemViewModel> nodes, string searchString)
         {

--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -391,6 +391,7 @@
     <Compile Include="UI\CodeExplorer\Commands\CodeExplorerCommandAttribute.cs" />
     <Compile Include="UI\CodeExplorer\Commands\AddUserFormCommand.cs" />
     <Compile Include="UI\CodeExplorer\Commands\CopyResultsCommand.cs" />
+    <Compile Include="UI\CodeExplorer\Commands\SetAsStartupProjectCommand.cs" />
     <Compile Include="UI\CodeMetrics\CodeMetricsWindow.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -88,6 +88,7 @@
             <Style x:Key="TreeViewItemStyle" TargetType="TextBlock">
                 <Setter Property="Text" Value="{Binding Name}" />
                 <Setter Property="FontSize" Value="10" />
+                <Setter Property="FontWeight" Value="{Binding FontWeight}"/>
                 <Setter Property="Margin" Value="2,0,2,0" />
                 <Setter Property="VerticalAlignment" Value="Center" />
                 <Setter Property="ToolTip" Value="{Binding Name}" />
@@ -101,9 +102,10 @@
                 </Style.Triggers>
             </Style>
 
-            <Style x:Key="TreeViewItemStyleWithSignatures" TargetType="TextBlock">
+            <Style  x:Key="TreeViewItemStyleWithSignatures" TargetType="TextBlock">
                 <Setter Property="Text" Value="{Binding NameWithSignature}" />
                 <Setter Property="FontSize" Value="10" />
+                <Setter Property="FontWeight" Value="{Binding FontWeight}"/>
                 <Setter Property="Margin" Value="2,0,2,0" />
                 <Setter Property="VerticalAlignment" Value="Center" />
                 <Setter Property="ToolTip" Value="{Binding NameWithSignature}" />
@@ -166,9 +168,13 @@
                                   Command="{Binding RenameCommand}"
                                   CommandParameter="{Binding SelectedItem}" />
                             <Separator />
+                            <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_SetAsStartupProject}"
+                                  Command="{Binding SetAsStartupProjectCommand}"
+                                  CommandParameter="{Binding SelectedItem}"  
+                                  Visibility="{Binding VB6Visibility}"/>
                             <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_OpenProjectProperties}"
                                   Command="{Binding OpenProjectPropertiesCommand}"
-                                  CommandParameter="{Binding SelectedItem}" />
+                                  CommandParameter="{Binding SelectedItem}"/>
                             <Separator />
                             <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_AddModule}">
                                 <MenuItem.Icon>

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -102,7 +102,7 @@
                 </Style.Triggers>
             </Style>
 
-            <Style  x:Key="TreeViewItemStyleWithSignatures" TargetType="TextBlock">
+            <Style x:Key="TreeViewItemStyleWithSignatures" TargetType="TextBlock">
                 <Setter Property="Text" Value="{Binding NameWithSignature}" />
                 <Setter Property="FontSize" Value="10" />
                 <Setter Property="FontWeight" Value="{Binding FontWeight}"/>
@@ -174,7 +174,7 @@
                                   Visibility="{Binding VB6Visibility}"/>
                             <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_OpenProjectProperties}"
                                   Command="{Binding OpenProjectPropertiesCommand}"
-                                  CommandParameter="{Binding SelectedItem}"/>
+                                  CommandParameter="{Binding SelectedItem}" />
                             <Separator />
                             <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_AddModule}">
                                 <MenuItem.Icon>

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
@@ -26,12 +26,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 if (project == null && _vbe.ProjectsCount == 1)
                 {
                     using (var vbProjects = _vbe.VBProjects)
-                    {
-                        project = vbProjects[1];
-                        using (project)
-                        {
-                            return project != null && allowableProjectTypes.Contains(project.Type);
-                        }
+                    using (project = vbProjects[1])
+                    {                        
+                        return project != null && allowableProjectTypes.Contains(project.Type);                        
                     }
                 }
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
@@ -25,7 +25,14 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
                 if (project == null && _vbe.ProjectsCount == 1)
                 {
-                    project = _vbe.VBProjects[1];
+                    using (var vbProjects = _vbe.VBProjects)
+                    {
+                        project = vbProjects[1];
+                        using (project)
+                        {
+                            return project != null && allowableProjectTypes.Contains(project.Type);
+                        }
+                    }
                 }
 
                 return project != null && allowableProjectTypes.Contains(project.Type);

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddMDIFormCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddMDIFormCommand.cs
@@ -30,12 +30,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             if (project == null  && _vbe.ProjectsCount == 1)
             {
                 using (var vbProjects = _vbe.VBProjects)
+                using (project = vbProjects[1])
                 {
-                    project = vbProjects[1];
-                    using (project)
-                    {
-                        return EvaluateCanExecuteCore(project, parameter as CodeExplorerItemViewModel);
-                    }
+                    return EvaluateCanExecuteCore(project, parameter as CodeExplorerItemViewModel);
                 }
             }
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddMDIFormCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddMDIFormCommand.cs
@@ -29,9 +29,21 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
             if (project == null  && _vbe.ProjectsCount == 1)
             {
-                project = _vbe.VBProjects[1];
+                using (var vbProjects = _vbe.VBProjects)
+                {
+                    project = vbProjects[1];
+                    using (project)
+                    {
+                        return EvaluateCanExecuteCore(project, parameter as CodeExplorerItemViewModel);
+                    }
+                }
             }
 
+            return EvaluateCanExecuteCore(project, parameter as CodeExplorerItemViewModel);
+        }
+
+        private bool EvaluateCanExecuteCore(IVBProject project, CodeExplorerItemViewModel itemViewModel)
+        {
             if (project == null)
             {
                 return false;
@@ -46,10 +58,10 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                         // Only one MDI Form allowed per project
                         return false;
                     }
-                }                    
-            }            
+                }
+            }
 
-            return _addComponentCommand.CanAddComponent(parameter as CodeExplorerItemViewModel, new[] { ProjectType.StandardExe, ProjectType.ActiveXExe });
+            return _addComponentCommand.CanAddComponent(itemViewModel, new[] {ProjectType.StandardExe, ProjectType.ActiveXExe});
         }
 
         protected override void OnExecute(object parameter)

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/SetAsStartupProjectCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/SetAsStartupProjectCommand.cs
@@ -1,0 +1,83 @@
+using System.Runtime.InteropServices;
+using NLog;
+using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.UI.Command;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.UI.CodeExplorer.Commands
+{
+    [CodeExplorerCommand]
+    public class SetAsStartupProjectCommand : CommandBase
+    {
+        private readonly IVBE _vbe;
+        private readonly RubberduckParserState _parserState;
+
+        public SetAsStartupProjectCommand(IVBE vbe, RubberduckParserState parserState)
+            : base(LogManager.GetCurrentClassLogger())
+        {
+            _vbe = vbe;
+            _parserState = parserState;
+        }
+
+        protected override bool EvaluateCanExecute(object parameter)
+        {
+            try
+            {
+                if (_vbe.ProjectsCount <= 1)
+                {
+                    return false;
+                }
+
+                var project = GetDeclaration(parameter as CodeExplorerItemViewModel)?.Project;
+
+                using (var vbProjects = _vbe.VBProjects)
+                {
+                    return project != null && !project.Equals(vbProjects.StartProject);
+                }
+            }
+            catch (COMException exception)
+            {
+                Logger.Error(exception);
+                return false;
+            }
+        }
+
+        protected override void OnExecute(object parameter)
+        {
+            try
+            {
+                if (_vbe.ProjectsCount <= 1)
+                {
+                    return;                    
+                }
+
+                var project = GetDeclaration(parameter as CodeExplorerItemViewModel)?.Project;
+
+                using (var vbProjects = _vbe.VBProjects)
+                {
+                    if (!vbProjects.StartProject.Equals(project))
+                    {
+                        vbProjects.StartProject = project;
+                        _parserState.OnParseRequested(this);
+                    }
+                }
+            }
+            catch (COMException exception)
+            {
+                Logger.Error(exception);
+            }
+        }
+
+        private Declaration GetDeclaration(CodeExplorerItemViewModel node)
+        {
+            while (node != null && !(node is ICodeExplorerDeclarationViewModel))
+            {
+                node = node.Parent;
+            }
+
+            return (node as ICodeExplorerDeclarationViewModel)?.Declaration;
+        }
+    }
+}

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
@@ -376,6 +376,15 @@ namespace Rubberduck.Resources.CodeExplorer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set as start up.
+        /// </summary>
+        public static string CodeExplorer_SetAsStartupProject {
+            get {
+                return ResourceManager.GetString("CodeExplorer_SetAsStartupProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open Designer.
         /// </summary>
         public static string CodeExplorer_ShowDesignerToolTip {

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
@@ -370,4 +370,7 @@
   <data name="CodeExplorer_AddVBFormText" xml:space="preserve">
     <value>Form (.frm)</value>
   </data>
+  <data name="CodeExplorer_SetAsStartupProject" xml:space="preserve">
+    <value>Set as start up</value>
+  </data>
 </root>

--- a/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBProjects.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/VB/Abstract/IVBProjects.cs
@@ -15,5 +15,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Abstract
         IVBProject Add(ProjectType type);
         IVBProject Open(string path);
         void Remove(IVBProject project);
+        IVBProject StartProject { get; set; } // VB6 only
     }
 }

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProject.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProject.cs
@@ -111,7 +111,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 
         public override bool Equals(ISafeComWrapper<VB.VBProject> other)
         {
-            return IsEqualIfNull(other) || (other != null && other.Target == Target);
+            // This is only safe in VB6 because project names must be unique within a session (which is not true of VBA)
+            // Need to do it this way as reference equality fails when compaing to VBProjects.StartProject
+            return IsEqualIfNull(other) || (other?.Target != null && other.Target.Name == Target.Name);
         }
 
         public bool Equals(IVBProject other)

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProject.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProject.cs
@@ -112,7 +112,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         public override bool Equals(ISafeComWrapper<VB.VBProject> other)
         {
             // This is only safe in VB6 because project names must be unique within a session (which is not true of VBA)
-            // Need to do it this way as reference equality fails when compaing to VBProjects.StartProject
+            // Need to do it this way as reference equality fails when comparing to VBProjects.StartProject
             return IsEqualIfNull(other) || (other?.Target != null && other.Target.Name == Target.Name);
         }
 

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProjects.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProjects.cs
@@ -38,6 +38,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 
         public IVBProject Open(string path) => new VBProject(IsWrappingNullReference? null : Target.AddFromFile(path).Item(1));
 
+        public IVBProject StartProject
+        {
+            get => new VBProject(IsWrappingNullReference ? null : Target.StartProject);
+            set => Target.StartProject = (VB.VBProject)value.Target;
+        }
+
         public IVBProject this[object index] => new VBProject(IsWrappingNullReference ? null : Target.Item(index));
 
         IEnumerator<IVBProject> IEnumerable<IVBProject>.GetEnumerator()

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBProjects.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBProjects.cs
@@ -41,6 +41,13 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             return new VBProject(IsWrappingNullReference ? null : Target.Open(path));
         }
 
+        // Not applicable to VBA
+        IVBProject IVBProjects.StartProject
+        {
+            get => new VBProject(null);
+            set { }
+        }
+
         public IVBProject this[object index] => new VBProject(IsWrappingNullReference ? null : Target.Item(index));
 
         IEnumerator<IVBProject> IEnumerable<IVBProject>.GetEnumerator()


### PR DESCRIPTION
Closes #4305.

This PR adds a menu entry to VB6 RD Code Explorer to Set as startup.

- Only enabled when more than 1 project in the session, and the node's project is not already set as startup
- Indicates the current start up project by bolding the project node (as per PE)

Not visible to VBA,

Also fixed a couple of RCW leaks with AddCommands