### PR TITLE
Fix URC inspection for international users

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ExpressionFilterFactory.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ExpressionFilterFactory.cs
@@ -2,18 +2,19 @@
 using Rubberduck.Parsing.Grammar;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection{
 
     public static class ExpressionFilterFactory
     {
-        private static Dictionary<string, (long typeMin, long typeMax)> IntegralNumberExtents = new Dictionary<string, (long typeMin, long typeMax)>()
+        private static readonly Dictionary<string, (long typeMin, long typeMax)> IntegralNumberExtents = new Dictionary<string, (long typeMin, long typeMax)>()
         {
             [Tokens.LongLong] = (long.MinValue, long.MaxValue),
-            [Tokens.Long] = (Int32.MinValue, Int32.MaxValue),
-            [Tokens.Integer] = (Int16.MinValue, Int16.MaxValue),
-            [Tokens.Int] = (Int16.MinValue, Int16.MaxValue),
+            [Tokens.Long] = (int.MinValue, int.MaxValue),
+            [Tokens.Integer] = (short.MinValue, short.MaxValue),
+            [Tokens.Int] = (short.MinValue, short.MaxValue),
             [Tokens.Byte] = (byte.MinValue, byte.MaxValue)
         };
 
@@ -21,36 +22,36 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection{
         {
             if (IntegralNumberExtents.Keys.Contains(valueType))
             {
-                var integralNumberFilter = new ExpressionFilterIntegral(valueType, long.Parse);
+                var integralNumberFilter = new ExpressionFilterIntegral(valueType, s => long.Parse(s, CultureInfo.InvariantCulture));
                 integralNumberFilter.SetExtents(IntegralNumberExtents[valueType].typeMin, IntegralNumberExtents[valueType].typeMax);
                 return integralNumberFilter;
             }
-            else if (valueType.Equals(Tokens.Double) || valueType.Equals(Tokens.Single))
+            if (valueType.Equals(Tokens.Double) || valueType.Equals(Tokens.Single))
             {
-                var floatingPointNumberFilter = new ExpressionFilter<double>(valueType, double.Parse);
+                var floatingPointNumberFilter = new ExpressionFilter<double>(valueType, s => double.Parse(s, CultureInfo.InvariantCulture));
                 if (valueType.Equals(Tokens.Single))
                 {
                     floatingPointNumberFilter.SetExtents(float.MinValue, float.MaxValue);
                 }
                 return floatingPointNumberFilter;
             }
-            else if (valueType.Equals(Tokens.Currency))
+            if (valueType.Equals(Tokens.Currency))
             {
                 var fixedPointNumberFilter = new ExpressionFilter<decimal>(valueType, VBACurrency.Parse);
                 fixedPointNumberFilter.SetExtents(VBACurrency.MinValue, VBACurrency.MaxValue);
                 return fixedPointNumberFilter;
             }
-            else if (valueType.Equals(Tokens.Boolean))
+            if (valueType.Equals(Tokens.Boolean))
             {
                 return new ExpressionFilterBoolean();
             }
 
-            else if (valueType.Equals(Tokens.Date))
+            if (valueType.Equals(Tokens.Date))
             {
                 return new ExpressionFilterDate();
             }
 
-            return new ExpressionFilter<string>(valueType, (a) => { return a; });
+            return new ExpressionFilter<string>(valueType, a => a);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/LetCoerce.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/LetCoerce.cs
@@ -120,7 +120,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
                 [Tokens.LongLong] = a => long.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
                 [Tokens.Double] = a => a,
                 [Tokens.Single] = a => a,
-                [Tokens.Currency] = a => decimal.Parse(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Currency] = a => decimal.Parse(a, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
                 [Tokens.Boolean] = NumericToBoolean,
                 [Tokens.Date] = NumericToDate,
             },

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/LetCoerce.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/LetCoerce.cs
@@ -43,128 +43,128 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         {
             [Tokens.String] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return a; },
-                [Tokens.Byte] = (a) => { return byte.Parse(StringToByte(a)).ToString(CultureInfo.InvariantCulture); },
-                [Tokens.Integer] = (a) => { return short.Parse(StringToIntegral(a)).ToString(CultureInfo.InvariantCulture); },
-                [Tokens.Long] = (a) => { return Int32.Parse(StringToIntegral(a)).ToString(CultureInfo.InvariantCulture); },
-                [Tokens.LongLong] = (a) => { return Int64.Parse(StringToIntegral(a)).ToString(CultureInfo.InvariantCulture); },
-                [Tokens.Double] = (a) => { return double.Parse(StringToRational(a), NumberStyles.Float, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture); },
-                [Tokens.Single] = (a) => { return float.Parse(StringToRational(a), NumberStyles.Float, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture); },
-                [Tokens.Currency] = (a) => { return VBACurrency.Parse(StringToRational(a)).ToString(CultureInfo.InvariantCulture); },
-                [Tokens.Boolean] = (a) => { return bool.Parse(StringToBoolean(a)) ? Tokens.True : Tokens.False; },
-                [Tokens.Date] = (a) => { return StringToDate(a); }
+                [Tokens.String] = a => a,
+                [Tokens.Byte] = a => byte.Parse(StringToByte(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => short.Parse(StringToIntegral(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Long] = a => int.Parse(StringToIntegral(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.LongLong] = a => long.Parse(StringToIntegral(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Double] = a => double.Parse(StringToRational(a), NumberStyles.Float, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Single] = a => float.Parse(StringToRational(a), NumberStyles.Float, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Currency] = a => VBACurrency.Parse(StringToRational(a)).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Boolean] = a => bool.Parse(StringToBoolean(a)) ? Tokens.True : Tokens.False,
+                [Tokens.Date] = StringToDate
             },
 
             [Tokens.Byte] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return a; },
-                [Tokens.Byte] = (a) => { return a; },
-                [Tokens.Integer] = (a) => { return a; },
-                [Tokens.Long] = (a) => { return a; },
-                [Tokens.LongLong] = (a) => { return a; },
-                [Tokens.Double] = (a) => { return a; },
-                [Tokens.Single] = (a) => { return a; },
-                [Tokens.Currency] = (a) => { return a; },
-                [Tokens.Boolean] = (a) => { return NumericToBoolean(a); },
-                [Tokens.Date] = (a) => { return NumericToDate(a); },
+                [Tokens.String] = a => a,
+                [Tokens.Byte] = a => a,
+                [Tokens.Integer] = a => a,
+                [Tokens.Long] = a => a,
+                [Tokens.LongLong] = a => a,
+                [Tokens.Double] = a => a,
+                [Tokens.Single] = a => a,
+                [Tokens.Currency] = a => a,
+                [Tokens.Boolean] = NumericToBoolean,
+                [Tokens.Date] = NumericToDate,
             },
 
             [Tokens.Integer] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return a; },
-                [Tokens.Byte] = (a) => { return byte.Parse(a).ToString(); },
-                [Tokens.Integer] = (a) => { return a; },
-                [Tokens.Long] = (a) => { return a; },
-                [Tokens.LongLong] = (a) => { return a; },
-                [Tokens.Double] = (a) => { return a; },
-                [Tokens.Single] = (a) => { return a; },
-                [Tokens.Currency] = (a) => { return a; },
-                [Tokens.Boolean] = (a) => { return NumericToBoolean(a); },
-                [Tokens.Date] = (a) => { return NumericToDate(a); },
+                [Tokens.String] = a => a,
+                [Tokens.Byte] = a => byte.Parse(a, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => a,
+                [Tokens.Long] = a => a,
+                [Tokens.LongLong] = a => a,
+                [Tokens.Double] = a => a,
+                [Tokens.Single] = a => a,
+                [Tokens.Currency] = a => a,
+                [Tokens.Boolean] = NumericToBoolean,
+                [Tokens.Date] = NumericToDate,
             },
 
             [Tokens.Long] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return a; },
-                [Tokens.Byte] = (a) => { return byte.Parse(a).ToString(); },
-                [Tokens.Integer] = (a) => { return Int16.Parse(a).ToString(); },
-                [Tokens.Long] = (a) => { return a; },
-                [Tokens.LongLong] = (a) => { return a; },
-                [Tokens.Double] = (a) => { return a; },
-                [Tokens.Single] = (a) => { return a; },
-                [Tokens.Currency] = (a) => { return a; },
-                [Tokens.Boolean] = (a) => { return NumericToBoolean(a); },
-                [Tokens.Date] = (a) => { return NumericToDate(a); },
+                [Tokens.String] = a => a,
+                [Tokens.Byte] = a => byte.Parse(a, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => short.Parse(a, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Long] = a => a,
+                [Tokens.LongLong] = a => a,
+                [Tokens.Double] = a => a,
+                [Tokens.Single] = a => a,
+                [Tokens.Currency] = a => a,
+                [Tokens.Boolean] = NumericToBoolean,
+                [Tokens.Date] = NumericToDate,
             },
 
             [Tokens.Double] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return a; },
-                [Tokens.Byte] = (a) => { a = BankersRound(a); return byte.Parse(a).ToString(); },
-                [Tokens.Integer] = (a) => { a = BankersRound(a); return Int16.Parse(a).ToString(); },
-                [Tokens.Long] = (a) => { a = BankersRound(a); return Int32.Parse(a).ToString(); },
-                [Tokens.LongLong] = (a) => { a = BankersRound(a); return long.Parse(a).ToString(); },
-                [Tokens.Double] = (a) => { return a; },
-                [Tokens.Single] = (a) => { return float.Parse(a).ToString(); },
-                [Tokens.Currency] = (a) => { return decimal.Parse(a).ToString(); },
-                [Tokens.Boolean] = (a) => { return NumericToBoolean(a); },
-                [Tokens.Date] = (a) => { return NumericToDate(a); },
+                [Tokens.String] = a => a,
+                [Tokens.Byte] = a => byte.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => short.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Long] = a => int.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.LongLong] = a => long.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Double] = a => a,
+                [Tokens.Single] = a => float.Parse(a, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Currency] = a => decimal.Parse(a, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Boolean] = NumericToBoolean,
+                [Tokens.Date] = NumericToDate,
             },
 
             [Tokens.Single] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return a; },
-                [Tokens.Byte] = (a) => { a = BankersRound(a); return byte.Parse(a).ToString(); },
-                [Tokens.Integer] = (a) => { a = BankersRound(a); return Int16.Parse(a).ToString(); },
-                [Tokens.Long] = (a) => { a = BankersRound(a); return Int32.Parse(a).ToString(); },
-                [Tokens.LongLong] = (a) => { a = BankersRound(a); return long.Parse(a).ToString(); },
-                [Tokens.Double] = (a) => { return a; },
-                [Tokens.Single] = (a) => { return a; },
-                [Tokens.Currency] = (a) => { return decimal.Parse(a).ToString(); },
-                [Tokens.Boolean] = (a) => { return NumericToBoolean(a); },
-                [Tokens.Date] = (a) => { return NumericToDate(a); },
+                [Tokens.String] = a => a,
+                [Tokens.Byte] = a => byte.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => short.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Long] = a => int.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.LongLong] = a => long.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Double] = a => a,
+                [Tokens.Single] = a => a,
+                [Tokens.Currency] = a => decimal.Parse(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Boolean] = NumericToBoolean,
+                [Tokens.Date] = NumericToDate,
             },
 
             [Tokens.Currency] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return a; },
-                [Tokens.Byte] = (a) => { a = BankersRound(a); return byte.Parse(a).ToString(); },
-                [Tokens.Integer] = (a) => { a = BankersRound(a); return Int16.Parse(a).ToString(); },
-                [Tokens.Long] = (a) => { a = BankersRound(a); return Int32.Parse(a).ToString(); },
-                [Tokens.LongLong] = (a) => { a = BankersRound(a); return long.Parse(a).ToString(); },
-                [Tokens.Double] = (a) => { return a; },
-                [Tokens.Single] = (a) => { return float.Parse(a).ToString(); },
-                [Tokens.Currency] = (a) => { return a; },
-                [Tokens.Boolean] = (a) => { return NumericToBoolean(a); },
-                [Tokens.Date] = (a) => { return NumericToDate(a); },
+                [Tokens.String] = a => a,
+                [Tokens.Byte] = a => byte.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => short.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Long] = a => int.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.LongLong] = a => long.Parse(BankersRound(a), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Double] = a => a,
+                [Tokens.Single] = a => float.Parse(a, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Currency] = a => a,
+                [Tokens.Boolean] = NumericToBoolean,
+                [Tokens.Date] = NumericToDate,
             },
 
             [Tokens.Boolean] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return BooleanToString(a); },
-                [Tokens.Byte] = (a) => { var val = BooleanAsLong(a); return val != 0 ? byte.MaxValue.ToString() : byte.MinValue.ToString(); },
-                [Tokens.Integer] = (a) => { return BooleanAsLong(a).ToString(); },
-                [Tokens.Long] = (a) => { return BooleanAsLong(a).ToString(); },
-                [Tokens.LongLong] = (a) => { return BooleanAsLong(a).ToString(); },
-                [Tokens.Double] = (a) => { return BooleanAsLong(a).ToString(); },
-                [Tokens.Single] = (a) => { return BooleanAsLong(a).ToString(); },
-                [Tokens.Currency] = (a) => { return BooleanAsLong(a).ToString(); },
-                [Tokens.Boolean] = (a) => { return a; },
-                [Tokens.Date] = (a) => { var val = BooleanAsLong(a); return NumericToDate(val.ToString()); },
+                [Tokens.String] = BooleanToString,
+                [Tokens.Byte] = a => BooleanAsLong(a) != 0 ? byte.MaxValue.ToString(CultureInfo.InvariantCulture) : byte.MinValue.ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => BooleanAsLong(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Long] = a => BooleanAsLong(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.LongLong] = a => BooleanAsLong(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Double] = a => BooleanAsLong(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Single] = a => BooleanAsLong(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Currency] = a => BooleanAsLong(a).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Boolean] = a => a,
+                [Tokens.Date] = a => NumericToDate(BooleanAsLong(a).ToString(CultureInfo.InvariantCulture)),
             },
 
             [Tokens.Date] = new Dictionary<string, Func<string, string>>
             {
-                [Tokens.String] = (a) => { return RemoveStartAndEnd(a, "#"); },
-                [Tokens.Byte] = (a) => { var result = ComparableDateValue.Parse(a); return Convert.ToByte(result.AsDecimal).ToString(); },
-                [Tokens.Integer] = (a) => { var result = ComparableDateValue.Parse(a); return Convert.ToInt16(result.AsDecimal).ToString(); },
-                [Tokens.Long] = (a) => { var result = ComparableDateValue.Parse(a); return Convert.ToInt32(result.AsDecimal).ToString(); },
-                [Tokens.LongLong] = (a) => { var result = ComparableDateValue.Parse(a); return Convert.ToInt64(result.AsDecimal).ToString(); },
-                [Tokens.Double] = (a) => { var result = ComparableDateValue.Parse(a); return Convert.ToDouble(result.AsDecimal).ToString(); },
-                [Tokens.Single] = (a) => { var result = ComparableDateValue.Parse(a); return float.Parse(result.AsDecimal.ToString()).ToString(); },
-                [Tokens.Currency] = (a) => { var result = ComparableDateValue.Parse(a); return result.AsDecimal.ToString(); },
-                [Tokens.Boolean] = (a) => { var result = ComparableDateValue.Parse(a); return result.AsDecimal != 0 ? Tokens.True : Tokens.False; },
-                [Tokens.Date] = (a) => { return a; },
+                [Tokens.String] = a => RemoveStartAndEnd(a, "#"),
+                [Tokens.Byte] = a => Convert.ToByte(ComparableDateValue.Parse(a).AsDecimal, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Integer] = a => Convert.ToInt16(ComparableDateValue.Parse(a).AsDecimal, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Long] = a => Convert.ToInt32(ComparableDateValue.Parse(a).AsDecimal, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.LongLong] = a => Convert.ToInt64(ComparableDateValue.Parse(a).AsDecimal, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Double] = a => Convert.ToDouble(ComparableDateValue.Parse(a).AsDecimal, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Single] = a => float.Parse(ComparableDateValue.Parse(a).AsDecimal.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+                [Tokens.Currency] = a => ComparableDateValue.Parse(a).AsDecimal.ToString(CultureInfo.InvariantCulture),
+                [Tokens.Boolean] = a => ComparableDateValue.Parse(a).AsDecimal != 0 ? Tokens.True : Tokens.False,
+                [Tokens.Date] = a => a,
             },
         };
 
@@ -218,22 +218,22 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         }
 
         public static bool TryCoerce(string valueText, out byte value)
-            => TryCoerce(valueText, Tokens.Byte, out value, byte.Parse);
+            => TryCoerce(valueText, Tokens.Byte, out value, s => byte.Parse(s, CultureInfo.InvariantCulture));
 
-        public static bool TryCoerce(string valueText, out Int16 value)
-            => TryCoerce(valueText, Tokens.Integer, out value, Int16.Parse);
+        public static bool TryCoerce(string valueText, out short value)
+            => TryCoerce(valueText, Tokens.Integer, out value, s => short.Parse(s, CultureInfo.InvariantCulture));
 
-        public static bool TryCoerce(string valueText, out Int32 value)
-            => TryCoerce(valueText, Tokens.Long, out value, Int32.Parse);
+        public static bool TryCoerce(string valueText, out int value)
+            => TryCoerce(valueText, Tokens.Long, out value, s => int.Parse(s, CultureInfo.InvariantCulture));
 
         public static bool TryCoerce(string valueText, out long value)
-            => TryCoerce(valueText, Tokens.LongLong, out value, long.Parse);
+            => TryCoerce(valueText, Tokens.LongLong, out value, s => long.Parse(s, CultureInfo.InvariantCulture));
 
         public static bool TryCoerce(string valueText, out double value)
-            => TryCoerce(valueText, Tokens.Double, out value, double.Parse);
+            => TryCoerce(valueText, Tokens.Double, out value, s => double.Parse(s, CultureInfo.InvariantCulture));
 
         public static bool TryCoerce(string valueText, out float value)
-            => TryCoerce(valueText, Tokens.Single, out value, float.Parse);
+            => TryCoerce(valueText, Tokens.Single, out value, s => float.Parse(s, CultureInfo.InvariantCulture));
 
         public static bool TryCoerce(string valueText, out decimal value)
             => TryCoerce(valueText, Tokens.Currency, out value, VBACurrency.Parse);
@@ -274,7 +274,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         private static bool TryCoerce<T>(string valueText, string typeName, out T value, Func<string, T> parser)
         {
             value = default;
-            if (TryCoerceToken((Tokens.String, valueText), typeName, out string valueToken))
+            if (TryCoerceToken((Tokens.String, valueText), typeName, out var valueToken))
             {
                 value = parser(valueToken);
                 return true;
@@ -284,14 +284,14 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 
         private static string StringToDate(string sourceText)
         {
-            int? intValue = BooleanTokenToInt(sourceText);
+            var intValue = BooleanTokenToInt(sourceText);
             var parseValue = intValue.HasValue ? intValue.ToString() : sourceText;
 
-            if (double.TryParse(parseValue, out double doubleValue))
+            if (double.TryParse(parseValue, NumberStyles.Any, CultureInfo.InvariantCulture, out _))
             {
                 return NumericToDate(parseValue);
             }
-            if (ComparableDateValue.TryParse(AnnotateAsDateLiteral(parseValue), out ComparableDateValue dvComparable))
+            if (ComparableDateValue.TryParse(AnnotateAsDateLiteral(parseValue), out var dvComparable))
             {
                 return dvComparable.AsDateLiteral();
             }
@@ -321,8 +321,11 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             var parseValue = intValue.HasValue ? intValue.ToString() : sourceText;
             parseValue = CoerceDateTokenToDouble(parseValue);
 
-            return decimal.TryParse(parseValue, out decimal decValue) ? decValue.ToString()
-                : double.TryParse(parseValue, out double value) ? value.ToString() : sourceText;
+            return decimal.TryParse(parseValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var decValue) 
+                ? decValue.ToString(CultureInfo.InvariantCulture)
+                : double.TryParse(parseValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var value) 
+                    ? value.ToString(CultureInfo.InvariantCulture) 
+                    : sourceText;
         }
 
         private static string StringToBoolean(string sourceText)
@@ -349,7 +352,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
             }
 
             parseValue = CoerceDateTokenToDouble(parseValue);
-            if (double.TryParse(parseValue, out double asDouble))
+            if (double.TryParse(parseValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var asDouble))
             {
                 return asDouble != 0 ? Tokens.True : Tokens.False;
             }
@@ -358,7 +361,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 
         private static string NumericToDate(string source)
         {
-            if (double.TryParse(source, out double dateAsDouble))
+            if (double.TryParse(source, NumberStyles.Any, CultureInfo.InvariantCulture, out double dateAsDouble))
             {
                 var dv = new DateValue(DateTime.FromOADate(dateAsDouble));
                 var dateValue = new ComparableDateValue(dv);
@@ -430,10 +433,10 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         }
 
         private static string BankersRound(string source)
-             => Math.Round(double.Parse(source), MidpointRounding.ToEven).ToString();
+             => Math.Round(double.Parse(source, CultureInfo.InvariantCulture), MidpointRounding.ToEven).ToString(CultureInfo.InvariantCulture);
 
         private static string NumericToBoolean(string source)
-             => double.Parse(source) != 0 ? Tokens.True : Tokens.False;
+             => double.Parse(source, CultureInfo.InvariantCulture) != 0 ? Tokens.True : Tokens.False;
 
         private static long BooleanAsLong(string source)
             => source.Equals(Tokens.True) ? -1 : 0;

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ParseTreeExpressionEvaluator.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ParseTreeExpressionEvaluator.cs
@@ -283,8 +283,8 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
                 return _valueFactory.CreateExpression($"{LHS.Token} {opSymbol} {RHS.Token}", opProvider.OperatorDeclaredType);
             }
 
-            if (!LHS.TryLetCoerce(opProvider.OperatorEffectiveType, out IParseTreeValue effLHS)
-                || !RHS.TryLetCoerce(opProvider.OperatorEffectiveType, out IParseTreeValue effRHS))
+            if (!LHS.TryLetCoerce(opProvider.OperatorEffectiveType, out var effLHS)
+                || !RHS.TryLetCoerce(opProvider.OperatorEffectiveType, out var effRHS))
             {
                 return _valueFactory.CreateExpression($"{LHS.Token} {opSymbol} {RHS.Token}", opProvider.OperatorDeclaredType);
             }
@@ -299,17 +299,17 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 
             if (opSymbol.Equals(ArithmeticOperators.MULTIPLY))
             {
-                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => { return a * b; }, (double a, double b) => { return a * b; }), opProvider.OperatorDeclaredType);
+                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => a * b, (double a, double b) => a * b), opProvider.OperatorDeclaredType);
             }
-            else if (opSymbol.Equals(ArithmeticOperators.DIVIDE))
+            if (opSymbol.Equals(ArithmeticOperators.DIVIDE))
             {
-                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => { return a / b; }, (double a, double b) => { return a / b; }), opProvider.OperatorDeclaredType);
+                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => a / b, (double a, double b) => a / b), opProvider.OperatorDeclaredType);
             }
-            else if (opSymbol.Equals(ArithmeticOperators.INTEGER_DIVIDE))
+            if (opSymbol.Equals(ArithmeticOperators.INTEGER_DIVIDE))
             {
                 return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, IntDivision, IntDivision), opProvider.OperatorDeclaredType);
             }
-            else if (opSymbol.Equals(ArithmeticOperators.PLUS))
+            if (opSymbol.Equals(ArithmeticOperators.PLUS))
             {
                 if (opProvider.OperatorEffectiveType.Equals(Tokens.String))
                 {
@@ -317,27 +317,27 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
                 }
                 if (opProvider.OperatorEffectiveType.Equals(Tokens.Date))
                 {
-                    var result = _valueFactory.CreateDeclaredType(Calculate(effLHS, effRHS, null, (double a, double b) => { return a + b; }), Tokens.Double);
+                    var result = _valueFactory.CreateDeclaredType(Calculate(effLHS, effRHS, null, (double a, double b) => a + b), Tokens.Double);
                     return _valueFactory.CreateDate(result.AsDouble());
                 }
-                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => { return a + b; }, (double a, double b) => { return a + b; }), opProvider.OperatorDeclaredType);
+                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => a + b, (double a, double b) => a + b), opProvider.OperatorDeclaredType);
             }
-            else if (opSymbol.Equals(ArithmeticOperators.MINUS))
+            if (opSymbol.Equals(ArithmeticOperators.MINUS))
             {
                 if (LHS.ValueType.Equals(Tokens.Date) && RHS.ValueType.Equals(Tokens.Date))
                 {
                     return _valueFactory.CreateDate(LHS.AsDouble() - RHS.AsDouble());
                 }
-                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => { return a - b; }, (double a, double b) => { return a - b; }), opProvider.OperatorDeclaredType);
+                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => a - b, (double a, double b) => a - b), opProvider.OperatorDeclaredType);
             }
-            else if (opSymbol.Equals(ArithmeticOperators.EXPONENT))
+            if (opSymbol.Equals(ArithmeticOperators.EXPONENT))
             {
                 //Math.Pow only takes doubles, so the decimal conversion option is null
-                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, null, (double a, double b) => { return Math.Pow(a, b); }), opProvider.OperatorDeclaredType);
+                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, null, Math.Pow), opProvider.OperatorDeclaredType);
             }
-            else if (opSymbol.Equals(ArithmeticOperators.MODULO))
+            if (opSymbol.Equals(ArithmeticOperators.MODULO))
             {
-                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => { return a % b; }, (double a, double b) => { return a % b; }), opProvider.OperatorDeclaredType);
+                return _valueFactory.CreateValueType(Calculate(effLHS, effRHS, (decimal a, decimal b) => a % b, (double a, double b) => a % b), opProvider.OperatorDeclaredType);
             }
 
             //ArithmeticOperators.AMPERSAND
@@ -377,9 +377,9 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 
             if (!(DecimalCalc is null) && LHS.TryLetCoerce(out decimal lhsValue) && RHS.TryLetCoerce(out decimal rhsValue))
             {
-                return DecimalCalc(lhsValue, rhsValue).ToString();
+                return DecimalCalc(lhsValue, rhsValue).ToString(CultureInfo.InvariantCulture);
             }
-            return DoubleCalc(LHS.AsDouble(), RHS.AsDouble()).ToString();
+            return DoubleCalc(LHS.AsDouble(), RHS.AsDouble()).ToString(CultureInfo.InvariantCulture);
         }
 
         private string Compare(IParseTreeValue LHS, IParseTreeValue RHS, Func<decimal, decimal, bool> DecimalCompare, Func<double, double, bool> DoubleCompare)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ParseTreeValue.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ParseTreeValue.cs
@@ -154,7 +154,7 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         public static bool TryLetCoerce(this IParseTreeValue parseTreeValue, string destinationType, out IParseTreeValue newValue)
         {
             newValue = null;
-            if (LetCoerce.TryCoerceToken((parseTreeValue.ValueType, parseTreeValue.Token), destinationType, out string valueText))
+            if (LetCoerce.TryCoerceToken((parseTreeValue.ValueType, parseTreeValue.Token), destinationType, out var valueText))
             {
                 newValue = ParseTreeValue.CreateValueType(new TypeTokenPair(destinationType, valueText));
                 return true;

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ParseTreeValue.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/ParseTreeValue.cs
@@ -1,6 +1,7 @@
 ﻿using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.PreProcessing;
 using System;
+using System.Globalization;
 
 namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 {
@@ -162,31 +163,31 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
         }
 
         public static double AsDouble(this IParseTreeValue parseTreeValue)
-            => double.Parse(LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Double));
+            => double.Parse(LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Double), CultureInfo.InvariantCulture);
 
         public static decimal AsCurrency(this IParseTreeValue parseTreeValue)
-            => decimal.Parse(LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Currency));
+            => decimal.Parse(LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Currency), CultureInfo.InvariantCulture);
 
         public static long AsLong(this IParseTreeValue parseTreeValue)
-            => long.Parse(LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Long));
+            => long.Parse(LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Long), CultureInfo.InvariantCulture);
 
         public static bool AsBoolean(this IParseTreeValue parseTreeValue)
-            =>LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Boolean).Equals(Tokens.True);
+            => LetCoerce.Coerce((parseTreeValue.ValueType, parseTreeValue.Token), Tokens.Boolean).Equals(Tokens.True);
 
         public static bool TryLetCoerce(this IParseTreeValue parseTreeValue, out long newValue)
-            => TryLetCoerce(parseTreeValue, long.Parse, Tokens.Long, out newValue);
+            => TryLetCoerce(parseTreeValue, s => long.Parse(s, CultureInfo.InvariantCulture), Tokens.Long, out newValue);
 
         public static bool TryLetCoerce(this IParseTreeValue parseTreeValue, out double newValue)
-        => TryLetCoerce(parseTreeValue, double.Parse, Tokens.Double, out newValue);
+        => TryLetCoerce(parseTreeValue, s => double.Parse(s, CultureInfo.InvariantCulture), Tokens.Double, out newValue);
 
         public static bool TryLetCoerce(this IParseTreeValue parseTreeValue, out decimal newValue)
-            => TryLetCoerce(parseTreeValue, decimal.Parse, Tokens.Currency, out newValue);
+            => TryLetCoerce(parseTreeValue, s => decimal.Parse(s, CultureInfo.InvariantCulture), Tokens.Currency, out newValue);
 
         public static bool TryLetCoerce(this IParseTreeValue parseTreeValue, out bool value)
             => TryLetCoerce(parseTreeValue, bool.Parse, Tokens.Boolean, out value);
 
         public static bool TryLetCoerce(this IParseTreeValue parseTreeValue, out string value)
-            => TryLetCoerce(parseTreeValue, (a) => { return a; }, Tokens.String, out value);
+            => TryLetCoerce(parseTreeValue, a => a, Tokens.String, out value);
 
         private static bool TryLetCoerce(this IParseTreeValue parseTreeValue, out ComparableDateValue value)
             => TryLetCoerceToDate(parseTreeValue, out value);

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/TypeTokenPair.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseInspection/TypeTokenPair.cs
@@ -8,8 +8,8 @@ namespace Rubberduck.Inspections.Concrete.UnreachableCaseInspection
 {
     public struct TypeTokenPair
     {
-        public string ValueType { private set; get; }
-        public string Token { private set; get; }
+        public string ValueType { get; }
+        public string Token { get; }
 
         public TypeTokenPair(string valueType, string token)
         {

--- a/RubberduckTests/Inspections/UnreachableCase/ExpressionFilterUnitTests.cs
+++ b/RubberduckTests/Inspections/UnreachableCase/ExpressionFilterUnitTests.cs
@@ -491,7 +491,7 @@ namespace RubberduckTests.Inspections.UnreachableCase
             {
                 var args = RetrieveDelimitedElements(valAndType, VALUE_TYPE_DELIMITER);
                 var value = args[0];
-                string declaredType = args[1].Equals(string.Empty) ? null : args[1];
+                var declaredType = args[1].Equals(string.Empty) ? null : args[1];
                 if (declaredType is null)
                 {
                     return ValueFactory.Create(value);
@@ -533,12 +533,12 @@ namespace RubberduckTests.Inspections.UnreachableCase
                 var operandDelimiters = clause.Where(ch => ch.Equals('_'));
                 if (operandDelimiters.Count() == 2)
                 {
-                    (IParseTreeValue lhs, IParseTreeValue rhs, string symbol) = GetBinaryOpValues(clause);
+                    var (lhs, rhs, symbol) = GetBinaryOpValues(clause);
                     expressionClause = CreateRangeClauseExpression((lhs, rhs, symbol));
                 }
                 else if (operandDelimiters.Count() <= 1)
                 {
-                    (IParseTreeValue operand, string symbol) = GetUnaryOpValues(clause);
+                    var (operand, symbol) = GetUnaryOpValues(clause);
                     if (symbol.Equals(LogicalOperators.NOT))
                     {
                         expressionClause = new UnaryExpression(operand, symbol);

--- a/RubberduckTests/Inspections/UnreachableCase/ParseTreeExpressionEvaluatorUnitTests.cs
+++ b/RubberduckTests/Inspections/UnreachableCase/ParseTreeExpressionEvaluatorUnitTests.cs
@@ -2,6 +2,7 @@
 using Rubberduck.Inspections.Concrete.UnreachableCaseInspection;
 using Rubberduck.Parsing.Grammar;
 using System;
+using System.Globalization;
 
 namespace RubberduckTests.Inspections.UnreachableCase
 {
@@ -942,8 +943,8 @@ namespace RubberduckTests.Inspections.UnreachableCase
             {
                 var compareLength = expected.Length > 5 ? 5 : expected.Length;
                 var accuracy = Math.Pow(10, -1.0 * compareLength);
-                var lhs = double.Parse(result.Token.Substring(0, compareLength));
-                var rhs = double.Parse(expected.Substring(0, compareLength));
+                var lhs = double.Parse(result.Token.Substring(0, compareLength), CultureInfo.InvariantCulture);
+                var rhs = double.Parse(expected.Substring(0, compareLength), CultureInfo.InvariantCulture);
                 Assert.IsTrue(Math.Abs(lhs - rhs) <= accuracy, $"Actual={result.Token} Expected={expected}");
                 return (result,result);
             }

--- a/RubberduckTests/Mocks/MockVbeBuilder.cs
+++ b/RubberduckTests/Mocks/MockVbeBuilder.cs
@@ -216,7 +216,9 @@ namespace RubberduckTests.Mocks
 
             var commandBars = DummyCommandBars();
             vbe.SetupGet(m => m.CommandBars).Returns(() => commandBars);
-            
+
+            vbe.Setup(m => m.IsInDesignMode).Returns(true);
+
             return vbe;
         }
 

--- a/RubberduckTests/UnitTesting/EngineTests.cs
+++ b/RubberduckTests/UnitTesting/EngineTests.cs
@@ -45,6 +45,7 @@ End Sub";
                 int refreshes = 0;
                 engine.TestsRefreshed += (sender, args) => refreshes++;
                 parser.Parse(new CancellationTokenSource());
+                var status = state.Status;
                 if (!engine.CanRun)
                 {
                     Assert.Inconclusive("Parser Error");

--- a/RubberduckTests/UnitTesting/EngineTests.cs
+++ b/RubberduckTests/UnitTesting/EngineTests.cs
@@ -45,7 +45,6 @@ End Sub";
                 int refreshes = 0;
                 engine.TestsRefreshed += (sender, args) => refreshes++;
                 parser.Parse(new CancellationTokenSource());
-                var status = state.Status;
                 if (!engine.CanRun)
                 {
                     Assert.Inconclusive("Parser Error");


### PR DESCRIPTION
This PR closes #4397 

I added `CultureInfo.InvariantCulrure` in a lot of `ToString`, `Parse` and `TryParse` calls, primarily in the `LetCoercer`.

Moreover, I performed some style adjustment regarding anonymous functions. 

Finally, I set up `IsInDesignMode` on the mock VBE as `true` in order to make the test engine tests pass that where previously inconclusive. 