### PR TITLE
Fix module annotation recognition

### DIFF
--- a/Rubberduck.CodeAnalysis/QuickFixes/RemoveDuplicatedAnnotationQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/RemoveDuplicatedAnnotationQuickFix.cs
@@ -40,7 +40,6 @@ namespace Rubberduck.Inspections.QuickFixes
                 var annotationList = (VBAParser.AnnotationListContext)annotation.Context.Parent;
 
                 RemoveAnnotationMarker(annotationList, annotation, rewriter);
-                RemoveWhiteSpaceAfterAnnotation(annotationList, annotation, rewriter);
 
                 rewriter.Remove(annotation.Context);
 
@@ -69,18 +68,6 @@ namespace Rubberduck.Inspections.QuickFixes
         {
             var index = Array.IndexOf(annotationList.annotation(), annotation.Context);
             rewriter.Remove(annotationList.AT(index));
-        }
-
-        private static void RemoveWhiteSpaceAfterAnnotation(VBAParser.AnnotationListContext annotationList,
-            IAnnotation annotation, IModuleRewriter rewriter)
-        {
-            var whitespace = annotationList.whiteSpace().FirstOrDefault(ws =>
-                ws.Start.StartIndex == annotation.Context.Stop.StopIndex + 1);
-
-            if (whitespace != null)
-            {
-                rewriter.Remove(whitespace);
-            }
         }
 
         private static bool OnlyQuoteRemainedFromAnnotationList(KeyValuePair<VBAParser.AnnotationListContext, int> pair)

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -926,8 +926,8 @@ commentOrAnnotation :
 remComment : REM whiteSpace? commentBody;
 comment : SINGLEQUOTE commentBody;
 commentBody : (~NEWLINE)*;
-annotationList : SINGLEQUOTE (AT annotation whiteSpace?)+ (COLON commentBody)?;
-annotation : annotationName annotationArgList?;
+annotationList : SINGLEQUOTE (AT annotation)+ (COLON commentBody)?;
+annotation : annotationName annotationArgList? whiteSpace?;
 annotationName : unrestrictedIdentifier;
 annotationArgList : 
     whiteSpace annotationArg

--- a/RubberduckTests/Annotations/DeclarationsListenerAnnotationsTests.cs
+++ b/RubberduckTests/Annotations/DeclarationsListenerAnnotationsTests.cs
@@ -1,0 +1,230 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Parsing.Symbols;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Annotations
+{
+    [TestFixture]
+    public class DeclarationsListenerAnnotationsTests
+    {
+        [Test]
+        public void AnnotationsAboveMemberGetScopedToMember_NotFirstMember()
+        {
+            const string inputCode =
+                @"
+Public Sub Foo()
+End Sub
+'@TestMethod
+'@Enumerator 17, 12 @DefaultMember
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var barDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.Function).Single();
+
+                var expectedAnnotationCount = 3;
+                var actualAnnotationCount = barDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void AnnotationsAboveMemberGetScopedToMember_FirstMember()
+        {
+            const string inputCode =
+                @"
+'@TestMethod
+'@Enumerator 17, 12 @DefaultMember
+Public Sub Foo()
+End Sub
+
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var fooDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.Procedure).Single();
+
+                var expectedAnnotationCount = 3;
+                var actualAnnotationCount = fooDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void LineContinuedAnnotationsAboveMemberGetScopedToMember_NotFirstMember()
+        {
+            const string inputCode =
+                @"
+Public Sub Foo()
+End Sub
+'@TestMethod _
+
+'@Enumerator _
+17 _
+, _
+12 _
+ _
+@DefaultMember _
+
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var barDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.Function).Single();
+
+                var expectedAnnotationCount = 3;
+                var actualAnnotationCount = barDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void LineContinuedAnnotationsAboveMemberGetScopedToMember_FirstMember()
+        {
+            const string inputCode =
+                @"
+'@TestMethod _
+
+'@Enumerator _
+17 _
+, _
+12 _
+ _
+@DefaultMember _
+
+Public Sub Foo()
+End Sub
+
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var fooDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.Procedure).Single();
+
+                var expectedAnnotationCount = 3;
+                var actualAnnotationCount = fooDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void AnnotationsRightAboveFirstMemberAreNotModuleAnnotations_WithDeclarationOnTop()
+        {
+            const string inputCode =
+                @"
+Public Foobar As Long
+
+'@TestMethod
+'@Enumerator 17, _
+12 _
+@DefaultMember
+Public Sub Foo()
+End Sub
+
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var moduleDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).Single();
+
+                var expectedAnnotationCount = 0;
+                var actualAnnotationCount = moduleDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void AnnotationsRightAboveFirstMemberAreNotModuleAnnotations_WithoutDeclarationOnTop()
+        {
+            const string inputCode =
+                @"
+'@TestMethod
+'@Enumerator 17, _
+12 _
+@DefaultMember
+Public Sub Foo()
+End Sub
+
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var moduleDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).Single();
+
+                var expectedAnnotationCount = 0;
+                var actualAnnotationCount = moduleDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void AnnotationsAboveNonAnnotationLineAboveFirstMemberAreModuleAnnotations_WithDeclarationOnTop()
+        {
+            const string inputCode =
+                @"
+Public Foobar As Long
+'@TestModule
+'@Folder(""Test"")
+'SomeComment
+'@Enumerator 17, _
+12 _
+@DefaultMember
+Public Sub Foo()
+End Sub
+
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var moduleDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).Single();
+
+                var expectedAnnotationCount = 2;
+                var actualAnnotationCount = moduleDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void AnnotationsAboveNonAnnotationLineAboveFirstMemberAreModuleAnnotations_WithoutDeclarationOnTop()
+        {
+            const string inputCode =
+                @"
+'@TestModule
+'@Folder(""Test"")
+'SomeComment
+'@Enumerator 17, _
+12 _
+@DefaultMember
+Public Sub Foo()
+End Sub
+
+Public Function Bar() As Variant
+End Function";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var moduleDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).Single();
+
+                var expectedAnnotationCount = 2;
+                var actualAnnotationCount = moduleDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+    }
+}

--- a/RubberduckTests/Annotations/DeclarationsListenerAnnotationsTests.cs
+++ b/RubberduckTests/Annotations/DeclarationsListenerAnnotationsTests.cs
@@ -148,8 +148,7 @@ End Function";
         public void AnnotationsRightAboveFirstMemberAreNotModuleAnnotations_WithoutDeclarationOnTop()
         {
             const string inputCode =
-                @"
-'@TestMethod
+                @"'@TestMethod
 '@Enumerator 17, _
 12 _
 @DefaultMember
@@ -221,6 +220,30 @@ End Function";
                 var moduleDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).Single();
 
                 var expectedAnnotationCount = 2;
+                var actualAnnotationCount = moduleDeclaration.Annotations.Count();
+
+                Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);
+            }
+        }
+
+        [Test]
+        public void AllAnnotationsAreModuleAnnotationsIfThereIsNoBody()
+        {
+            const string inputCode =
+                @"
+'@TestModule
+'@Folder(""Test"")
+'SomeComment
+'@Enumerator 17, _
+12 _
+@DefaultMember
+";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var moduleDeclaration = state.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).Single();
+
+                var expectedAnnotationCount = 4;
                 var actualAnnotationCount = moduleDeclaration.Annotations.Count();
 
                 Assert.AreEqual(expectedAnnotationCount, actualAnnotationCount);

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -95,6 +95,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="Annotations\DeclarationsListenerAnnotationsTests.cs" />
     <Compile Include="AutoComplete\BlockCompletionTests.cs" />
     <Compile Include="AutoComplete\CodeStringTests.cs" />
     <Compile Include="AutoComplete\SelfClosingPairCompletionTests.cs" />


### PR DESCRIPTION
This PR changes two points regarding how the `DeclarationSymbolsListener` finds annotations:

1. It is now able to find member annotations even if these are line-continued. Previously, it was expecting at least one annotation per physical line, not logical line.
2. The determination of the declaration section is no longer delegated to the VBE. Now, it ends on the first line above the member annotations of the first module body element, i.e. on the first physical line above the block of consecutive logical lines right above the first module body element.  