### PR TITLE
Refresh references on project priority change

### DIFF
--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Symbols\IInterfaceExposable.cs" />
     <Compile Include="Symbols\ModuleBodyElementDeclaration.cs" />
     <Compile Include="Symbols\ModuleDeclaration.cs" />
+    <Compile Include="VBA\Extensions\DictionaryExtensions.cs" />
     <Compile Include="VBA\Parsing\ParsingExceptions\ExceptionErrorListenerFactory.cs" />
     <Compile Include="VBA\Parsing\ParsingExceptions\PreprocessingParseErrorListenerFactory.cs" />
     <Compile Include="VBA\Parsing\ParsingExceptions\IRubberduckParserErrorListenerFactory.cs" />

--- a/Rubberduck.Parsing/VBA/ComReferenceLoading/COMReferenceSynchronizerBase.cs
+++ b/Rubberduck.Parsing/VBA/ComReferenceLoading/COMReferenceSynchronizerBase.cs
@@ -24,7 +24,7 @@ namespace Rubberduck.Parsing.VBA.ComReferenceLoading
         private readonly IProjectsProvider _projectsProvider;
         private readonly IReferencedDeclarationsCollector _referencedDeclarationsCollector;
 
-        private readonly List<QualifiedModuleName> _unloadedCOMReferences = new List<QualifiedModuleName>();
+        private readonly List<string> _unloadedCOMReferences = new List<string>();
         private readonly List<(string projectId, string referencedProjectId)> _referencesAffectedByPriorityChanges = new List<(string projectId, string referencedProjectId)>();
 
         private readonly Dictionary<(string identifierName, string fullPath), string> _projectIdsByFilePathAndProjectName = new Dictionary<(string identifierName, string fullPath), string>();
@@ -59,7 +59,7 @@ namespace Rubberduck.Parsing.VBA.ComReferenceLoading
 
 
         public bool LastSyncOfCOMReferencesLoadedReferences { get; private set; }
-        public IEnumerable<QualifiedModuleName> COMReferencesUnloadedInLastSync => _unloadedCOMReferences;
+        public IEnumerable<string> COMReferencesUnloadedInLastSync => _unloadedCOMReferences;
         public IEnumerable<(string projectId, string referencedProjectId)> COMReferencesAffectedByPriorityChangesInLastSync => _referencesAffectedByPriorityChanges;
 
         private readonly IDictionary<string, ReferencePriorityMap> _projectReferences = new Dictionary<string, ReferencePriorityMap>();
@@ -362,9 +362,9 @@ namespace Rubberduck.Parsing.VBA.ComReferenceLoading
             //There is nothing to unload for a user project.
             if (!IsUserProjectProjectId(referencedProjectId))
             {
-                var projectQMN = ProjectQMNFromBuildInProjectId(referencedProjectId);
+                _unloadedCOMReferences.Add(referencedProjectId);
 
-                _unloadedCOMReferences.Add(projectQMN);
+                var projectQMN = ProjectQMNFromBuildInProjectId(referencedProjectId);
                 _state.RemoveBuiltInDeclarations(projectQMN);
             }
         }

--- a/Rubberduck.Parsing/VBA/ComReferenceLoading/ICOMReferenceSynchronizer.cs
+++ b/Rubberduck.Parsing/VBA/ComReferenceLoading/ICOMReferenceSynchronizer.cs
@@ -7,7 +7,8 @@ namespace Rubberduck.Parsing.VBA.ComReferenceLoading
     public interface ICOMReferenceSynchronizer
     {
         bool LastSyncOfCOMReferencesLoadedReferences { get; }
-        IEnumerable<QualifiedModuleName> COMReferencesUnloadedUnloadedInLastSync { get; }
+        IEnumerable<QualifiedModuleName> COMReferencesUnloadedInLastSync { get; }
+        IEnumerable<(string projectId, string referencedProjectId)> COMReferencesAffectedByPriorityChangesInLastSync { get; }
 
         void SyncComReferences(CancellationToken token);
     }

--- a/Rubberduck.Parsing/VBA/ComReferenceLoading/ICOMReferenceSynchronizer.cs
+++ b/Rubberduck.Parsing/VBA/ComReferenceLoading/ICOMReferenceSynchronizer.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
-using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.VBA.ComReferenceLoading
 {
     public interface ICOMReferenceSynchronizer
     {
         bool LastSyncOfCOMReferencesLoadedReferences { get; }
-        IEnumerable<QualifiedModuleName> COMReferencesUnloadedInLastSync { get; }
+        IEnumerable<string> COMReferencesUnloadedInLastSync { get; }
         IEnumerable<(string projectId, string referencedProjectId)> COMReferencesAffectedByPriorityChangesInLastSync { get; }
 
         void SyncComReferences(CancellationToken token);

--- a/Rubberduck.Parsing/VBA/Extensions/DictionaryExtensions.cs
+++ b/Rubberduck.Parsing/VBA/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Rubberduck.Parsing.VBA.Extensions
+{
+    public static class DictionaryExtensions
+    {
+        public static IDictionary<TKey, TValue>ToDictionary<TKey, TValue>(this IDictionary<TKey, TValue> source)
+        {
+            return new Dictionary<TKey, TValue>(source);
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -224,9 +224,9 @@ namespace Rubberduck.Parsing.VBA
             token.ThrowIfCancellationRequested();
 
             _parsingStageService.SyncComReferences(token);
-            if (_parsingStageService.LastSyncOfCOMReferencesLoadedReferences || _parsingStageService.COMReferencesUnloadedUnloadedInLastSync.Any())
+            if (_parsingStageService.LastSyncOfCOMReferencesLoadedReferences || _parsingStageService.COMReferencesUnloadedInLastSync.Any())
             {
-                var unloadedReferences = _parsingStageService.COMReferencesUnloadedUnloadedInLastSync;
+                var unloadedReferences = _parsingStageService.COMReferencesUnloadedInLastSync;
                 var additionalModulesToBeReresolved = OtherModulesReferencingAnyNotToBeParsed(unloadedReferences.ToHashSet().AsReadOnly(), toParse);
                 toReresolveReferences.UnionWith(additionalModulesToBeReresolved);
                 _parserStateManager.SetModuleStates(additionalModulesToBeReresolved, ParserState.ResolvingReferences, token);

--- a/Rubberduck.Parsing/VBA/ParsingStageService.cs
+++ b/Rubberduck.Parsing/VBA/ParsingStageService.cs
@@ -54,7 +54,7 @@ namespace Rubberduck.Parsing.VBA
 
         public bool LastLoadOfBuiltInDeclarationsLoadedDeclarations => _builtInDeclarationLoader.LastLoadOfBuiltInDeclarationsLoadedDeclarations;
         public bool LastSyncOfCOMReferencesLoadedReferences => _comSynchronizer.LastSyncOfCOMReferencesLoadedReferences;
-        public IEnumerable<QualifiedModuleName> COMReferencesUnloadedInLastSync => _comSynchronizer.COMReferencesUnloadedInLastSync;
+        public IEnumerable<string> COMReferencesUnloadedInLastSync => _comSynchronizer.COMReferencesUnloadedInLastSync;
         public IEnumerable<(string projectId, string referencedProjectId)>COMReferencesAffectedByPriorityChangesInLastSync =>_comSynchronizer.COMReferencesAffectedByPriorityChangesInLastSync;
 
         public void LoadBuitInDeclarations()

--- a/Rubberduck.Parsing/VBA/ParsingStageService.cs
+++ b/Rubberduck.Parsing/VBA/ParsingStageService.cs
@@ -52,30 +52,10 @@ namespace Rubberduck.Parsing.VBA
             _referenceResolver = referenceResolver;
         }
 
-
-        public bool LastLoadOfBuiltInDeclarationsLoadedDeclarations
-        {
-            get
-            {
-                return _builtInDeclarationLoader.LastLoadOfBuiltInDeclarationsLoadedDeclarations;
-            }
-        }
-
-        public bool LastSyncOfCOMReferencesLoadedReferences
-        {
-            get
-            {
-                return _comSynchronizer.LastSyncOfCOMReferencesLoadedReferences;
-            }
-        }
-
-        public IEnumerable<QualifiedModuleName> COMReferencesUnloadedUnloadedInLastSync
-        {
-            get
-            {
-                return _comSynchronizer.COMReferencesUnloadedUnloadedInLastSync;
-            }
-        }
+        public bool LastLoadOfBuiltInDeclarationsLoadedDeclarations => _builtInDeclarationLoader.LastLoadOfBuiltInDeclarationsLoadedDeclarations;
+        public bool LastSyncOfCOMReferencesLoadedReferences => _comSynchronizer.LastSyncOfCOMReferencesLoadedReferences;
+        public IEnumerable<QualifiedModuleName> COMReferencesUnloadedInLastSync => _comSynchronizer.COMReferencesUnloadedInLastSync;
+        public IEnumerable<(string projectId, string referencedProjectId)>COMReferencesAffectedByPriorityChangesInLastSync =>_comSynchronizer.COMReferencesAffectedByPriorityChangesInLastSync;
 
         public void LoadBuitInDeclarations()
         {

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -1045,14 +1045,13 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        public void RemoveBuiltInDeclarations(ReferenceInfo reference)
+        public void RemoveBuiltInDeclarations(QualifiedModuleName projectQmn)
         {
-            var key = new QualifiedModuleName(reference);
-            ClearAsTypeDeclarationPointingToReference(key);
-            if (_moduleStates.TryRemove(key, out var moduleState))
+            ClearAsTypeDeclarationPointingToReference(projectQmn);
+            if (_moduleStates.TryRemove(projectQmn, out var moduleState))
             {
                 moduleState?.Dispose();
-                Logger.Warn("Could not remove declarations for removed reference '{0}' ({1}).", reference.Name, QualifiedModuleName.GetProjectId(reference));
+                Logger.Warn("Could not remove declarations for removed reference '{0}' ({1}).", projectQmn.Name, projectQmn.ProjectId);
             }
         }
         


### PR DESCRIPTION
This PR closes #3300.

So far, the logic which references to unload was seriously borked resulting in never unloading anything. 
Moreover, we never considered that priority changes could invalidate references. 

Both problems get fixed via this PR.