### PR TITLE
Introduce Serialize method for COM Safe

### DIFF
--- a/Rubberduck.VBEEditor/ComManagement/WeakComSafe.cs
+++ b/Rubberduck.VBEEditor/ComManagement/WeakComSafe.cs
@@ -3,13 +3,17 @@ using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
+#if DEBUG
+using System.Linq;
+using System.Runtime.InteropServices;
+#endif
+
 namespace Rubberduck.VBEditor.ComManagement
 {
     public class WeakComSafe : IComSafe
     {
         //We use weak references to allow the GC to reclaim RCWs earlier if possible.
-        private readonly ConcurrentDictionary<int, WeakReference<ISafeComWrapper>> _comWrapperCache = new ConcurrentDictionary<int, WeakReference<ISafeComWrapper>>();
-
+        private readonly ConcurrentDictionary<int, (DateTime insertTime, WeakReference<ISafeComWrapper> weakRef)> _comWrapperCache = new ConcurrentDictionary<int, (DateTime, WeakReference<ISafeComWrapper>)>();
 
         public void Add(ISafeComWrapper comWrapper)
         {
@@ -17,8 +21,8 @@ namespace Rubberduck.VBEditor.ComManagement
             {
                 _comWrapperCache.AddOrUpdate(
                     GetComWrapperObjectHashCode(comWrapper), 
-                    key => new WeakReference<ISafeComWrapper>(comWrapper), 
-                    (key, value) => new WeakReference<ISafeComWrapper>(comWrapper));
+                    key => (DateTime.UtcNow, new WeakReference<ISafeComWrapper>(comWrapper)), 
+                    (key, value) => (DateTime.UtcNow, new WeakReference<ISafeComWrapper>(comWrapper)));
             }
 
         }
@@ -47,7 +51,7 @@ namespace Rubberduck.VBEditor.ComManagement
 
             foreach (var weakReference in _comWrapperCache.Values)
             {
-                if(weakReference.TryGetTarget(out var comWrapper))
+                if(weakReference.weakRef.TryGetTarget(out var comWrapper))
                 {
                     comWrapper.Dispose();
                 }
@@ -55,5 +59,57 @@ namespace Rubberduck.VBEditor.ComManagement
 
             _comWrapperCache.Clear();
         }
+
+#if DEBUG
+        /// <summary>
+        /// Provide a serialized list of the COM Safe
+        /// to make it easy to analyze what is inside
+        /// the COM Safe at the different points of
+        /// the session's lifetime.
+        /// </summary>
+        public void Serialize()
+        {
+            using (var stream = System.IO.File.AppendText($"comSafeOutput {DateTime.UtcNow:yyyyMMddhhmmss}.csv"))
+            {
+                stream.WriteLine("Ordinal\tKey\tCOM Wrapper Type\tWrapping Null?\tIUnknown Pointer Address");
+                var i = 0;
+                foreach (var kvp in _comWrapperCache.OrderBy(kvp => kvp.Value.insertTime))
+                {
+                    var line = kvp.Value.weakRef.TryGetTarget(out var target) 
+                        ? $"{i++}\t{kvp.Key}\t\"{target.GetType().FullName}\"\t\"{target.IsWrappingNullReference}\"\t\"{(target.IsWrappingNullReference ? "null" : GetPtrAddress(target.Target))}\"" 
+                        : $"{i++}\t{kvp.Key}\t\"null\"\t\"null\"\t\"null\"";
+                    stream.WriteLine(line);
+                }
+            }
+        }
+
+        private static string GetPtrAddress(object target)
+        {
+            if (target == null)
+            {
+                return IntPtr.Zero.ToString();
+            }
+
+            if (!Marshal.IsComObject(target))
+            {
+                return "Not a COM object";
+            }
+
+            var pointer = IntPtr.Zero;
+            try
+            {
+                pointer = Marshal.GetIUnknownForObject(target);
+            }
+            finally
+            {
+                if (pointer != IntPtr.Zero)
+                {
+                    Marshal.Release(pointer);
+                }
+            }
+
+            return pointer.ToString();
+        }
+#endif
     }
 }


### PR DESCRIPTION
This PR is primarily for developers' convenience and was made necessary because there can be a large number of objects being stored in the COM safe, which can make it difficult to track object's lifetime using only Watch or Immediate Window.

This provides a debug-only serialize which generates a tab-delimited file that can be then opened in Excel:

[!image](https://user-images.githubusercontent.com/2367644/46806239-b8f32e00-cd2c-11e8-98cf-8633be85065e.png)

At this point, there is no UI for this functionality. I've been considering overloading the existing `Serialize` button for this. Any ideas welcome.

For now, I wanted to put this out for reviews in case others might have some useful suggestions or something else.

Todo:

1) Work out the UI, if any at al
2) Implement for the `StrongComSafe`