### PR TITLE
Revert use of 'default' language feature to lower c# version

### DIFF
--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Walker.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Walker.cs
@@ -62,7 +62,7 @@ namespace Rubberduck.Inspections.CodePathAnalysis
                 }
             }
 
-            if (node == default)
+            if (node == null)
             {
                 node = new GenericNode();
             }


### PR DESCRIPTION
Use of `default` was keeping me from building.