### PR TITLE
Fix rewrapping of CommandBarButtons as CommandBarControls

### DIFF
--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/Office/CommandBarButton.cs
@@ -21,7 +21,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office8
         public CommandBarButton(MSO.CommandBarButton target, IVBE vbe, bool rewrapping = false) 
             : base(target, rewrapping)
         {
-            _control = new CommandBarControl(target, vbe, rewrapping);
+            _control = new CommandBarControl(target, vbe, true);
             _vbe = vbe;
         }
         

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/Office/CommandBarButton.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/Office/CommandBarButton.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
         public CommandBarButton(MSO.CommandBarButton target, bool rewrapping = false) 
             : base(target, rewrapping)
         {
-            _control = new CommandBarControl(target, rewrapping);
+            _control = new CommandBarControl(target, true);
         }
         
         private MSO.CommandBarButton Button => Target;


### PR DESCRIPTION
This tiny PR fixes the rewrapping of `CommandBarButton`s that caused the corresponding RCWs to be released twice instead of once.