### PR TITLE
Remove content hash from the QMN

### DIFF
--- a/Rubberduck.VBEEditor/QualifiedModuleName.cs
+++ b/Rubberduck.VBEEditor/QualifiedModuleName.cs
@@ -48,21 +48,12 @@ namespace Rubberduck.VBEditor
             _projectName = project.Name;
             ProjectPath = string.Empty;
             ProjectId = GetProjectId(project);
-            ModuleContentHashOnCreation = GetContentHash(null);
         }
 
         public QualifiedModuleName(IVBComponent component)
         {
             ComponentType = component.Type;
             _componentName = component.IsWrappingNullReference ? string.Empty : component.Name;
-
-            //note: We set this property in order to stabelize the component.
-            //For some reason, components sometimes seem to get removed on the COM side although 
-            //an RCW is still holding a reference. For some reason, opening the CodeModule of a 
-            //component seems to prevent this. 
-            //This is a hack to open the code module on each component for which we get a QMN 
-            //in a way that does not get optimized away.
-            ModuleContentHashOnCreation = GetContentHash(component);
 
             using (var components = component.Collection)
             {
@@ -96,7 +87,6 @@ namespace Rubberduck.VBEditor
             ProjectId = "External" + $"{_projectName};{ProjectPath}".GetHashCode().ToString(CultureInfo.InvariantCulture);
             _componentName = componentName;
             ComponentType = ComponentType.ComComponent;
-            ModuleContentHashOnCreation = GetContentHash(null);
         }
 
         public QualifiedMemberName QualifyMemberName(string member)
@@ -118,7 +108,6 @@ namespace Rubberduck.VBEditor
         public string ProjectName => _projectName ?? string.Empty;
 
         public string ProjectPath { get; }
-        public int ModuleContentHashOnCreation { get; }
 
         public override string ToString()
         {


### PR DESCRIPTION
Calculating the content hash of the module on creation of a QMN is actively hurting their usability in hot-paths. The content hash was not really used and only was left there because it seemed to prevent some strange behaviour of COM components. Testing, I did no longer run into the strange behaviour. So, I think it is prudent to remove the content hash.