### PR TITLE
Add Funnel.png to resource project as Resource

### DIFF
--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -695,6 +695,7 @@
     <Resource Include="Icons\Custom\PNG\AddUserControl.png" />
     <Resource Include="Icons\Custom\PNG\AddPropertyPage.png" />
     <Resource Include="Icons\Custom\PNG\AddUserDocument.png" />
+    <Resource Include="Icons\Fugue\Funnel.png" />
     <Content Include="Splash.png" />
     <Resource Include="Icons\Fugue\lock--exclamation.png" />
     <Resource Include="Rubberduck.png" />


### PR DESCRIPTION
The addition of this resource had been lost when resolving merge conflicts and caused the settings window to throw and not open.

This PR closes #4445.