### PR TITLE
Trace logging by default; change to None after successful run

### DIFF
--- a/Rubberduck.Core/App.cs
+++ b/Rubberduck.Core/App.cs
@@ -105,6 +105,24 @@ namespace Rubberduck
             LogLevelHelper.SetMinimumLogLevel(LogLevel.FromOrdinal(_config.UserSettings.GeneralSettings.MinimumLogLevel));
         }
 
+        /// <summary>
+        /// Ensure that log level is changed to "none" after a successful
+        /// run of Rubberduck for first time. By default, we ship with 
+        /// log level set to Trace (0) but once it's installed and has
+        /// ran without problem, it should be set to None (6)
+        /// </summary>
+        private void UpdateLoggingLevelOnShutdown()
+        {
+            if (_config.UserSettings.GeneralSettings.UserEditedLogLevel ||
+                _config.UserSettings.GeneralSettings.MinimumLogLevel != LogLevel.Trace.Ordinal)
+            {
+                return;
+            }
+
+            _config.UserSettings.GeneralSettings.MinimumLogLevel = LogLevel.Off.Ordinal;
+            _configService.SaveConfiguration(_config);
+        }
+
         public void Startup()
         {
             EnsureLogFolderPathExists();
@@ -131,6 +149,8 @@ namespace Rubberduck
             {
                 Debug.WriteLine("App calling Hooks.Detach.");
                 _hooks.Detach();
+
+                UpdateLoggingLevelOnShutdown();
             }
             catch
             {

--- a/Rubberduck.Core/Properties/Settings.Designer.cs
+++ b/Rubberduck.Core/Properties/Settings.Designer.cs
@@ -12,8 +12,8 @@ namespace Rubberduck.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
-    public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         

--- a/Rubberduck.Core/Properties/Settings.settings
+++ b/Rubberduck.Core/Properties/Settings.settings
@@ -178,7 +178,8 @@
   &lt;IsSmartIndenterPrompted&gt;false&lt;/IsSmartIndenterPrompted&gt;
   &lt;IsAutoSaveEnabled&gt;false&lt;/IsAutoSaveEnabled&gt;
   &lt;AutoSavePeriod&gt;10&lt;/AutoSavePeriod&gt;
-  &lt;MinimumLogLevel&gt;6&lt;/MinimumLogLevel&gt;
+  &lt;UserEditedLogLevel&gt;false&lt;/UserEditedLogLevel&gt;
+  &lt;MinimumLogLevel&gt;0&lt;/MinimumLogLevel&gt;
   &lt;EnableExperimentalFeatures /&gt;
 &lt;/GeneralSettings&gt;</Value>
     </Setting>

--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -123,9 +123,10 @@
       <AutoGen>True</AutoGen>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <None Include="Properties\Settings.settings">
-      <Generator>PublicSettingsSingleFileGenerator</Generator>
+      <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>

--- a/Rubberduck.Core/Settings/GeneralSettings.cs
+++ b/Rubberduck.Core/Settings/GeneralSettings.cs
@@ -16,6 +16,7 @@ namespace Rubberduck.Settings
         bool IsSmartIndenterPrompted { get; set; }
         bool IsAutoSaveEnabled { get; set; }
         int AutoSavePeriod { get; set; }
+        bool UserEditedLogLevel { get; set; }
         int MinimumLogLevel { get; set; }
         List<ExperimentalFeatures> EnableExperimentalFeatures { get; set; }
     }
@@ -31,6 +32,8 @@ namespace Rubberduck.Settings
         public bool IsSmartIndenterPrompted { get; set; }
         public bool IsAutoSaveEnabled { get; set; }
         public int AutoSavePeriod { get; set; }
+
+        public bool UserEditedLogLevel { get; set; }
 
         private int _logLevel;
         public int MinimumLogLevel
@@ -73,6 +76,7 @@ namespace Rubberduck.Settings
                    IsSmartIndenterPrompted == other.IsSmartIndenterPrompted &&
                    IsAutoSaveEnabled == other.IsAutoSaveEnabled &&
                    AutoSavePeriod == other.AutoSavePeriod &&
+                   UserEditedLogLevel == other.UserEditedLogLevel &&
                    MinimumLogLevel == other.MinimumLogLevel &&
                    EnableExperimentalFeatures.All(a => other.EnableExperimentalFeatures.Contains(a)) &&
                    EnableExperimentalFeatures.Count == other.EnableExperimentalFeatures.Count;

--- a/Rubberduck.Core/UI/Settings/GeneralSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/GeneralSettingsViewModel.cs
@@ -200,6 +200,7 @@ namespace Rubberduck.UI.Settings
 
         public ObservableCollection<MinimumLogLevel> LogLevels { get; set; }
         private MinimumLogLevel _selectedLogLevel;
+        private bool _userEditedLogLevel;
 
         public MinimumLogLevel SelectedLogLevel
         {
@@ -208,6 +209,7 @@ namespace Rubberduck.UI.Settings
             {
                 if (!Equals(_selectedLogLevel, value))
                 {
+                    _userEditedLogLevel = true;
                     _selectedLogLevel = value;
                     OnPropertyChanged();
                 }
@@ -243,7 +245,8 @@ namespace Rubberduck.UI.Settings
                 IsSmartIndenterPrompted = _indenterPrompted,
                 IsAutoSaveEnabled = AutoSaveEnabled,
                 AutoSavePeriod = AutoSavePeriod,
-                MinimumLogLevel = SelectedLogLevel.Ordinal,
+                UserEditedLogLevel = _userEditedLogLevel,
+                MinimumLogLevel = _selectedLogLevel.Ordinal,
                 EnableExperimentalFeatures = ExperimentalFeatures
             };
         }
@@ -258,7 +261,8 @@ namespace Rubberduck.UI.Settings
             _indenterPrompted = general.IsSmartIndenterPrompted;
             AutoSaveEnabled = general.IsAutoSaveEnabled;
             AutoSavePeriod = general.AutoSavePeriod;
-            SelectedLogLevel = LogLevels.First(l => l.Ordinal == general.MinimumLogLevel);
+            _userEditedLogLevel = general.UserEditedLogLevel;
+            _selectedLogLevel = LogLevels.First(l => l.Ordinal == general.MinimumLogLevel);
 
             ExperimentalFeatures = _experimentalFeatureTypes
                 .SelectMany(s => s.CustomAttributes.Where(a => a.ConstructorArguments.Any()).Select(a => (string)a.ConstructorArguments.First().Value))

--- a/Rubberduck.Core/app.config
+++ b/Rubberduck.Core/app.config
@@ -228,7 +228,8 @@
             <IsSmartIndenterPrompted>false</IsSmartIndenterPrompted>
             <IsAutoSaveEnabled>false</IsAutoSaveEnabled>
             <AutoSavePeriod>10</AutoSavePeriod>
-            <MinimumLogLevel>6</MinimumLogLevel>
+            <UserEditedLogLevel>false</UserEditedLogLevel>
+            <MinimumLogLevel>0</MinimumLogLevel>
             <EnableExperimentalFeatures />
           </GeneralSettings>
         </value>


### PR DESCRIPTION
Closes #3861 

Introduces new setting that isn't UI-visible, `UserEditedLogLevel` that allows us to ship Rubberduck with `Trace` as the default logging level. If the user do not edit it, at the shutdown of the Rubberduck, the log level will be changed to `None`.