### PR TITLE
SCP hotfix

### DIFF
--- a/Rubberduck.Core/AutoComplete/Service/SelfClosingPairCompletionService.cs
+++ b/Rubberduck.Core/AutoComplete/Service/SelfClosingPairCompletionService.cs
@@ -78,7 +78,7 @@ namespace Rubberduck.AutoComplete.Service
             var line = lines[original.CaretPosition.StartLine];
 
             string newCode;
-            if (string.IsNullOrEmpty(original.Code))
+            if (string.IsNullOrEmpty(line))
             {
                 newCode = autoCode;
             }

--- a/Rubberduck.Core/AutoComplete/Service/SelfClosingPairCompletionService.cs
+++ b/Rubberduck.Core/AutoComplete/Service/SelfClosingPairCompletionService.cs
@@ -88,7 +88,7 @@ namespace Rubberduck.AutoComplete.Service
             }
             else
             {
-                newCode = original.CaretPosition.StartColumn == line.Length
+                newCode = original.CaretPosition.StartColumn >= line.Length
                     ? line + autoCode
                     : line.Insert(original.CaretPosition.StartColumn, autoCode);
             }

--- a/Rubberduck.VBEEditor/SourceCodeHandling/CodePaneSourceCodeHandler.cs
+++ b/Rubberduck.VBEEditor/SourceCodeHandling/CodePaneSourceCodeHandler.cs
@@ -125,10 +125,10 @@ namespace Rubberduck.VBEditor.SourceCodeHandling
             }
 
             var prettifiedPosition = new Selection(
-                    original.SnippetPosition.StartLine - 1 + original.CaretPosition.StartLine,
+                    original.SnippetPosition.ToZeroBased().StartLine + original.CaretPosition.StartLine,
                     prettifiedCode[original.CaretPosition.StartLine].Trim().Length == 0
                         ? indent
-                        : Math.Min(prettifiedCode[original.CaretPosition.StartLine].Length, prettifiedCaretCharIndex + 1))
+                        : Math.Min(prettifiedCode[original.CaretPosition.StartLine].Length, original.CaretPosition.StartColumn))
                 .ToOneBased();
 
             SetSelection(module, prettifiedPosition);

--- a/Rubberduck.VBEEditor/SourceCodeHandling/CodePaneSourceCodeHandler.cs
+++ b/Rubberduck.VBEEditor/SourceCodeHandling/CodePaneSourceCodeHandler.cs
@@ -91,15 +91,17 @@ namespace Rubberduck.VBEditor.SourceCodeHandling
             var originalCode = original.Code.Replace("\r", string.Empty).Split('\n');
             var originalPosition = original.CaretPosition.StartColumn;
             var originalNonWhitespaceCharacters = 0;
+            var isAllWhitespace = true;
             for (var i = 0; i <= Math.Min(originalPosition - 1, originalCode[original.CaretPosition.StartLine].Length - 1); i++)
             {
                 if (originalCode[original.CaretPosition.StartLine][i] != ' ')
                 {
                     originalNonWhitespaceCharacters++;
+                    isAllWhitespace = false;
                 }
             }
 
-            var indent = originalCode[original.CaretPosition.StartLine].TakeWhile(c => c == ' ').Count();
+            var indent = original.CaretLine.TakeWhile(c => c == ' ').Count();
 
             module.DeleteLines(original.SnippetPosition.StartLine, original.SnippetPosition.LineCount);
             module.InsertLines(original.SnippetPosition.StartLine, string.Join("\r\n", originalCode));
@@ -126,9 +128,9 @@ namespace Rubberduck.VBEditor.SourceCodeHandling
 
             var prettifiedPosition = new Selection(
                     original.SnippetPosition.ToZeroBased().StartLine + original.CaretPosition.StartLine,
-                    prettifiedCode[original.CaretPosition.StartLine].Trim().Length == 0
-                        ? indent
-                        : Math.Min(prettifiedCode[original.CaretPosition.StartLine].Length, original.CaretPosition.StartColumn))
+                    prettifiedCode[original.CaretPosition.StartLine].Trim().Length == 0 || (isAllWhitespace && !string.IsNullOrEmpty(original.CaretLine.Substring(original.CaretPosition.StartColumn).Trim()))
+                        ? Math.Min(indent, original.CaretPosition.StartColumn)
+                        : Math.Min(prettifiedCode[original.CaretPosition.StartLine].Length, prettifiedCaretCharIndex + 1))
                 .ToOneBased();
 
             SetSelection(module, prettifiedPosition);

--- a/RubberduckTests/AutoComplete/CodePaneHandlerTests.cs
+++ b/RubberduckTests/AutoComplete/CodePaneHandlerTests.cs
@@ -79,11 +79,25 @@ namespace RubberduckTests.AutoComplete
 
         [Test]
         [Category("AutoComplete")]
-        public void GivenMultilineLogicalLine_StillTracksCaret()
+        public void GivenMultilineLogicalLine_TracksCaret()
         {
             var original = @"
 MsgBox ""test"" & vbNewLine & _
        ""|"")".ToCodeString();
+
+            var sut = InitializeSut(original, original, out var module, out _);
+            var actual = new TestCodeString(sut.Prettify(module.Object, original));
+
+            Assert.AreEqual(original, actual);
+        }
+
+        [Test]
+        [Category("AutoComplete")]
+        public void GivenPartialMultilineInstruction_TracksCaret()
+        {
+            var original = @"
+ExecuteStoredProcedure (""AddAppointmentCountForAClinic"", False,dbconfig.SQLConString, _
+                | thisClinic.ClinicID ,".ToCodeString();
 
             var sut = InitializeSut(original, original, out var module, out _);
             var actual = new TestCodeString(sut.Prettify(module.Object, original));

--- a/RubberduckTests/AutoComplete/SelfClosingPairCompletionTests.cs
+++ b/RubberduckTests/AutoComplete/SelfClosingPairCompletionTests.cs
@@ -176,6 +176,22 @@ namespace RubberduckTests.AutoComplete
             Assert.AreEqual(expected, result);
         }
 
+        [Test] // ref. #4460
+        public void OpeningOnSecondLineDoesNotJumpToEndOfLine()
+        {
+            var pair = new SelfClosingPair('"', '"');
+            var input = '"';
+            var original = @"
+ExecuteStoredProcedure (""AddAppointmentCountForAClinic"", False,dbconfig.SQLConString, _
+                | thisClinic.ClinicID ,".ToCodeString();
+            var expected = @"
+ExecuteStoredProcedure (""AddAppointmentCountForAClinic"", False,dbconfig.SQLConString, _
+                ""|"" thisClinic.ClinicID ,".ToCodeString();
+
+            var result = Run(pair, original, input);
+            Assert.AreEqual(expected, result);
+        }
+
         [Test]
         public void DeletingOpeningCharRemovesPairedClosingChar_NestedParensMultiline()
         {

--- a/RubberduckTests/AutoComplete/SelfClosingPairCompletionTests.cs
+++ b/RubberduckTests/AutoComplete/SelfClosingPairCompletionTests.cs
@@ -343,6 +343,18 @@ namespace RubberduckTests.AutoComplete
         }
 
         [Test]
+        public void GivenEmptyIndentedLine_OpeningCharIsInsertedAtCaretPosition()
+        {
+            var pair = new SelfClosingPair('"', '"');
+            var input = '"';
+            var original = @"    |".ToCodeString();
+            var expected = @"    ""|""".ToCodeString();
+
+            var result = Run(pair, original, input);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
         public void DeleteKey_ReturnsNull()
         {
             var pair = new SelfClosingPair('(', ')');

--- a/RubberduckTests/AutoComplete/SelfClosingPairCompletionTests.cs
+++ b/RubberduckTests/AutoComplete/SelfClosingPairCompletionTests.cs
@@ -176,22 +176,6 @@ namespace RubberduckTests.AutoComplete
             Assert.AreEqual(expected, result);
         }
 
-        [Test] // ref. #4460
-        public void OpeningOnSecondLineDoesNotJumpToEndOfLine()
-        {
-            var pair = new SelfClosingPair('"', '"');
-            var input = '"';
-            var original = @"
-ExecuteStoredProcedure (""AddAppointmentCountForAClinic"", False,dbconfig.SQLConString, _
-                | thisClinic.ClinicID ,".ToCodeString();
-            var expected = @"
-ExecuteStoredProcedure (""AddAppointmentCountForAClinic"", False,dbconfig.SQLConString, _
-                ""|"" thisClinic.ClinicID ,".ToCodeString();
-
-            var result = Run(pair, original, input);
-            Assert.AreEqual(expected, result);
-        }
-
         [Test]
         public void DeletingOpeningCharRemovesPairedClosingChar_NestedParensMultiline()
         {


### PR DESCRIPTION
SCP was missing a case where caret was located before the first non-whitespace character of a code line.

```vb
    | foo
```

Given input `"`, the above now produces the expected result:

```vb
    "|" foo
```
