### PR TITLE
Update Stubs & Fakes to use VBERuntime class

### DIFF
--- a/Rubberduck.Core/AutoComplete/Service/AutoCompleteService.cs
+++ b/Rubberduck.Core/AutoComplete/Service/AutoCompleteService.cs
@@ -57,8 +57,8 @@ namespace Rubberduck.AutoComplete.Service
 
             if (!_enabled)
             {
-                VBENativeServices.KeyDown += HandleKeyDown;
-                VBENativeServices.IntelliSenseChanged += HandleIntelliSenseChanged;
+                VbeNativeServices.KeyDown += HandleKeyDown;
+                VbeNativeServices.IntelliSenseChanged += HandleIntelliSenseChanged;
                 _enabled = true;
             }
         }
@@ -67,8 +67,8 @@ namespace Rubberduck.AutoComplete.Service
         {
             if (_enabled && _initialized)
             {
-                VBENativeServices.KeyDown -= HandleKeyDown;
-                VBENativeServices.IntelliSenseChanged -= HandleIntelliSenseChanged;
+                VbeNativeServices.KeyDown -= HandleKeyDown;
+                VbeNativeServices.IntelliSenseChanged -= HandleIntelliSenseChanged;
                 _enabled = false;
                 _popupShown = false;
             }

--- a/Rubberduck.Core/UI/Command/ReparseCommand.cs
+++ b/Rubberduck.Core/UI/Command/ReparseCommand.cs
@@ -9,11 +9,10 @@ using Rubberduck.Parsing.VBA;
 using Rubberduck.Settings;
 using Rubberduck.SettingsProvider;
 using Rubberduck.Resources;
-using Rubberduck.UI.CodeExplorer.Commands;
 using Rubberduck.VBEditor.ComManagement.TypeLibsAPI;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
-using Rubberduck.VBEditor.VBERuntime.Settings;
+using Rubberduck.VBEditor.VbeRuntime.Settings;
 
 namespace Rubberduck.UI.Command
 {
@@ -22,12 +21,12 @@ namespace Rubberduck.UI.Command
     {
         private readonly IVBE _vbe;
         private readonly IVBETypeLibsAPI _typeLibApi;
-        private readonly IVBESettings _vbeSettings;
+        private readonly IVbeSettings _vbeSettings;
         private readonly IMessageBox _messageBox;
         private readonly RubberduckParserState _state;
         private readonly GeneralSettings _settings;
 
-        public ReparseCommand(IVBE vbe, IConfigProvider<GeneralSettings> settingsProvider, RubberduckParserState state, IVBETypeLibsAPI typeLibApi, IVBESettings vbeSettings, IMessageBox messageBox) : base(LogManager.GetCurrentClassLogger())
+        public ReparseCommand(IVBE vbe, IConfigProvider<GeneralSettings> settingsProvider, RubberduckParserState state, IVBETypeLibsAPI typeLibApi, IVbeSettings vbeSettings, IMessageBox messageBox) : base(LogManager.GetCurrentClassLogger())
         {
             _vbe = vbe;
             _vbeSettings = vbeSettings;

--- a/Rubberduck.Core/UI/SelectionChangeService.cs
+++ b/Rubberduck.Core/UI/SelectionChangeService.cs
@@ -30,8 +30,8 @@ namespace Rubberduck.UI
         {
             _parser = parser;
             _vbe = vbe;
-            VBENativeServices.SelectionChanged += OnVbeSelectionChanged;
-            VBENativeServices.WindowFocusChange += OnVbeFocusChanged;
+            VbeNativeServices.SelectionChanged += OnVbeSelectionChanged;
+            VbeNativeServices.WindowFocusChange += OnVbeFocusChanged;
         }
         
         private void OnVbeSelectionChanged(object sender, EventArgs e)
@@ -69,7 +69,7 @@ namespace Rubberduck.UI
                         //Caret changed in a code pane.
                         Task.Run(() =>
                         {
-                            using (var pane = VBENativeServices.GetCodePaneFromHwnd(e.Hwnd))
+                            using (var pane = VbeNativeServices.GetCodePaneFromHwnd(e.Hwnd))
                             {
                                 DispatchSelectedDeclaration(
                                     new DeclarationChangedEventArgs(_vbe, _parser.State.FindSelectedDeclaration(pane)));
@@ -186,8 +186,8 @@ namespace Rubberduck.UI
 
         public void Dispose()
         {
-            VBENativeServices.SelectionChanged -= OnVbeSelectionChanged;
-            VBENativeServices.WindowFocusChange -= OnVbeFocusChanged;
+            VbeNativeServices.SelectionChanged -= OnVbeSelectionChanged;
+            VbeNativeServices.WindowFocusChange -= OnVbeFocusChanged;
         }
     }
 

--- a/Rubberduck.Core/UI/Settings/GeneralSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/GeneralSettingsViewModel.cs
@@ -8,7 +8,7 @@ using Rubberduck.Interaction;
 using NLog;
 using Rubberduck.SettingsProvider;
 using Rubberduck.UI.Command;
-using Rubberduck.VBEditor.VBERuntime.Settings;
+using Rubberduck.VBEditor.VbeRuntime.Settings;
 using Rubberduck.Resources;
 
 namespace Rubberduck.UI.Settings
@@ -23,12 +23,12 @@ namespace Rubberduck.UI.Settings
     {
         private readonly IOperatingSystem _operatingSystem;
         private readonly IMessageBox _messageBox;
-        private readonly IVBESettings _vbeSettings;
+        private readonly IVbeSettings _vbeSettings;
 
         private bool _indenterPrompted;
         private readonly ReadOnlyCollection<Type> _experimentalFeatureTypes;
 
-        public GeneralSettingsViewModel(Configuration config, IOperatingSystem operatingSystem, IMessageBox messageBox, IVBESettings vbeSettings, IEnumerable<Type> experimentalFeatureTypes)
+        public GeneralSettingsViewModel(Configuration config, IOperatingSystem operatingSystem, IMessageBox messageBox, IVbeSettings vbeSettings, IEnumerable<Type> experimentalFeatureTypes)
         {
             _operatingSystem = operatingSystem;
             _messageBox = messageBox;

--- a/Rubberduck.Core/UI/Settings/SettingsForm.cs
+++ b/Rubberduck.Core/UI/Settings/SettingsForm.cs
@@ -2,7 +2,7 @@
 using Rubberduck.Settings;
 using Rubberduck.Common;
 using Rubberduck.Interaction;
-using Rubberduck.VBEditor.VBERuntime.Settings;
+using Rubberduck.VBEditor.VbeRuntime.Settings;
 using System.Collections.Generic;
 using System;
 
@@ -21,7 +21,7 @@ namespace Rubberduck.UI.Settings
             InitializeComponent();
         }
 
-        public SettingsForm(IGeneralConfigService configService, IOperatingSystem operatingSystem, IMessageBox messageBox, IVBESettings vbeSettings, SettingsViews activeView = SettingsViews.GeneralSettings) : this()
+        public SettingsForm(IGeneralConfigService configService, IOperatingSystem operatingSystem, IMessageBox messageBox, IVbeSettings vbeSettings, SettingsViews activeView = SettingsViews.GeneralSettings) : this()
         {
             var config = configService.LoadConfiguration();
 

--- a/Rubberduck.Deployment/Rubberduck.Deployment.csproj
+++ b/Rubberduck.Deployment/Rubberduck.Deployment.csproj
@@ -17,6 +17,7 @@
     <None Include="BuildRegistryScript.ps1" />
     <None Include="Licenses\License.rtf" />
     <None Include="PreInnoSetupConfiguration.ps1" />
+    <Content Include="..\packages\EasyHook.2.7.6684\content\net40\**" CopyToPublishDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rubberduck.API\Rubberduck.API.csproj" />
@@ -36,7 +37,19 @@
       <HintPath>OleWoo\olewoo_interop.dll</HintPath>
     </Reference>
   </ItemGroup>
-
+  <Target Name="CopyLinkedContentFiles" BeforeTargets="Build">
+    <Copy SourceFiles="%(Content.Identity)"
+          DestinationFiles="$(OutputPath)\%(Content.Link)"
+          SkipUnchangedFiles="true"
+          OverwriteReadOnlyFiles="true" />
+  </Target>
+  <Target Name="InnoSetupConfig" BeforeTargets="PreBuildEvent">
+      <CreateProperty Value="&amp;  '$(ProjectDir)PreInnoSetupConfiguration.ps1' -WorkingDir  '$(ProjectDir)'">
+      <Output TaskParameter="Value" PropertyName="PowershellCommand" />
+    </CreateProperty>
+    <Exec Command="%25SystemRoot%25\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command &quot;$(PowershellCommand)&quot;" ConsoleToMsBuild="true" />
+    <Message Text="Ran InnoSetupConfig" Importance="normal" />
+  </Target>
   <Target Name="Register" AfterTargets="PostBuildEvent">
     <GetFrameworkSdkPath>
       <Output TaskParameter="Path" PropertyName="SdkPath" />
@@ -49,12 +62,5 @@
     </CreateProperty>
     <Exec Command="%25SystemRoot%25\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command &quot;$(PowershellCommand)&quot;" ConsoleToMsBuild="true" />
     <Message Text="Ran Registration script" Importance="normal" />
-  </Target>
-  <Target Name="InnoSetupConfig" BeforeTargets="PreBuildEvent">
-      <CreateProperty Value="&amp;  '$(ProjectDir)PreInnoSetupConfiguration.ps1' -WorkingDir  '$(ProjectDir)'">
-      <Output TaskParameter="Value" PropertyName="PowershellCommand" />
-    </CreateProperty>
-    <Exec Command="%25SystemRoot%25\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -command &quot;$(PowershellCommand)&quot;" ConsoleToMsBuild="true" />
-    <Message Text="Ran InnoSetupConfig" Importance="normal" />
   </Target>
 </Project>

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/CurDir.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/CurDir.cs
@@ -6,13 +6,13 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class CurDir : FakeBase
     {
-        private static readonly IntPtr ProcessAddressVariant = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcCurrentDir");
-        private static readonly IntPtr ProcessAddressString = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcCurrentDirBstr");
-
         public CurDir()
         {
-            InjectDelegate(new CurDirStringDelegate(CurDirStringCallback), ProcessAddressString);
-            InjectDelegate(new CurDirVariantDelegate(CurDirVariantCallback), ProcessAddressVariant);
+            var processAddressVariant = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcCurrentDir");
+            var processAddressString = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcCurrentDirBstr");
+
+            InjectDelegate(new CurDirStringDelegate(CurDirStringCallback), processAddressString);
+            InjectDelegate(new CurDirVariantDelegate(CurDirVariantCallback), processAddressVariant);
         }
 
         public override bool PassThrough

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
@@ -5,15 +5,12 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class Date : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcGetDateVar");
-
         public Date()
         {
-            InjectDelegate(new DateDelegate(DateCallback), ProcessAddress);
-        }
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcGetDateVar");
 
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcGetDateVar(out object retVal);
+            InjectDelegate(new DateDelegate(DateCallback), processAddress);
+        }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void DateDelegate(IntPtr retVal);
@@ -28,7 +25,7 @@ namespace Rubberduck.UnitTesting.Fakes
             if (PassThrough)
             {
                 object result;
-                rtcGetDateVar(out result);
+                VbeProvider.VbeRuntime.GetDateVar(out result);
                 Marshal.GetNativeVariantForObject(result, retVal);
                 return;
             }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/DoEvents.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/DoEvents.cs
@@ -1,16 +1,15 @@
 ﻿using Rubberduck.UnitTesting.ComClientHelpers;
-using System;
 using System.Runtime.InteropServices;
 
 namespace Rubberduck.UnitTesting.Fakes
 {
     internal class DoEvents : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcDoEvents");
-
         public DoEvents()
         {
-            InjectDelegate(new DoEventsDelegate(DoEventsCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcDoEvents");
+
+            InjectDelegate(new DoEventsDelegate(DoEventsCallback), processAddress);
         }
 
         private readonly ValueTypeConverter<int> _converter = new ValueTypeConverter<int>();
@@ -19,10 +18,6 @@ namespace Rubberduck.UnitTesting.Fakes
             _converter.Value = value;
             base.Returns((int)_converter.Value, invocation);
         }
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.I4)]
-        private static extern int rtcDoEvents();
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.I4)]
@@ -34,7 +29,7 @@ namespace Rubberduck.UnitTesting.Fakes
 
             if (PassThrough)
             {
-                return rtcDoEvents();
+                return VbeProvider.VbeRuntime.DoEvents();
             }
             return (int)(ReturnValue ?? 0);
         }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Environ.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Environ.cs
@@ -6,13 +6,13 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class Environ : FakeBase
     {
-        private static readonly IntPtr ProcessAddressString = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcEnvironBstr");
-        private static readonly IntPtr ProcessAddressVariant = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcEnvironVar");
-
         public Environ()
         {
-            InjectDelegate(new EnvironStringDelegate(EnvironStringCallback), ProcessAddressString);
-            InjectDelegate(new EnvironVariantDelegate(EnvironVariantCallback), ProcessAddressVariant);
+            var processAddressString = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcEnvironBstr");
+            var processAddressVariant = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcEnvironVar");
+
+            InjectDelegate(new EnvironStringDelegate(EnvironStringCallback), processAddressString);
+            InjectDelegate(new EnvironVariantDelegate(EnvironVariantCallback), processAddressVariant);
         }
 
         public override bool PassThrough

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/InputBox.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/InputBox.cs
@@ -6,11 +6,11 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class InputBox : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcInputBox");
-
         public InputBox()
         {
-            InjectDelegate(new InputBoxDelegate(InputBoxCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcInputBox");
+
+            InjectDelegate(new InputBoxDelegate(InputBoxCallback), processAddress);
         }
 
         public override bool PassThrough

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/MsgBox.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/MsgBox.cs
@@ -8,11 +8,11 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class MsgBox : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcMsgBox");
-
         public MsgBox()
         {
-            InjectDelegate(new MessageBoxDelegate(MsgBoxCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcMsgBox");
+
+            InjectDelegate(new MessageBoxDelegate(MsgBoxCallback), processAddress);
         }
 
         public override bool PassThrough

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Now.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Now.cs
@@ -5,15 +5,12 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class Now : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcGetPresentDate");
-
         public Now()
         {
-            InjectDelegate(new NowDelegate(NowCallback), ProcessAddress);
-        }
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcGetPresentDate");
 
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcGetPresentDate(out object retVal);
+            InjectDelegate(new NowDelegate(NowCallback), processAddress);
+        }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void NowDelegate(IntPtr retVal);
@@ -28,7 +25,7 @@ namespace Rubberduck.UnitTesting.Fakes
             if (PassThrough)
             {
                 object result;
-                rtcGetPresentDate(out result);
+                VbeProvider.VbeRuntime.GetPresentDate(out result);
                 Marshal.GetNativeVariantForObject(result, retVal);
                 return;
             }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Shell.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Shell.cs
@@ -7,11 +7,11 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class Shell : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcShell");
-
         public Shell()
         {
-            InjectDelegate(new ShellDelegate(ShellCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcShell");
+
+            InjectDelegate(new ShellDelegate(ShellCallback), processAddress);
         }
 
         private readonly ValueTypeConverter<double> _converter = new ValueTypeConverter<double>();
@@ -21,9 +21,6 @@ namespace Rubberduck.UnitTesting.Fakes
             base.Returns((double)_converter.Value, invocation);
         }
 
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern double rtcShell(IntPtr pathname, short windowstyle);
-        
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.R8)]
         private delegate double ShellDelegate(IntPtr pathname, short windowstyle);
@@ -39,7 +36,7 @@ namespace Rubberduck.UnitTesting.Fakes
 
             if (PassThrough)
             {
-                return Convert.ToDouble(rtcShell(pathname, windowstyle));
+                return Convert.ToDouble(VbeProvider.VbeRuntime.Shell(pathname, windowstyle));
             }
             return Convert.ToDouble(ReturnValue ?? 0);
         }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
@@ -5,15 +5,12 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class Time : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcGetTimeVar");
-
         public Time()
         {
-            InjectDelegate(new TimeDelegate(TimeCallback), ProcessAddress);
-        }
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcGetTimeVar");
 
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcGetTimeVar(out object retVal);
+            InjectDelegate(new TimeDelegate(TimeCallback), processAddress);
+        }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void TimeDelegate(IntPtr retVal);
@@ -28,7 +25,7 @@ namespace Rubberduck.UnitTesting.Fakes
             if (PassThrough)
             {
                 object result;
-                rtcGetTimeVar(out result);
+                VbeProvider.VbeRuntime.GetTimeVar(out result);
                 Marshal.GetNativeVariantForObject(result, retVal);
                 return;
             }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Timer.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Timer.cs
@@ -6,11 +6,11 @@ namespace Rubberduck.UnitTesting.Fakes
 {
     internal class Timer : FakeBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcGetTimer");
-
         public Timer()
         {
-            InjectDelegate(new TimerDelegate(TimerCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcGetTimer");
+
+            InjectDelegate(new TimerDelegate(TimerCallback), processAddress);
         }
 
         private readonly ValueTypeConverter<float> _converter = new ValueTypeConverter<float>();
@@ -19,10 +19,6 @@ namespace Rubberduck.UnitTesting.Fakes
             _converter.Value = value;
             base.Returns((float)_converter.Value, invocation);
         }
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.R4)]
-        private static extern float rtcGetTimer();
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.R4)]
@@ -34,7 +30,7 @@ namespace Rubberduck.UnitTesting.Fakes
 
             if (PassThrough)
             {
-                return rtcGetTimer();
+                return VbeProvider.VbeRuntime.GetTimer();
             }
             return Convert.ToSingle(ReturnValue ?? 0);
         } 

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/StubBase.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/StubBase.cs
@@ -7,7 +7,6 @@ namespace Rubberduck.UnitTesting
 {
     internal class StubBase : IStub, IDisposable
     {
-        internal const string TargetLibrary = "vbe7.dll";
         private readonly List<LocalHook> _hooks = new List<LocalHook>();
 
         #region Internal

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/Beep.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/Beep.cs
@@ -1,22 +1,18 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace Rubberduck.UnitTesting
 {
     internal class Beep : StubBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcBeep");
-
-        public Beep() 
+        public Beep()
         {
-            InjectDelegate(new BeepDelegate(BeepCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcBeep");
+
+            InjectDelegate(new BeepDelegate(BeepCallback), processAddress);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void BeepDelegate();
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcBeep();
 
         public void BeepCallback()
         {
@@ -24,7 +20,7 @@ namespace Rubberduck.UnitTesting
 
             if (PassThrough)
             {
-                rtcBeep();
+                VbeProvider.VbeRuntime.Beep();
             }
         }
     }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/ChDir.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/ChDir.cs
@@ -6,18 +6,15 @@ namespace Rubberduck.UnitTesting
 {
     internal class ChDir : StubBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcChangeDir");
-
         public ChDir()
         {
-            InjectDelegate(new ChDirDelegate(ChDirCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcChangeDir");
+
+            InjectDelegate(new ChDirDelegate(ChDirCallback), processAddress);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void ChDirDelegate(IntPtr path);
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcChangeDir(IntPtr path);
 
         public void ChDirCallback(IntPtr path)
         {
@@ -28,7 +25,7 @@ namespace Rubberduck.UnitTesting
             TrackUsage("path", pathArg, Tokens.String);
             if (PassThrough)
             {
-                rtcChangeDir(path);
+                VbeProvider.VbeRuntime.ChangeDir(path);
             }
         }
     }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/ChDrive.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/ChDrive.cs
@@ -6,18 +6,15 @@ namespace Rubberduck.UnitTesting
 {
     internal class ChDrive : StubBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcChangeDrive");
-
         public ChDrive()
         {
-            InjectDelegate(new ChDriveDelegate(ChDriveCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcChangeDrive");
+
+            InjectDelegate(new ChDriveDelegate(ChDriveCallback), processAddress);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void ChDriveDelegate(IntPtr driveletter);
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcChangeDrive(IntPtr driveletter);
 
         public void ChDriveCallback(IntPtr driveletter)
         {
@@ -28,7 +25,7 @@ namespace Rubberduck.UnitTesting
             TrackUsage("driveletter", driveletterArg, Tokens.String);
             if (PassThrough)
             {
-                rtcChangeDrive(driveletter);
+                VbeProvider.VbeRuntime.ChangeDrive(driveletter);
             }
         }
     }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/Kill.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/Kill.cs
@@ -5,18 +5,15 @@ namespace Rubberduck.UnitTesting
 {
     internal class Kill : StubBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcKillFiles");
-
         public Kill()
         {
-            InjectDelegate(new KillDelegate(KillCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcKillFiles");
+
+            InjectDelegate(new KillDelegate(KillCallback), processAddress);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void KillDelegate(IntPtr pathname);
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcKillFiles(IntPtr pathname);
 
         public void KillCallback(IntPtr pathname)
         {
@@ -25,7 +22,7 @@ namespace Rubberduck.UnitTesting
             TrackUsage("pathname", pathname);
             if (PassThrough)
             {
-                rtcKillFiles(pathname);
+                VbeProvider.VbeRuntime.KillFiles(pathname);
             }
         }
     }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/MkDir.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/MkDir.cs
@@ -6,18 +6,15 @@ namespace Rubberduck.UnitTesting
 {
     internal class MkDir : StubBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcMakeDir");
-
         public MkDir()
         {
-            InjectDelegate(new MkDirDelegate(MkDirCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcMakeDir");
+
+            InjectDelegate(new MkDirDelegate(MkDirCallback), processAddress);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void MkDirDelegate(IntPtr path);
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcMakeDir(IntPtr path);
 
         public void MkDirCallback(IntPtr path)
         {
@@ -28,7 +25,7 @@ namespace Rubberduck.UnitTesting
             TrackUsage("path", pathArg, Tokens.String);
             if (PassThrough)
             {
-                rtcMakeDir(path);
+                VbeProvider.VbeRuntime.MakeDir(path);
             }
         }
     }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/RmDir.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/RmDir.cs
@@ -6,18 +6,15 @@ namespace Rubberduck.UnitTesting
 {
     internal class RmDir : StubBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcRemoveDir");
-
         public RmDir()
         {
-            InjectDelegate(new RmDirDelegate(RmDirCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcRemoveDir");
+
+            InjectDelegate(new RmDirDelegate(RmDirCallback), processAddress);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate void RmDirDelegate(IntPtr path);
-
-        [DllImport(TargetLibrary, SetLastError = true)]
-        private static extern void rtcRemoveDir(IntPtr path);
 
         public void RmDirCallback(IntPtr path)
         {
@@ -28,7 +25,7 @@ namespace Rubberduck.UnitTesting
             TrackUsage("path", pathArg, Tokens.String);
             if (PassThrough)
             {
-                rtcRemoveDir(path);
+                VbeProvider.VbeRuntime.RemoveDir(path);
             }
         }
     }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/SendKeys.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Stubs/SendKeys.cs
@@ -7,16 +7,16 @@ namespace Rubberduck.UnitTesting
 {
     internal class SendKeys : StubBase
     {
-        private static readonly IntPtr ProcessAddress = EasyHook.LocalHook.GetProcAddress(TargetLibrary, "rtcSendKeys");
-
         public SendKeys()
         {
-            InjectDelegate(new SendKeysDelegate(SendKeysCallback), ProcessAddress);
+            var processAddress = EasyHook.LocalHook.GetProcAddress(VbeProvider.VbeRuntime.DllName, "rtcSendKeys");
+
+            InjectDelegate(new SendKeysDelegate(SendKeysCallback), processAddress);
         }
 
         public override bool PassThrough
         {
-            get { return false; }
+            get => false;
             // ReSharper disable once ValueParameterNotUsed
             set
             {

--- a/Rubberduck.Main/Extension.cs
+++ b/Rubberduck.Main/Extension.cs
@@ -60,7 +60,7 @@ namespace Rubberduck
                 _addin.Object = this;
 
                 VbeProvider.Initialize(_vbe);
-                VBENativeServices.HookEvents(_vbe);
+                VbeNativeServices.HookEvents(_vbe);
 
 #if DEBUG
                 // FOR DEBUGGING/DEVELOPMENT PURPOSES, ALLOW ACCESS TO SOME VBETypeLibsAPI FEATURES FROM VBA
@@ -242,7 +242,7 @@ namespace Rubberduck
             {
                 _logger.Log(LogLevel.Info, "Rubberduck is shutting down.");
                 _logger.Log(LogLevel.Trace, "Unhooking VBENativeServices events...");
-                VBENativeServices.UnhookEvents();
+                VbeNativeServices.UnhookEvents();
                 VbeProvider.Terminate();
 
                 _logger.Log(LogLevel.Trace, "Releasing dockable hosts...");

--- a/Rubberduck.Main/Extension.cs
+++ b/Rubberduck.Main/Extension.cs
@@ -59,6 +59,7 @@ namespace Rubberduck
                 _addin = RootComWrapperFactory.GetAddInWrapper(AddInInst);
                 _addin.Object = this;
 
+                VbeProvider.Initialize(_vbe);
                 VBENativeServices.HookEvents(_vbe);
 
 #if DEBUG
@@ -242,6 +243,7 @@ namespace Rubberduck
                 _logger.Log(LogLevel.Info, "Rubberduck is shutting down.");
                 _logger.Log(LogLevel.Trace, "Unhooking VBENativeServices events...");
                 VBENativeServices.UnhookEvents();
+                VbeProvider.Terminate();
 
                 _logger.Log(LogLevel.Trace, "Releasing dockable hosts...");
 

--- a/Rubberduck.Main/VbeProvider.cs
+++ b/Rubberduck.Main/VbeProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
-using Rubberduck.VBEditor.VBERuntime;
+using Rubberduck.VBEditor.VbeRuntime;
 
 namespace Rubberduck
 {
@@ -19,7 +19,7 @@ namespace Rubberduck
         internal static void Initialize(IVBE vbe)
         {
             Vbe = vbe;
-            VbeRuntime = new VBERuntimeAccessor(vbe);
+            VbeRuntime = new VbeNativeApiAccessor(vbe);
         }
 
         internal static void Terminate()
@@ -30,6 +30,6 @@ namespace Rubberduck
         }
 
         internal static IVBE Vbe { get; private set; }
-        internal static IVBERuntime VbeRuntime { get; private set; }
+        internal static IVbeNativeApi VbeRuntime { get; private set; }
     }
 }

--- a/Rubberduck.Main/VbeProvider.cs
+++ b/Rubberduck.Main/VbeProvider.cs
@@ -1,0 +1,35 @@
+﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using Rubberduck.VBEditor.VBERuntime;
+
+namespace Rubberduck
+{
+    /// <summary>
+    /// ANTI-PATTERN: Service locator for COM class. Think carefully before using it, and regret it.
+    /// </summary>
+    /// <remarks>
+    /// This is a hacky workaround to provide support to COM-visible classes without breaking the
+    /// interface or violating the security settings of the Office host. Because a COM class must
+    /// have a parameterless constructor if it is to be newed up and because COM class cannot come
+    /// from the IoC container nor have any dependencies coming out of it, we use the service
+    /// locator anti-pattern here to provide the necessary functionality for the COM classes'
+    /// internal implementations. The use should never expand beyond that limited scope. 
+    /// </remarks>
+    internal static class VbeProvider
+    {
+        internal static void Initialize(IVBE vbe)
+        {
+            Vbe = vbe;
+            VbeRuntime = new VBERuntimeAccessor(vbe);
+        }
+
+        internal static void Terminate()
+        {
+            Vbe.Dispose();
+            Vbe = null;
+            VbeRuntime = null;
+        }
+
+        internal static IVBE Vbe { get; private set; }
+        internal static IVBERuntime VbeRuntime { get; private set; }
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/ComMessagePumper.cs
+++ b/Rubberduck.VBEEditor/ComManagement/ComMessagePumper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Threading;
 using Rubberduck.VBEditor.Utility;
-using Rubberduck.VBEditor.VBERuntime;
+using Rubberduck.VBEditor.VbeRuntime;
 
 namespace Rubberduck.VBEditor.ComManagement
 {
@@ -12,10 +11,10 @@ namespace Rubberduck.VBEditor.ComManagement
 
     public class ComMessagePumper : IComMessagePumper
     {
-        private readonly IVBERuntime _runtime;
+        private readonly IVbeNativeApi _runtime;
         private readonly IUiContextProvider _uiContext;
 
-        public ComMessagePumper(IUiContextProvider uiContext, IVBERuntime runtime)
+        public ComMessagePumper(IUiContextProvider uiContext, IVbeNativeApi runtime)
         {
             _uiContext = uiContext;
             _runtime = runtime;

--- a/Rubberduck.VBEEditor/Events/VBENativeServices.cs
+++ b/Rubberduck.VBEEditor/Events/VBENativeServices.cs
@@ -10,7 +10,7 @@ using Rubberduck.VBEditor.WindowsApi;
 namespace Rubberduck.VBEditor.Events
 {
     // ReSharper disable once InconsistentNaming
-    public static class VBENativeServices
+    public static class VbeNativeServices
     {
         private static User32.WinEventProc _eventProc;
         private static IntPtr _eventHandle;

--- a/Rubberduck.VBEEditor/VBERuntime/IVBERuntime.cs
+++ b/Rubberduck.VBEEditor/VBERuntime/IVBERuntime.cs
@@ -1,8 +1,21 @@
-﻿namespace Rubberduck.VBEditor.VBERuntime
+﻿using System;
+
+namespace Rubberduck.VBEditor.VBERuntime
 {
     public interface IVBERuntime
     {
-        float Timer();
+        string DllName { get; }
         int DoEvents();
+        float GetTimer();
+        void GetDateVar(out object retval);
+        void GetPresentDate(out object retVal);
+        double Shell(IntPtr pathname, short windowstyle);
+        void GetTimeVar(out object retVal);
+        void ChangeDir(IntPtr path);
+        void ChangeDrive(IntPtr driveletter);
+        void KillFiles(IntPtr pathname);
+        void MakeDir(IntPtr path);
+        void RemoveDir(IntPtr path);
+        void Beep();
     }
 }

--- a/Rubberduck.VBEEditor/VBERuntime/Settings/IVBESettings.cs
+++ b/Rubberduck.VBEEditor/VBERuntime/Settings/IVBESettings.cs
@@ -1,6 +1,6 @@
-namespace Rubberduck.VBEditor.VBERuntime.Settings
+namespace Rubberduck.VBEditor.VbeRuntime.Settings
 {
-    public interface IVBESettings
+    public interface IVbeSettings
     {
         DllVersion Version { get; }
         bool CompileOnDemand { get; set; }

--- a/Rubberduck.VBEEditor/VBERuntime/Settings/VBESettings.cs
+++ b/Rubberduck.VBEEditor/VBERuntime/Settings/VBESettings.cs
@@ -3,9 +3,9 @@ using Microsoft.Win32;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.Utility;
 
-namespace Rubberduck.VBEditor.VBERuntime.Settings
+namespace Rubberduck.VBEditor.VbeRuntime.Settings
 {
-    public class VBESettings : IVBESettings
+    public class VbeSettings : IVbeSettings
     {
         private const string Vbe7SettingPath = @"HKEY_CURRENT_USER\Software\Microsoft\VBA\7.0\Common";
         private const string Vbe6SettingPath = @"HKEY_CURRENT_USER\Software\Microsoft\VBA\6.0\Common";
@@ -14,11 +14,11 @@ namespace Rubberduck.VBEditor.VBERuntime.Settings
         private readonly string _activeRegistryRootPath;
         private readonly string[] _registryRootPaths = { Vbe7SettingPath, Vbe6SettingPath };
 
-        public VBESettings(IVBE vbe, IRegistryWrapper registry)
+        public VbeSettings(IVBE vbe, IRegistryWrapper registry)
         {
             try
             {
-                switch (VBEDllVersion.GetCurrentVersion(vbe))
+                switch (VbeDllVersion.GetCurrentVersion(vbe))
                 {
                     case DllVersion.Vbe6:
                         Version = DllVersion.Vbe6;

--- a/Rubberduck.VBEEditor/VBERuntime/VBEDllVersion.cs
+++ b/Rubberduck.VBEEditor/VBERuntime/VBEDllVersion.cs
@@ -1,6 +1,6 @@
 ﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
-namespace Rubberduck.VBEditor.VBERuntime
+namespace Rubberduck.VBEditor.VbeRuntime
 {
     public enum DllVersion
     {
@@ -9,7 +9,7 @@ namespace Rubberduck.VBEditor.VBERuntime
         Vbe7
     }
 
-    public static class VBEDllVersion
+    public static class VbeDllVersion
     {
         public static DllVersion GetCurrentVersion(IVBE vbe)
         {

--- a/Rubberduck.VBEEditor/VBERuntime/VBERuntime6.cs
+++ b/Rubberduck.VBEEditor/VBERuntime/VBERuntime6.cs
@@ -1,23 +1,97 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Rubberduck.VBEditor.VBERuntime
 {
     internal class VBERuntime6 : IVBERuntime
     {
-        private const string DllName = "vbe6.dll";
+        private const string _dllName = "vbe6.dll";
 
-        [DllImport(DllName)]
+        public string DllName => _dllName;
+
+        [DllImport(_dllName)]
         private static extern int rtcDoEvents();
         public int DoEvents()
         {
             return rtcDoEvents();
         }
 
-        [DllImport(DllName)]
+        [DllImport(_dllName, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.R4)]
         private static extern float rtcGetTimer();
-        public float Timer()
+        public float GetTimer()
         {
             return rtcGetTimer();
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcGetDateVar(out object retVal);
+        public void GetDateVar(out object retval)
+        {
+            rtcGetDateVar(out retval);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcGetPresentDate(out object retVal);
+        public void GetPresentDate(out object retVal)
+        {
+            rtcGetPresentDate(out retVal);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern double rtcShell(IntPtr pathname, short windowstyle);
+        public double Shell(IntPtr pathname, short windowstyle)
+        {
+            return rtcShell(pathname, windowstyle);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcGetTimeVar(out object retVal);
+        public void GetTimeVar(out object retVal)
+        {
+            rtcGetTimeVar(out retVal);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcChangeDir(IntPtr path);
+        public void ChangeDir(IntPtr path)
+        {
+            rtcChangeDir(path);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcChangeDrive(IntPtr driveletter);
+        public void ChangeDrive(IntPtr driveletter)
+        {
+            rtcChangeDrive(driveletter);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcKillFiles(IntPtr pathname);
+        public void KillFiles(IntPtr pathname)
+        {
+            rtcKillFiles(pathname);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcMakeDir(IntPtr path);
+        public void MakeDir(IntPtr path)
+        {
+            rtcMakeDir(path);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcRemoveDir(IntPtr path);
+        public void RemoveDir(IntPtr path)
+        {
+            rtcRemoveDir(path);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcBeep();
+        public void Beep()
+        {
+            rtcBeep();
         }
     }
 }

--- a/Rubberduck.VBEEditor/VBERuntime/VBERuntime7.cs
+++ b/Rubberduck.VBEEditor/VBERuntime/VBERuntime7.cs
@@ -1,23 +1,97 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Rubberduck.VBEditor.VBERuntime
 {
     internal class VBERuntime7 : IVBERuntime
     {
-        private const string DllName = "vbe7.dll";
+        private const string _dllName = "vbe7.dll";
 
-        [DllImport(DllName)]
+        public string DllName => _dllName;
+
+        [DllImport(_dllName)]
         private static extern int rtcDoEvents();
         public int DoEvents()
         {
             return rtcDoEvents();
         }
 
-        [DllImport(DllName)]
+        [DllImport(_dllName, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.R4)]
         private static extern float rtcGetTimer();
-        public float Timer()
+        public float GetTimer()
         {
             return rtcGetTimer();
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcGetDateVar(out object retVal);
+        public void GetDateVar(out object retval)
+        {
+            rtcGetDateVar(out retval);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcGetPresentDate(out object retVal);
+        public void GetPresentDate(out object retVal)
+        {
+            rtcGetPresentDate(out retVal);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern double rtcShell(IntPtr pathname, short windowstyle);
+        public double Shell(IntPtr pathname, short windowstyle)
+        {
+            return rtcShell(pathname, windowstyle);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcGetTimeVar(out object retVal);
+        public void GetTimeVar(out object retVal)
+        {
+            rtcGetTimeVar(out retVal);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcChangeDir(IntPtr path);
+        public void ChangeDir(IntPtr path)
+        {
+            rtcChangeDir(path);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcChangeDrive(IntPtr driveletter);
+        public void ChangeDrive(IntPtr driveletter)
+        {
+            rtcChangeDrive(driveletter);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcKillFiles(IntPtr pathname);
+        public void KillFiles(IntPtr pathname)
+        {
+            rtcKillFiles(pathname);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcMakeDir(IntPtr path);
+        public void MakeDir(IntPtr path)
+        {
+            rtcMakeDir(path);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcRemoveDir(IntPtr path);
+        public void RemoveDir(IntPtr path)
+        {
+            rtcRemoveDir(path);
+        }
+
+        [DllImport(_dllName, SetLastError = true)]
+        private static extern void rtcBeep();
+        public void Beep()
+        {
+            rtcBeep();
         }
     }
 }

--- a/Rubberduck.VBEEditor/VBERuntime/VBERuntimeAccessor.cs
+++ b/Rubberduck.VBEEditor/VBERuntime/VBERuntimeAccessor.cs
@@ -48,7 +48,7 @@ namespace Rubberduck.VBEditor.VBERuntime
             try
             {
                 runtime = new VBERuntime7();
-                runtime.Timer();
+                runtime.GetTimer();
                 _version = DllVersion.Vbe7;
             }
             catch
@@ -56,7 +56,7 @@ namespace Rubberduck.VBEditor.VBERuntime
                 try
                 {
                     runtime = new VBERuntime6();
-                    runtime.Timer();
+                    runtime.GetTimer();
                     _version = DllVersion.Vbe6;
                 }
                 catch
@@ -69,14 +69,66 @@ namespace Rubberduck.VBEditor.VBERuntime
             return _version != DllVersion.Unknown ? runtime : null;
         }
 
-        public float Timer()
+        public string DllName => _runtime.DllName;
+
+        public float GetTimer()
         {
-            return _runtime.Timer();
+            return _runtime.GetTimer();
+        }
+
+        public void GetDateVar(out object retval)
+        {
+            _runtime.GetDateVar(out retval);
+        }
+
+        public void GetPresentDate(out object retVal)
+        {
+            _runtime.GetPresentDate(out retVal);
+        }
+
+        public double Shell(IntPtr pathname, short windowstyle)
+        {
+            return _runtime.Shell(pathname, windowstyle);
+        }
+
+        public void GetTimeVar(out object retVal)
+        {
+            _runtime.GetTimeVar(out retVal);
+        }
+
+        public void ChangeDir(IntPtr path)
+        {
+            _runtime.ChangeDir(path);
+        }
+
+        public void ChangeDrive(IntPtr driveletter)
+        {
+            _runtime.ChangeDrive(driveletter);
+        }
+
+        public void KillFiles(IntPtr pathname)
+        {
+            _runtime.KillFiles(pathname);
+        }
+
+        public void MakeDir(IntPtr path)
+        {
+            _runtime.MakeDir(path);
+        }
+
+        public void RemoveDir(IntPtr path)
+        {
+            _runtime.RemoveDir(path);
         }
 
         public int DoEvents()
         {
             return _runtime.DoEvents();
+        }
+
+        public void Beep()
+        {
+            _runtime.Beep();
         }
     }
 }

--- a/Rubberduck.VBEEditor/VbeRuntime/IVbeNativeApi.cs
+++ b/Rubberduck.VBEEditor/VbeRuntime/IVbeNativeApi.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 
-namespace Rubberduck.VBEditor.VBERuntime
+namespace Rubberduck.VBEditor.VbeRuntime
 {
-    public interface IVBERuntime
+    public interface IVbeNativeApi
     {
         string DllName { get; }
         int DoEvents();

--- a/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApi6.cs
+++ b/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApi6.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace Rubberduck.VBEditor.VBERuntime
+namespace Rubberduck.VBEditor.VbeRuntime
 {
-    internal class VBERuntime7 : IVBERuntime
+    internal class VbeNativeApi6 : IVbeNativeApi
     {
-        private const string _dllName = "vbe7.dll";
+        private const string _dllName = "vbe6.dll";
 
         public string DllName => _dllName;
 

--- a/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApi7.cs
+++ b/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApi7.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace Rubberduck.VBEditor.VBERuntime
+namespace Rubberduck.VBEditor.VbeRuntime
 {
-    internal class VBERuntime6 : IVBERuntime
+    internal class VbeNativeApi7 : IVbeNativeApi
     {
-        private const string _dllName = "vbe6.dll";
+        private const string _dllName = "vbe7.dll";
 
         public string DllName => _dllName;
 

--- a/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApiAccessor.cs
+++ b/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApiAccessor.cs
@@ -1,25 +1,25 @@
 ﻿using System;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
-namespace Rubberduck.VBEditor.VBERuntime
+namespace Rubberduck.VBEditor.VbeRuntime
 {
-    public class VBERuntimeAccessor : IVBERuntime
+    public class VbeNativeApiAccessor : IVbeNativeApi
     {
         private static DllVersion _version;
-        private readonly IVBERuntime _runtime;
+        private readonly IVbeNativeApi _runtime;
         
-        static VBERuntimeAccessor()
+        static VbeNativeApiAccessor()
         {
             _version = DllVersion.Unknown;
         }
         
-        public VBERuntimeAccessor(IVBE vbe)
+        public VbeNativeApiAccessor(IVBE vbe)
         {
             if (_version == DllVersion.Unknown)
             {
                 try
                 {
-                    _version = VBEDllVersion.GetCurrentVersion(vbe);
+                    _version = VbeDllVersion.GetCurrentVersion(vbe);
                 }
                 catch
                 {
@@ -29,25 +29,25 @@ namespace Rubberduck.VBEditor.VBERuntime
             _runtime = InitializeRuntime();
         }
 
-        private static IVBERuntime InitializeRuntime()
+        private static IVbeNativeApi InitializeRuntime()
         {
             switch (_version)
             {
                 case DllVersion.Vbe7:
-                    return new VBERuntime7();
+                    return new VbeNativeApi7();
                 case DllVersion.Vbe6:
-                    return new VBERuntime6();
+                    return new VbeNativeApi6();
                 default:
                     return DetermineVersion();
             }
         }
 
-        private static IVBERuntime DetermineVersion()
+        private static IVbeNativeApi DetermineVersion()
         {
-            IVBERuntime runtime;
+            IVbeNativeApi runtime;
             try
             {
-                runtime = new VBERuntime7();
+                runtime = new VbeNativeApi7();
                 runtime.GetTimer();
                 _version = DllVersion.Vbe7;
             }
@@ -55,7 +55,7 @@ namespace Rubberduck.VBEditor.VBERuntime
             {
                 try
                 {
-                    runtime = new VBERuntime6();
+                    runtime = new VbeNativeApi6();
                     runtime.GetTimer();
                     _version = DllVersion.Vbe6;
                 }

--- a/Rubberduck.VBEEditor/WindowsApi/SubclassManager.cs
+++ b/Rubberduck.VBEEditor/WindowsApi/SubclassManager.cs
@@ -86,7 +86,7 @@ namespace Rubberduck.VBEditor.WindowsApi
         private static void AssociateCodePane(object sender, EventArgs eventArgs)
         {
             var subclass = (CodePaneSubclass)sender;
-            subclass.VbeObject = VBENativeServices.GetCodePaneFromHwnd(subclass.Hwnd);
+            subclass.VbeObject = VbeNativeServices.GetCodePaneFromHwnd(subclass.Hwnd);
             SubclassLogger.Trace($"CodePane subclass for hWnd 0x{subclass.Hwnd.ToInt64():X8} associated itself with its VBE object.");
         }
 

--- a/RubberduckTests/Settings/GeneralSettingsTests.cs
+++ b/RubberduckTests/Settings/GeneralSettingsTests.cs
@@ -6,8 +6,7 @@ using Rubberduck.UI.Settings;
 using GeneralSettings = Rubberduck.Settings.GeneralSettings;
 using Rubberduck.Common;
 using Moq;
-using Rubberduck.UI;
-using Rubberduck.VBEditor.VBERuntime.Settings;
+using Rubberduck.VBEditor.VbeRuntime.Settings;
 using System;
 using Rubberduck.Interaction;
 
@@ -26,9 +25,9 @@ namespace RubberduckTests.Settings
             return new Mock<IMessageBox>();
         }
 
-        private Mock<IVBESettings> GetVBESettingsMock()
+        private Mock<IVbeSettings> GetVbeSettingsMock()
         {
-            return new Mock<IVBESettings>();
+            return new Mock<IVbeSettings>();
         }
 
         private Configuration GetDefaultConfig()
@@ -83,7 +82,7 @@ namespace RubberduckTests.Settings
         public void SaveConfigWorks()
         {
             var customConfig = GetNondefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(customConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object, new List<Type>());
+            var viewModel = new GeneralSettingsViewModel(customConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVbeSettingsMock().Object, new List<Type>());
 
             var config = GetDefaultConfig();
             viewModel.UpdateConfig(config);
@@ -101,7 +100,7 @@ namespace RubberduckTests.Settings
         [Test]
         public void SetDefaultsWorks()
         {
-            var viewModel = new GeneralSettingsViewModel(GetNondefaultConfig(), GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object, new List<Type>());
+            var viewModel = new GeneralSettingsViewModel(GetNondefaultConfig(), GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVbeSettingsMock().Object, new List<Type>());
 
             var defaultConfig = GetDefaultConfig();
             viewModel.SetToDefaults(defaultConfig);
@@ -120,7 +119,7 @@ namespace RubberduckTests.Settings
         public void LanguageIsSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object, new List<Type>());
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVbeSettingsMock().Object, new List<Type>());
 
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.Language, viewModel.SelectedLanguage);
         }
@@ -130,7 +129,7 @@ namespace RubberduckTests.Settings
         public void HotkeysAreSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object, new List<Type>());
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVbeSettingsMock().Object, new List<Type>());
 
             Assert.IsTrue(defaultConfig.UserSettings.HotkeySettings.Settings.SequenceEqual(viewModel.Hotkeys));
         }
@@ -140,7 +139,7 @@ namespace RubberduckTests.Settings
         public void AutoSaveEnabledIsSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object, new List<Type>());
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVbeSettingsMock().Object, new List<Type>());
 
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.IsAutoSaveEnabled, viewModel.AutoSaveEnabled);
         }
@@ -150,7 +149,7 @@ namespace RubberduckTests.Settings
         public void AutoSavePeriodIsSetInCtor()
         {
             var defaultConfig = GetDefaultConfig();
-            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVBESettingsMock().Object, new List<Type>());
+            var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object, GetMessageBoxMock().Object, GetVbeSettingsMock().Object, new List<Type>());
 
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.AutoSavePeriod, viewModel.AutoSavePeriod);
         }

--- a/RubberduckTests/VBE/VBESettingsTests.cs
+++ b/RubberduckTests/VBE/VBESettingsTests.cs
@@ -2,14 +2,14 @@
 using Moq;
 using NUnit.Framework;
 using Rubberduck.VBEditor.Utility;
-using Rubberduck.VBEditor.VBERuntime;
-using Rubberduck.VBEditor.VBERuntime.Settings;
+using Rubberduck.VBEditor.VbeRuntime;
+using Rubberduck.VBEditor.VbeRuntime.Settings;
 using RubberduckTests.Mocks;
 
 namespace RubberduckTests.VBE
 {
     [TestFixture]
-    public class VBESettingsTests
+    public class VbeSettingsTests
     {
         private const string Vbe7SettingPath = @"HKEY_CURRENT_USER\Software\Microsoft\VBA\7.0\Common";
         private const string Vbe6SettingPath = @"HKEY_CURRENT_USER\Software\Microsoft\VBA\6.0\Common";
@@ -29,7 +29,7 @@ namespace RubberduckTests.VBE
             var registry = GetRegistryMock();
 
             vbe.SetupGet(s => s.Version).Returns("6.00");
-            var settings = new VBESettings(vbe.Object, registry.Object);
+            var settings = new VbeSettings(vbe.Object, registry.Object);
 
             Assert.AreEqual(DllVersion.Vbe6, settings.Version);
         }
@@ -42,7 +42,7 @@ namespace RubberduckTests.VBE
             var registry = GetRegistryMock();
 
             vbe.SetupGet(s => s.Version).Returns("7.00");
-            var settings = new VBESettings(vbe.Object, registry.Object);
+            var settings = new VbeSettings(vbe.Object, registry.Object);
 
             Assert.AreEqual(DllVersion.Vbe7, settings.Version);
         }
@@ -55,7 +55,7 @@ namespace RubberduckTests.VBE
             var registry = GetRegistryMock();
 
             vbe.SetupGet(s => s.Version).Returns("foo");
-            var settings = new VBESettings(vbe.Object, registry.Object);
+            var settings = new VbeSettings(vbe.Object, registry.Object);
 
             Assert.AreEqual(DllVersion.Unknown, settings.Version);
         }
@@ -68,7 +68,7 @@ namespace RubberduckTests.VBE
             var registry = GetRegistryMock();
 
             vbe.SetupGet(s => s.Version).Returns((string)null);
-            var settings = new VBESettings(vbe.Object, registry.Object);
+            var settings = new VbeSettings(vbe.Object, registry.Object);
 
             Assert.IsTrue(settings.Version == DllVersion.Unknown);
         }
@@ -84,7 +84,7 @@ namespace RubberduckTests.VBE
             registry.Setup(s => s.SetValue(Vbe7SettingPath, "CompileOnDemand", true, RegistryValueKind.DWord));
             registry.Setup(s => s.GetValue(Vbe7SettingPath, "CompileOnDemand", DWordFalseValue)).Returns(DWordTrueValue);
 
-            var settings = new VBESettings(vbe.Object, registry.Object);
+            var settings = new VbeSettings(vbe.Object, registry.Object);
 
             settings.CompileOnDemand = true;
             Assert.IsTrue(settings.CompileOnDemand);
@@ -101,7 +101,7 @@ namespace RubberduckTests.VBE
             registry.Setup(s => s.SetValue(Vbe7SettingPath, "BackGroundCompile", false, RegistryValueKind.DWord));
             registry.Setup(s => s.GetValue(Vbe7SettingPath, "BackGroundCompile", DWordFalseValue)).Returns(DWordFalseValue);
 
-            var settings = new VBESettings(vbe.Object, registry.Object);
+            var settings = new VbeSettings(vbe.Object, registry.Object);
             
             settings.BackGroundCompile = false;
             Assert.IsTrue(settings.BackGroundCompile == false);


### PR DESCRIPTION
Closes #4464 

This fixes two issues:

1) Since csproj format change, EasyHook was apparently broken because certain files from the `content` folder wasn't being copied over to the output directory. This now does and thus enable use of stubs/fakes.

2) Originally, stubs/fakes had a hard-coded reference to `vbe7` library. This wouldn't work for those rocking it old skool with VB6 or pre-2010 Office. This makes use of the existing `IVBERuntime` implementations, which has a `VBERuntimeAccessor` to abstract the loading of correct VBA.dll file. Accordingly the extern declarations were moved out of the stubs/fakes into the `VBERuntime6` and `VBERuntime7`. implementations. 


This unfortunately means the stubs & fakes now depend on `VBERuntime` which in turns depends on the `VBE`. Because stubs & fakes are not part of CW (and they never should be) we cannot dependency-inject them. Furthermore, we do not want to change the interfaces nor existing unit tests code. For that reason, we create `VbeProvider` (note the consistency in naming, har har) service locator which is internal to the `Rubberduck.Main` project and used only to support the stubs & fakes. I've put in a large comment about how evil it is, and that it should be limited in scope.