### PR TITLE
Add Inspection for members that can return Nothing. Ref #4440

### DIFF
--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Abstract/NodeBase.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Abstract/NodeBase.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using Antlr4.Runtime.Tree;
+using Rubberduck.Parsing.Symbols;
+
+namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
+{
+    public abstract class NodeBase : INode
+    {
+        protected NodeBase(IParseTree tree)
+        {
+            Children = new List<INode>().ToImmutableList();
+            ParseTree = tree;
+        }
+
+        public int SortOrder { get; set; }
+        public ImmutableList<INode> Children { get; set; }
+        public INode Parent { get; set; }
+        public IParseTree ParseTree { get; }
+        public Declaration Declaration { get; set; }
+        public IdentifierReference Reference { get; set; }
+    }
+}

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/INode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/INode.cs
@@ -1,5 +1,6 @@
 ﻿using Rubberduck.Parsing.Symbols;
 using System.Collections.Immutable;
+using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
@@ -8,7 +9,7 @@ namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
         int SortOrder { get; set; }
         ImmutableList<INode> Children { get; set; }
         INode Parent { get; set; }
-
+        IParseTree ParseTree { get; }
         Declaration Declaration { get; set; }
         IdentifierReference Reference { get; set; }
     }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/AssignmentNode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/AssignmentNode.cs
@@ -1,21 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using Rubberduck.Parsing.Symbols;
+﻿using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
-    public class AssignmentNode : INode
+    public class AssignmentNode : NodeBase
     {
-        public AssignmentNode()
-        {
-            Children = new List<INode>().ToImmutableList();
-        }
-
-        public int SortOrder { get; set; }
-        public ImmutableList<INode> Children { get; set; }
-        public INode Parent { get; set; }
-
-        public Declaration Declaration { get; set; }
-        public IdentifierReference Reference { get; set; }
+        public AssignmentNode(IParseTree tree) : base(tree) { }
     }
 }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/BlockNode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/BlockNode.cs
@@ -1,21 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using Rubberduck.Parsing.Symbols;
+﻿using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
-    public class BlockNode : INode
+    public class BlockNode : NodeBase
     {
-        public BlockNode()
-        {
-            Children = new List<INode>().ToImmutableList();
-        }
-
-        public int SortOrder { get; set; }
-        public ImmutableList<INode> Children { get; set; }
-        public INode Parent { get; set; }
-
-        public Declaration Declaration { get; set; }
-        public IdentifierReference Reference { get; set; }
+        public BlockNode(IParseTree tree) : base(tree) { }
     }
 }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/BranchNode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/BranchNode.cs
@@ -1,21 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using Rubberduck.Parsing.Symbols;
+﻿using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
-    public class BranchNode : IBranchNode
+    public class BranchNode : NodeBase, IBranchNode
     {
-        public BranchNode()
-        {
-            Children = new List<INode>().ToImmutableList();
-        }
-
-        public int SortOrder { get; set; }
-        public ImmutableList<INode> Children { get; set; }
-        public INode Parent { get; set; }
-
-        public Declaration Declaration { get; set; }
-        public IdentifierReference Reference { get; set; }
+        public BranchNode(IParseTree tree) : base(tree) { }
     }
 }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/DeclarationNode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/DeclarationNode.cs
@@ -1,21 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using Rubberduck.Parsing.Symbols;
+﻿using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
-    public class DeclarationNode : INode
+    public class DeclarationNode : NodeBase
     {
-        public DeclarationNode()
-        {
-            Children = new List<INode>().ToImmutableList();
-        }
-
-        public int SortOrder { get; set; }
-        public ImmutableList<INode> Children { get; set; }
-        public INode Parent { get; set; }
-
-        public Declaration Declaration { get; set; }
-        public IdentifierReference Reference { get; set; }
+        public DeclarationNode(IParseTree tree) : base(tree) { }
     }
 }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/GenericNode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/GenericNode.cs
@@ -1,21 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using Rubberduck.Parsing.Symbols;
+﻿using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
-    public class GenericNode : INode
+    public class GenericNode : NodeBase
     {
-        public GenericNode()
-        {
-            Children = new List<INode>().ToImmutableList();
-        }
-
-        public int SortOrder { get; set; }
-        public ImmutableList<INode> Children { get; set; }
-        public INode Parent { get; set; }
-
-        public Declaration Declaration { get; set; }
-        public IdentifierReference Reference { get; set; }
+        public GenericNode(IParseTree tree) : base(tree) { }
     }
 }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/LoopNode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/LoopNode.cs
@@ -1,21 +1,9 @@
-﻿using Rubberduck.Parsing.Symbols;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
-    public class LoopNode : ILoopNode
+    public class LoopNode : NodeBase, ILoopNode
     {
-        public LoopNode()
-        {
-            Children = new List<INode>().ToImmutableList();
-        }
-
-        public int SortOrder { get; set; }
-        public ImmutableList<INode> Children { get; set; }
-        public INode Parent { get; set; }
-
-        public Declaration Declaration { get; set; }
-        public IdentifierReference Reference { get; set; }
+        public LoopNode(IParseTree tree) : base(tree) { }
     }
 }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/ReferenceNode.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Nodes/Implementations/ReferenceNode.cs
@@ -1,21 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using Rubberduck.Parsing.Symbols;
+﻿using Antlr4.Runtime.Tree;
 
 namespace Rubberduck.Inspections.CodePathAnalysis.Nodes
 {
-    public class ReferenceNode : INode
+    public class ReferenceNode : NodeBase
     {
-        public ReferenceNode()
-        {
-            Children = new List<INode>().ToImmutableList();
-        }
-
-        public int SortOrder { get; set; }
-        public ImmutableList<INode> Children { get; set; }
-        public INode Parent { get; set; }
-
-        public Declaration Declaration { get; set; }
-        public IdentifierReference Reference { get; set; }
+        public ReferenceNode(IParseTree tree) : base(tree) { }
     }
 }

--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Walker.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Walker.cs
@@ -5,6 +5,7 @@ using Rubberduck.Parsing.Symbols;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Antlr4.Runtime;
 
 namespace Rubberduck.Inspections.CodePathAnalysis
 {
@@ -19,7 +20,7 @@ namespace Rubberduck.Inspections.CodePathAnalysis
                 case VBAParser.ForEachStmtContext _:
                 case VBAParser.WhileWendStmtContext _:
                 case VBAParser.DoLoopStmtContext _:
-                    node = new LoopNode();
+                    node = new LoopNode(tree);
                     break;
                 case VBAParser.IfStmtContext _:
                 case VBAParser.ElseBlockContext _:
@@ -28,16 +29,16 @@ namespace Rubberduck.Inspections.CodePathAnalysis
                 case VBAParser.SingleLineElseClauseContext _:
                 case VBAParser.CaseClauseContext _:
                 case VBAParser.CaseElseClauseContext _:
-                    node = new BranchNode();
+                    node = new BranchNode(tree);
                     break;
                 case VBAParser.BlockContext _:
-                    node = new BlockNode();
+                    node = new BlockNode(tree);
                     break;
             }
 
             if (declaration.Context == tree)
             {
-                node = new DeclarationNode
+                node = new DeclarationNode(tree)
                 {
                     Declaration = declaration
                 };
@@ -48,14 +49,14 @@ namespace Rubberduck.Inspections.CodePathAnalysis
             {
                 if (reference.IsAssignment)
                 {
-                    node = new AssignmentNode
+                    node = new AssignmentNode(tree)
                     {
                         Reference = reference
                     };
                 }
                 else
                 {
-                    node = new ReferenceNode
+                    node = new ReferenceNode(tree)
                     {
                         Reference = reference
                     };
@@ -64,7 +65,7 @@ namespace Rubberduck.Inspections.CodePathAnalysis
 
             if (node == null)
             {
-                node = new GenericNode();
+                node = new GenericNode(tree);
             }
 
             var children = new List<INode>();

--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/MemberAccessMayReturnNothingInspectionBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/MemberAccessMayReturnNothingInspectionBase.cs
@@ -28,7 +28,7 @@ namespace Rubberduck.Inspections.Abstract
             }
 
             var output = new List<IInspectionResult>();
-            foreach (var reference in interesting)
+            foreach (var reference in interesting.Where(use => !IsIgnoringInspectionResultFor(use, AnnotationName)))
             {
                 var access = reference.Context.GetAncestor<VBAParser.MemberAccessExprContext>();
                 var usageContext = access.Parent is VBAParser.IndexExprContext

--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/MemberAccessMayReturnNothingInspectionBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/MemberAccessMayReturnNothingInspectionBase.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime.Tree;
+using Rubberduck.Inspections.CodePathAnalysis;
+using Rubberduck.Inspections.CodePathAnalysis.Nodes;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+
+namespace Rubberduck.Inspections.Abstract
+{
+   public abstract class MemberAccessMayReturnNothingInspectionBase : InspectionBase
+    {
+        protected MemberAccessMayReturnNothingInspectionBase(RubberduckParserState state) : base(state) { }
+
+        public abstract List<Declaration> MembersUnderTest { get; }
+        public abstract string ResultTemplate { get; }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            var interesting = MembersUnderTest.SelectMany(member => member.References).ToList();
+            if (!interesting.Any())
+            {
+                return Enumerable.Empty<IInspectionResult>();
+            }
+
+            var output = new List<IInspectionResult>();
+            foreach (var reference in interesting)
+            {
+                var access = reference.Context.GetAncestor<VBAParser.MemberAccessExprContext>();
+                var usageContext = access.Parent is VBAParser.IndexExprContext
+                    ? access.Parent.Parent
+                    : access.Parent;
+
+                var setter = usageContext is VBAParser.LExprContext lexpr && lexpr.Parent is VBAParser.SetStmtContext
+                    ? lexpr.Parent
+                    : null;
+
+                if (setter is null)
+                {
+                    if (usageContext is VBAParser.MemberAccessExprContext || !ContextIsNothingTest(usageContext))
+                    {
+                        output.Add(new IdentifierReferenceInspectionResult(this,
+                            string.Format(ResultTemplate,
+                                $"{reference.Declaration.ParentDeclaration.IdentifierName}.{reference.IdentifierName}"),
+                            State, reference));
+                    }
+                    continue;                   
+                }
+
+                var assignedTo = Declarations.SelectMany(decl => decl.References).SingleOrDefault(assign =>
+                    assign.IsAssignment && (assign.Context.GetAncestor<VBAParser.SetStmtContext>()?.Equals(setter) ?? false));
+                if (assignedTo is null)
+                {
+                    continue;                    
+                }
+
+                var tree = new Walker().GenerateTree(assignedTo.Declaration.ParentScopeDeclaration.Context, assignedTo.Declaration);
+                var firstUse = GetReferenceNodes(tree).FirstOrDefault();
+                if (firstUse is null || ContextIsNothingTest(firstUse.Reference.Context.Parent))
+                {
+                    continue;
+                }
+
+                output.Add(new IdentifierReferenceInspectionResult(this,
+                    string.Format(ResultTemplate,
+                        $"{reference.Declaration.ParentDeclaration.IdentifierName}.{reference.IdentifierName}"),
+                    State, reference));
+            }
+
+            return output;
+        }
+
+        private bool ContextIsNothingTest(IParseTree context)
+        {
+            return context is VBAParser.LExprContext &&
+                   context.Parent is VBAParser.RelationalOpContext comparison &&
+                   comparison.IS() != null
+                   && comparison.GetDescendent<VBAParser.ObjectLiteralIdentifierContext>() != null;
+        }
+
+        private IEnumerable<INode> GetReferenceNodes(INode node)
+        {
+            if (node is ReferenceNode && node.Reference != null)
+            {
+                yield return node;
+            }
+            
+            foreach (var child in node.Children)
+            {
+                foreach (var childNode in GetReferenceNodes(child))
+                {
+                    yield return childNode;
+                }
+            }
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
@@ -4,7 +4,6 @@ using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Inspections.CodePathAnalysis;
 using Rubberduck.Parsing.Symbols;
-using Rubberduck.Inspections.CodePathAnalysis.Nodes;
 using Rubberduck.Inspections.CodePathAnalysis.Extensions;
 using System.Linq;
 using Rubberduck.Inspections.Results;
@@ -29,41 +28,12 @@ namespace Rubberduck.Inspections.Concrete
             {
                 var tree = _walker.GenerateTree(variable.ParentScopeDeclaration.Context, variable);
 
-                nodes.AddRange(GetIdentifierReferences(tree, variable));
+                nodes.AddRange(tree.GetIdentifierReferences());
             }
 
             return nodes
                 .Select(issue => new IdentifierReferenceInspectionResult(this, Description, State, issue))
                 .ToList();
-        }
-
-        private List<IdentifierReference> GetIdentifierReferences(INode node, Declaration declaration)
-        {
-            var nodes = new List<IdentifierReference>();
-
-            var blockNodes = node.GetNodes(new[] { typeof(BlockNode) });
-            foreach (var block in blockNodes)
-            {
-                INode lastNode = default;
-                foreach (var flattenedNode in block.GetFlattenedNodes(new[] { typeof(GenericNode), typeof(BlockNode) }))
-                {
-                    if (flattenedNode is AssignmentNode &&
-                        lastNode is AssignmentNode)
-                    {
-                        nodes.Add(lastNode.Reference);
-                    }
-
-                    lastNode = flattenedNode;
-                }
-
-                if (lastNode is AssignmentNode &&
-                    block.Children[0].GetFirstNode(new[] { typeof(GenericNode) }) is DeclarationNode)
-                {
-                    nodes.Add(lastNode.Reference);
-                }
-            }
-
-            return nodes;
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MemberAccessMayReturnNothingInspection/ExcelMemberMayReturnNothingInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MemberAccessMayReturnNothingInspection/ExcelMemberMayReturnNothingInspection.cs
@@ -25,6 +25,6 @@ namespace Rubberduck.Inspections.Concrete
             .Where(decl => decl.ProjectName.Equals("Excel") && ExcelMembers.Any(member => decl.QualifiedName.ToString().EndsWith(member)))
             .ToList();
 
-        public override string ResultTemplate => Description; //InspectionResults.ExcelMemberMayReturnNothingInspection;
+        public override string ResultTemplate => InspectionResults.ExcelMemberMayReturnNothingInspection;
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MemberAccessMayReturnNothingInspection/ExcelMemberMayReturnNothingInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MemberAccessMayReturnNothingInspection/ExcelMemberMayReturnNothingInspection.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Parsing.Inspections;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+
+namespace Rubberduck.Inspections.Concrete
+{
+    [RequiredLibrary("Excel")]
+    public class ExcelMemberMayReturnNothingInspection : MemberAccessMayReturnNothingInspectionBase
+    {
+        public ExcelMemberMayReturnNothingInspection(RubberduckParserState state) : base(state) { }
+
+        private static readonly List<string> ExcelMembers = new List<string>
+        {
+            "Range.Find",
+            "Range.FindNext",
+            "Range.FindPrevious"
+        };
+
+        public override List<Declaration> MembersUnderTest => BuiltInDeclarations
+            .Where(decl => decl.ProjectName.Equals("Excel") && ExcelMembers.Any(member => decl.QualifiedName.ToString().EndsWith(member)))
+            .ToList();
+
+        public override string ResultTemplate => Description; //InspectionResults.ExcelMemberMayReturnNothingInspection;
+    }
+}

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -223,7 +223,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A Function or Property returning a reference type that can be &apos;Nothing&apos; should not have the return value used with a test for &apos;Is Nothing&apos;. If the member does not return a valid object, attempting to use the return value will result in a run-time error 91 - &quot;Object variable or With block variable not set&quot;..
+        ///   Looks up a localized string similar to A procedure that returns an object may return &apos;Nothing&apos;. That will cause a runtime error 91 - &quot;Object variable or With block variable not set&quot; on subsequent member access. Perform an &apos;Is Nothing&apos; check after the &apos;Set&apos; assignment to guard against runtime errors..
         /// </summary>
         public static string ExcelMemberMayReturnNothingInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.Resources.Inspections {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class InspectionInfo {
+    public class InspectionInfo {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Rubberduck.Resources.Inspections.InspectionInfo", typeof(InspectionInfo).Assembly);
@@ -51,7 +51,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The Excel Application object does not implement the WorksheetFunction interface directly. All calls made to WorksheetFunction members are handled as late bound and errors in the called member will be returned wrapped in a Variant of VbVarType.vbError. This makes errors un-trappable with error handlers and adds a performance penalty in comparison to early bound calls. Consider calling Application.WorksheetFunction explicitly. Note: If this call generated errors in the past, those errors were ignored. If appl [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string ApplicationWorksheetFunctionInspection {
+        public static string ApplicationWorksheetFunctionInspection {
             get {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionInspection", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter is passed by value, but is assigned a new value/reference. Consider making a local copy instead if the caller isn&apos;t supposed to know the new value. If the caller should see the new value, the parameter should be passed ByRef instead, and you have a bug..
         /// </summary>
-        internal static string AssignedByValParameterInspection {
+        public static string AssignedByValParameterInspection {
             get {
                 return ResourceManager.GetString("AssignedByValParameterInspection", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
         /// </summary>
-        internal static string AssignmentNotUsedInspection {
+        public static string AssignmentNotUsedInspection {
             get {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A member is assigned True/False in different branches of an if statement with no other statements in the conditional. Use the condition directly to the member instead..
         /// </summary>
-        internal static string BooleanAssignedInIfElseInspection {
+        public static string BooleanAssignedInIfElseInspection {
             get {
                 return ResourceManager.GetString("BooleanAssignedInIfElseInspection", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Rubberduck could not find any reference to constant. Consider removing the unused declaration..
         /// </summary>
-        internal static string ConstantNotUsedInspection {
+        public static string ConstantNotUsedInspection {
             get {
                 return ResourceManager.GetString("ConstantNotUsedInspection", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider naming your VBA project..
         /// </summary>
-        internal static string DefaultProjectNameInspection {
+        public static string DefaultProjectNameInspection {
             get {
                 return ResourceManager.GetString("DefaultProjectNameInspection", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Using the &apos;Def[Type]&apos; statement leads to specifying types by using a prefix. This style of naming is heavily discouraged and should be avoided..
         /// </summary>
-        internal static string DefTypeStatementInspection {
+        public static string DefTypeStatementInspection {
             get {
                 return ResourceManager.GetString("DefTypeStatementInspection", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An annotation is specified multiple times, but is intended to be specified only once..
         /// </summary>
-        internal static string DuplicatedAnnotationInspection {
+        public static string DuplicatedAnnotationInspection {
             get {
                 return ResourceManager.GetString("DuplicatedAnnotationInspection", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Case&apos; block without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        internal static string EmptyCaseBlockInspection {
+        public static string EmptyCaseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyCaseBlockInspection", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Do...While&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        internal static string EmptyDoWhileBlockInspection {
+        public static string EmptyDoWhileBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyDoWhileBlockInspection", resourceCulture);
             }
@@ -153,7 +153,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Else&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        internal static string EmptyElseBlockInspection {
+        public static string EmptyElseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyElseBlockInspection", resourceCulture);
             }
@@ -162,7 +162,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;For Each...Next&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        internal static string EmptyForEachBlockInspection {
+        public static string EmptyForEachBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForEachBlockInspection", resourceCulture);
             }
@@ -171,7 +171,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;For...Next&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        internal static string EmptyForLoopBlockInspection {
+        public static string EmptyForLoopBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForLoopBlockInspection", resourceCulture);
             }
@@ -180,7 +180,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty conditional branch without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        internal static string EmptyIfBlockInspection {
+        public static string EmptyIfBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyIfBlockInspection", resourceCulture);
             }
@@ -189,7 +189,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty modules and classes either point to not yet implemented functionality or represent unnecessary baggage that can hurt the maintainability of a project..
         /// </summary>
-        internal static string EmptyModuleInspection {
+        public static string EmptyModuleInspection {
             get {
                 return ResourceManager.GetString("EmptyModuleInspection", resourceCulture);
             }
@@ -198,7 +198,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The built-in constant &apos;vbNullString&apos; is a null string pointer taking up 0 bytes of memory, that unambiguously conveys the intent of an empty string..
         /// </summary>
-        internal static string EmptyStringLiteralInspection {
+        public static string EmptyStringLiteralInspection {
             get {
                 return ResourceManager.GetString("EmptyStringLiteralInspection", resourceCulture);
             }
@@ -207,7 +207,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Loop&apos; block without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        internal static string EmptyWhileWendBlockInspection {
+        public static string EmptyWhileWendBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyWhileWendBlockInspection", resourceCulture);
             }
@@ -216,7 +216,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider exposing a property instead..
         /// </summary>
-        internal static string EncapsulatePublicFieldInspection {
+        public static string EncapsulatePublicFieldInspection {
             get {
                 return ResourceManager.GetString("EncapsulatePublicFieldInspection", resourceCulture);
             }
@@ -225,7 +225,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A Function or Property returning a reference type that can be &apos;Nothing&apos; should not have the return value used with a test for &apos;Is Nothing&apos;. If the member does not return a valid object, attempting to use the return value will result in a run-time error 91 - &quot;Object variable or With block variable not set&quot;..
         /// </summary>
-        internal static string ExcelMemberMayReturnNothingInspection {
+        public static string ExcelMemberMayReturnNothingInspection {
             get {
                 return ResourceManager.GetString("ExcelMemberMayReturnNothingInspection", resourceCulture);
             }
@@ -234,7 +234,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A member is written as a function, but used as a procedure. Unless the function is recursive, consider converting the &apos;Function&apos; into a &apos;Sub&apos;. If the function is recursive, none of its external callers are using the returned value..
         /// </summary>
-        internal static string FunctionReturnValueNotUsedInspection {
+        public static string FunctionReturnValueNotUsedInspection {
             get {
                 return ResourceManager.GetString("FunctionReturnValueNotUsedInspection", resourceCulture);
             }
@@ -243,7 +243,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Bracketed expressions are evaluated by the host application at runtime, which means VBA can&apos;t validate the expression at compile-time. Consider using the host application&apos;s object model instead..
         /// </summary>
-        internal static string HostSpecificExpressionInspection {
+        public static string HostSpecificExpressionInspection {
             get {
                 return ResourceManager.GetString("HostSpecificExpressionInspection", resourceCulture);
             }
@@ -252,7 +252,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Hungarian notation makes code less readable, and is redundant when strongly typed variables and meaningful names are used..
         /// </summary>
-        internal static string HungarianNotationInspection {
+        public static string HungarianNotationInspection {
             get {
                 return ResourceManager.GetString("HungarianNotationInspection", resourceCulture);
             }
@@ -261,7 +261,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An annotation meant to be specified at module level cannot be used to annotate members; annotations meant to be annotate members cannot be used at module level..
         /// </summary>
-        internal static string IllegalAnnotationInspection {
+        public static string IllegalAnnotationInspection {
             get {
                 return ResourceManager.GetString("IllegalAnnotationInspection", resourceCulture);
             }
@@ -270,7 +270,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit references to the active sheet make the code frail and harder to debug. Consider making these references explicit when they&apos;re intended, and prefer working off object references. Ignore if the member call is referring to a type Rubberduck can&apos;t resolve..
         /// </summary>
-        internal static string ImplicitActiveSheetReferenceInspection {
+        public static string ImplicitActiveSheetReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveSheetReferenceInspection", resourceCulture);
             }
@@ -279,7 +279,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit references to the active workbook make the code frail and harder to debug. Consider making these references explicit when they&apos;re intended, and prefer working off object references. Ignore if the member call is referring to a type Rubberduck can&apos;t resolve..
         /// </summary>
-        internal static string ImplicitActiveWorkbookReferenceInspection {
+        public static string ImplicitActiveWorkbookReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveWorkbookReferenceInspection", resourceCulture);
             }
@@ -288,7 +288,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameters are passed by reference unless specified otherwise, which can be confusing and bug-prone. Prefer passing parameters by value, and specify ByRef explicitly when passing parameters by reference..
         /// </summary>
-        internal static string ImplicitByRefModifierInspection {
+        public static string ImplicitByRefModifierInspection {
             get {
                 return ResourceManager.GetString("ImplicitByRefModifierInspection", resourceCulture);
             }
@@ -297,7 +297,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Such assignments look like they are assigning an object variable to a value type on the surface, but they are actually assigning that object&apos;s default member, implicitly. Consider referring to the default member explicitly, for improved readability..
         /// </summary>
-        internal static string ImplicitDefaultMemberAssignmentInspection {
+        public static string ImplicitDefaultMemberAssignmentInspection {
             get {
                 return ResourceManager.GetString("ImplicitDefaultMemberAssignmentInspection", resourceCulture);
             }
@@ -306,7 +306,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module members are public by default, which can be counter-intuitive. Consider specifying explicit access modifiers to avoid ambiguity..
         /// </summary>
-        internal static string ImplicitPublicMemberInspection {
+        public static string ImplicitPublicMemberInspection {
             get {
                 return ResourceManager.GetString("ImplicitPublicMemberInspection", resourceCulture);
             }
@@ -315,7 +315,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Members with a return value implicitly return a &apos;Variant&apos; unless specified otherwise. Consider returning an explicit &apos;Variant&apos; when the return type isn&apos;t known, or specify it explicitly..
         /// </summary>
-        internal static string ImplicitVariantReturnTypeInspection {
+        public static string ImplicitVariantReturnTypeInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantReturnTypeInspection", resourceCulture);
             }
@@ -324,7 +324,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The maximum value of a 16-bit signed integer is 32,767 - using a 32-bit (Long) integer data type where possible can help prevent &apos;Overflow&apos; run-time errors, and is better handled by modern CPUs..
         /// </summary>
-        internal static string IntegerDataTypeInspection {
+        public static string IntegerDataTypeInspection {
             get {
                 return ResourceManager.GetString("IntegerDataTypeInspection", resourceCulture);
             }
@@ -333,7 +333,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to IsMissing is only intended to be called on optional arguments, and will only return correct results if the type of the argument is &apos;Variant&apos; with no explicit default value. All other uses will return &apos;False&apos;..
         /// </summary>
-        internal static string IsMissingOnInappropriateArgumentInspection {
+        public static string IsMissingOnInappropriateArgumentInspection {
             get {
                 return ResourceManager.GetString("IsMissingOnInappropriateArgumentInspection", resourceCulture);
             }
@@ -342,7 +342,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to IsMissing is only intended to be called on arguments of the containing procedure, and almost all other usages will return &apos;False&apos;. Passing any other expression to the function is the equivalent to &apos;VarType({expression}) = vbError&apos;, and in rare circumstances can cause the host application to crash..
         /// </summary>
-        internal static string IsMissingWithNonArgumentParameterInspection {
+        public static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
             }
@@ -351,7 +351,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A line label that is never jumpted to (&apos;GoTo&apos;, &apos;Resume&apos;, ...), serves no purpose. Consider removing it..
         /// </summary>
-        internal static string LineLabelNotUsedInspection {
+        public static string LineLabelNotUsedInspection {
             get {
                 return ResourceManager.GetString("LineLabelNotUsedInspection", resourceCulture);
             }
@@ -360,7 +360,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A member access call is made against an extended interface that Rubberduck couldn&apos;t resolve, or the member couldn&apos;t be found. If VBA cannot resolve the type at run-time, error 438 will be raised. If an equivalent, non-extended interface that Rubberduck can resolve is available, consider using it instead..
         /// </summary>
-        internal static string MemberNotOnInterfaceInspection {
+        public static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
             }
@@ -369,7 +369,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An annotation parameter is missing or incorrectly specified. The correct syntax is : &apos;@Annotation([parameter])\nExample: &apos;@Folder(&quot;Parent.Child&quot;).
         /// </summary>
-        internal static string MissingAnnotationArgumentInspection {
+        public static string MissingAnnotationArgumentInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationArgumentInspection", resourceCulture);
             }
@@ -378,7 +378,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
         /// </summary>
-        internal static string MissingAnnotationInspection {
+        public static string MissingAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
             }
@@ -387,7 +387,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A Rubberduck annotation is specified for a module or member, but the corresponding attribute isn&apos;t present. Module attributes and annotations need to be synchronized..
         /// </summary>
-        internal static string MissingAttributeInspection {
+        public static string MissingAttributeInspection {
             get {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
@@ -396,7 +396,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Public&apos; keyword can only be used at module level; its counterpart &apos;Private&apos; can also only be used at module level. &apos;Dim&apos; however, can be used to declare both procedure and module scope variables. For consistency, it would be preferable to reserve &apos;Dim&apos; for locals, and thus to use &apos;Private&apos; instead of &apos;Dim&apos; at module level..
         /// </summary>
-        internal static string ModuleScopeDimKeywordInspection {
+        public static string ModuleScopeDimKeywordInspection {
             get {
                 return ResourceManager.GetString("ModuleScopeDimKeywordInspection", resourceCulture);
             }
@@ -405,7 +405,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Modules without the &apos;@Folder&apos; annotation cannot receive custom groupings in the Code Explorer. .
         /// </summary>
-        internal static string ModuleWithoutFolderInspection {
+        public static string ModuleWithoutFolderInspection {
             get {
                 return ResourceManager.GetString("ModuleWithoutFolderInspection", resourceCulture);
             }
@@ -414,7 +414,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A module-level variable used only in one procedure should be declared in that procedure..
         /// </summary>
-        internal static string MoveFieldCloserToUsageInspection {
+        public static string MoveFieldCloserToUsageInspection {
             get {
                 return ResourceManager.GetString("MoveFieldCloserToUsageInspection", resourceCulture);
             }
@@ -423,7 +423,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider continuing long signatures between parameters. Splitting a parameter declaration across multiple lines arguably hurts readability..
         /// </summary>
-        internal static string MultilineParameterInspection {
+        public static string MultilineParameterInspection {
             get {
                 return ResourceManager.GetString("MultilineParameterInspection", resourceCulture);
             }
@@ -432,7 +432,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Declaring multiple variables in the same instruction is legal, but should be used sparingly. Consider declaring variables closer to their usage, in a single instruction per declaration..
         /// </summary>
-        internal static string MultipleDeclarationsInspection {
+        public static string MultipleDeclarationsInspection {
             get {
                 return ResourceManager.GetString("MultipleDeclarationsInspection", resourceCulture);
             }
@@ -441,7 +441,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This is likely a bug. The return value of a function or property getter must be assigned before exiting, otherwise the program will not be working with expected results. If a function has no meaningful return value, consider declaring it as a &apos;Sub&apos; procedure instead..
         /// </summary>
-        internal static string NonReturningFunctionInspection {
+        public static string NonReturningFunctionInspection {
             get {
                 return ResourceManager.GetString("NonReturningFunctionInspection", resourceCulture);
             }
@@ -450,7 +450,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to As far as Rubberduck can tell, this variable is an object variable, assigned without the &apos;Set&apos; keyword. This causes run-time error 91 &apos;Object or With block variable not set&apos;..
         /// </summary>
-        internal static string ObjectVariableNotSetInspection {
+        public static string ObjectVariableNotSetInspection {
             get {
                 return ResourceManager.GetString("ObjectVariableNotSetInspection", resourceCulture);
             }
@@ -459,7 +459,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Windows implementations of Visual Basic only support the StdCall calling convention, and use of of the CDecl calling convention is only supported in Macintosh versions of VBA. Use of this keyword in Windows will result in runtime error 49 - &apos;Bad DLL calling convention&apos;. If this procedure is only intended to be used on Macintosh hosts, it should be conditionally compiled..
         /// </summary>
-        internal static string ObsoleteCallingConventionInspection {
+        public static string ObsoleteCallingConventionInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallingConventionInspection", resourceCulture);
             }
@@ -468,7 +468,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Call&apos; statement is no longer required to call procedures, and only exists in the language to support legacy code that required it; it can be safely rewritten to an implicit call..
         /// </summary>
-        internal static string ObsoleteCallStatementInspection {
+        public static string ObsoleteCallStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallStatementInspection", resourceCulture);
             }
@@ -477,7 +477,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Rem&apos; statement only exists in the language to support legacy code that required it; it can be safely replaced with an apostrophe / single-quote comment..
         /// </summary>
-        internal static string ObsoleteCommentSyntaxInspection {
+        public static string ObsoleteCommentSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCommentSyntaxInspection", resourceCulture);
             }
@@ -486,7 +486,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Error&apos; statement only exists in the language to support legacy code that required it; prefer using &apos;Err.Raise&apos; instead..
         /// </summary>
-        internal static string ObsoleteErrorSyntaxInspection {
+        public static string ObsoleteErrorSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteErrorSyntaxInspection", resourceCulture);
             }
@@ -495,7 +495,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Global&apos; keyword only exists in the language to support legacy code that required it; it can be safely replaced with the &apos;Public&apos; modifier..
         /// </summary>
-        internal static string ObsoleteGlobalInspection {
+        public static string ObsoleteGlobalInspection {
             get {
                 return ResourceManager.GetString("ObsoleteGlobalInspection", resourceCulture);
             }
@@ -504,7 +504,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Let&apos; statement only exists in the language to support legacy code that required it; it can be safely removed, since modern VBA does not require that keyword for value assignments..
         /// </summary>
-        internal static string ObsoleteLetStatementInspection {
+        public static string ObsoleteLetStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteLetStatementInspection", resourceCulture);
             }
@@ -513,7 +513,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This member is marked &apos;@Obsolete&apos;. It should no longer be used, there should be a better alternative..
         /// </summary>
-        internal static string ObsoleteMemberUsageInspection {
+        public static string ObsoleteMemberUsageInspection {
             get {
                 return ResourceManager.GetString("ObsoleteMemberUsageInspection", resourceCulture);
             }
@@ -522,7 +522,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Type hint characters only exist in the language to support legacy code that required it; they can be safely replaced in declarations with an &quot;As&quot; type clause that specifies the type explicitly, and they can be omitted in other identifier references..
         /// </summary>
-        internal static string ObsoleteTypeHintInspection {
+        public static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
             }
@@ -531,7 +531,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to On Local Error exists only for compatibility with previous versions of Visual Basic, and all Errors are treated as Local regardless of the Error statement. Use of this keyword inaccurately gives the impression that there is a distinction between types of error handling when there is not..
         /// </summary>
-        internal static string OnLocalErrorInspection {
+        public static string OnLocalErrorInspection {
             get {
                 return ResourceManager.GetString("OnLocalErrorInspection", resourceCulture);
             }
@@ -540,7 +540,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Arrays are typically zero-based. This option changes the default lower boundary for implicitly-sized arrays, which can introduce off-by-one errors if one isn&apos;t cautious..
         /// </summary>
-        internal static string OptionBaseInspection {
+        public static string OptionBaseInspection {
             get {
                 return ResourceManager.GetString("OptionBaseInspection", resourceCulture);
             }
@@ -549,7 +549,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This is the default setting, it does not need to be specified..
         /// </summary>
-        internal static string OptionBaseZeroInspection {
+        public static string OptionBaseZeroInspection {
             get {
                 return ResourceManager.GetString("OptionBaseZeroInspection", resourceCulture);
             }
@@ -558,7 +558,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to VBA will happily compile a typo: use &apos;Option Explicit&apos; to prevent successfully compiling an erroneous program..
         /// </summary>
-        internal static string OptionExplicitInspection {
+        public static string OptionExplicitInspection {
             get {
                 return ResourceManager.GetString("OptionExplicitInspection", resourceCulture);
             }
@@ -567,7 +567,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A parameter that is passed by reference and isn&apos;t assigned a new value/reference, could be passed by value instead..
         /// </summary>
-        internal static string ParameterCanBeByValInspection {
+        public static string ParameterCanBeByValInspection {
             get {
                 return ResourceManager.GetString("ParameterCanBeByValInspection", resourceCulture);
             }
@@ -576,7 +576,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A parameter is passed into a member that does not use it. Consider removing that parameter..
         /// </summary>
-        internal static string ParameterNotUsedInspection {
+        public static string ParameterNotUsedInspection {
             get {
                 return ResourceManager.GetString("ParameterNotUsedInspection", resourceCulture);
             }
@@ -585,7 +585,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A procedure that only has one parameter passed by reference that is assigned a new value/reference before the procedure exits, is using a ByRef parameter as a return value: consider making it a function instead..
         /// </summary>
-        internal static string ProcedureCanBeWrittenAsFunctionInspection {
+        public static string ProcedureCanBeWrittenAsFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureCanBeWrittenAsFunctionInspection", resourceCulture);
             }
@@ -594,7 +594,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Rubberduck could not find any caller for a procedure. If the procedure is hooked to a macro-button, used as a user-defined function (UDF) or handles an application event that Rubberduck didn&apos;t know of you can safely ignore this inspection result; otherwise, consider removing it..
         /// </summary>
-        internal static string ProcedureNotUsedInspection {
+        public static string ProcedureNotUsedInspection {
             get {
                 return ResourceManager.GetString("ProcedureNotUsedInspection", resourceCulture);
             }
@@ -603,7 +603,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to By default, all parameters are passed by reference, so it is not necessary to include the &apos;ByRef&apos; modifier..
         /// </summary>
-        internal static string RedundantByRefModifierInspection {
+        public static string RedundantByRefModifierInspection {
             get {
                 return ResourceManager.GetString("RedundantByRefModifierInspection", resourceCulture);
             }
@@ -612,7 +612,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Being the default/implicit setting for this option, this instruction can be safely omitted..
         /// </summary>
-        internal static string RedundantOptionInspection {
+        public static string RedundantOptionInspection {
             get {
                 return ResourceManager.GetString("RedundantOptionInspection", resourceCulture);
             }
@@ -621,7 +621,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An auto-instantiated object variable declaration at procedure scope changes how nulling the reference works, which can lead to unexpected behavior..
         /// </summary>
-        internal static string SelfAssignedDeclarationInspection {
+        public static string SelfAssignedDeclarationInspection {
             get {
                 return ResourceManager.GetString("SelfAssignedDeclarationInspection", resourceCulture);
             }
@@ -630,7 +630,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Two declarations are in scope and have the same identifier name. This means that only one of them will be available to use..
         /// </summary>
-        internal static string ShadowedDeclarationInspection {
+        public static string ShadowedDeclarationInspection {
             get {
                 return ResourceManager.GetString("ShadowedDeclarationInspection", resourceCulture);
             }
@@ -639,7 +639,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Excel already defines a globally scoped object variable with this reference. Consider using the sheet&apos;s &apos;CodeName&apos; property..
         /// </summary>
-        internal static string SheetAccessedUsingStringInspection {
+        public static string SheetAccessedUsingStringInspection {
             get {
                 return ResourceManager.GetString("SheetAccessedUsingStringInspection", resourceCulture);
             }
@@ -648,7 +648,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Step of the for-next loop is not specified. This might be unintentional..
         /// </summary>
-        internal static string StepIsNotSpecifiedInspection {
+        public static string StepIsNotSpecifiedInspection {
             get {
                 return ResourceManager.GetString("StepIsNotSpecifiedInspection", resourceCulture);
             }
@@ -657,7 +657,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to 1 is the default step in a for-next loop and therefore is redundant..
         /// </summary>
-        internal static string StepOneIsRedundantInspection {
+        public static string StepOneIsRedundantInspection {
             get {
                 return ResourceManager.GetString("StepOneIsRedundantInspection", resourceCulture);
             }
@@ -666,7 +666,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Stop&apos; keyword halts execution and brings up the debugger. Avoid its use in distributed code..
         /// </summary>
-        internal static string StopKeywordInspection {
+        public static string StopKeywordInspection {
             get {
                 return ResourceManager.GetString("StopKeywordInspection", resourceCulture);
             }
@@ -675,7 +675,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This is likely a bug. A variable is being referred to, but is never assigned..
         /// </summary>
-        internal static string UnassignedVariableUsageInspection {
+        public static string UnassignedVariableUsageInspection {
             get {
                 return ResourceManager.GetString("UnassignedVariableUsageInspection", resourceCulture);
             }
@@ -684,7 +684,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Code that uses undeclared variables does not compile when Option Explicit is specified. Undeclared variables are always Variant, a data type that incurs unnecessary overhead and storage..
         /// </summary>
-        internal static string UndeclaredVariableInspection {
+        public static string UndeclaredVariableInspection {
             get {
                 return ResourceManager.GetString("UndeclaredVariableInspection", resourceCulture);
             }
@@ -693,7 +693,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Error handling should be restored after using &apos;On Error Resume Next&apos;..
         /// </summary>
-        internal static string UnhandledOnErrorResumeNextInspection {
+        public static string UnhandledOnErrorResumeNextInspection {
             get {
                 return ResourceManager.GetString("UnhandledOnErrorResumeNextInspection", resourceCulture);
             }
@@ -702,7 +702,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Detects Case Clauses that will never execute. .
         /// </summary>
-        internal static string UnreachableCaseInspection {
+        public static string UnreachableCaseInspection {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection", resourceCulture);
             }
@@ -712,7 +712,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Looks up a localized string similar to A string-returning equivalent function exists and should preferably be used to avoid implicit type conversions. 
         ///If the parameter can be null, ignore this inspection result; passing a null value to a function expecting a string would raise a type mismatch runtime error..
         /// </summary>
-        internal static string UntypedFunctionUsageInspection {
+        public static string UntypedFunctionUsageInspection {
             get {
                 return ResourceManager.GetString("UntypedFunctionUsageInspection", resourceCulture);
             }
@@ -721,7 +721,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Identifier names should indicate what they&apos;re used for and should be readable; avoid disemvoweling, numeric suffixes, and 1-2 character names..
         /// </summary>
-        internal static string UseMeaningfulNameInspection {
+        public static string UseMeaningfulNameInspection {
             get {
                 return ResourceManager.GetString("UseMeaningfulNameInspection", resourceCulture);
             }
@@ -730,7 +730,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not assigned. If this isn&apos;t intended, there&apos;s probably a bug. Ignore this inspection result if the variable is assigned in another procedure via a ByRef parameter..
         /// </summary>
-        internal static string VariableNotAssignedInspection {
+        public static string VariableNotAssignedInspection {
             get {
                 return ResourceManager.GetString("VariableNotAssignedInspection", resourceCulture);
             }
@@ -739,7 +739,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not referred to.
         /// </summary>
-        internal static string VariableNotUsedInspection {
+        public static string VariableNotUsedInspection {
             get {
                 return ResourceManager.GetString("VariableNotUsedInspection", resourceCulture);
             }
@@ -748,7 +748,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A variable whose type isn&apos;t explicitly declared, is implicitly &apos;Variant&apos;. Consider making it an explicit &apos;Variant&apos; if that&apos;s intended, or declare a more specific type..
         /// </summary>
-        internal static string VariableTypeNotDeclaredInspection {
+        public static string VariableTypeNotDeclaredInspection {
             get {
                 return ResourceManager.GetString("VariableTypeNotDeclaredInspection", resourceCulture);
             }
@@ -757,7 +757,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A property that exposes a mutator but no accessor is a design smell and makes a confusing API. Consider exposing a getter, or converting the mutator to a method..
         /// </summary>
-        internal static string WriteOnlyPropertyInspection {
+        public static string WriteOnlyPropertyInspection {
             get {
                 return ResourceManager.GetString("WriteOnlyPropertyInspection", resourceCulture);
             }

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.Resources.Inspections {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class InspectionInfo {
+    internal class InspectionInfo {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Rubberduck.Resources.Inspections.InspectionInfo", typeof(InspectionInfo).Assembly);
@@ -51,7 +51,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Globalization.CultureInfo Culture {
+        internal static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The Excel Application object does not implement the WorksheetFunction interface directly. All calls made to WorksheetFunction members are handled as late bound and errors in the called member will be returned wrapped in a Variant of VbVarType.vbError. This makes errors un-trappable with error handlers and adds a performance penalty in comparison to early bound calls. Consider calling Application.WorksheetFunction explicitly. Note: If this call generated errors in the past, those errors were ignored. If appl [rest of string was truncated]&quot;;.
         /// </summary>
-        public static string ApplicationWorksheetFunctionInspection {
+        internal static string ApplicationWorksheetFunctionInspection {
             get {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionInspection", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter is passed by value, but is assigned a new value/reference. Consider making a local copy instead if the caller isn&apos;t supposed to know the new value. If the caller should see the new value, the parameter should be passed ByRef instead, and you have a bug..
         /// </summary>
-        public static string AssignedByValParameterInspection {
+        internal static string AssignedByValParameterInspection {
             get {
                 return ResourceManager.GetString("AssignedByValParameterInspection", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
         /// </summary>
-        public static string AssignmentNotUsedInspection {
+        internal static string AssignmentNotUsedInspection {
             get {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A member is assigned True/False in different branches of an if statement with no other statements in the conditional. Use the condition directly to the member instead..
         /// </summary>
-        public static string BooleanAssignedInIfElseInspection {
+        internal static string BooleanAssignedInIfElseInspection {
             get {
                 return ResourceManager.GetString("BooleanAssignedInIfElseInspection", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Rubberduck could not find any reference to constant. Consider removing the unused declaration..
         /// </summary>
-        public static string ConstantNotUsedInspection {
+        internal static string ConstantNotUsedInspection {
             get {
                 return ResourceManager.GetString("ConstantNotUsedInspection", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider naming your VBA project..
         /// </summary>
-        public static string DefaultProjectNameInspection {
+        internal static string DefaultProjectNameInspection {
             get {
                 return ResourceManager.GetString("DefaultProjectNameInspection", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Using the &apos;Def[Type]&apos; statement leads to specifying types by using a prefix. This style of naming is heavily discouraged and should be avoided..
         /// </summary>
-        public static string DefTypeStatementInspection {
+        internal static string DefTypeStatementInspection {
             get {
                 return ResourceManager.GetString("DefTypeStatementInspection", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An annotation is specified multiple times, but is intended to be specified only once..
         /// </summary>
-        public static string DuplicatedAnnotationInspection {
+        internal static string DuplicatedAnnotationInspection {
             get {
                 return ResourceManager.GetString("DuplicatedAnnotationInspection", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Case&apos; block without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        public static string EmptyCaseBlockInspection {
+        internal static string EmptyCaseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyCaseBlockInspection", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Do...While&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        public static string EmptyDoWhileBlockInspection {
+        internal static string EmptyDoWhileBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyDoWhileBlockInspection", resourceCulture);
             }
@@ -153,7 +153,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Else&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        public static string EmptyElseBlockInspection {
+        internal static string EmptyElseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyElseBlockInspection", resourceCulture);
             }
@@ -162,7 +162,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;For Each...Next&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        public static string EmptyForEachBlockInspection {
+        internal static string EmptyForEachBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForEachBlockInspection", resourceCulture);
             }
@@ -171,7 +171,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;For...Next&apos; loop without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        public static string EmptyForLoopBlockInspection {
+        internal static string EmptyForLoopBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForLoopBlockInspection", resourceCulture);
             }
@@ -180,7 +180,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty conditional branch without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        public static string EmptyIfBlockInspection {
+        internal static string EmptyIfBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyIfBlockInspection", resourceCulture);
             }
@@ -189,7 +189,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty modules and classes either point to not yet implemented functionality or represent unnecessary baggage that can hurt the maintainability of a project..
         /// </summary>
-        public static string EmptyModuleInspection {
+        internal static string EmptyModuleInspection {
             get {
                 return ResourceManager.GetString("EmptyModuleInspection", resourceCulture);
             }
@@ -198,7 +198,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The built-in constant &apos;vbNullString&apos; is a null string pointer taking up 0 bytes of memory, that unambiguously conveys the intent of an empty string..
         /// </summary>
-        public static string EmptyStringLiteralInspection {
+        internal static string EmptyStringLiteralInspection {
             get {
                 return ResourceManager.GetString("EmptyStringLiteralInspection", resourceCulture);
             }
@@ -207,7 +207,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An empty &apos;Loop&apos; block without any executable statements, leaves a maintainer wondering about the intent of the code. Avoid writing code that doesn&apos;t need to be written..
         /// </summary>
-        public static string EmptyWhileWendBlockInspection {
+        internal static string EmptyWhileWendBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyWhileWendBlockInspection", resourceCulture);
             }
@@ -216,16 +216,25 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider exposing a property instead..
         /// </summary>
-        public static string EncapsulatePublicFieldInspection {
+        internal static string EncapsulatePublicFieldInspection {
             get {
                 return ResourceManager.GetString("EncapsulatePublicFieldInspection", resourceCulture);
             }
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A Function or Property returning a reference type that can be &apos;Nothing&apos; should not have the return value used with a test for &apos;Is Nothing&apos;. If the member does not return a valid object, attempting to use the return value will result in a run-time error 91 - &quot;Object variable or With block variable not set&quot;..
+        /// </summary>
+        internal static string ExcelMemberMayReturnNothingInspection {
+            get {
+                return ResourceManager.GetString("ExcelMemberMayReturnNothingInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A member is written as a function, but used as a procedure. Unless the function is recursive, consider converting the &apos;Function&apos; into a &apos;Sub&apos;. If the function is recursive, none of its external callers are using the returned value..
         /// </summary>
-        public static string FunctionReturnValueNotUsedInspection {
+        internal static string FunctionReturnValueNotUsedInspection {
             get {
                 return ResourceManager.GetString("FunctionReturnValueNotUsedInspection", resourceCulture);
             }
@@ -234,7 +243,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Bracketed expressions are evaluated by the host application at runtime, which means VBA can&apos;t validate the expression at compile-time. Consider using the host application&apos;s object model instead..
         /// </summary>
-        public static string HostSpecificExpressionInspection {
+        internal static string HostSpecificExpressionInspection {
             get {
                 return ResourceManager.GetString("HostSpecificExpressionInspection", resourceCulture);
             }
@@ -243,7 +252,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Hungarian notation makes code less readable, and is redundant when strongly typed variables and meaningful names are used..
         /// </summary>
-        public static string HungarianNotationInspection {
+        internal static string HungarianNotationInspection {
             get {
                 return ResourceManager.GetString("HungarianNotationInspection", resourceCulture);
             }
@@ -252,7 +261,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An annotation meant to be specified at module level cannot be used to annotate members; annotations meant to be annotate members cannot be used at module level..
         /// </summary>
-        public static string IllegalAnnotationInspection {
+        internal static string IllegalAnnotationInspection {
             get {
                 return ResourceManager.GetString("IllegalAnnotationInspection", resourceCulture);
             }
@@ -261,7 +270,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit references to the active sheet make the code frail and harder to debug. Consider making these references explicit when they&apos;re intended, and prefer working off object references. Ignore if the member call is referring to a type Rubberduck can&apos;t resolve..
         /// </summary>
-        public static string ImplicitActiveSheetReferenceInspection {
+        internal static string ImplicitActiveSheetReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveSheetReferenceInspection", resourceCulture);
             }
@@ -270,7 +279,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit references to the active workbook make the code frail and harder to debug. Consider making these references explicit when they&apos;re intended, and prefer working off object references. Ignore if the member call is referring to a type Rubberduck can&apos;t resolve..
         /// </summary>
-        public static string ImplicitActiveWorkbookReferenceInspection {
+        internal static string ImplicitActiveWorkbookReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveWorkbookReferenceInspection", resourceCulture);
             }
@@ -279,7 +288,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameters are passed by reference unless specified otherwise, which can be confusing and bug-prone. Prefer passing parameters by value, and specify ByRef explicitly when passing parameters by reference..
         /// </summary>
-        public static string ImplicitByRefModifierInspection {
+        internal static string ImplicitByRefModifierInspection {
             get {
                 return ResourceManager.GetString("ImplicitByRefModifierInspection", resourceCulture);
             }
@@ -288,7 +297,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Such assignments look like they are assigning an object variable to a value type on the surface, but they are actually assigning that object&apos;s default member, implicitly. Consider referring to the default member explicitly, for improved readability..
         /// </summary>
-        public static string ImplicitDefaultMemberAssignmentInspection {
+        internal static string ImplicitDefaultMemberAssignmentInspection {
             get {
                 return ResourceManager.GetString("ImplicitDefaultMemberAssignmentInspection", resourceCulture);
             }
@@ -297,7 +306,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module members are public by default, which can be counter-intuitive. Consider specifying explicit access modifiers to avoid ambiguity..
         /// </summary>
-        public static string ImplicitPublicMemberInspection {
+        internal static string ImplicitPublicMemberInspection {
             get {
                 return ResourceManager.GetString("ImplicitPublicMemberInspection", resourceCulture);
             }
@@ -306,7 +315,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Members with a return value implicitly return a &apos;Variant&apos; unless specified otherwise. Consider returning an explicit &apos;Variant&apos; when the return type isn&apos;t known, or specify it explicitly..
         /// </summary>
-        public static string ImplicitVariantReturnTypeInspection {
+        internal static string ImplicitVariantReturnTypeInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantReturnTypeInspection", resourceCulture);
             }
@@ -315,7 +324,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The maximum value of a 16-bit signed integer is 32,767 - using a 32-bit (Long) integer data type where possible can help prevent &apos;Overflow&apos; run-time errors, and is better handled by modern CPUs..
         /// </summary>
-        public static string IntegerDataTypeInspection {
+        internal static string IntegerDataTypeInspection {
             get {
                 return ResourceManager.GetString("IntegerDataTypeInspection", resourceCulture);
             }
@@ -324,7 +333,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to IsMissing is only intended to be called on optional arguments, and will only return correct results if the type of the argument is &apos;Variant&apos; with no explicit default value. All other uses will return &apos;False&apos;..
         /// </summary>
-        public static string IsMissingOnInappropriateArgumentInspection {
+        internal static string IsMissingOnInappropriateArgumentInspection {
             get {
                 return ResourceManager.GetString("IsMissingOnInappropriateArgumentInspection", resourceCulture);
             }
@@ -333,7 +342,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to IsMissing is only intended to be called on arguments of the containing procedure, and almost all other usages will return &apos;False&apos;. Passing any other expression to the function is the equivalent to &apos;VarType({expression}) = vbError&apos;, and in rare circumstances can cause the host application to crash..
         /// </summary>
-        public static string IsMissingWithNonArgumentParameterInspection {
+        internal static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
             }
@@ -342,7 +351,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A line label that is never jumpted to (&apos;GoTo&apos;, &apos;Resume&apos;, ...), serves no purpose. Consider removing it..
         /// </summary>
-        public static string LineLabelNotUsedInspection {
+        internal static string LineLabelNotUsedInspection {
             get {
                 return ResourceManager.GetString("LineLabelNotUsedInspection", resourceCulture);
             }
@@ -351,7 +360,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A member access call is made against an extended interface that Rubberduck couldn&apos;t resolve, or the member couldn&apos;t be found. If VBA cannot resolve the type at run-time, error 438 will be raised. If an equivalent, non-extended interface that Rubberduck can resolve is available, consider using it instead..
         /// </summary>
-        public static string MemberNotOnInterfaceInspection {
+        internal static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
             }
@@ -360,7 +369,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An annotation parameter is missing or incorrectly specified. The correct syntax is : &apos;@Annotation([parameter])\nExample: &apos;@Folder(&quot;Parent.Child&quot;).
         /// </summary>
-        public static string MissingAnnotationArgumentInspection {
+        internal static string MissingAnnotationArgumentInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationArgumentInspection", resourceCulture);
             }
@@ -369,7 +378,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
         /// </summary>
-        public static string MissingAnnotationInspection {
+        internal static string MissingAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
             }
@@ -378,7 +387,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A Rubberduck annotation is specified for a module or member, but the corresponding attribute isn&apos;t present. Module attributes and annotations need to be synchronized..
         /// </summary>
-        public static string MissingAttributeInspection {
+        internal static string MissingAttributeInspection {
             get {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
@@ -387,7 +396,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Public&apos; keyword can only be used at module level; its counterpart &apos;Private&apos; can also only be used at module level. &apos;Dim&apos; however, can be used to declare both procedure and module scope variables. For consistency, it would be preferable to reserve &apos;Dim&apos; for locals, and thus to use &apos;Private&apos; instead of &apos;Dim&apos; at module level..
         /// </summary>
-        public static string ModuleScopeDimKeywordInspection {
+        internal static string ModuleScopeDimKeywordInspection {
             get {
                 return ResourceManager.GetString("ModuleScopeDimKeywordInspection", resourceCulture);
             }
@@ -396,7 +405,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Modules without the &apos;@Folder&apos; annotation cannot receive custom groupings in the Code Explorer. .
         /// </summary>
-        public static string ModuleWithoutFolderInspection {
+        internal static string ModuleWithoutFolderInspection {
             get {
                 return ResourceManager.GetString("ModuleWithoutFolderInspection", resourceCulture);
             }
@@ -405,7 +414,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A module-level variable used only in one procedure should be declared in that procedure..
         /// </summary>
-        public static string MoveFieldCloserToUsageInspection {
+        internal static string MoveFieldCloserToUsageInspection {
             get {
                 return ResourceManager.GetString("MoveFieldCloserToUsageInspection", resourceCulture);
             }
@@ -414,7 +423,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider continuing long signatures between parameters. Splitting a parameter declaration across multiple lines arguably hurts readability..
         /// </summary>
-        public static string MultilineParameterInspection {
+        internal static string MultilineParameterInspection {
             get {
                 return ResourceManager.GetString("MultilineParameterInspection", resourceCulture);
             }
@@ -423,7 +432,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Declaring multiple variables in the same instruction is legal, but should be used sparingly. Consider declaring variables closer to their usage, in a single instruction per declaration..
         /// </summary>
-        public static string MultipleDeclarationsInspection {
+        internal static string MultipleDeclarationsInspection {
             get {
                 return ResourceManager.GetString("MultipleDeclarationsInspection", resourceCulture);
             }
@@ -432,7 +441,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This is likely a bug. The return value of a function or property getter must be assigned before exiting, otherwise the program will not be working with expected results. If a function has no meaningful return value, consider declaring it as a &apos;Sub&apos; procedure instead..
         /// </summary>
-        public static string NonReturningFunctionInspection {
+        internal static string NonReturningFunctionInspection {
             get {
                 return ResourceManager.GetString("NonReturningFunctionInspection", resourceCulture);
             }
@@ -441,7 +450,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to As far as Rubberduck can tell, this variable is an object variable, assigned without the &apos;Set&apos; keyword. This causes run-time error 91 &apos;Object or With block variable not set&apos;..
         /// </summary>
-        public static string ObjectVariableNotSetInspection {
+        internal static string ObjectVariableNotSetInspection {
             get {
                 return ResourceManager.GetString("ObjectVariableNotSetInspection", resourceCulture);
             }
@@ -450,7 +459,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Windows implementations of Visual Basic only support the StdCall calling convention, and use of of the CDecl calling convention is only supported in Macintosh versions of VBA. Use of this keyword in Windows will result in runtime error 49 - &apos;Bad DLL calling convention&apos;. If this procedure is only intended to be used on Macintosh hosts, it should be conditionally compiled..
         /// </summary>
-        public static string ObsoleteCallingConventionInspection {
+        internal static string ObsoleteCallingConventionInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallingConventionInspection", resourceCulture);
             }
@@ -459,7 +468,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Call&apos; statement is no longer required to call procedures, and only exists in the language to support legacy code that required it; it can be safely rewritten to an implicit call..
         /// </summary>
-        public static string ObsoleteCallStatementInspection {
+        internal static string ObsoleteCallStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallStatementInspection", resourceCulture);
             }
@@ -468,7 +477,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Rem&apos; statement only exists in the language to support legacy code that required it; it can be safely replaced with an apostrophe / single-quote comment..
         /// </summary>
-        public static string ObsoleteCommentSyntaxInspection {
+        internal static string ObsoleteCommentSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCommentSyntaxInspection", resourceCulture);
             }
@@ -477,7 +486,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Error&apos; statement only exists in the language to support legacy code that required it; prefer using &apos;Err.Raise&apos; instead..
         /// </summary>
-        public static string ObsoleteErrorSyntaxInspection {
+        internal static string ObsoleteErrorSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteErrorSyntaxInspection", resourceCulture);
             }
@@ -486,7 +495,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Global&apos; keyword only exists in the language to support legacy code that required it; it can be safely replaced with the &apos;Public&apos; modifier..
         /// </summary>
-        public static string ObsoleteGlobalInspection {
+        internal static string ObsoleteGlobalInspection {
             get {
                 return ResourceManager.GetString("ObsoleteGlobalInspection", resourceCulture);
             }
@@ -495,7 +504,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Let&apos; statement only exists in the language to support legacy code that required it; it can be safely removed, since modern VBA does not require that keyword for value assignments..
         /// </summary>
-        public static string ObsoleteLetStatementInspection {
+        internal static string ObsoleteLetStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteLetStatementInspection", resourceCulture);
             }
@@ -504,7 +513,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This member is marked &apos;@Obsolete&apos;. It should no longer be used, there should be a better alternative..
         /// </summary>
-        public static string ObsoleteMemberUsageInspection {
+        internal static string ObsoleteMemberUsageInspection {
             get {
                 return ResourceManager.GetString("ObsoleteMemberUsageInspection", resourceCulture);
             }
@@ -513,7 +522,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Type hint characters only exist in the language to support legacy code that required it; they can be safely replaced in declarations with an &quot;As&quot; type clause that specifies the type explicitly, and they can be omitted in other identifier references..
         /// </summary>
-        public static string ObsoleteTypeHintInspection {
+        internal static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
             }
@@ -522,7 +531,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to On Local Error exists only for compatibility with previous versions of Visual Basic, and all Errors are treated as Local regardless of the Error statement. Use of this keyword inaccurately gives the impression that there is a distinction between types of error handling when there is not..
         /// </summary>
-        public static string OnLocalErrorInspection {
+        internal static string OnLocalErrorInspection {
             get {
                 return ResourceManager.GetString("OnLocalErrorInspection", resourceCulture);
             }
@@ -531,7 +540,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Arrays are typically zero-based. This option changes the default lower boundary for implicitly-sized arrays, which can introduce off-by-one errors if one isn&apos;t cautious..
         /// </summary>
-        public static string OptionBaseInspection {
+        internal static string OptionBaseInspection {
             get {
                 return ResourceManager.GetString("OptionBaseInspection", resourceCulture);
             }
@@ -540,7 +549,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This is the default setting, it does not need to be specified..
         /// </summary>
-        public static string OptionBaseZeroInspection {
+        internal static string OptionBaseZeroInspection {
             get {
                 return ResourceManager.GetString("OptionBaseZeroInspection", resourceCulture);
             }
@@ -549,7 +558,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to VBA will happily compile a typo: use &apos;Option Explicit&apos; to prevent successfully compiling an erroneous program..
         /// </summary>
-        public static string OptionExplicitInspection {
+        internal static string OptionExplicitInspection {
             get {
                 return ResourceManager.GetString("OptionExplicitInspection", resourceCulture);
             }
@@ -558,7 +567,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A parameter that is passed by reference and isn&apos;t assigned a new value/reference, could be passed by value instead..
         /// </summary>
-        public static string ParameterCanBeByValInspection {
+        internal static string ParameterCanBeByValInspection {
             get {
                 return ResourceManager.GetString("ParameterCanBeByValInspection", resourceCulture);
             }
@@ -567,7 +576,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A parameter is passed into a member that does not use it. Consider removing that parameter..
         /// </summary>
-        public static string ParameterNotUsedInspection {
+        internal static string ParameterNotUsedInspection {
             get {
                 return ResourceManager.GetString("ParameterNotUsedInspection", resourceCulture);
             }
@@ -576,7 +585,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A procedure that only has one parameter passed by reference that is assigned a new value/reference before the procedure exits, is using a ByRef parameter as a return value: consider making it a function instead..
         /// </summary>
-        public static string ProcedureCanBeWrittenAsFunctionInspection {
+        internal static string ProcedureCanBeWrittenAsFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureCanBeWrittenAsFunctionInspection", resourceCulture);
             }
@@ -585,7 +594,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Rubberduck could not find any caller for a procedure. If the procedure is hooked to a macro-button, used as a user-defined function (UDF) or handles an application event that Rubberduck didn&apos;t know of you can safely ignore this inspection result; otherwise, consider removing it..
         /// </summary>
-        public static string ProcedureNotUsedInspection {
+        internal static string ProcedureNotUsedInspection {
             get {
                 return ResourceManager.GetString("ProcedureNotUsedInspection", resourceCulture);
             }
@@ -594,7 +603,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to By default, all parameters are passed by reference, so it is not necessary to include the &apos;ByRef&apos; modifier..
         /// </summary>
-        public static string RedundantByRefModifierInspection {
+        internal static string RedundantByRefModifierInspection {
             get {
                 return ResourceManager.GetString("RedundantByRefModifierInspection", resourceCulture);
             }
@@ -603,7 +612,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Being the default/implicit setting for this option, this instruction can be safely omitted..
         /// </summary>
-        public static string RedundantOptionInspection {
+        internal static string RedundantOptionInspection {
             get {
                 return ResourceManager.GetString("RedundantOptionInspection", resourceCulture);
             }
@@ -612,7 +621,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An auto-instantiated object variable declaration at procedure scope changes how nulling the reference works, which can lead to unexpected behavior..
         /// </summary>
-        public static string SelfAssignedDeclarationInspection {
+        internal static string SelfAssignedDeclarationInspection {
             get {
                 return ResourceManager.GetString("SelfAssignedDeclarationInspection", resourceCulture);
             }
@@ -621,7 +630,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Two declarations are in scope and have the same identifier name. This means that only one of them will be available to use..
         /// </summary>
-        public static string ShadowedDeclarationInspection {
+        internal static string ShadowedDeclarationInspection {
             get {
                 return ResourceManager.GetString("ShadowedDeclarationInspection", resourceCulture);
             }
@@ -630,7 +639,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Excel already defines a globally scoped object variable with this reference. Consider using the sheet&apos;s &apos;CodeName&apos; property..
         /// </summary>
-        public static string SheetAccessedUsingStringInspection {
+        internal static string SheetAccessedUsingStringInspection {
             get {
                 return ResourceManager.GetString("SheetAccessedUsingStringInspection", resourceCulture);
             }
@@ -639,7 +648,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Step of the for-next loop is not specified. This might be unintentional..
         /// </summary>
-        public static string StepIsNotSpecifiedInspection {
+        internal static string StepIsNotSpecifiedInspection {
             get {
                 return ResourceManager.GetString("StepIsNotSpecifiedInspection", resourceCulture);
             }
@@ -648,7 +657,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to 1 is the default step in a for-next loop and therefore is redundant..
         /// </summary>
-        public static string StepOneIsRedundantInspection {
+        internal static string StepOneIsRedundantInspection {
             get {
                 return ResourceManager.GetString("StepOneIsRedundantInspection", resourceCulture);
             }
@@ -657,7 +666,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Stop&apos; keyword halts execution and brings up the debugger. Avoid its use in distributed code..
         /// </summary>
-        public static string StopKeywordInspection {
+        internal static string StopKeywordInspection {
             get {
                 return ResourceManager.GetString("StopKeywordInspection", resourceCulture);
             }
@@ -666,7 +675,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to This is likely a bug. A variable is being referred to, but is never assigned..
         /// </summary>
-        public static string UnassignedVariableUsageInspection {
+        internal static string UnassignedVariableUsageInspection {
             get {
                 return ResourceManager.GetString("UnassignedVariableUsageInspection", resourceCulture);
             }
@@ -675,7 +684,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Code that uses undeclared variables does not compile when Option Explicit is specified. Undeclared variables are always Variant, a data type that incurs unnecessary overhead and storage..
         /// </summary>
-        public static string UndeclaredVariableInspection {
+        internal static string UndeclaredVariableInspection {
             get {
                 return ResourceManager.GetString("UndeclaredVariableInspection", resourceCulture);
             }
@@ -684,7 +693,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Error handling should be restored after using &apos;On Error Resume Next&apos;..
         /// </summary>
-        public static string UnhandledOnErrorResumeNextInspection {
+        internal static string UnhandledOnErrorResumeNextInspection {
             get {
                 return ResourceManager.GetString("UnhandledOnErrorResumeNextInspection", resourceCulture);
             }
@@ -693,7 +702,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Detects Case Clauses that will never execute. .
         /// </summary>
-        public static string UnreachableCaseInspection {
+        internal static string UnreachableCaseInspection {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection", resourceCulture);
             }
@@ -703,7 +712,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Looks up a localized string similar to A string-returning equivalent function exists and should preferably be used to avoid implicit type conversions. 
         ///If the parameter can be null, ignore this inspection result; passing a null value to a function expecting a string would raise a type mismatch runtime error..
         /// </summary>
-        public static string UntypedFunctionUsageInspection {
+        internal static string UntypedFunctionUsageInspection {
             get {
                 return ResourceManager.GetString("UntypedFunctionUsageInspection", resourceCulture);
             }
@@ -712,7 +721,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Identifier names should indicate what they&apos;re used for and should be readable; avoid disemvoweling, numeric suffixes, and 1-2 character names..
         /// </summary>
-        public static string UseMeaningfulNameInspection {
+        internal static string UseMeaningfulNameInspection {
             get {
                 return ResourceManager.GetString("UseMeaningfulNameInspection", resourceCulture);
             }
@@ -721,7 +730,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not assigned. If this isn&apos;t intended, there&apos;s probably a bug. Ignore this inspection result if the variable is assigned in another procedure via a ByRef parameter..
         /// </summary>
-        public static string VariableNotAssignedInspection {
+        internal static string VariableNotAssignedInspection {
             get {
                 return ResourceManager.GetString("VariableNotAssignedInspection", resourceCulture);
             }
@@ -730,7 +739,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not referred to.
         /// </summary>
-        public static string VariableNotUsedInspection {
+        internal static string VariableNotUsedInspection {
             get {
                 return ResourceManager.GetString("VariableNotUsedInspection", resourceCulture);
             }
@@ -739,7 +748,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A variable whose type isn&apos;t explicitly declared, is implicitly &apos;Variant&apos;. Consider making it an explicit &apos;Variant&apos; if that&apos;s intended, or declare a more specific type..
         /// </summary>
-        public static string VariableTypeNotDeclaredInspection {
+        internal static string VariableTypeNotDeclaredInspection {
             get {
                 return ResourceManager.GetString("VariableTypeNotDeclaredInspection", resourceCulture);
             }
@@ -748,7 +757,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A property that exposes a mutator but no accessor is a design smell and makes a confusing API. Consider exposing a getter, or converting the mutator to a method..
         /// </summary>
-        public static string WriteOnlyPropertyInspection {
+        internal static string WriteOnlyPropertyInspection {
             get {
                 return ResourceManager.GetString("WriteOnlyPropertyInspection", resourceCulture);
             }

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -350,6 +350,6 @@ If the parameter can be null, ignore this inspection result; passing a null valu
     <value>An assignment is immediately overridden by another assignment or is never referenced.</value>
   </data>
   <data name="ExcelMemberMayReturnNothingInspection" xml:space="preserve">
-    <value>A Function or Property returning a reference type that can be 'Nothing' should not have the return value used with a test for 'Is Nothing'. If the member does not return a valid object, attempting to use the return value will result in a run-time error 91 - "Object variable or With block variable not set".</value>
+    <value>A procedure that returns an object may return 'Nothing'. That will cause a runtime error 91 - "Object variable or With block variable not set" on subsequent member access. Perform an 'Is Nothing' check after the 'Set' assignment to guard against runtime errors.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -349,4 +349,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="AssignmentNotUsedInspection" xml:space="preserve">
     <value>An assignment is immediately overridden by another assignment or is never referenced.</value>
   </data>
+  <data name="ExcelMemberMayReturnNothingInspection" xml:space="preserve">
+    <value>A Function or Property returning a reference type that can be 'Nothing' should not have the return value used with a test for 'Is Nothing'. If the member does not return a valid object, attempting to use the return value will result in a run-time error 91 - "Object variable or With block variable not set".</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.Resources.Inspections {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class InspectionNames {
+    public class InspectionNames {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Rubberduck.Resources.Inspections.InspectionNames", typeof(InspectionNames).Assembly);
@@ -51,7 +51,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Late bound WorksheetFunction call..
         /// </summary>
-        internal static string ApplicationWorksheetFunctionInspection {
+        public static string ApplicationWorksheetFunctionInspection {
             get {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionInspection", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to ByVal parameter is assigned.
         /// </summary>
-        internal static string AssignedByValParameterInspection {
+        public static string AssignedByValParameterInspection {
             get {
                 return ResourceManager.GetString("AssignedByValParameterInspection", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment is not used.
         /// </summary>
-        internal static string AssignmentNotUsedInspection {
+        public static string AssignmentNotUsedInspection {
             get {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal assignment in conditional.
         /// </summary>
-        internal static string BooleanAssignedInIfElseInspection {
+        public static string BooleanAssignedInIfElseInspection {
             get {
                 return ResourceManager.GetString("BooleanAssignedInIfElseInspection", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Constant is not used.
         /// </summary>
-        internal static string ConstantNotUsedInspection {
+        public static string ConstantNotUsedInspection {
             get {
                 return ResourceManager.GetString("ConstantNotUsedInspection", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Project name is not specified.
         /// </summary>
-        internal static string DefaultProjectNameInspection {
+        public static string DefaultProjectNameInspection {
             get {
                 return ResourceManager.GetString("DefaultProjectNameInspection", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Usage of &apos;Def[Type]&apos; statement.
         /// </summary>
-        internal static string DefTypeStatementInspection {
+        public static string DefTypeStatementInspection {
             get {
                 return ResourceManager.GetString("DefTypeStatementInspection", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Annotation is duplicated.
         /// </summary>
-        internal static string DuplicatedAnnotationInspection {
+        public static string DuplicatedAnnotationInspection {
             get {
                 return ResourceManager.GetString("DuplicatedAnnotationInspection", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;Case&apos; block.
         /// </summary>
-        internal static string EmptyCaseBlockInspection {
+        public static string EmptyCaseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyCaseBlockInspection", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;Do...While&apos; Loop.
         /// </summary>
-        internal static string EmptyDoWhileBlockInspection {
+        public static string EmptyDoWhileBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyDoWhileBlockInspection", resourceCulture);
             }
@@ -153,7 +153,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;Else&apos; block.
         /// </summary>
-        internal static string EmptyElseBlockInspection {
+        public static string EmptyElseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyElseBlockInspection", resourceCulture);
             }
@@ -162,7 +162,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;For Each...Next&apos; Loop.
         /// </summary>
-        internal static string EmptyForEachBlockInspection {
+        public static string EmptyForEachBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForEachBlockInspection", resourceCulture);
             }
@@ -171,7 +171,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;For...Next&apos; Loop.
         /// </summary>
-        internal static string EmptyForLoopBlockInspection {
+        public static string EmptyForLoopBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForLoopBlockInspection", resourceCulture);
             }
@@ -180,7 +180,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty conditional branch.
         /// </summary>
-        internal static string EmptyIfBlockInspection {
+        public static string EmptyIfBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyIfBlockInspection", resourceCulture);
             }
@@ -189,7 +189,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty module.
         /// </summary>
-        internal static string EmptyModuleInspection {
+        public static string EmptyModuleInspection {
             get {
                 return ResourceManager.GetString("EmptyModuleInspection", resourceCulture);
             }
@@ -198,7 +198,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty string literal.
         /// </summary>
-        internal static string EmptyStringLiteralInspection {
+        public static string EmptyStringLiteralInspection {
             get {
                 return ResourceManager.GetString("EmptyStringLiteralInspection", resourceCulture);
             }
@@ -207,7 +207,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;While...Wend&apos; loop.
         /// </summary>
-        internal static string EmptyWhileWendBlockInspection {
+        public static string EmptyWhileWendBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyWhileWendBlockInspection", resourceCulture);
             }
@@ -216,7 +216,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Public field breaks encapsulation.
         /// </summary>
-        internal static string EncapsulatePublicFieldInspection {
+        public static string EncapsulatePublicFieldInspection {
             get {
                 return ResourceManager.GetString("EncapsulatePublicFieldInspection", resourceCulture);
             }
@@ -225,7 +225,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member access may return &apos;Nothing&apos;.
         /// </summary>
-        internal static string ExcelMemberMayReturnNothingInspection {
+        public static string ExcelMemberMayReturnNothingInspection {
             get {
                 return ResourceManager.GetString("ExcelMemberMayReturnNothingInspection", resourceCulture);
             }
@@ -234,7 +234,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Function return value is never used.
         /// </summary>
-        internal static string FunctionReturnValueNotUsedInspection {
+        public static string FunctionReturnValueNotUsedInspection {
             get {
                 return ResourceManager.GetString("FunctionReturnValueNotUsedInspection", resourceCulture);
             }
@@ -243,7 +243,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Host-specific bracketed expression is only evaluated at runtime.
         /// </summary>
-        internal static string HostSpecificExpressionInspection {
+        public static string HostSpecificExpressionInspection {
             get {
                 return ResourceManager.GetString("HostSpecificExpressionInspection", resourceCulture);
             }
@@ -252,7 +252,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable uses Hungarian notation..
         /// </summary>
-        internal static string HungarianNotationInspection {
+        public static string HungarianNotationInspection {
             get {
                 return ResourceManager.GetString("HungarianNotationInspection", resourceCulture);
             }
@@ -261,7 +261,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Illegal annotation.
         /// </summary>
-        internal static string IllegalAnnotationInspection {
+        public static string IllegalAnnotationInspection {
             get {
                 return ResourceManager.GetString("IllegalAnnotationInspection", resourceCulture);
             }
@@ -270,7 +270,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit reference to ActiveSheet.
         /// </summary>
-        internal static string ImplicitActiveSheetReferenceInspection {
+        public static string ImplicitActiveSheetReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveSheetReferenceInspection", resourceCulture);
             }
@@ -279,7 +279,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit reference to ActiveWorkbook.
         /// </summary>
-        internal static string ImplicitActiveWorkbookReferenceInspection {
+        public static string ImplicitActiveWorkbookReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveWorkbookReferenceInspection", resourceCulture);
             }
@@ -288,7 +288,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit ByRef parameter.
         /// </summary>
-        internal static string ImplicitByRefModifierInspection {
+        public static string ImplicitByRefModifierInspection {
             get {
                 return ResourceManager.GetString("ImplicitByRefModifierInspection", resourceCulture);
             }
@@ -297,7 +297,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit default member assignment.
         /// </summary>
-        internal static string ImplicitDefaultMemberAssignmentInspection {
+        public static string ImplicitDefaultMemberAssignmentInspection {
             get {
                 return ResourceManager.GetString("ImplicitDefaultMemberAssignmentInspection", resourceCulture);
             }
@@ -306,7 +306,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicitly public member.
         /// </summary>
-        internal static string ImplicitPublicMemberInspection {
+        public static string ImplicitPublicMemberInspection {
             get {
                 return ResourceManager.GetString("ImplicitPublicMemberInspection", resourceCulture);
             }
@@ -315,7 +315,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member return type is implicitly &apos;Variant&apos;.
         /// </summary>
-        internal static string ImplicitVariantReturnTypeInspection {
+        public static string ImplicitVariantReturnTypeInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantReturnTypeInspection", resourceCulture);
             }
@@ -324,7 +324,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of 16-bit integer type.
         /// </summary>
-        internal static string IntegerDataTypeInspection {
+        public static string IntegerDataTypeInspection {
             get {
                 return ResourceManager.GetString("IntegerDataTypeInspection", resourceCulture);
             }
@@ -333,7 +333,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; function.
         /// </summary>
-        internal static string IsMissingOnInappropriateArgumentInspection {
+        public static string IsMissingOnInappropriateArgumentInspection {
             get {
                 return ResourceManager.GetString("IsMissingOnInappropriateArgumentInspection", resourceCulture);
             }
@@ -342,7 +342,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; function.
         /// </summary>
-        internal static string IsMissingWithNonArgumentParameterInspection {
+        public static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
             }
@@ -351,7 +351,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Line label is not used.
         /// </summary>
-        internal static string LineLabelNotUsedInspection {
+        public static string LineLabelNotUsedInspection {
             get {
                 return ResourceManager.GetString("LineLabelNotUsedInspection", resourceCulture);
             }
@@ -360,7 +360,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member not found.
         /// </summary>
-        internal static string MemberNotOnInterfaceInspection {
+        public static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
             }
@@ -369,7 +369,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Missing annotation parameter.
         /// </summary>
-        internal static string MissingAnnotationArgumentInspection {
+        public static string MissingAnnotationArgumentInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationArgumentInspection", resourceCulture);
             }
@@ -378,7 +378,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Missing annotation.
         /// </summary>
-        internal static string MissingAnnotationInspection {
+        public static string MissingAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
             }
@@ -387,7 +387,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Missing attribute.
         /// </summary>
-        internal static string MissingAttributeInspection {
+        public static string MissingAttributeInspection {
             get {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
@@ -396,7 +396,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of &apos;Dim&apos; keyword at module level.
         /// </summary>
-        internal static string ModuleScopeDimKeywordInspection {
+        public static string ModuleScopeDimKeywordInspection {
             get {
                 return ResourceManager.GetString("ModuleScopeDimKeywordInspection", resourceCulture);
             }
@@ -405,7 +405,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module without &apos;@Folder&apos; annotation.
         /// </summary>
-        internal static string ModuleWithoutFolderInspection {
+        public static string ModuleWithoutFolderInspection {
             get {
                 return ResourceManager.GetString("ModuleWithoutFolderInspection", resourceCulture);
             }
@@ -414,7 +414,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Scope of variable is broader than it needs to be.
         /// </summary>
-        internal static string MoveFieldCloserToUsageInspection {
+        public static string MoveFieldCloserToUsageInspection {
             get {
                 return ResourceManager.GetString("MoveFieldCloserToUsageInspection", resourceCulture);
             }
@@ -423,7 +423,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter declaration is split on multiple lines.
         /// </summary>
-        internal static string MultilineParameterInspection {
+        public static string MultilineParameterInspection {
             get {
                 return ResourceManager.GetString("MultilineParameterInspection", resourceCulture);
             }
@@ -432,7 +432,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Multiple declarations in single instruction.
         /// </summary>
-        internal static string MultipleDeclarationsInspection {
+        public static string MultipleDeclarationsInspection {
             get {
                 return ResourceManager.GetString("MultipleDeclarationsInspection", resourceCulture);
             }
@@ -441,7 +441,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Non-returning function or property getter.
         /// </summary>
-        internal static string NonReturningFunctionInspection {
+        public static string NonReturningFunctionInspection {
             get {
                 return ResourceManager.GetString("NonReturningFunctionInspection", resourceCulture);
             }
@@ -450,7 +450,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object variable assignment requires &apos;Set&apos; keyword.
         /// </summary>
-        internal static string ObjectVariableNotSetInspection {
+        public static string ObjectVariableNotSetInspection {
             get {
                 return ResourceManager.GetString("ObjectVariableNotSetInspection", resourceCulture);
             }
@@ -459,7 +459,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;CDecl&apos; calling convention.
         /// </summary>
-        internal static string ObsoleteCallingConventionInspection {
+        public static string ObsoleteCallingConventionInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallingConventionInspection", resourceCulture);
             }
@@ -468,7 +468,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Call&apos; statement.
         /// </summary>
-        internal static string ObsoleteCallStatementInspection {
+        public static string ObsoleteCallStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallStatementInspection", resourceCulture);
             }
@@ -477,7 +477,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Rem&apos; statement.
         /// </summary>
-        internal static string ObsoleteCommentSyntaxInspection {
+        public static string ObsoleteCommentSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCommentSyntaxInspection", resourceCulture);
             }
@@ -486,7 +486,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Error&apos; statement.
         /// </summary>
-        internal static string ObsoleteErrorSyntaxInspection {
+        public static string ObsoleteErrorSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteErrorSyntaxInspection", resourceCulture);
             }
@@ -495,7 +495,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Global&apos; access modifier.
         /// </summary>
-        internal static string ObsoleteGlobalInspection {
+        public static string ObsoleteGlobalInspection {
             get {
                 return ResourceManager.GetString("ObsoleteGlobalInspection", resourceCulture);
             }
@@ -504,7 +504,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete explicit &apos;Let&apos; statement.
         /// </summary>
-        internal static string ObsoleteLetStatementInspection {
+        public static string ObsoleteLetStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteLetStatementInspection", resourceCulture);
             }
@@ -513,7 +513,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member marked as &apos;@Obsolete&apos; is used.
         /// </summary>
-        internal static string ObsoleteMemberUsageInspection {
+        public static string ObsoleteMemberUsageInspection {
             get {
                 return ResourceManager.GetString("ObsoleteMemberUsageInspection", resourceCulture);
             }
@@ -522,7 +522,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Obsolete Type hint usage.
         /// </summary>
-        internal static string ObsoleteTypeHintInspection {
+        public static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
             }
@@ -531,7 +531,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to On Local Error statement.
         /// </summary>
-        internal static string OnLocalErrorInspection {
+        public static string OnLocalErrorInspection {
             get {
                 return ResourceManager.GetString("OnLocalErrorInspection", resourceCulture);
             }
@@ -540,7 +540,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Base 1&apos; is specified.
         /// </summary>
-        internal static string OptionBaseInspection {
+        public static string OptionBaseInspection {
             get {
                 return ResourceManager.GetString("OptionBaseInspection", resourceCulture);
             }
@@ -549,7 +549,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Base 0&apos; is redundant.
         /// </summary>
-        internal static string OptionBaseZeroInspection {
+        public static string OptionBaseZeroInspection {
             get {
                 return ResourceManager.GetString("OptionBaseZeroInspection", resourceCulture);
             }
@@ -558,7 +558,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Explicit&apos; is not specified.
         /// </summary>
-        internal static string OptionExplicitInspection {
+        public static string OptionExplicitInspection {
             get {
                 return ResourceManager.GetString("OptionExplicitInspection", resourceCulture);
             }
@@ -567,7 +567,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter can be passed by value.
         /// </summary>
-        internal static string ParameterCanBeByValInspection {
+        public static string ParameterCanBeByValInspection {
             get {
                 return ResourceManager.GetString("ParameterCanBeByValInspection", resourceCulture);
             }
@@ -576,7 +576,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter is not referred to.
         /// </summary>
-        internal static string ParameterNotUsedInspection {
+        public static string ParameterNotUsedInspection {
             get {
                 return ResourceManager.GetString("ParameterNotUsedInspection", resourceCulture);
             }
@@ -585,7 +585,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure can be written as a function.
         /// </summary>
-        internal static string ProcedureCanBeWrittenAsFunctionInspection {
+        public static string ProcedureCanBeWrittenAsFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureCanBeWrittenAsFunctionInspection", resourceCulture);
             }
@@ -594,7 +594,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure is not referred to.
         /// </summary>
-        internal static string ProcedureNotUsedInspection {
+        public static string ProcedureNotUsedInspection {
             get {
                 return ResourceManager.GetString("ProcedureNotUsedInspection", resourceCulture);
             }
@@ -603,7 +603,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Redundant &apos;ByRef&apos; modifier.
         /// </summary>
-        internal static string RedundantByRefModifierInspection {
+        public static string RedundantByRefModifierInspection {
             get {
                 return ResourceManager.GetString("RedundantByRefModifierInspection", resourceCulture);
             }
@@ -612,7 +612,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Redundant module option.
         /// </summary>
-        internal static string RedundantOptionInspection {
+        public static string RedundantOptionInspection {
             get {
                 return ResourceManager.GetString("RedundantOptionInspection", resourceCulture);
             }
@@ -621,7 +621,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object variable reference is auto-instantiated.
         /// </summary>
-        internal static string SelfAssignedDeclarationInspection {
+        public static string SelfAssignedDeclarationInspection {
             get {
                 return ResourceManager.GetString("SelfAssignedDeclarationInspection", resourceCulture);
             }
@@ -630,7 +630,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Shadowed declaration.
         /// </summary>
-        internal static string ShadowedDeclarationInspection {
+        public static string ShadowedDeclarationInspection {
             get {
                 return ResourceManager.GetString("ShadowedDeclarationInspection", resourceCulture);
             }
@@ -639,7 +639,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Statically accessible sheet accessed using string.
         /// </summary>
-        internal static string SheetAccessedUsingStringInspection {
+        public static string SheetAccessedUsingStringInspection {
             get {
                 return ResourceManager.GetString("SheetAccessedUsingStringInspection", resourceCulture);
             }
@@ -648,7 +648,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Next&apos; loop step is not specified.
         /// </summary>
-        internal static string StepIsNotSpecifiedInspection {
+        public static string StepIsNotSpecifiedInspection {
             get {
                 return ResourceManager.GetString("StepIsNotSpecifiedInspection", resourceCulture);
             }
@@ -657,7 +657,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Next&apos; loop step 1 is redundant.
         /// </summary>
-        internal static string StepOneIsRedundantInspection {
+        public static string StepOneIsRedundantInspection {
             get {
                 return ResourceManager.GetString("StepOneIsRedundantInspection", resourceCulture);
             }
@@ -666,7 +666,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Stop&apos; keyword.
         /// </summary>
-        internal static string StopKeywordInspection {
+        public static string StopKeywordInspection {
             get {
                 return ResourceManager.GetString("StopKeywordInspection", resourceCulture);
             }
@@ -675,7 +675,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is used but not assigned.
         /// </summary>
-        internal static string UnassignedVariableUsageInspection {
+        public static string UnassignedVariableUsageInspection {
             get {
                 return ResourceManager.GetString("UnassignedVariableUsageInspection", resourceCulture);
             }
@@ -684,7 +684,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Undeclared variable.
         /// </summary>
-        internal static string UndeclaredVariableInspection {
+        public static string UndeclaredVariableInspection {
             get {
                 return ResourceManager.GetString("UndeclaredVariableInspection", resourceCulture);
             }
@@ -693,7 +693,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unhandled &apos;On Error Resume Next&apos;.
         /// </summary>
-        internal static string UnhandledOnErrorResumeNextInspection {
+        public static string UnhandledOnErrorResumeNextInspection {
             get {
                 return ResourceManager.GetString("UnhandledOnErrorResumeNextInspection", resourceCulture);
             }
@@ -702,7 +702,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Case Clause(s) cannot be reached.
         /// </summary>
-        internal static string UnreachableCaseInspection {
+        public static string UnreachableCaseInspection {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection", resourceCulture);
             }
@@ -711,7 +711,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of variant-returning string function.
         /// </summary>
-        internal static string UntypedFunctionUsageInspection {
+        public static string UntypedFunctionUsageInspection {
             get {
                 return ResourceManager.GetString("UntypedFunctionUsageInspection", resourceCulture);
             }
@@ -720,7 +720,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use meaningful names.
         /// </summary>
-        internal static string UseMeaningfulNameInspection {
+        public static string UseMeaningfulNameInspection {
             get {
                 return ResourceManager.GetString("UseMeaningfulNameInspection", resourceCulture);
             }
@@ -729,7 +729,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not assigned.
         /// </summary>
-        internal static string VariableNotAssignedInspection {
+        public static string VariableNotAssignedInspection {
             get {
                 return ResourceManager.GetString("VariableNotAssignedInspection", resourceCulture);
             }
@@ -738,7 +738,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not referred to.
         /// </summary>
-        internal static string VariableNotUsedInspection {
+        public static string VariableNotUsedInspection {
             get {
                 return ResourceManager.GetString("VariableNotUsedInspection", resourceCulture);
             }
@@ -747,7 +747,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicitly &apos;Variant&apos; variable.
         /// </summary>
-        internal static string VariableTypeNotDeclaredInspection {
+        public static string VariableTypeNotDeclaredInspection {
             get {
                 return ResourceManager.GetString("VariableTypeNotDeclaredInspection", resourceCulture);
             }
@@ -756,7 +756,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Write-only property.
         /// </summary>
-        internal static string WriteOnlyPropertyInspection {
+        public static string WriteOnlyPropertyInspection {
             get {
                 return ResourceManager.GetString("WriteOnlyPropertyInspection", resourceCulture);
             }

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.Resources.Inspections {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class InspectionNames {
+    internal class InspectionNames {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Rubberduck.Resources.Inspections.InspectionNames", typeof(InspectionNames).Assembly);
@@ -51,7 +51,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Globalization.CultureInfo Culture {
+        internal static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Late bound WorksheetFunction call..
         /// </summary>
-        public static string ApplicationWorksheetFunctionInspection {
+        internal static string ApplicationWorksheetFunctionInspection {
             get {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionInspection", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to ByVal parameter is assigned.
         /// </summary>
-        public static string AssignedByValParameterInspection {
+        internal static string AssignedByValParameterInspection {
             get {
                 return ResourceManager.GetString("AssignedByValParameterInspection", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment is not used.
         /// </summary>
-        public static string AssignmentNotUsedInspection {
+        internal static string AssignmentNotUsedInspection {
             get {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal assignment in conditional.
         /// </summary>
-        public static string BooleanAssignedInIfElseInspection {
+        internal static string BooleanAssignedInIfElseInspection {
             get {
                 return ResourceManager.GetString("BooleanAssignedInIfElseInspection", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Constant is not used.
         /// </summary>
-        public static string ConstantNotUsedInspection {
+        internal static string ConstantNotUsedInspection {
             get {
                 return ResourceManager.GetString("ConstantNotUsedInspection", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Project name is not specified.
         /// </summary>
-        public static string DefaultProjectNameInspection {
+        internal static string DefaultProjectNameInspection {
             get {
                 return ResourceManager.GetString("DefaultProjectNameInspection", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Usage of &apos;Def[Type]&apos; statement.
         /// </summary>
-        public static string DefTypeStatementInspection {
+        internal static string DefTypeStatementInspection {
             get {
                 return ResourceManager.GetString("DefTypeStatementInspection", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Annotation is duplicated.
         /// </summary>
-        public static string DuplicatedAnnotationInspection {
+        internal static string DuplicatedAnnotationInspection {
             get {
                 return ResourceManager.GetString("DuplicatedAnnotationInspection", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;Case&apos; block.
         /// </summary>
-        public static string EmptyCaseBlockInspection {
+        internal static string EmptyCaseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyCaseBlockInspection", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;Do...While&apos; Loop.
         /// </summary>
-        public static string EmptyDoWhileBlockInspection {
+        internal static string EmptyDoWhileBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyDoWhileBlockInspection", resourceCulture);
             }
@@ -153,7 +153,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;Else&apos; block.
         /// </summary>
-        public static string EmptyElseBlockInspection {
+        internal static string EmptyElseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyElseBlockInspection", resourceCulture);
             }
@@ -162,7 +162,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;For Each...Next&apos; Loop.
         /// </summary>
-        public static string EmptyForEachBlockInspection {
+        internal static string EmptyForEachBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForEachBlockInspection", resourceCulture);
             }
@@ -171,7 +171,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;For...Next&apos; Loop.
         /// </summary>
-        public static string EmptyForLoopBlockInspection {
+        internal static string EmptyForLoopBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForLoopBlockInspection", resourceCulture);
             }
@@ -180,7 +180,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty conditional branch.
         /// </summary>
-        public static string EmptyIfBlockInspection {
+        internal static string EmptyIfBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyIfBlockInspection", resourceCulture);
             }
@@ -189,7 +189,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty module.
         /// </summary>
-        public static string EmptyModuleInspection {
+        internal static string EmptyModuleInspection {
             get {
                 return ResourceManager.GetString("EmptyModuleInspection", resourceCulture);
             }
@@ -198,7 +198,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty string literal.
         /// </summary>
-        public static string EmptyStringLiteralInspection {
+        internal static string EmptyStringLiteralInspection {
             get {
                 return ResourceManager.GetString("EmptyStringLiteralInspection", resourceCulture);
             }
@@ -207,7 +207,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Empty &apos;While...Wend&apos; loop.
         /// </summary>
-        public static string EmptyWhileWendBlockInspection {
+        internal static string EmptyWhileWendBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyWhileWendBlockInspection", resourceCulture);
             }
@@ -216,16 +216,25 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Public field breaks encapsulation.
         /// </summary>
-        public static string EncapsulatePublicFieldInspection {
+        internal static string EncapsulatePublicFieldInspection {
             get {
                 return ResourceManager.GetString("EncapsulatePublicFieldInspection", resourceCulture);
             }
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Member access may return &apos;Nothing&apos;.
+        /// </summary>
+        internal static string ExcelMemberMayReturnNothingInspection {
+            get {
+                return ResourceManager.GetString("ExcelMemberMayReturnNothingInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Function return value is never used.
         /// </summary>
-        public static string FunctionReturnValueNotUsedInspection {
+        internal static string FunctionReturnValueNotUsedInspection {
             get {
                 return ResourceManager.GetString("FunctionReturnValueNotUsedInspection", resourceCulture);
             }
@@ -234,7 +243,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Host-specific bracketed expression is only evaluated at runtime.
         /// </summary>
-        public static string HostSpecificExpressionInspection {
+        internal static string HostSpecificExpressionInspection {
             get {
                 return ResourceManager.GetString("HostSpecificExpressionInspection", resourceCulture);
             }
@@ -243,7 +252,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable uses Hungarian notation..
         /// </summary>
-        public static string HungarianNotationInspection {
+        internal static string HungarianNotationInspection {
             get {
                 return ResourceManager.GetString("HungarianNotationInspection", resourceCulture);
             }
@@ -252,7 +261,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Illegal annotation.
         /// </summary>
-        public static string IllegalAnnotationInspection {
+        internal static string IllegalAnnotationInspection {
             get {
                 return ResourceManager.GetString("IllegalAnnotationInspection", resourceCulture);
             }
@@ -261,7 +270,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit reference to ActiveSheet.
         /// </summary>
-        public static string ImplicitActiveSheetReferenceInspection {
+        internal static string ImplicitActiveSheetReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveSheetReferenceInspection", resourceCulture);
             }
@@ -270,7 +279,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit reference to ActiveWorkbook.
         /// </summary>
-        public static string ImplicitActiveWorkbookReferenceInspection {
+        internal static string ImplicitActiveWorkbookReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveWorkbookReferenceInspection", resourceCulture);
             }
@@ -279,7 +288,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit ByRef parameter.
         /// </summary>
-        public static string ImplicitByRefModifierInspection {
+        internal static string ImplicitByRefModifierInspection {
             get {
                 return ResourceManager.GetString("ImplicitByRefModifierInspection", resourceCulture);
             }
@@ -288,7 +297,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicit default member assignment.
         /// </summary>
-        public static string ImplicitDefaultMemberAssignmentInspection {
+        internal static string ImplicitDefaultMemberAssignmentInspection {
             get {
                 return ResourceManager.GetString("ImplicitDefaultMemberAssignmentInspection", resourceCulture);
             }
@@ -297,7 +306,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicitly public member.
         /// </summary>
-        public static string ImplicitPublicMemberInspection {
+        internal static string ImplicitPublicMemberInspection {
             get {
                 return ResourceManager.GetString("ImplicitPublicMemberInspection", resourceCulture);
             }
@@ -306,7 +315,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member return type is implicitly &apos;Variant&apos;.
         /// </summary>
-        public static string ImplicitVariantReturnTypeInspection {
+        internal static string ImplicitVariantReturnTypeInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantReturnTypeInspection", resourceCulture);
             }
@@ -315,7 +324,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of 16-bit integer type.
         /// </summary>
-        public static string IntegerDataTypeInspection {
+        internal static string IntegerDataTypeInspection {
             get {
                 return ResourceManager.GetString("IntegerDataTypeInspection", resourceCulture);
             }
@@ -324,7 +333,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; function.
         /// </summary>
-        public static string IsMissingOnInappropriateArgumentInspection {
+        internal static string IsMissingOnInappropriateArgumentInspection {
             get {
                 return ResourceManager.GetString("IsMissingOnInappropriateArgumentInspection", resourceCulture);
             }
@@ -333,7 +342,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; function.
         /// </summary>
-        public static string IsMissingWithNonArgumentParameterInspection {
+        internal static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
             }
@@ -342,7 +351,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Line label is not used.
         /// </summary>
-        public static string LineLabelNotUsedInspection {
+        internal static string LineLabelNotUsedInspection {
             get {
                 return ResourceManager.GetString("LineLabelNotUsedInspection", resourceCulture);
             }
@@ -351,7 +360,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member not found.
         /// </summary>
-        public static string MemberNotOnInterfaceInspection {
+        internal static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
             }
@@ -360,7 +369,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Missing annotation parameter.
         /// </summary>
-        public static string MissingAnnotationArgumentInspection {
+        internal static string MissingAnnotationArgumentInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationArgumentInspection", resourceCulture);
             }
@@ -369,7 +378,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Missing annotation.
         /// </summary>
-        public static string MissingAnnotationInspection {
+        internal static string MissingAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
             }
@@ -378,7 +387,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Missing attribute.
         /// </summary>
-        public static string MissingAttributeInspection {
+        internal static string MissingAttributeInspection {
             get {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
@@ -387,7 +396,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of &apos;Dim&apos; keyword at module level.
         /// </summary>
-        public static string ModuleScopeDimKeywordInspection {
+        internal static string ModuleScopeDimKeywordInspection {
             get {
                 return ResourceManager.GetString("ModuleScopeDimKeywordInspection", resourceCulture);
             }
@@ -396,7 +405,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module without &apos;@Folder&apos; annotation.
         /// </summary>
-        public static string ModuleWithoutFolderInspection {
+        internal static string ModuleWithoutFolderInspection {
             get {
                 return ResourceManager.GetString("ModuleWithoutFolderInspection", resourceCulture);
             }
@@ -405,7 +414,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Scope of variable is broader than it needs to be.
         /// </summary>
-        public static string MoveFieldCloserToUsageInspection {
+        internal static string MoveFieldCloserToUsageInspection {
             get {
                 return ResourceManager.GetString("MoveFieldCloserToUsageInspection", resourceCulture);
             }
@@ -414,7 +423,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter declaration is split on multiple lines.
         /// </summary>
-        public static string MultilineParameterInspection {
+        internal static string MultilineParameterInspection {
             get {
                 return ResourceManager.GetString("MultilineParameterInspection", resourceCulture);
             }
@@ -423,7 +432,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Multiple declarations in single instruction.
         /// </summary>
-        public static string MultipleDeclarationsInspection {
+        internal static string MultipleDeclarationsInspection {
             get {
                 return ResourceManager.GetString("MultipleDeclarationsInspection", resourceCulture);
             }
@@ -432,7 +441,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Non-returning function or property getter.
         /// </summary>
-        public static string NonReturningFunctionInspection {
+        internal static string NonReturningFunctionInspection {
             get {
                 return ResourceManager.GetString("NonReturningFunctionInspection", resourceCulture);
             }
@@ -441,7 +450,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object variable assignment requires &apos;Set&apos; keyword.
         /// </summary>
-        public static string ObjectVariableNotSetInspection {
+        internal static string ObjectVariableNotSetInspection {
             get {
                 return ResourceManager.GetString("ObjectVariableNotSetInspection", resourceCulture);
             }
@@ -450,7 +459,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;CDecl&apos; calling convention.
         /// </summary>
-        public static string ObsoleteCallingConventionInspection {
+        internal static string ObsoleteCallingConventionInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallingConventionInspection", resourceCulture);
             }
@@ -459,7 +468,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Call&apos; statement.
         /// </summary>
-        public static string ObsoleteCallStatementInspection {
+        internal static string ObsoleteCallStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallStatementInspection", resourceCulture);
             }
@@ -468,7 +477,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Rem&apos; statement.
         /// </summary>
-        public static string ObsoleteCommentSyntaxInspection {
+        internal static string ObsoleteCommentSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCommentSyntaxInspection", resourceCulture);
             }
@@ -477,7 +486,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Error&apos; statement.
         /// </summary>
-        public static string ObsoleteErrorSyntaxInspection {
+        internal static string ObsoleteErrorSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteErrorSyntaxInspection", resourceCulture);
             }
@@ -486,7 +495,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete &apos;Global&apos; access modifier.
         /// </summary>
-        public static string ObsoleteGlobalInspection {
+        internal static string ObsoleteGlobalInspection {
             get {
                 return ResourceManager.GetString("ObsoleteGlobalInspection", resourceCulture);
             }
@@ -495,7 +504,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of obsolete explicit &apos;Let&apos; statement.
         /// </summary>
-        public static string ObsoleteLetStatementInspection {
+        internal static string ObsoleteLetStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteLetStatementInspection", resourceCulture);
             }
@@ -504,7 +513,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member marked as &apos;@Obsolete&apos; is used.
         /// </summary>
-        public static string ObsoleteMemberUsageInspection {
+        internal static string ObsoleteMemberUsageInspection {
             get {
                 return ResourceManager.GetString("ObsoleteMemberUsageInspection", resourceCulture);
             }
@@ -513,7 +522,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Obsolete Type hint usage.
         /// </summary>
-        public static string ObsoleteTypeHintInspection {
+        internal static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
             }
@@ -522,7 +531,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to On Local Error statement.
         /// </summary>
-        public static string OnLocalErrorInspection {
+        internal static string OnLocalErrorInspection {
             get {
                 return ResourceManager.GetString("OnLocalErrorInspection", resourceCulture);
             }
@@ -531,7 +540,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Base 1&apos; is specified.
         /// </summary>
-        public static string OptionBaseInspection {
+        internal static string OptionBaseInspection {
             get {
                 return ResourceManager.GetString("OptionBaseInspection", resourceCulture);
             }
@@ -540,7 +549,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Base 0&apos; is redundant.
         /// </summary>
-        public static string OptionBaseZeroInspection {
+        internal static string OptionBaseZeroInspection {
             get {
                 return ResourceManager.GetString("OptionBaseZeroInspection", resourceCulture);
             }
@@ -549,7 +558,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Explicit&apos; is not specified.
         /// </summary>
-        public static string OptionExplicitInspection {
+        internal static string OptionExplicitInspection {
             get {
                 return ResourceManager.GetString("OptionExplicitInspection", resourceCulture);
             }
@@ -558,7 +567,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter can be passed by value.
         /// </summary>
-        public static string ParameterCanBeByValInspection {
+        internal static string ParameterCanBeByValInspection {
             get {
                 return ResourceManager.GetString("ParameterCanBeByValInspection", resourceCulture);
             }
@@ -567,7 +576,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter is not referred to.
         /// </summary>
-        public static string ParameterNotUsedInspection {
+        internal static string ParameterNotUsedInspection {
             get {
                 return ResourceManager.GetString("ParameterNotUsedInspection", resourceCulture);
             }
@@ -576,7 +585,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure can be written as a function.
         /// </summary>
-        public static string ProcedureCanBeWrittenAsFunctionInspection {
+        internal static string ProcedureCanBeWrittenAsFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureCanBeWrittenAsFunctionInspection", resourceCulture);
             }
@@ -585,7 +594,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure is not referred to.
         /// </summary>
-        public static string ProcedureNotUsedInspection {
+        internal static string ProcedureNotUsedInspection {
             get {
                 return ResourceManager.GetString("ProcedureNotUsedInspection", resourceCulture);
             }
@@ -594,7 +603,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Redundant &apos;ByRef&apos; modifier.
         /// </summary>
-        public static string RedundantByRefModifierInspection {
+        internal static string RedundantByRefModifierInspection {
             get {
                 return ResourceManager.GetString("RedundantByRefModifierInspection", resourceCulture);
             }
@@ -603,7 +612,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Redundant module option.
         /// </summary>
-        public static string RedundantOptionInspection {
+        internal static string RedundantOptionInspection {
             get {
                 return ResourceManager.GetString("RedundantOptionInspection", resourceCulture);
             }
@@ -612,7 +621,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object variable reference is auto-instantiated.
         /// </summary>
-        public static string SelfAssignedDeclarationInspection {
+        internal static string SelfAssignedDeclarationInspection {
             get {
                 return ResourceManager.GetString("SelfAssignedDeclarationInspection", resourceCulture);
             }
@@ -621,7 +630,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Shadowed declaration.
         /// </summary>
-        public static string ShadowedDeclarationInspection {
+        internal static string ShadowedDeclarationInspection {
             get {
                 return ResourceManager.GetString("ShadowedDeclarationInspection", resourceCulture);
             }
@@ -630,7 +639,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Statically accessible sheet accessed using string.
         /// </summary>
-        public static string SheetAccessedUsingStringInspection {
+        internal static string SheetAccessedUsingStringInspection {
             get {
                 return ResourceManager.GetString("SheetAccessedUsingStringInspection", resourceCulture);
             }
@@ -639,7 +648,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Next&apos; loop step is not specified.
         /// </summary>
-        public static string StepIsNotSpecifiedInspection {
+        internal static string StepIsNotSpecifiedInspection {
             get {
                 return ResourceManager.GetString("StepIsNotSpecifiedInspection", resourceCulture);
             }
@@ -648,7 +657,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Next&apos; loop step 1 is redundant.
         /// </summary>
-        public static string StepOneIsRedundantInspection {
+        internal static string StepOneIsRedundantInspection {
             get {
                 return ResourceManager.GetString("StepOneIsRedundantInspection", resourceCulture);
             }
@@ -657,7 +666,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Stop&apos; keyword.
         /// </summary>
-        public static string StopKeywordInspection {
+        internal static string StopKeywordInspection {
             get {
                 return ResourceManager.GetString("StopKeywordInspection", resourceCulture);
             }
@@ -666,7 +675,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is used but not assigned.
         /// </summary>
-        public static string UnassignedVariableUsageInspection {
+        internal static string UnassignedVariableUsageInspection {
             get {
                 return ResourceManager.GetString("UnassignedVariableUsageInspection", resourceCulture);
             }
@@ -675,7 +684,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Undeclared variable.
         /// </summary>
-        public static string UndeclaredVariableInspection {
+        internal static string UndeclaredVariableInspection {
             get {
                 return ResourceManager.GetString("UndeclaredVariableInspection", resourceCulture);
             }
@@ -684,7 +693,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unhandled &apos;On Error Resume Next&apos;.
         /// </summary>
-        public static string UnhandledOnErrorResumeNextInspection {
+        internal static string UnhandledOnErrorResumeNextInspection {
             get {
                 return ResourceManager.GetString("UnhandledOnErrorResumeNextInspection", resourceCulture);
             }
@@ -693,7 +702,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Case Clause(s) cannot be reached.
         /// </summary>
-        public static string UnreachableCaseInspection {
+        internal static string UnreachableCaseInspection {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection", resourceCulture);
             }
@@ -702,7 +711,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of variant-returning string function.
         /// </summary>
-        public static string UntypedFunctionUsageInspection {
+        internal static string UntypedFunctionUsageInspection {
             get {
                 return ResourceManager.GetString("UntypedFunctionUsageInspection", resourceCulture);
             }
@@ -711,7 +720,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use meaningful names.
         /// </summary>
-        public static string UseMeaningfulNameInspection {
+        internal static string UseMeaningfulNameInspection {
             get {
                 return ResourceManager.GetString("UseMeaningfulNameInspection", resourceCulture);
             }
@@ -720,7 +729,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not assigned.
         /// </summary>
-        public static string VariableNotAssignedInspection {
+        internal static string VariableNotAssignedInspection {
             get {
                 return ResourceManager.GetString("VariableNotAssignedInspection", resourceCulture);
             }
@@ -729,7 +738,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable is not referred to.
         /// </summary>
-        public static string VariableNotUsedInspection {
+        internal static string VariableNotUsedInspection {
             get {
                 return ResourceManager.GetString("VariableNotUsedInspection", resourceCulture);
             }
@@ -738,7 +747,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Implicitly &apos;Variant&apos; variable.
         /// </summary>
-        public static string VariableTypeNotDeclaredInspection {
+        internal static string VariableTypeNotDeclaredInspection {
             get {
                 return ResourceManager.GetString("VariableTypeNotDeclaredInspection", resourceCulture);
             }
@@ -747,7 +756,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Write-only property.
         /// </summary>
-        public static string WriteOnlyPropertyInspection {
+        internal static string WriteOnlyPropertyInspection {
             get {
                 return ResourceManager.GetString("WriteOnlyPropertyInspection", resourceCulture);
             }

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -348,4 +348,7 @@
   <data name="AssignmentNotUsedInspection" xml:space="preserve">
     <value>Assignment is not used</value>
   </data>
+  <data name="ExcelMemberMayReturnNothingInspection" xml:space="preserve">
+    <value>Member access may return 'Nothing'</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.Resources.Inspections {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class InspectionResults {
+    internal class InspectionResults {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Rubberduck.Resources.Inspections.InspectionResults", typeof(InspectionResults).Assembly);
@@ -51,7 +51,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Globalization.CultureInfo Culture {
+        internal static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} ({1} results)..
         /// </summary>
-        public static string AggregateInspection {
+        internal static string AggregateInspection {
             get {
                 return ResourceManager.GetString("AggregateInspection", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of late bound &apos;Application.{0}&apos; member..
         /// </summary>
-        public static string ApplicationWorksheetFunctionInspection {
+        internal static string ApplicationWorksheetFunctionInspection {
             get {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionInspection", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is passed &apos;ByVal&apos; and assigned a value..
         /// </summary>
-        public static string AssignedByValParameterInspection {
+        internal static string AssignedByValParameterInspection {
             get {
                 return ResourceManager.GetString("AssignedByValParameterInspection", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
         /// </summary>
-        public static string AssignmentNotUsedInspection {
+        internal static string AssignmentNotUsedInspection {
             get {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal &apos;{0}&apos; assigned in conditional..
         /// </summary>
-        public static string BooleanAssignedInIfElseInspection {
+        internal static string BooleanAssignedInIfElseInspection {
             get {
                 return ResourceManager.GetString("BooleanAssignedInIfElseInspection", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Project &apos;{0}&apos; has default name..
         /// </summary>
-        public static string DefaultProjectNameInspection {
+        internal static string DefaultProjectNameInspection {
             get {
                 return ResourceManager.GetString("DefaultProjectNameInspection", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider the explicit use of &apos;As {0}&apos; instead of &apos;{1}&apos;..
         /// </summary>
-        public static string DefTypeStatementInspection {
+        internal static string DefTypeStatementInspection {
             get {
                 return ResourceManager.GetString("DefTypeStatementInspection", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Annotation &apos;{0}&apos; is duplicated..
         /// </summary>
-        public static string DuplicatedAnnotationInspection {
+        internal static string DuplicatedAnnotationInspection {
             get {
                 return ResourceManager.GetString("DuplicatedAnnotationInspection", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Case&apos; block contains no executable statements..
         /// </summary>
-        public static string EmptyCaseBlockInspection {
+        internal static string EmptyCaseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyCaseBlockInspection", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Do...While&apos; loop contains no executable statements..
         /// </summary>
-        public static string EmptyDoWhileBlockInspection {
+        internal static string EmptyDoWhileBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyDoWhileBlockInspection", resourceCulture);
             }
@@ -153,7 +153,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Else&apos; block contains no executable statements..
         /// </summary>
-        public static string EmptyElseBlockInspection {
+        internal static string EmptyElseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyElseBlockInspection", resourceCulture);
             }
@@ -162,7 +162,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Each&apos; loop contains no executable statements..
         /// </summary>
-        public static string EmptyForEachBlockInspection {
+        internal static string EmptyForEachBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForEachBlockInspection", resourceCulture);
             }
@@ -171,7 +171,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Next&apos; loop contains no executable statements..
         /// </summary>
-        public static string EmptyForLoopBlockInspection {
+        internal static string EmptyForLoopBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForLoopBlockInspection", resourceCulture);
             }
@@ -180,7 +180,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;If&apos; block contains no executable statements..
         /// </summary>
-        public static string EmptyIfBlockInspection {
+        internal static string EmptyIfBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyIfBlockInspection", resourceCulture);
             }
@@ -189,7 +189,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module/class &apos;{0}&apos; is empty..
         /// </summary>
-        public static string EmptyModuleInspection {
+        internal static string EmptyModuleInspection {
             get {
                 return ResourceManager.GetString("EmptyModuleInspection", resourceCulture);
             }
@@ -198,7 +198,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;vbNullString&apos; preferred to empty string literals..
         /// </summary>
-        public static string EmptyStringLiteralInspection {
+        internal static string EmptyStringLiteralInspection {
             get {
                 return ResourceManager.GetString("EmptyStringLiteralInspection", resourceCulture);
             }
@@ -207,7 +207,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;While...Wend&apos; loop contains no executable statements..
         /// </summary>
-        public static string EmptyWhileWendBlockInspection {
+        internal static string EmptyWhileWendBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyWhileWendBlockInspection", resourceCulture);
             }
@@ -216,16 +216,25 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Public field &apos;{0}&apos; breaks encapsulation..
         /// </summary>
-        public static string EncapsulatePublicFieldInspection {
+        internal static string EncapsulatePublicFieldInspection {
             get {
                 return ResourceManager.GetString("EncapsulatePublicFieldInspection", resourceCulture);
             }
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Result of &apos;{0}&apos; call is not tested for &apos;Nothing&apos;..
+        /// </summary>
+        internal static string ExcelMemberMayReturnNothingInspection {
+            get {
+                return ResourceManager.GetString("ExcelMemberMayReturnNothingInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Return value of function &apos;{0}&apos; is never used..
         /// </summary>
-        public static string FunctionReturnValueNotUsedInspection {
+        internal static string FunctionReturnValueNotUsedInspection {
             get {
                 return ResourceManager.GetString("FunctionReturnValueNotUsedInspection", resourceCulture);
             }
@@ -234,7 +243,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Expression &apos;{0}&apos; cannot be validated at compile-time..
         /// </summary>
-        public static string HostSpecificExpressionInspection {
+        internal static string HostSpecificExpressionInspection {
             get {
                 return ResourceManager.GetString("HostSpecificExpressionInspection", resourceCulture);
             }
@@ -243,7 +252,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider renaming {0} &apos;{1}&apos;..
         /// </summary>
-        public static string IdentifierNameInspection {
+        internal static string IdentifierNameInspection {
             get {
                 return ResourceManager.GetString("IdentifierNameInspection", resourceCulture);
             }
@@ -252,7 +261,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is not used..
         /// </summary>
-        public static string IdentifierNotUsedInspection {
+        internal static string IdentifierNotUsedInspection {
             get {
                 return ResourceManager.GetString("IdentifierNotUsedInspection", resourceCulture);
             }
@@ -261,7 +270,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Annotation &apos;{0}&apos; is illegal in this context..
         /// </summary>
-        public static string IllegalAnnotationInspection {
+        internal static string IllegalAnnotationInspection {
             get {
                 return ResourceManager.GetString("IllegalAnnotationInspection", resourceCulture);
             }
@@ -270,7 +279,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; implicitly references &apos;ActiveSheet&apos;..
         /// </summary>
-        public static string ImplicitActiveSheetReferenceInspection {
+        internal static string ImplicitActiveSheetReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveSheetReferenceInspection", resourceCulture);
             }
@@ -279,7 +288,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; implicitly references &apos;ActiveWorkbook&apos;..
         /// </summary>
-        public static string ImplicitActiveWorkbookReferenceInspection {
+        internal static string ImplicitActiveWorkbookReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveWorkbookReferenceInspection", resourceCulture);
             }
@@ -288,7 +297,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is implicitly passed by reference..
         /// </summary>
-        public static string ImplicitByRefModifierInspection {
+        internal static string ImplicitByRefModifierInspection {
             get {
                 return ResourceManager.GetString("ImplicitByRefModifierInspection", resourceCulture);
             }
@@ -297,7 +306,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment to &apos;{0}&apos; implicitly assigns default member of class &apos;{1}&apos;..
         /// </summary>
-        public static string ImplicitDefaultMemberAssignmentInspection {
+        internal static string ImplicitDefaultMemberAssignmentInspection {
             get {
                 return ResourceManager.GetString("ImplicitDefaultMemberAssignmentInspection", resourceCulture);
             }
@@ -306,7 +315,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; is implicitly public..
         /// </summary>
-        public static string ImplicitPublicMemberInspection {
+        internal static string ImplicitPublicMemberInspection {
             get {
                 return ResourceManager.GetString("ImplicitPublicMemberInspection", resourceCulture);
             }
@@ -315,7 +324,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is implicitly &apos;Variant&apos;..
         /// </summary>
-        public static string ImplicitVariantDeclarationInspection {
+        internal static string ImplicitVariantDeclarationInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantDeclarationInspection", resourceCulture);
             }
@@ -324,7 +333,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Return type of member &apos;{0}&apos; is implicitly &apos;Variant&apos;..
         /// </summary>
-        public static string ImplicitVariantReturnTypeInspection {
+        internal static string ImplicitVariantReturnTypeInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantReturnTypeInspection", resourceCulture);
             }
@@ -333,7 +342,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is declared as &apos;Integer&apos;..
         /// </summary>
-        public static string IntegerDataTypeInspection {
+        internal static string IntegerDataTypeInspection {
             get {
                 return ResourceManager.GetString("IntegerDataTypeInspection", resourceCulture);
             }
@@ -342,7 +351,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;IsMissing&apos; will always return false with the passed argument..
         /// </summary>
-        public static string IsMissingOnInappropriateArgumentInspection {
+        internal static string IsMissingOnInappropriateArgumentInspection {
             get {
                 return ResourceManager.GetString("IsMissingOnInappropriateArgumentInspection", resourceCulture);
             }
@@ -351,7 +360,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;IsMissing&apos; is passed an expresssion that is not an argument to the enclosing procedure..
         /// </summary>
-        public static string IsMissingWithNonArgumentParameterInspection {
+        internal static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
             }
@@ -360,7 +369,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Line label &apos;{0}&apos; is not used..
         /// </summary>
-        public static string LineLabelNotUsedInspection {
+        internal static string LineLabelNotUsedInspection {
             get {
                 return ResourceManager.GetString("LineLabelNotUsedInspection", resourceCulture);
             }
@@ -369,7 +378,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; was not found on the compile-time interface for type &apos;{1}&apos;..
         /// </summary>
-        public static string MemberNotOnInterfaceInspection {
+        internal static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
             }
@@ -378,7 +387,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Expression &apos;{0}&apos; was expected to contain a parameter, but none was specified..
         /// </summary>
-        public static string MissingAnnotationArgumentInspection {
+        internal static string MissingAnnotationArgumentInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationArgumentInspection", resourceCulture);
             }
@@ -387,7 +396,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; attribute, but no corresponding annotation..
         /// </summary>
-        public static string MissingAnnotationInspection {
+        internal static string MissingAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
             }
@@ -396,7 +405,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; annotation, but no corresponding attribute..
         /// </summary>
-        public static string MissingAttributeInspection {
+        internal static string MissingAttributeInspection {
             get {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
@@ -405,7 +414,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module-level variable &apos;{0}&apos; is declared with the &apos;Dim&apos; keyword..
         /// </summary>
-        public static string ModuleScopeDimKeywordInspection {
+        internal static string ModuleScopeDimKeywordInspection {
             get {
                 return ResourceManager.GetString("ModuleScopeDimKeywordInspection", resourceCulture);
             }
@@ -414,7 +423,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module &apos;{0}&apos; has no &apos;@Folder&apos; annotation.
         /// </summary>
-        public static string ModuleWithoutFolderInspection {
+        internal static string ModuleWithoutFolderInspection {
             get {
                 return ResourceManager.GetString("ModuleWithoutFolderInspection", resourceCulture);
             }
@@ -423,7 +432,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Move module-level variable &apos;{0}&apos; to a smaller scope..
         /// </summary>
-        public static string MoveFieldCloserToUsageInspection {
+        internal static string MoveFieldCloserToUsageInspection {
             get {
                 return ResourceManager.GetString("MoveFieldCloserToUsageInspection", resourceCulture);
             }
@@ -432,7 +441,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is specified on multiple lines..
         /// </summary>
-        public static string MultilineParameterInspection {
+        internal static string MultilineParameterInspection {
             get {
                 return ResourceManager.GetString("MultilineParameterInspection", resourceCulture);
             }
@@ -441,7 +450,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Instruction contains multiple declarations..
         /// </summary>
-        public static string MultipleDeclarationsInspection {
+        internal static string MultipleDeclarationsInspection {
             get {
                 return ResourceManager.GetString("MultipleDeclarationsInspection", resourceCulture);
             }
@@ -450,7 +459,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Return value for member &apos;{0}&apos; is never assigned..
         /// </summary>
-        public static string NonReturningFunctionInspection {
+        internal static string NonReturningFunctionInspection {
             get {
                 return ResourceManager.GetString("NonReturningFunctionInspection", resourceCulture);
             }
@@ -459,7 +468,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object variable &apos;{0}&apos; is assigned without the &apos;Set&apos; keyword..
         /// </summary>
-        public static string ObjectVariableNotSetInspection {
+        internal static string ObjectVariableNotSetInspection {
             get {
                 return ResourceManager.GetString("ObjectVariableNotSetInspection", resourceCulture);
             }
@@ -468,7 +477,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is declared using the obsolete &apos;CDecl&apos; calling convention..
         /// </summary>
-        public static string ObsoleteCallingConventionInspection {
+        internal static string ObsoleteCallingConventionInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallingConventionInspection", resourceCulture);
             }
@@ -477,7 +486,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment uses obsolete &apos;Call&apos; modifier..
         /// </summary>
-        public static string ObsoleteCallStatementInspection {
+        internal static string ObsoleteCallStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallStatementInspection", resourceCulture);
             }
@@ -486,7 +495,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Comment uses obsolete &apos;Rem&apos; marker..
         /// </summary>
-        public static string ObsoleteCommentSyntaxInspection {
+        internal static string ObsoleteCommentSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCommentSyntaxInspection", resourceCulture);
             }
@@ -495,7 +504,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A run-time error is raised using the obsolete &apos;Error&apos; statement..
         /// </summary>
-        public static string ObsoleteErrorSyntaxInspection {
+        internal static string ObsoleteErrorSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteErrorSyntaxInspection", resourceCulture);
             }
@@ -504,7 +513,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; uses obsolete &apos;Global&apos; access modifier..
         /// </summary>
-        public static string ObsoleteGlobalInspection {
+        internal static string ObsoleteGlobalInspection {
             get {
                 return ResourceManager.GetString("ObsoleteGlobalInspection", resourceCulture);
             }
@@ -513,7 +522,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment uses obsolete &apos;Let&apos; modifier..
         /// </summary>
-        public static string ObsoleteLetStatementInspection {
+        internal static string ObsoleteLetStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteLetStatementInspection", resourceCulture);
             }
@@ -522,7 +531,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider replacing the call to &apos;{0}&apos;. {1}.
         /// </summary>
-        public static string ObsoleteMemberUsageInspection {
+        internal static string ObsoleteMemberUsageInspection {
             get {
                 return ResourceManager.GetString("ObsoleteMemberUsageInspection", resourceCulture);
             }
@@ -531,7 +540,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} of {1} &apos;{2}&apos; uses an obsolete type hint..
         /// </summary>
-        public static string ObsoleteTypeHintInspection {
+        internal static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
             }
@@ -540,7 +549,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;On Local Error&apos; statement detected..
         /// </summary>
-        public static string OnLocalErrorInspection {
+        internal static string OnLocalErrorInspection {
             get {
                 return ResourceManager.GetString("OnLocalErrorInspection", resourceCulture);
             }
@@ -549,7 +558,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Component &apos;{0}&apos; uses &apos;Option Base 1&apos;..
         /// </summary>
-        public static string OptionBaseInspection {
+        internal static string OptionBaseInspection {
             get {
                 return ResourceManager.GetString("OptionBaseInspection", resourceCulture);
             }
@@ -558,7 +567,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Component &apos;{0}&apos; uses &apos;Option Base 0&apos;..
         /// </summary>
-        public static string OptionBaseZeroInspection {
+        internal static string OptionBaseZeroInspection {
             get {
                 return ResourceManager.GetString("OptionBaseZeroInspection", resourceCulture);
             }
@@ -567,7 +576,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Explicit&apos; is not specified in &apos;{0}&apos;..
         /// </summary>
-        public static string OptionExplicitInspection {
+        internal static string OptionExplicitInspection {
             get {
                 return ResourceManager.GetString("OptionExplicitInspection", resourceCulture);
             }
@@ -576,7 +585,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; can be passed by value..
         /// </summary>
-        public static string ParameterCanBeByValInspection {
+        internal static string ParameterCanBeByValInspection {
             get {
                 return ResourceManager.GetString("ParameterCanBeByValInspection", resourceCulture);
             }
@@ -585,7 +594,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is never used..
         /// </summary>
-        public static string ParameterNotUsedInspection {
+        internal static string ParameterNotUsedInspection {
             get {
                 return ResourceManager.GetString("ParameterNotUsedInspection", resourceCulture);
             }
@@ -594,7 +603,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure &apos;{0}&apos; can be written as a function..
         /// </summary>
-        public static string ProcedureCanBeWrittenAsFunctionInspection {
+        internal static string ProcedureCanBeWrittenAsFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureCanBeWrittenAsFunctionInspection", resourceCulture);
             }
@@ -603,7 +612,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure &apos;{0}&apos; can be written as a function..
         /// </summary>
-        public static string ProcedureShouldBeFunctionInspection {
+        internal static string ProcedureShouldBeFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureShouldBeFunctionInspection", resourceCulture);
             }
@@ -612,7 +621,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; has a redundant &apos;ByRef&apos; modifier..
         /// </summary>
-        public static string RedundantByRefModifierInspection {
+        internal static string RedundantByRefModifierInspection {
             get {
                 return ResourceManager.GetString("RedundantByRefModifierInspection", resourceCulture);
             }
@@ -621,7 +630,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; has no effect..
         /// </summary>
-        public static string RedundantOptionInspection {
+        internal static string RedundantOptionInspection {
             get {
                 return ResourceManager.GetString("RedundantOptionInspection", resourceCulture);
             }
@@ -630,7 +639,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object reference &apos;{0}&apos; is auto-instantiated..
         /// </summary>
-        public static string SelfAssignedDeclarationInspection {
+        internal static string SelfAssignedDeclarationInspection {
             get {
                 return ResourceManager.GetString("SelfAssignedDeclarationInspection", resourceCulture);
             }
@@ -639,7 +648,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; hides {2} &apos;{3}&apos;..
         /// </summary>
-        public static string ShadowedDeclarationInspection {
+        internal static string ShadowedDeclarationInspection {
             get {
                 return ResourceManager.GetString("ShadowedDeclarationInspection", resourceCulture);
             }
@@ -648,7 +657,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Statically accessible sheet can be referred to by its code name..
         /// </summary>
-        public static string SheetAccessedUsingStringInspection {
+        internal static string SheetAccessedUsingStringInspection {
             get {
                 return ResourceManager.GetString("SheetAccessedUsingStringInspection", resourceCulture);
             }
@@ -657,7 +666,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Step&apos; not specified..
         /// </summary>
-        public static string StepIsNotSpecifiedInspection {
+        internal static string StepIsNotSpecifiedInspection {
             get {
                 return ResourceManager.GetString("StepIsNotSpecifiedInspection", resourceCulture);
             }
@@ -666,7 +675,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to 1 is the default step in a &apos;For...Next&apos; loop and therefore is redundant..
         /// </summary>
-        public static string StepOneIsRedundantInspection {
+        internal static string StepOneIsRedundantInspection {
             get {
                 return ResourceManager.GetString("StepOneIsRedundantInspection", resourceCulture);
             }
@@ -675,7 +684,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Stop&apos; keyword halts execution..
         /// </summary>
-        public static string StopKeywordInspection {
+        internal static string StopKeywordInspection {
             get {
                 return ResourceManager.GetString("StopKeywordInspection", resourceCulture);
             }
@@ -684,7 +693,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable &apos;{0}&apos; is used but not assigned..
         /// </summary>
-        public static string UnassignedVariableUsageInspection {
+        internal static string UnassignedVariableUsageInspection {
             get {
                 return ResourceManager.GetString("UnassignedVariableUsageInspection", resourceCulture);
             }
@@ -693,7 +702,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Local variable &apos;{0}&apos; is not declared..
         /// </summary>
-        public static string UndeclaredVariableInspection {
+        internal static string UndeclaredVariableInspection {
             get {
                 return ResourceManager.GetString("UndeclaredVariableInspection", resourceCulture);
             }
@@ -702,7 +711,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Errors are ignored but never handled again..
         /// </summary>
-        public static string UnhandledOnErrorResumeNextInspection {
+        internal static string UnhandledOnErrorResumeNextInspection {
             get {
                 return ResourceManager.GetString("UnhandledOnErrorResumeNextInspection", resourceCulture);
             }
@@ -711,7 +720,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Case clause &apos;{0}&apos; cannot be reached..
         /// </summary>
-        public static string UnreachableCaseInspection {
+        internal static string UnreachableCaseInspection {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection", resourceCulture);
             }
@@ -720,7 +729,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable Case Else: all matches exist within prior Case statement(s)..
         /// </summary>
-        public static string UnreachableCaseInspection_CaseElse {
+        internal static string UnreachableCaseInspection_CaseElse {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_CaseElse", resourceCulture);
             }
@@ -729,7 +738,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Case Statement contains invalid range clause(s)..
         /// </summary>
-        public static string UnreachableCaseInspection_InherentlyUnreachable {
+        internal static string UnreachableCaseInspection_InherentlyUnreachable {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_InherentlyUnreachable", resourceCulture);
             }
@@ -738,7 +747,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Case Statement will cause a Run-time error 6 (Overflow)..
         /// </summary>
-        public static string UnreachableCaseInspection_Overflow {
+        internal static string UnreachableCaseInspection_Overflow {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_Overflow", resourceCulture);
             }
@@ -747,7 +756,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Case Statement will cause a Run-time error 13 (Mismatch)..
         /// </summary>
-        public static string UnreachableCaseInspection_TypeMismatch {
+        internal static string UnreachableCaseInspection_TypeMismatch {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_TypeMismatch", resourceCulture);
             }
@@ -756,7 +765,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Never matches or is equivalent to a prior Case statement..
         /// </summary>
-        public static string UnreachableCaseInspection_Unreachable {
+        internal static string UnreachableCaseInspection_Unreachable {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_Unreachable", resourceCulture);
             }
@@ -765,7 +774,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Replace function &apos;{0}&apos; with existing typed function..
         /// </summary>
-        public static string UntypedFunctionUsageInspection {
+        internal static string UntypedFunctionUsageInspection {
             get {
                 return ResourceManager.GetString("UntypedFunctionUsageInspection", resourceCulture);
             }
@@ -774,7 +783,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable &apos;{0}&apos; is not assigned..
         /// </summary>
-        public static string VariableNotAssignedInspection {
+        internal static string VariableNotAssignedInspection {
             get {
                 return ResourceManager.GetString("VariableNotAssignedInspection", resourceCulture);
             }
@@ -783,7 +792,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is implicitly &apos;Variant&apos;..
         /// </summary>
-        public static string VariableTypeNotDeclaredInspection {
+        internal static string VariableTypeNotDeclaredInspection {
             get {
                 return ResourceManager.GetString("VariableTypeNotDeclaredInspection", resourceCulture);
             }
@@ -792,7 +801,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Property &apos;{0}&apos; has no getter..
         /// </summary>
-        public static string WriteOnlyPropertyInspection {
+        internal static string WriteOnlyPropertyInspection {
             get {
                 return ResourceManager.GetString("WriteOnlyPropertyInspection", resourceCulture);
             }

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.Resources.Inspections {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class InspectionResults {
+    public class InspectionResults {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Rubberduck.Resources.Inspections.InspectionResults", typeof(InspectionResults).Assembly);
@@ -51,7 +51,7 @@ namespace Rubberduck.Resources.Inspections {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} ({1} results)..
         /// </summary>
-        internal static string AggregateInspection {
+        public static string AggregateInspection {
             get {
                 return ResourceManager.GetString("AggregateInspection", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Use of late bound &apos;Application.{0}&apos; member..
         /// </summary>
-        internal static string ApplicationWorksheetFunctionInspection {
+        public static string ApplicationWorksheetFunctionInspection {
             get {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionInspection", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is passed &apos;ByVal&apos; and assigned a value..
         /// </summary>
-        internal static string AssignedByValParameterInspection {
+        public static string AssignedByValParameterInspection {
             get {
                 return ResourceManager.GetString("AssignedByValParameterInspection", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
         /// </summary>
-        internal static string AssignmentNotUsedInspection {
+        public static string AssignmentNotUsedInspection {
             get {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal &apos;{0}&apos; assigned in conditional..
         /// </summary>
-        internal static string BooleanAssignedInIfElseInspection {
+        public static string BooleanAssignedInIfElseInspection {
             get {
                 return ResourceManager.GetString("BooleanAssignedInIfElseInspection", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Project &apos;{0}&apos; has default name..
         /// </summary>
-        internal static string DefaultProjectNameInspection {
+        public static string DefaultProjectNameInspection {
             get {
                 return ResourceManager.GetString("DefaultProjectNameInspection", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider the explicit use of &apos;As {0}&apos; instead of &apos;{1}&apos;..
         /// </summary>
-        internal static string DefTypeStatementInspection {
+        public static string DefTypeStatementInspection {
             get {
                 return ResourceManager.GetString("DefTypeStatementInspection", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Annotation &apos;{0}&apos; is duplicated..
         /// </summary>
-        internal static string DuplicatedAnnotationInspection {
+        public static string DuplicatedAnnotationInspection {
             get {
                 return ResourceManager.GetString("DuplicatedAnnotationInspection", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Case&apos; block contains no executable statements..
         /// </summary>
-        internal static string EmptyCaseBlockInspection {
+        public static string EmptyCaseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyCaseBlockInspection", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Do...While&apos; loop contains no executable statements..
         /// </summary>
-        internal static string EmptyDoWhileBlockInspection {
+        public static string EmptyDoWhileBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyDoWhileBlockInspection", resourceCulture);
             }
@@ -153,7 +153,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Else&apos; block contains no executable statements..
         /// </summary>
-        internal static string EmptyElseBlockInspection {
+        public static string EmptyElseBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyElseBlockInspection", resourceCulture);
             }
@@ -162,7 +162,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Each&apos; loop contains no executable statements..
         /// </summary>
-        internal static string EmptyForEachBlockInspection {
+        public static string EmptyForEachBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForEachBlockInspection", resourceCulture);
             }
@@ -171,7 +171,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;For...Next&apos; loop contains no executable statements..
         /// </summary>
-        internal static string EmptyForLoopBlockInspection {
+        public static string EmptyForLoopBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyForLoopBlockInspection", resourceCulture);
             }
@@ -180,7 +180,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;If&apos; block contains no executable statements..
         /// </summary>
-        internal static string EmptyIfBlockInspection {
+        public static string EmptyIfBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyIfBlockInspection", resourceCulture);
             }
@@ -189,7 +189,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module/class &apos;{0}&apos; is empty..
         /// </summary>
-        internal static string EmptyModuleInspection {
+        public static string EmptyModuleInspection {
             get {
                 return ResourceManager.GetString("EmptyModuleInspection", resourceCulture);
             }
@@ -198,7 +198,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;vbNullString&apos; preferred to empty string literals..
         /// </summary>
-        internal static string EmptyStringLiteralInspection {
+        public static string EmptyStringLiteralInspection {
             get {
                 return ResourceManager.GetString("EmptyStringLiteralInspection", resourceCulture);
             }
@@ -207,7 +207,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;While...Wend&apos; loop contains no executable statements..
         /// </summary>
-        internal static string EmptyWhileWendBlockInspection {
+        public static string EmptyWhileWendBlockInspection {
             get {
                 return ResourceManager.GetString("EmptyWhileWendBlockInspection", resourceCulture);
             }
@@ -216,7 +216,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Public field &apos;{0}&apos; breaks encapsulation..
         /// </summary>
-        internal static string EncapsulatePublicFieldInspection {
+        public static string EncapsulatePublicFieldInspection {
             get {
                 return ResourceManager.GetString("EncapsulatePublicFieldInspection", resourceCulture);
             }
@@ -225,7 +225,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Result of &apos;{0}&apos; call is not tested for &apos;Nothing&apos;..
         /// </summary>
-        internal static string ExcelMemberMayReturnNothingInspection {
+        public static string ExcelMemberMayReturnNothingInspection {
             get {
                 return ResourceManager.GetString("ExcelMemberMayReturnNothingInspection", resourceCulture);
             }
@@ -234,7 +234,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Return value of function &apos;{0}&apos; is never used..
         /// </summary>
-        internal static string FunctionReturnValueNotUsedInspection {
+        public static string FunctionReturnValueNotUsedInspection {
             get {
                 return ResourceManager.GetString("FunctionReturnValueNotUsedInspection", resourceCulture);
             }
@@ -243,7 +243,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Expression &apos;{0}&apos; cannot be validated at compile-time..
         /// </summary>
-        internal static string HostSpecificExpressionInspection {
+        public static string HostSpecificExpressionInspection {
             get {
                 return ResourceManager.GetString("HostSpecificExpressionInspection", resourceCulture);
             }
@@ -252,7 +252,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider renaming {0} &apos;{1}&apos;..
         /// </summary>
-        internal static string IdentifierNameInspection {
+        public static string IdentifierNameInspection {
             get {
                 return ResourceManager.GetString("IdentifierNameInspection", resourceCulture);
             }
@@ -261,7 +261,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is not used..
         /// </summary>
-        internal static string IdentifierNotUsedInspection {
+        public static string IdentifierNotUsedInspection {
             get {
                 return ResourceManager.GetString("IdentifierNotUsedInspection", resourceCulture);
             }
@@ -270,7 +270,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Annotation &apos;{0}&apos; is illegal in this context..
         /// </summary>
-        internal static string IllegalAnnotationInspection {
+        public static string IllegalAnnotationInspection {
             get {
                 return ResourceManager.GetString("IllegalAnnotationInspection", resourceCulture);
             }
@@ -279,7 +279,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; implicitly references &apos;ActiveSheet&apos;..
         /// </summary>
-        internal static string ImplicitActiveSheetReferenceInspection {
+        public static string ImplicitActiveSheetReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveSheetReferenceInspection", resourceCulture);
             }
@@ -288,7 +288,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; implicitly references &apos;ActiveWorkbook&apos;..
         /// </summary>
-        internal static string ImplicitActiveWorkbookReferenceInspection {
+        public static string ImplicitActiveWorkbookReferenceInspection {
             get {
                 return ResourceManager.GetString("ImplicitActiveWorkbookReferenceInspection", resourceCulture);
             }
@@ -297,7 +297,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is implicitly passed by reference..
         /// </summary>
-        internal static string ImplicitByRefModifierInspection {
+        public static string ImplicitByRefModifierInspection {
             get {
                 return ResourceManager.GetString("ImplicitByRefModifierInspection", resourceCulture);
             }
@@ -306,7 +306,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment to &apos;{0}&apos; implicitly assigns default member of class &apos;{1}&apos;..
         /// </summary>
-        internal static string ImplicitDefaultMemberAssignmentInspection {
+        public static string ImplicitDefaultMemberAssignmentInspection {
             get {
                 return ResourceManager.GetString("ImplicitDefaultMemberAssignmentInspection", resourceCulture);
             }
@@ -315,7 +315,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; is implicitly public..
         /// </summary>
-        internal static string ImplicitPublicMemberInspection {
+        public static string ImplicitPublicMemberInspection {
             get {
                 return ResourceManager.GetString("ImplicitPublicMemberInspection", resourceCulture);
             }
@@ -324,7 +324,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is implicitly &apos;Variant&apos;..
         /// </summary>
-        internal static string ImplicitVariantDeclarationInspection {
+        public static string ImplicitVariantDeclarationInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantDeclarationInspection", resourceCulture);
             }
@@ -333,7 +333,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Return type of member &apos;{0}&apos; is implicitly &apos;Variant&apos;..
         /// </summary>
-        internal static string ImplicitVariantReturnTypeInspection {
+        public static string ImplicitVariantReturnTypeInspection {
             get {
                 return ResourceManager.GetString("ImplicitVariantReturnTypeInspection", resourceCulture);
             }
@@ -342,7 +342,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is declared as &apos;Integer&apos;..
         /// </summary>
-        internal static string IntegerDataTypeInspection {
+        public static string IntegerDataTypeInspection {
             get {
                 return ResourceManager.GetString("IntegerDataTypeInspection", resourceCulture);
             }
@@ -351,7 +351,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;IsMissing&apos; will always return false with the passed argument..
         /// </summary>
-        internal static string IsMissingOnInappropriateArgumentInspection {
+        public static string IsMissingOnInappropriateArgumentInspection {
             get {
                 return ResourceManager.GetString("IsMissingOnInappropriateArgumentInspection", resourceCulture);
             }
@@ -360,7 +360,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;IsMissing&apos; is passed an expresssion that is not an argument to the enclosing procedure..
         /// </summary>
-        internal static string IsMissingWithNonArgumentParameterInspection {
+        public static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
             }
@@ -369,7 +369,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Line label &apos;{0}&apos; is not used..
         /// </summary>
-        internal static string LineLabelNotUsedInspection {
+        public static string LineLabelNotUsedInspection {
             get {
                 return ResourceManager.GetString("LineLabelNotUsedInspection", resourceCulture);
             }
@@ -378,7 +378,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Member &apos;{0}&apos; was not found on the compile-time interface for type &apos;{1}&apos;..
         /// </summary>
-        internal static string MemberNotOnInterfaceInspection {
+        public static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
             }
@@ -387,7 +387,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Expression &apos;{0}&apos; was expected to contain a parameter, but none was specified..
         /// </summary>
-        internal static string MissingAnnotationArgumentInspection {
+        public static string MissingAnnotationArgumentInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationArgumentInspection", resourceCulture);
             }
@@ -396,7 +396,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; attribute, but no corresponding annotation..
         /// </summary>
-        internal static string MissingAnnotationInspection {
+        public static string MissingAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
             }
@@ -405,7 +405,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; annotation, but no corresponding attribute..
         /// </summary>
-        internal static string MissingAttributeInspection {
+        public static string MissingAttributeInspection {
             get {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
@@ -414,7 +414,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module-level variable &apos;{0}&apos; is declared with the &apos;Dim&apos; keyword..
         /// </summary>
-        internal static string ModuleScopeDimKeywordInspection {
+        public static string ModuleScopeDimKeywordInspection {
             get {
                 return ResourceManager.GetString("ModuleScopeDimKeywordInspection", resourceCulture);
             }
@@ -423,7 +423,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Module &apos;{0}&apos; has no &apos;@Folder&apos; annotation.
         /// </summary>
-        internal static string ModuleWithoutFolderInspection {
+        public static string ModuleWithoutFolderInspection {
             get {
                 return ResourceManager.GetString("ModuleWithoutFolderInspection", resourceCulture);
             }
@@ -432,7 +432,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Move module-level variable &apos;{0}&apos; to a smaller scope..
         /// </summary>
-        internal static string MoveFieldCloserToUsageInspection {
+        public static string MoveFieldCloserToUsageInspection {
             get {
                 return ResourceManager.GetString("MoveFieldCloserToUsageInspection", resourceCulture);
             }
@@ -441,7 +441,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is specified on multiple lines..
         /// </summary>
-        internal static string MultilineParameterInspection {
+        public static string MultilineParameterInspection {
             get {
                 return ResourceManager.GetString("MultilineParameterInspection", resourceCulture);
             }
@@ -450,7 +450,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Instruction contains multiple declarations..
         /// </summary>
-        internal static string MultipleDeclarationsInspection {
+        public static string MultipleDeclarationsInspection {
             get {
                 return ResourceManager.GetString("MultipleDeclarationsInspection", resourceCulture);
             }
@@ -459,7 +459,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Return value for member &apos;{0}&apos; is never assigned..
         /// </summary>
-        internal static string NonReturningFunctionInspection {
+        public static string NonReturningFunctionInspection {
             get {
                 return ResourceManager.GetString("NonReturningFunctionInspection", resourceCulture);
             }
@@ -468,7 +468,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object variable &apos;{0}&apos; is assigned without the &apos;Set&apos; keyword..
         /// </summary>
-        internal static string ObjectVariableNotSetInspection {
+        public static string ObjectVariableNotSetInspection {
             get {
                 return ResourceManager.GetString("ObjectVariableNotSetInspection", resourceCulture);
             }
@@ -477,7 +477,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is declared using the obsolete &apos;CDecl&apos; calling convention..
         /// </summary>
-        internal static string ObsoleteCallingConventionInspection {
+        public static string ObsoleteCallingConventionInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallingConventionInspection", resourceCulture);
             }
@@ -486,7 +486,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment uses obsolete &apos;Call&apos; modifier..
         /// </summary>
-        internal static string ObsoleteCallStatementInspection {
+        public static string ObsoleteCallStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCallStatementInspection", resourceCulture);
             }
@@ -495,7 +495,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Comment uses obsolete &apos;Rem&apos; marker..
         /// </summary>
-        internal static string ObsoleteCommentSyntaxInspection {
+        public static string ObsoleteCommentSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteCommentSyntaxInspection", resourceCulture);
             }
@@ -504,7 +504,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to A run-time error is raised using the obsolete &apos;Error&apos; statement..
         /// </summary>
-        internal static string ObsoleteErrorSyntaxInspection {
+        public static string ObsoleteErrorSyntaxInspection {
             get {
                 return ResourceManager.GetString("ObsoleteErrorSyntaxInspection", resourceCulture);
             }
@@ -513,7 +513,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; uses obsolete &apos;Global&apos; access modifier..
         /// </summary>
-        internal static string ObsoleteGlobalInspection {
+        public static string ObsoleteGlobalInspection {
             get {
                 return ResourceManager.GetString("ObsoleteGlobalInspection", resourceCulture);
             }
@@ -522,7 +522,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Assignment uses obsolete &apos;Let&apos; modifier..
         /// </summary>
-        internal static string ObsoleteLetStatementInspection {
+        public static string ObsoleteLetStatementInspection {
             get {
                 return ResourceManager.GetString("ObsoleteLetStatementInspection", resourceCulture);
             }
@@ -531,7 +531,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Consider replacing the call to &apos;{0}&apos;. {1}.
         /// </summary>
-        internal static string ObsoleteMemberUsageInspection {
+        public static string ObsoleteMemberUsageInspection {
             get {
                 return ResourceManager.GetString("ObsoleteMemberUsageInspection", resourceCulture);
             }
@@ -540,7 +540,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} of {1} &apos;{2}&apos; uses an obsolete type hint..
         /// </summary>
-        internal static string ObsoleteTypeHintInspection {
+        public static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
             }
@@ -549,7 +549,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;On Local Error&apos; statement detected..
         /// </summary>
-        internal static string OnLocalErrorInspection {
+        public static string OnLocalErrorInspection {
             get {
                 return ResourceManager.GetString("OnLocalErrorInspection", resourceCulture);
             }
@@ -558,7 +558,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Component &apos;{0}&apos; uses &apos;Option Base 1&apos;..
         /// </summary>
-        internal static string OptionBaseInspection {
+        public static string OptionBaseInspection {
             get {
                 return ResourceManager.GetString("OptionBaseInspection", resourceCulture);
             }
@@ -567,7 +567,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Component &apos;{0}&apos; uses &apos;Option Base 0&apos;..
         /// </summary>
-        internal static string OptionBaseZeroInspection {
+        public static string OptionBaseZeroInspection {
             get {
                 return ResourceManager.GetString("OptionBaseZeroInspection", resourceCulture);
             }
@@ -576,7 +576,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Option Explicit&apos; is not specified in &apos;{0}&apos;..
         /// </summary>
-        internal static string OptionExplicitInspection {
+        public static string OptionExplicitInspection {
             get {
                 return ResourceManager.GetString("OptionExplicitInspection", resourceCulture);
             }
@@ -585,7 +585,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; can be passed by value..
         /// </summary>
-        internal static string ParameterCanBeByValInspection {
+        public static string ParameterCanBeByValInspection {
             get {
                 return ResourceManager.GetString("ParameterCanBeByValInspection", resourceCulture);
             }
@@ -594,7 +594,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is never used..
         /// </summary>
-        internal static string ParameterNotUsedInspection {
+        public static string ParameterNotUsedInspection {
             get {
                 return ResourceManager.GetString("ParameterNotUsedInspection", resourceCulture);
             }
@@ -603,7 +603,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure &apos;{0}&apos; can be written as a function..
         /// </summary>
-        internal static string ProcedureCanBeWrittenAsFunctionInspection {
+        public static string ProcedureCanBeWrittenAsFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureCanBeWrittenAsFunctionInspection", resourceCulture);
             }
@@ -612,7 +612,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Procedure &apos;{0}&apos; can be written as a function..
         /// </summary>
-        internal static string ProcedureShouldBeFunctionInspection {
+        public static string ProcedureShouldBeFunctionInspection {
             get {
                 return ResourceManager.GetString("ProcedureShouldBeFunctionInspection", resourceCulture);
             }
@@ -621,7 +621,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; has a redundant &apos;ByRef&apos; modifier..
         /// </summary>
-        internal static string RedundantByRefModifierInspection {
+        public static string RedundantByRefModifierInspection {
             get {
                 return ResourceManager.GetString("RedundantByRefModifierInspection", resourceCulture);
             }
@@ -630,7 +630,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; has no effect..
         /// </summary>
-        internal static string RedundantOptionInspection {
+        public static string RedundantOptionInspection {
             get {
                 return ResourceManager.GetString("RedundantOptionInspection", resourceCulture);
             }
@@ -639,7 +639,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Object reference &apos;{0}&apos; is auto-instantiated..
         /// </summary>
-        internal static string SelfAssignedDeclarationInspection {
+        public static string SelfAssignedDeclarationInspection {
             get {
                 return ResourceManager.GetString("SelfAssignedDeclarationInspection", resourceCulture);
             }
@@ -648,7 +648,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; hides {2} &apos;{3}&apos;..
         /// </summary>
-        internal static string ShadowedDeclarationInspection {
+        public static string ShadowedDeclarationInspection {
             get {
                 return ResourceManager.GetString("ShadowedDeclarationInspection", resourceCulture);
             }
@@ -657,7 +657,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Statically accessible sheet can be referred to by its code name..
         /// </summary>
-        internal static string SheetAccessedUsingStringInspection {
+        public static string SheetAccessedUsingStringInspection {
             get {
                 return ResourceManager.GetString("SheetAccessedUsingStringInspection", resourceCulture);
             }
@@ -666,7 +666,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Step&apos; not specified..
         /// </summary>
-        internal static string StepIsNotSpecifiedInspection {
+        public static string StepIsNotSpecifiedInspection {
             get {
                 return ResourceManager.GetString("StepIsNotSpecifiedInspection", resourceCulture);
             }
@@ -675,7 +675,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to 1 is the default step in a &apos;For...Next&apos; loop and therefore is redundant..
         /// </summary>
-        internal static string StepOneIsRedundantInspection {
+        public static string StepOneIsRedundantInspection {
             get {
                 return ResourceManager.GetString("StepOneIsRedundantInspection", resourceCulture);
             }
@@ -684,7 +684,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Stop&apos; keyword halts execution..
         /// </summary>
-        internal static string StopKeywordInspection {
+        public static string StopKeywordInspection {
             get {
                 return ResourceManager.GetString("StopKeywordInspection", resourceCulture);
             }
@@ -693,7 +693,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable &apos;{0}&apos; is used but not assigned..
         /// </summary>
-        internal static string UnassignedVariableUsageInspection {
+        public static string UnassignedVariableUsageInspection {
             get {
                 return ResourceManager.GetString("UnassignedVariableUsageInspection", resourceCulture);
             }
@@ -702,7 +702,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Local variable &apos;{0}&apos; is not declared..
         /// </summary>
-        internal static string UndeclaredVariableInspection {
+        public static string UndeclaredVariableInspection {
             get {
                 return ResourceManager.GetString("UndeclaredVariableInspection", resourceCulture);
             }
@@ -711,7 +711,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Errors are ignored but never handled again..
         /// </summary>
-        internal static string UnhandledOnErrorResumeNextInspection {
+        public static string UnhandledOnErrorResumeNextInspection {
             get {
                 return ResourceManager.GetString("UnhandledOnErrorResumeNextInspection", resourceCulture);
             }
@@ -720,7 +720,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Case clause &apos;{0}&apos; cannot be reached..
         /// </summary>
-        internal static string UnreachableCaseInspection {
+        public static string UnreachableCaseInspection {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection", resourceCulture);
             }
@@ -729,7 +729,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable Case Else: all matches exist within prior Case statement(s)..
         /// </summary>
-        internal static string UnreachableCaseInspection_CaseElse {
+        public static string UnreachableCaseInspection_CaseElse {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_CaseElse", resourceCulture);
             }
@@ -738,7 +738,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Case Statement contains invalid range clause(s)..
         /// </summary>
-        internal static string UnreachableCaseInspection_InherentlyUnreachable {
+        public static string UnreachableCaseInspection_InherentlyUnreachable {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_InherentlyUnreachable", resourceCulture);
             }
@@ -747,7 +747,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Case Statement will cause a Run-time error 6 (Overflow)..
         /// </summary>
-        internal static string UnreachableCaseInspection_Overflow {
+        public static string UnreachableCaseInspection_Overflow {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_Overflow", resourceCulture);
             }
@@ -756,7 +756,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Case Statement will cause a Run-time error 13 (Mismatch)..
         /// </summary>
-        internal static string UnreachableCaseInspection_TypeMismatch {
+        public static string UnreachableCaseInspection_TypeMismatch {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_TypeMismatch", resourceCulture);
             }
@@ -765,7 +765,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Unreachable: Never matches or is equivalent to a prior Case statement..
         /// </summary>
-        internal static string UnreachableCaseInspection_Unreachable {
+        public static string UnreachableCaseInspection_Unreachable {
             get {
                 return ResourceManager.GetString("UnreachableCaseInspection_Unreachable", resourceCulture);
             }
@@ -774,7 +774,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Replace function &apos;{0}&apos; with existing typed function..
         /// </summary>
-        internal static string UntypedFunctionUsageInspection {
+        public static string UntypedFunctionUsageInspection {
             get {
                 return ResourceManager.GetString("UntypedFunctionUsageInspection", resourceCulture);
             }
@@ -783,7 +783,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Variable &apos;{0}&apos; is not assigned..
         /// </summary>
-        internal static string VariableNotAssignedInspection {
+        public static string VariableNotAssignedInspection {
             get {
                 return ResourceManager.GetString("VariableNotAssignedInspection", resourceCulture);
             }
@@ -792,7 +792,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to {0} &apos;{1}&apos; is implicitly &apos;Variant&apos;..
         /// </summary>
-        internal static string VariableTypeNotDeclaredInspection {
+        public static string VariableTypeNotDeclaredInspection {
             get {
                 return ResourceManager.GetString("VariableTypeNotDeclaredInspection", resourceCulture);
             }
@@ -801,7 +801,7 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to Property &apos;{0}&apos; has no getter..
         /// </summary>
-        internal static string WriteOnlyPropertyInspection {
+        public static string WriteOnlyPropertyInspection {
             get {
                 return ResourceManager.GetString("WriteOnlyPropertyInspection", resourceCulture);
             }

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -378,4 +378,8 @@
   <data name="AssignmentNotUsedInspection" xml:space="preserve">
     <value>An assignment is immediately overridden by another assignment or is never referenced.</value>
   </data>
+  <data name="ExcelMemberMayReturnNothingInspection" xml:space="preserve">
+    <value>Result of '{0}' call is not tested for 'Nothing'.</value>
+    <comment>{0} Member identifier</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -12,12 +12,20 @@
     <Resource Include="**\*.png" />
     <Resource Include="**\*.bmp" />
     <Resource Include="**\*.txt" />
-    <Resource Update="**\*.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>$([System.String]::Copy('%(FileName)')).Designer.cs</LastGenOutput>
-    </Resource>
+  </ItemGroup>
+  
+  <ItemGroup>
     <Compile Update="**\*.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
       <DependentUpon>$([System.String]::Copy('%(Filename)').Replace('.Designer', '')).resx</DependentUpon>
     </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="**\*.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>$([System.String]::Copy('%(FileName)')).Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <EmbeddedResource Update="**\*.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>$([System.String]::Copy('%(FileName)')).Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
@@ -61,182 +61,74 @@ namespace Rubberduck.Resources.Settings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Close curly braces &apos;{&apos;.
+        ///   Looks up a localized string similar to Block Completion.
         /// </summary>
-        public static string AutoCompleteClosingBraceDescription {
+        public static string BlockCompletion {
             get {
-                return ResourceManager.GetString("AutoCompleteClosingBraceDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close square brackets &apos;[&apos;.
-        /// </summary>
-        public static string AutoCompleteClosingBracketDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteClosingBracketDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close parentheses &apos;(&apos;.
-        /// </summary>
-        public static string AutoCompleteClosingParentheseDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteClosingParentheseDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close string literals &apos;&quot;&apos;.
-        /// </summary>
-        public static string AutoCompleteClosingStringDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteClosingStringDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;Do [Until|While]...Loop&apos; loop blocks.
-        /// </summary>
-        public static string AutoCompleteDoBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteDoBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;Enum&apos; blocks.
-        /// </summary>
-        public static string AutoCompleteEnumBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteEnumBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;For [Each]...Next&apos; loop blocks.
-        /// </summary>
-        public static string AutoCompleteForBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteForBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Override &apos;Function&apos; member block completion.
-        /// </summary>
-        public static string AutoCompleteFunctionBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteFunctionBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;If&apos; blocks.
-        /// </summary>
-        public static string AutoCompleteIfBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteIfBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Treat &apos;On Error Resume Next...GoTo 0&apos; as a block.
-        /// </summary>
-        public static string AutoCompleteOnErrorResumeNextBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteOnErrorResumeNextBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close precompiler &apos;#If&apos; blocks.
-        /// </summary>
-        public static string AutoCompletePrecompilerIfBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompletePrecompilerIfBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Override &apos;Property&apos; member block completion.
-        /// </summary>
-        public static string AutoCompletePropertyBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompletePropertyBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;Select&apos; blocks.
-        /// </summary>
-        public static string AutoCompleteSelectBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteSelectBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Override &apos;Sub&apos; member block completion.
-        /// </summary>
-        public static string AutoCompleteSubBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteSubBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;Type&apos; blocks.
-        /// </summary>
-        public static string AutoCompleteTypeBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteTypeBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;While...Wend&apos; loop blocks.
-        /// </summary>
-        public static string AutoCompleteWhileBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteWhileBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Close &apos;With&apos; blocks.
-        /// </summary>
-        public static string AutoCompleteWithBlockDescription {
-            get {
-                return ResourceManager.GetString("AutoCompleteWithBlockDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Enable smart concatenation.
-        /// </summary>
-        public static string EnableSmartConcat {
-            get {
-                return ResourceManager.GetString("EnableSmartConcat", resourceCulture);
+                return ResourceManager.GetString("BlockCompletion", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Autocomplete blocks on ENTER.
         /// </summary>
-        public static string HandleEnterKey {
+        public static string CompleteBlockOnEnter {
             get {
-                return ResourceManager.GetString("HandleEnterKey", resourceCulture);
+                return ResourceManager.GetString("CompleteBlockOnEnter", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Autocomplete blocks on TAB.
         /// </summary>
-        public static string HandleTabKey {
+        public static string CompleteBlockOnTab {
             get {
-                return ResourceManager.GetString("HandleTabKey", resourceCulture);
+                return ResourceManager.GetString("CompleteBlockOnTab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Concatenate &apos;vbNewLine&apos; on Ctrl+Enter.
+        /// </summary>
+        public static string ConcatVbNewLine {
+            get {
+                return ResourceManager.GetString("ConcatVbNewLine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable autocompletion features.
+        /// </summary>
+        public static string EnableAutocompleteLabel {
+            get {
+                return ResourceManager.GetString("EnableAutocompleteLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable block completion.
+        /// </summary>
+        public static string EnableBlockCompletion {
+            get {
+                return ResourceManager.GetString("EnableBlockCompletion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable self-closing pairs.
+        /// </summary>
+        public static string EnableSelfClosingPairs {
+            get {
+                return ResourceManager.GetString("EnableSelfClosingPairs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable smart-concatenation.
+        /// </summary>
+        public static string EnableSmartConcat {
+            get {
+                return ResourceManager.GetString("EnableSmartConcat", resourceCulture);
             }
         }
         
@@ -255,6 +147,24 @@ namespace Rubberduck.Resources.Settings {
         public static string PageInstructions {
             get {
                 return ResourceManager.GetString("PageInstructions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Self-Closing Pairs.
+        /// </summary>
+        public static string SelfClosingPairs {
+            get {
+                return ResourceManager.GetString("SelfClosingPairs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Smart-Concatenation.
+        /// </summary>
+        public static string SmartConcat {
+            get {
+                return ResourceManager.GetString("SmartConcat", resourceCulture);
             }
         }
     }

--- a/Rubberduck.Resources/Settings/SettingsUI.Designer.cs
+++ b/Rubberduck.Resources/Settings/SettingsUI.Designer.cs
@@ -70,15 +70,6 @@ namespace Rubberduck.Resources.Settings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable autocompletion. Feature isn&apos;t fully completed and may behave in unintended ways..
-        /// </summary>
-        public static string EnableAutocompleteLabel {
-            get {
-                return ResourceManager.GetString("EnableAutocompleteLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Export.
         /// </summary>
         public static string ExportPageSettingsButton {

--- a/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
@@ -1,0 +1,298 @@
+﻿using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class ExcelMemberMayReturnNothingInspectionTests
+    {
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_FindWithMemberAccess()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    foo = ws.UsedRange.Find(""foo"").Row
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsNoResult_ResultIsNothingInAssignment()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim foo As Boolean
+    foo = ws.UsedRange.Find(""foo"") Is Nothing
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsNoResult_TransientAccessIsNothing()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    If ws.UsedRange.Find(""foo"") Is Nothing Then
+        Debug.Print ""Not found""
+    End If
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsNoResult_AssignedToVariableIsNothing()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim result As Range
+    Set result = ws.UsedRange.Find(""foo"")
+    If result Is Nothing Then
+        Debug.Print ""Not found""
+    End If
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_AssignedAndNotTested()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim result As Range
+    Set result = ws.UsedRange.Find(""foo"")
+    result.Value = ""bar""
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_ResultIsSomethingElse()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim result As Range
+    Set result = ws.Range(""A1"")
+    If ws.UsedRange.Find(""foo"") Is result Then
+        Debug.Print ""Found it the dumb way""
+    End If
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_FindNext()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim foo As Range
+    Set foo = ws.UsedRange.Find(""foo"")
+    If Not foo Is Nothing Then
+        bar = ws.UsedRange.FindNext(foo).Row
+    End If
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_FindPrevious()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim foo As Range
+    Set foo = ws.UsedRange.Find(""foo"")
+    If Not foo Is Nothing Then
+        bar = ws.UsedRange.FindPrevious(foo).Row
+    End If
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_DefaultAccessExpression()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    If ws.Range(""B:B"").Find(""bar"") = 1 Then 
+        Debug.Print ""bar""
+    End If
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_FindAsWithBlockVariable()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    With ws.UsedRange.Find(""foo"")
+        foo = .Row
+    End With
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_AssignedToWithBlockVariable()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim result As Range
+    Set result = ws.UsedRange.Find(""foo"")
+    With result
+        .Value = ""bar""
+    End With
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        private static RubberduckParserState ArrangeParserAndParse(string inputCode)
+        {
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
+                .AddComponent("Module1", ComponentType.StandardModule, inputCode)
+                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .Build();
+
+            var vbe = builder.AddProject(project).Build();
+
+            return MockParser.CreateAndParse(vbe.Object); ;
+        }
+    }
+}

--- a/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
@@ -35,6 +35,29 @@ End Sub
 
         [Test]
         [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_Ignored_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    '@Ignore ExcelMemberMayReturnNothing
+    foo = ws.UsedRange.Find(""foo"").Row
+End Sub
+";
+
+            using (var state = ArrangeParserAndParse(inputCode))
+            {
+
+                var inspection = new ExcelMemberMayReturnNothingInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ExcelMemberMayReturnNothing_ReturnsNoResult_ResultIsNothingInAssignment()
         {
             const string inputCode =


### PR DESCRIPTION
This also unscrews the csproj that was preventing the resx files from generating the designers.

Note that the members being inspected are not intended to be an exhaustive list at this point.
