### PR TITLE
Add a check for easy hook's nuget package from nuget cache

### DIFF
--- a/Rubberduck.Deployment/Rubberduck.Deployment.csproj
+++ b/Rubberduck.Deployment/Rubberduck.Deployment.csproj
@@ -17,7 +17,10 @@
     <None Include="BuildRegistryScript.ps1" />
     <None Include="Licenses\License.rtf" />
     <None Include="PreInnoSetupConfiguration.ps1" />
+    
+    <!-- EasyHook nuget may be not be within the solution so we need to check different places. The PreserveNewest should hopefully avoid repetitive (but harmless) copying -->
     <Content Include="..\packages\EasyHook.2.7.6684\content\net40\**" CopyToPublishDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
+    <Content Include="$(USERPROFILE)\.nuget\packages\easyHook\2.7.6684\content\net40\**" CopyToPublishDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rubberduck.API\Rubberduck.API.csproj" />
@@ -28,6 +31,11 @@
     <ProjectReference Include="..\Rubberduck.SettingsProvider\Rubberduck.SettingsProvider.csproj" />
     <ProjectReference Include="..\Rubberduck.SmartIndenter\Rubberduck.SmartIndenter.csproj" />
     <ProjectReference Include="..\Rubberduck.VBEEditor\Rubberduck.VBEditor.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="EasyHook" Version="2.7.6684">
+      <CopyToOutputDirectory>content/net40/*</CopyToOutputDirectory>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="olewoo">


### PR DESCRIPTION
Due to how nuget changed how they cache packages and that they are now external to the solution folder, it is possible to have case where the package isn't present within the solution and therefore we would fail to build. This PR now will check in 2 different places.

Note: this is really a hack since the Right Way Of Doing Things isn't supported. Ref: https://github.com/NuGet/Home/issues/4837