### PR TITLE
Include property accessor type in the "search results" tab

### DIFF
--- a/Rubberduck.Core/UI/Command/FindAllImplementationsCommand.cs
+++ b/Rubberduck.Core/UI/Command/FindAllImplementationsCommand.cs
@@ -180,8 +180,15 @@ namespace Rubberduck.UI.Command
                     new NavigateCodeEventArgs(declaration.QualifiedName.QualifiedModuleName, declaration.Selection),
                     GetModuleLine(declaration.QualifiedName.QualifiedModuleName, declaration.Selection.StartLine)));
 
+            var accessor = target.DeclarationType.HasFlag(DeclarationType.PropertyGet) ? "(get)"
+                         : target.DeclarationType.HasFlag(DeclarationType.PropertyLet) ? "(let)"
+                         : target.DeclarationType.HasFlag(DeclarationType.PropertySet) ? "(set)"
+                         : string.Empty;
+
+            var tabCaption = $"{target.IdentifierName} {accessor}".Trim();
+
             var viewModel = new SearchResultsViewModel(_navigateCommand,
-                string.Format(RubberduckUI.SearchResults_AllImplementationsTabFormat, target.IdentifierName), target, results);
+                string.Format(RubberduckUI.SearchResults_AllImplementationsTabFormat, tabCaption), target, results);
 
             return viewModel;
         }

--- a/Rubberduck.Core/UI/Command/FindAllReferencesCommand.cs
+++ b/Rubberduck.Core/UI/Command/FindAllReferencesCommand.cs
@@ -169,9 +169,17 @@ namespace Rubberduck.UI.Command
                     reference.ParentNonScoping,
                     new NavigateCodeEventArgs(reference.QualifiedModuleName, reference.Selection),
                     GetModuleLine(reference.QualifiedModuleName, reference.Selection.StartLine)));
-            
+
+            var accessor = declaration.DeclarationType.HasFlag(DeclarationType.PropertyGet) ? "(get)"
+                         : declaration.DeclarationType.HasFlag(DeclarationType.PropertyLet) ? "(let)"
+                         : declaration.DeclarationType.HasFlag(DeclarationType.PropertySet) ? "(set)"
+                         : string.Empty;
+
+            var tabCaption = $"{declaration.IdentifierName} {accessor}".Trim();
+
+
             var viewModel = new SearchResultsViewModel(_navigateCommand,
-                string.Format(RubberduckUI.SearchResults_AllReferencesTabFormat, declaration.IdentifierName), declaration, results);
+                string.Format(RubberduckUI.SearchResults_AllReferencesTabFormat, tabCaption), declaration, results);
 
             return viewModel;
         }


### PR DESCRIPTION
Appends ` (get)`, ` (let)`, or ` (set)` to the identifier name when the target declaration is a property.

![image](https://user-images.githubusercontent.com/5751684/48462031-74800580-e7a4-11e8-8ba6-b21283dbb06c.png)

![image](https://user-images.githubusercontent.com/5751684/48462050-882b6c00-e7a4-11e8-8c90-8d4bd0c01c89.png)