### PR TITLE
Fixes 4349...take two

### DIFF
--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -1034,12 +1034,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
 
             if (IsEnumOrUDTMemberDeclaration(renameTarget)) 
             {
-                var memberMatches = identifierMatches.Where(idm =>
+                return identifierMatches.Where(idm =>
                     IsEnumOrUDTMemberDeclaration(idm) && idm.ParentDeclaration == renameTarget.ParentDeclaration);
-                if (memberMatches.Any())
-                {
-                    return memberMatches;
-                }
             }
 
             identifierMatches = identifierMatches.Where(nc => !IsEnumOrUDTMemberDeclaration(nc));

--- a/RubberduckTests/Refactoring/RenameTests.cs
+++ b/RubberduckTests/Refactoring/RenameTests.cs
@@ -2384,10 +2384,11 @@ End Sub
             tdo.MsgBox.Verify(m => m.NotifyWarn(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
+        //Issue: https://github.com/rubberduck-vba/Rubberduck/issues/4349
         [Test]
         [Category("Refactorings")]
         [Category("Rename")]
-        public void RenameRefactoring_DoesNotWarnForUDTMember_Issue4349()
+        public void RenameRefactoring_DoesNotWarnForUDTMember()
         {
             var tdo = new RenameTestsDataObject(selection: "VS", newName: "VerySatisfiedResponses");
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
@@ -2424,10 +2425,11 @@ End Sub
             tdo.MsgBox.Verify(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
         }
 
+        //Issue: https://github.com/rubberduck-vba/Rubberduck/issues/4349
         [Test]
         [Category("Refactorings")]
         [Category("Rename")]
-        public void RenameRefactoring_DoesNotWarnForEnumMember_Issue4349()
+        public void RenameRefactoring_DoesNotWarnForEnumMember()
         {
             var tdo = new RenameTestsDataObject(selection: "VerySatisfiedID", newName: "VerySatisfiedResponse");
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
@@ -2456,10 +2458,11 @@ End Sub
             tdo.MsgBox.Verify(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
         }
 
+        //Issue: https://github.com/rubberduck-vba/Rubberduck/issues/4349
         [Test]
         [Category("Refactorings")]
         [Category("Rename")]
-        public void RenameRefactoring_DoesNotWarnForMember_Issue4349()
+        public void RenameRefactoring_DoesNotWarnForMember()
         {
             var tdo = new RenameTestsDataObject(selection: "VerySatisfiedResponse", newName: "VerySatisfiedID");
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)

--- a/RubberduckTests/Refactoring/RenameTests.cs
+++ b/RubberduckTests/Refactoring/RenameTests.cs
@@ -2386,34 +2386,34 @@ End Sub
         [Category("Rename")]
         public void RenameRefactoring_DoesNotWarnForUDTMember_Issue4349()
         {
-            var tdo = new RenameTestsDataObject(selection: "VS", newName: "verySatisfiedResponses");
+            var tdo = new RenameTestsDataObject(selection: "VS", newName: "VerySatisfiedResponses");
             var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
             {
                 Input =
 @"Private Type TMonthScoreInfo
-            verySatisfiedResponses As Long
+            VerySatisfiedResponses As Long
         End Type
 
         Private monthScoreInfo As TMonthScoreInfo
 
         Public Property Get V|S() As Long
-            VS = monthScoreInfo.verySatisfiedResponses
+            VS = monthScoreInfo.VerySatisfiedResponses
         End Property
         Public Property Let VS(ByVal theVal As Long)
-            monthScoreInfo.verySatisfiedResponses = theVal
+            monthScoreInfo.VerySatisfiedResponses = theVal
         End Property",
                 Expected =
 @"Private Type TMonthScoreInfo
-            verySatisfiedResponses As Long
+            VerySatisfiedResponses As Long
         End Type
 
         Private monthScoreInfo As TMonthScoreInfo
 
-        Public Property Get verySatisfiedResponses() As Long
-            verySatisfiedResponses = monthScoreInfo.verySatisfiedResponses
+        Public Property Get VerySatisfiedResponses() As Long
+            VerySatisfiedResponses = monthScoreInfo.VerySatisfiedResponses
         End Property
-        Public Property Let verySatisfiedResponses(ByVal theVal As Long)
-            monthScoreInfo.verySatisfiedResponses = theVal
+        Public Property Let VerySatisfiedResponses(ByVal theVal As Long)
+            monthScoreInfo.VerySatisfiedResponses = theVal
         End Property"
             };
 
@@ -2436,7 +2436,7 @@ End Sub
         End Enum
 
         Public Property Get V|erySatisfiedID() As Long
-            VS = MonthScoreTypes.VerySatisfiedResponse
+            VerySatisfiedID = MonthScoreTypes.VerySatisfiedResponse
         End Property",
                 Expected =
 @"Private Enum MonthScoreTypes
@@ -2445,7 +2445,39 @@ End Sub
         End Enum
 
         Public Property Get VerySatisfiedResponse() As Long
-            VS = MonthScoreTypes.VerySatisfiedResponse
+            VerySatisfiedResponse = MonthScoreTypes.VerySatisfiedResponse
+        End Property",
+            };
+
+            PerformExpectedVersusActualRenameTests(tdo, inputOutput);
+            tdo.MsgBox.Verify(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [Category("Rename")]
+        public void RenameRefactoring_DoesNotWarnForMember_Issue4349()
+        {
+            var tdo = new RenameTestsDataObject(selection: "VerySatisfiedResponse", newName: "VerySatisfiedID");
+            var inputOutput = new RenameTestModuleDefinition("Module1", ComponentType.StandardModule)
+            {
+                Input =
+@"Private Enum MonthScoreTypes
+            VerySa|tisfiedResponse
+            VeryDissatisfiedResponse
+        End Enum
+
+        Public Property Get VerySatisfiedID() As Long
+            VerySatisfiedID = MonthScoreTypes.VerySatisfiedResponse
+        End Property",
+                Expected =
+@"Private Enum MonthScoreTypes
+            VerySatisfiedID
+            VeryDissatisfiedResponse
+        End Enum
+
+        Public Property Get VerySatisfiedID() As Long
+            VerySatisfiedID = MonthScoreTypes.VerySatisfiedID
         End Property",
             };
 


### PR DESCRIPTION
Resolves #4349.  Removes Enums/UDTs rename conflict detection false-positive.
Added a failing repro test for last reported false-positive and some tweaks to the VBA input code for prior #4349 tests. 