### PR TITLE
Restore WinForms designer

### DIFF
--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -94,4 +94,21 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
+
+  <!-- BEGIN WINDOWS FORMS WORKAROUND SECTION -->
+  <ItemGroup>
+    <Compile Update="**\*Window.cs" SubType="Form" />
+    <Compile Update="**\*Dialog.cs" SubType="Form" />
+    <Compile Update="**\SettingsForm.cs" SubType="Form" />
+    <Compile Update="**\SimpleListControl.cs" SubType="Form" />
+    <Compile Update="**\Splash.cs" SubType="Form" />
+    <Compile Update="**\*.Designer.cs">
+      <DependentUpon>$([System.String]::Copy('%(Filename)').Replace('.Designer', '')).cs</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="UI\**\*.resx">
+      <DependentUpon>%(Filename).cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <!-- END WINDOWS FORMS WORKAROUND SECTION -->
+
 </Project>


### PR DESCRIPTION
The sunburst SDK didn't shine on WinForms classes. This brings sun to the WinForms, allow designer and association to work again. 