### PR TITLE
Update CE correctly with external references

### DIFF
--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -293,6 +293,7 @@ namespace Rubberduck.Navigation.CodeExplorer
 
             var userDeclarations = _state.DeclarationFinder.AllUserDeclarations
                 .GroupBy(declaration => declaration.ProjectId)
+                .Where(grouping => grouping.Any(declaration => declaration.DeclarationType == DeclarationType.Project))
                 .ToList();
 
             if (userDeclarations.Any(


### PR DESCRIPTION
Fixes #4060 -- the issue is that the external references gets their own "project" -- but they don't have a project type. For CE's purposes, it only cares about the groups with a project declaration contained within the group. Thus we add a filter to exclude any groups without a project declaration.

Also added a(n useless?) test for rename with bracketed expression, which is green anyway since it was already working. 