### PR TITLE
Rewrite ignore once quickfix

### DIFF
--- a/Rubberduck.CodeAnalysis/QuickFixes/IgnoreOnceQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/IgnoreOnceQuickFix.cs
@@ -31,7 +31,7 @@ namespace Rubberduck.Inspections.QuickFixes
 
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
-            if (result.Target?.DeclarationType.HasFlag(DeclarationType.Module) == true)
+            if (result.Target?.DeclarationType.HasFlag(DeclarationType.Module) ?? false)
             {
                 FixModule(result, rewriteSession);
             }
@@ -92,7 +92,7 @@ namespace Rubberduck.Inspections.QuickFixes
             rewriter.InsertAfter(insertionIndex, insertText);
         }
 
-        private string WhitespaceAfter(VBAParser.EndOfLineContext endOfLine)
+        private static string WhitespaceAfter(VBAParser.EndOfLineContext endOfLine)
         {
             var individualEndOfStatement = (VBAParser.IndividualNonEOFEndOfStatementContext) endOfLine.Parent;
             var whiteSpaceOnNextLine = individualEndOfStatement.whiteSpace(0);

--- a/Rubberduck.CodeAnalysis/QuickFixes/IgnoreOnceQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/IgnoreOnceQuickFix.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
 using Rubberduck.Inspections.Abstract;
+using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Inspections;
 using Rubberduck.Parsing.Inspections.Abstract;
@@ -31,97 +31,109 @@ namespace Rubberduck.Inspections.QuickFixes
 
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
-            var annotationText = result.Target?.DeclarationType.HasFlag(DeclarationType.Module) == true
-                                    ? $"'@IgnoreModule {result.Inspection.AnnotationName}"
-                                    : $"'@Ignore {result.Inspection.AnnotationName}";
-
-            int annotationLine;
-            //TODO: Make this use the parse tree instead of the code module.
-            var component = _state.ProjectsProvider.Component(result.QualifiedSelection.QualifiedName);
-            using (var codeModule = component.CodeModule)
+            if (result.Target?.DeclarationType.HasFlag(DeclarationType.Module) == true)
             {
-                annotationLine = result.QualifiedSelection.Selection.StartLine;
-                while (annotationLine != 1 && codeModule.GetLines(annotationLine - 1, 1).EndsWith(" _"))
-                {
-                    annotationLine--;
-                }
-            }
-
-            var module = result.QualifiedSelection.QualifiedName;
-            var parseTree = _state.GetParseTree(module, CodeKind.CodePaneCode);
-
-            var listener = new CommentOrAnnotationListener();
-            ParseTreeWalker.Default.Walk(listener, parseTree);
-            var commentContext = listener.Contexts.LastOrDefault(i => i.Stop.TokenIndex <= result.Context.Start.TokenIndex);
-            var commented = commentContext?.Stop.Line + 1 == annotationLine;
-
-            var rewriter = rewriteSession.CheckOutModuleRewriter(module);
-
-            if (commented)
-            {
-                var annotation = commentContext.annotationList()?.annotation(0);
-                if (annotation != null && annotation.GetText().StartsWith("Ignore"))
-                {
-                    rewriter.InsertAfter(annotation.annotationName().Stop.TokenIndex, $" {result.Inspection.AnnotationName},");
-                }
-                else
-                {
-                    var indent = new string(Enumerable.Repeat(' ', commentContext.Start.Column).ToArray());
-                    rewriter.InsertAfter(commentContext.Stop.TokenIndex, $"{indent}{annotationText}{Environment.NewLine}");
-                }
+                FixModule(result, rewriteSession);
             }
             else
             {
-                int insertIndex;
-
-                // this value is used when the annotation should be on line 1--we need to insert before token index 0
-                if (annotationLine == 1)
-                {
-                    insertIndex = 0;
-                    annotationText += Environment.NewLine;
-                }
-                else
-                {
-                    var eol = new EndOfLineListener();
-                    ParseTreeWalker.Default.Walk(eol, parseTree);
-
-                    // we subtract 2 here to get the insertion index to A) account for VBE's one-based indexing
-                    // and B) to get the newline token that introduces that line
-                    var eolContext = eol.Contexts.OrderBy(o => o.Start.TokenIndex).ElementAt(annotationLine - 2);
-                    insertIndex = eolContext.Start.TokenIndex;
-
-                    annotationText = Environment.NewLine + annotationText;
-                }
-
-                rewriter.InsertBefore(insertIndex, annotationText);
+                FixNonModule(result, rewriteSession);
             }
+        }
+
+        private void FixNonModule(IInspectionResult result, IRewriteSession rewriteSession)
+        {
+            int insertionIndex;
+            string insertText;
+            var annotationText = $"'@Ignore {result.Inspection.AnnotationName}";
+
+            var module = result.QualifiedSelection.QualifiedName;
+            var parseTree = _state.GetParseTree(module, CodeKind.CodePaneCode);
+            var eolListener = new EndOfLineListener();
+            ParseTreeWalker.Default.Walk(eolListener, parseTree);
+            var previousEol = eolListener.Contexts
+                .OrderBy(eol => eol.Start.TokenIndex)
+                .LastOrDefault(eol => eol.Start.Line < result.QualifiedSelection.Selection.StartLine);
+
+            var rewriter = rewriteSession.CheckOutModuleRewriter(module);
+
+            if (previousEol == null)
+            {
+                // The context to get annotated is on the first line; we need to insert before token index 0.
+                insertionIndex = 0;
+                insertText = annotationText + Environment.NewLine;
+                rewriter.InsertBefore(insertionIndex, insertText);
+                return;
+            }
+
+            var commentContext = previousEol.commentOrAnnotation();
+            if (commentContext == null)
+            {
+                insertionIndex = previousEol.Start.TokenIndex;
+                var indent = WhitespaceAfter(previousEol);
+                insertText = $"{Environment.NewLine}{indent}{annotationText}";
+                rewriter.InsertBefore(insertionIndex, insertText);
+                return;
+            }
+
+            var ignoreAnnotation = commentContext.annotationList()?.annotation()
+                .FirstOrDefault(annotationContext => annotationContext.annotationName().GetText() == AnnotationType.Ignore.ToString());
+            if (ignoreAnnotation == null)
+            {
+                insertionIndex = commentContext.Stop.TokenIndex;
+                var indent = WhitespaceAfter(previousEol);
+                insertText = $"{indent}{annotationText}{Environment.NewLine}";
+                rewriter.InsertAfter(insertionIndex, insertText);
+                return;
+            }
+
+            insertionIndex = ignoreAnnotation.annotationName().Stop.TokenIndex;
+            insertText = $" {result.Inspection.AnnotationName},";
+            rewriter.InsertAfter(insertionIndex, insertText);
+        }
+
+        private string WhitespaceAfter(VBAParser.EndOfLineContext endOfLine)
+        {
+            var individualEndOfStatement = (VBAParser.IndividualNonEOFEndOfStatementContext) endOfLine.Parent;
+            var whiteSpaceOnNextLine = individualEndOfStatement.whiteSpace(0);
+            return whiteSpaceOnNextLine != null
+                ? whiteSpaceOnNextLine.GetText()
+                : string.Empty;
+        }
+
+        private void FixModule(IInspectionResult result, IRewriteSession rewriteSession)
+        {
+            var module = result.QualifiedSelection.QualifiedName;
+            var moduleAnnotations = _state.GetModuleAnnotations(module);
+            var firstIgnoreModuleAnnotation = moduleAnnotations
+                .Where(annotation => annotation.AnnotationType == AnnotationType.IgnoreModule)
+                .OrderBy(annotation => annotation.Context.Start.TokenIndex)
+                .FirstOrDefault();
+
+            var rewriter = rewriteSession.CheckOutModuleRewriter(module);
+
+            int insertionIndex;
+            string insertText;
+
+            if (firstIgnoreModuleAnnotation == null)
+            {
+                insertionIndex = 0;
+                insertText = $"'@IgnoreModule {result.Inspection.AnnotationName}{Environment.NewLine}";
+                rewriter.InsertBefore(insertionIndex, insertText);
+                return;
+            }
+
+            insertionIndex = firstIgnoreModuleAnnotation.Context.annotationName().Stop.TokenIndex;
+            insertText = $" {result.Inspection.AnnotationName},";
+            rewriter.InsertAfter(insertionIndex, insertText);
         }
 
         public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.IgnoreOnce;
 
-        private class CommentOrAnnotationListener : VBAParserBaseListener
-        {
-            private readonly IList<VBAParser.CommentOrAnnotationContext> _contexts = new List<VBAParser.CommentOrAnnotationContext>();
-            public IEnumerable<VBAParser.CommentOrAnnotationContext> Contexts => _contexts;
-
-            public override void ExitCommentOrAnnotation([NotNull] VBAParser.CommentOrAnnotationContext context)
-            {
-                _contexts.Add(context);
-            }
-        }
-
         private class EndOfLineListener : VBAParserBaseListener
         {
-            private readonly IList<ParserRuleContext> _contexts = new List<ParserRuleContext>();
-            public IEnumerable<ParserRuleContext> Contexts => _contexts;
-
-            public override void ExitWhiteSpace([NotNull] VBAParser.WhiteSpaceContext context)
-            {
-                if (context.GetText().Contains(Environment.NewLine))
-                {
-                    _contexts.Add(context);
-                }
-            }
+            private readonly IList<VBAParser.EndOfLineContext> _contexts = new List<VBAParser.EndOfLineContext>();
+            public IEnumerable<VBAParser.EndOfLineContext> Contexts => _contexts;
 
             public override void ExitEndOfLine([NotNull] VBAParser.EndOfLineContext context)
             {

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -898,7 +898,7 @@ statementKeyword :
 ;
 
 endOfLine :
-    whiteSpace? NEWLINE whiteSpace?
+    whiteSpace? NEWLINE
     | whiteSpace? commentOrAnnotation
 ;
 

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -649,6 +649,16 @@ namespace Rubberduck.Parsing.VBA
             _moduleStates[module].SetComments(new List<CommentNode>(comments));
         }
 
+        public IReadOnlyCollection<CommentNode> GetModuleComments(QualifiedModuleName module)
+        {
+            if (!_moduleStates.TryGetValue(module, out var moduleState))
+            {
+                return new List<CommentNode>();
+            }
+
+            return moduleState.Comments;
+        }
+
         public List<IAnnotation> AllAnnotations
         {
             get

--- a/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
@@ -830,6 +830,38 @@ End Sub";
             Assert.AreEqual(expectedCode, actualCode);
         }
 
+
+        [Test]
+        [Category("QuickFixes")]
+        public void EmptyModule_IgnoreQuickFixWorks()
+        {
+            const string inputCode =
+                @"Option Explicit";
+
+            const string expectedCode =
+                @"'@IgnoreModule EmptyModule
+Option Explicit";
+
+            var actualCode = ApplyIgnoreOnceToFirstResult(inputCode, state => new EmptyModuleInspection(state), TestStandardModuleVbeSetup);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+
+        [Test]
+        [Category("QuickFixes")]
+        public void ModuleWithoutFolder_IgnoreQuickFixWorks()
+        {
+            const string inputCode =
+                @"Option Explicit";
+
+            const string expectedCode =
+                @"'@IgnoreModule ModuleWithoutFolder
+Option Explicit";
+
+            var actualCode = ApplyIgnoreOnceToFirstResult(inputCode, state => new ModuleWithoutFolderInspection(state), TestStandardModuleVbeSetup);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
         [Test]
         [Category("QuickFixes")]
         public void WriteOnlyProperty_IgnoreQuickFixWorks()

--- a/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
@@ -31,7 +31,7 @@ End Sub";
             const string expectedCode =
                 @"Sub ExcelSub()
     Dim foo As Double
-'@Ignore ApplicationWorksheetFunction
+    '@Ignore ApplicationWorksheetFunction
     foo = Application.Pi
 End Sub";
 
@@ -69,7 +69,7 @@ End Sub";
 
             const string expectedCode =
                 @"Public Sub Foo()
-'@Ignore ConstantNotUsed
+    '@Ignore ConstantNotUsed
     Const const1 As Integer = 9
 End Sub";
 
@@ -88,7 +88,7 @@ End Sub";
 
             const string expectedCode =
                 @"Public Sub Foo(ByRef arg1 As String)
-'@Ignore EmptyStringLiteral
+    '@Ignore EmptyStringLiteral
     arg1 = """"
 End Sub";
 
@@ -174,7 +174,7 @@ End Sub";
             const string expectedCode =
                 @"Sub foo()
     Dim arr1() As Variant
-'@Ignore ImplicitActiveSheetReference
+    '@Ignore ImplicitActiveSheetReference
     arr1 = Range(""A1:B2"")
 End Sub";
 
@@ -197,7 +197,7 @@ End Sub";
                 @"
 Sub foo()
     Dim sheet As Worksheet
-'@Ignore ImplicitActiveWorkbookReference
+    '@Ignore ImplicitActiveWorkbookReference
     Set sheet = Worksheets(""Sheet1"")
 End Sub";
 
@@ -356,7 +356,7 @@ End Sub";
 
             const string expectedCode =
                 @"Public Sub Foo()
-'@Ignore MultipleDeclarations
+    '@Ignore MultipleDeclarations
     Dim var1 As Integer, var2 As String
 End Sub";
 
@@ -401,7 +401,7 @@ End Sub";
 Private Sub DoSomething()
     
     Dim target As Object
-'@Ignore ObjectVariableNotSet
+    '@Ignore ObjectVariableNotSet
     target = New Object
     
     target.Value = ""forgot something?""
@@ -428,12 +428,12 @@ End Sub";
 
             const string expectedCode =
                 @"Sub Foo()
-'@Ignore ObsoleteCallStatement
+    '@Ignore ObsoleteCallStatement
     Call Goo(1, ""test"")
 End Sub
 
 Sub Goo(arg1 As Integer, arg1 As String)
-'@Ignore ObsoleteCallStatement
+    '@Ignore ObsoleteCallStatement
     Call Foo
 End Sub";
 
@@ -467,7 +467,7 @@ End Sub";
 
             const string expectedCode =
                 @"Sub Foo()
-'@Ignore ObsoleteErrorSyntax
+    '@Ignore ObsoleteErrorSyntax
     Error 91
 End Sub";
 
@@ -508,7 +508,7 @@ End Sub";
     Dim var1 As Integer
     Dim var2 As Integer
     
-'@Ignore ObsoleteLetStatement
+    '@Ignore ObsoleteLetStatement
     Let var2 = var1
 End Sub";
 
@@ -657,7 +657,7 @@ End Sub";
 
             const string expectedCode =
                 @"Sub Foo()
-'@Ignore SelfAssignedDeclaration
+    '@Ignore SelfAssignedDeclaration
     Dim b As New Collection
 End Sub";
 
@@ -681,7 +681,7 @@ End Sub";
                 @"Sub Foo()
     Dim b As Boolean
     Dim bb As Boolean
-'@Ignore UnassignedVariableUsage
+    '@Ignore UnassignedVariableUsage
     bb = b
 End Sub";
 
@@ -896,7 +896,7 @@ End Sub";
             const string expectedCode =
                 @"Sub Foo()
     Dim d As Boolean
-'@Ignore BooleanAssignedInIfElse
+    '@Ignore BooleanAssignedInIfElse
     If True Then
         d = True
     Else
@@ -925,6 +925,60 @@ End Sub";
 End Sub";
 
             var actualCode = ApplyIgnoreOnceToFirstResult(inputCode, state => new UndeclaredVariableInspection(state), TestClassVbeSetup);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void IgnoreQuickFixPrependsToExistingAnnotation_Module()
+        {
+            const string inputCode =
+                @"'@IgnoreModule EmptyModule
+Option Explicit";
+
+            const string expectedCode =
+                @"'@IgnoreModule ModuleWithoutFolder, EmptyModule
+Option Explicit";
+
+            var actualCode = ApplyIgnoreOnceToFirstResult(inputCode, state => new ModuleWithoutFolderInspection(state), TestStandardModuleVbeSetup);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void IgnoreQuickFixDoesNotAppendToExistingAnnotationMixed_ModuleAfterNonModule()
+        {
+            const string inputCode =
+                @"'@Ignore ParameterCanBeByVal
+Private Sub Foo(arg)
+End Sub";
+
+            const string expectedCode =
+                @"'@IgnoreModule ModuleWithoutFolder
+'@Ignore ParameterCanBeByVal
+Private Sub Foo(arg)
+End Sub";
+
+            var actualCode = ApplyIgnoreOnceToFirstResult(inputCode, state => new ModuleWithoutFolderInspection(state), TestStandardModuleVbeSetup);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void IgnoreQuickFixDoesNotPrependToExistingAnnotationMixed_NonModuleAfterModule()
+        {
+            const string inputCode =
+                @"'@IgnoreModule ModuleWithoutFolder
+Private Sub Foo(arg)
+End Sub";
+
+            const string expectedCode =
+                @"'@IgnoreModule ModuleWithoutFolder
+'@Ignore ParameterCanBeByVal
+Private Sub Foo(arg)
+End Sub";
+
+            var actualCode = ApplyIgnoreOnceToFirstResult(inputCode, state => new ParameterCanBeByValInspection(state), TestStandardModuleVbeSetup);
             Assert.AreEqual(expectedCode, actualCode);
         }
 


### PR DESCRIPTION
Closes #4579.

Priviously, the quickfix assumed implicitly that it worked on something inside a module. Moreover, it did not use the right annotation for module annotations. 

In addition, the quickfix now honors the indentation. 
