### PR TITLE
Always deem annotations with GeneralAnnotation flag legal

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/IllegalAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/IllegalAnnotationInspection.cs
@@ -24,7 +24,8 @@ namespace Rubberduck.Inspections.Concrete
             var identifierReferences = State.DeclarationFinder.AllIdentifierReferences().ToList();
             var annotations = State.AllAnnotations;
 
-            var illegalAnnotations = UnboundAnnotations(annotations, userDeclarations, identifierReferences);
+            var illegalAnnotations = UnboundAnnotations(annotations, userDeclarations, identifierReferences)
+                .Where(annotation => !annotation.AnnotationType.HasFlag(AnnotationType.GeneralAnnotation));
 
             return illegalAnnotations.Select(annotation => 
                 new QualifiedContextInspectionResult(

--- a/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
+++ b/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
@@ -784,6 +784,31 @@ End Sub
 
         [Test]
         [Category("Inspections")]
+        public void GeneralAnnotationOnNonDeclarationNonIdentifier_NoResult()
+        {
+            const string inputCode = @"
+Option Explicit
+'@Ignore OptionBase
+Option Base 1
+
+Public foo As Long
+
+Public Sub Test2()
+End Sub
+";
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
         [Ignore("We cannot really test this because we currently do not have a pure IdentifierReferenceAnnotation.")]
         public void IdentifierReferenceAnnotationDoesNotEndMemberAnnotationSection()
         {


### PR DESCRIPTION
These annotation can be placed anywhere and do not necessarily bind to a declaration or identifier reference.

Closes  #4594