### PR TITLE
Fix for variable not set inspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableRequiresSetAssignmentEvaluator.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableRequiresSetAssignmentEvaluator.cs
@@ -53,13 +53,7 @@ namespace Rubberduck.Inspections
             {
                 // get the members of the returning type, a default member could make us lie otherwise
                 var classModule = declaration.AsTypeDeclaration as ClassModuleDeclaration;
-                if (classModule?.DefaultMember == null)
-                {
-                    return true;
-                }
-                var parameters = (classModule.DefaultMember as IParameterizedDeclaration)?.Parameters;
-                // assign declaration is an object without a default parameterless (or with all parameters optional) member - LHS needs a 'Set' keyword.
-                return parameters != null && parameters.Any(p => !p.IsOptional);
+                return !HasPotentiallyNonObjectParameterlessDefaultMember(classModule);
             }
 
             // assigned declaration is a variant. we need to know about the RHS of the assignment.           
@@ -76,9 +70,30 @@ namespace Rubberduck.Inspections
                 return false;
             }
 
-            if (expression is VBAParser.NewExprContext)
+
+            var module = Declaration.GetModuleParent(reference.ParentScoping);
+
+            if (expression is VBAParser.NewExprContext newExpr)
             {
-                // RHS expression is newing up an object reference - LHS needs a 'Set' keyword:
+                var newTypeExpression = newExpr.expression();
+                
+                // todo resolve expression type
+
+                //Covers the case of a single type on the RHS of the assignment.
+                var simpleTypeName = newTypeExpression.GetDescendent<VBAParser.SimpleNameExprContext>();
+                if (simpleTypeName != null && simpleTypeName.GetText() == newTypeExpression.GetText())
+                {
+                    var qualifiedIdentifierSelection = new QualifiedSelection(module.QualifiedModuleName,
+                        simpleTypeName.identifier().GetSelection());
+                    var identifierText = simpleTypeName.identifier().GetText();
+                    return declarationFinderProvider.DeclarationFinder.IdentifierReferences(qualifiedIdentifierSelection)
+                        .Select(identifierReference => identifierReference.Declaration)
+                        .Where(decl => identifierText == decl.IdentifierName)
+                        .OfType<ClassModuleDeclaration>()
+                        .Any(typeDecl => !HasPotentiallyNonObjectParameterlessDefaultMember(typeDecl));
+                }
+                //Here, we err on the side of false-positives, but that seems more appropriate than not to treat qualified type expressions incorrectly.
+                //Whether there is a legitimate use here for default members is questionable anyway.
                 return true;
             }
 
@@ -94,8 +109,6 @@ namespace Rubberduck.Inspections
             }
 
             // todo resolve expression return type
-            var project = Declaration.GetProjectParent(reference.ParentScoping);
-            var module = Declaration.GetModuleParent(reference.ParentScoping);
 
             //Covers the case of a single variable on the RHS of the assignment.
             var simpleName = expression.GetDescendent<VBAParser.SimpleNameExprContext>();
@@ -104,15 +117,40 @@ namespace Rubberduck.Inspections
                 var qualifiedIdentifierSelection = new QualifiedSelection(module.QualifiedModuleName,
                     simpleName.identifier().GetSelection());
                 return declarationFinderProvider.DeclarationFinder.IdentifierReferences(qualifiedIdentifierSelection)
-                    .Any(identifierReference => identifierReference.Declaration.IsObject 
-                                                && simpleName.identifier().GetText() == identifierReference.Declaration.IdentifierName);
+                    .Select(identifierReference => identifierReference.Declaration)
+                    .Where(decl => decl.IsObject
+                                   && simpleName.identifier().GetText() == decl.IdentifierName)
+                    .Select(typeDeclaration => typeDeclaration.AsTypeDeclaration as ClassModuleDeclaration)
+                    .Any(typeDecl => !HasPotentiallyNonObjectParameterlessDefaultMember(typeDecl));
             }
+
+            var project = Declaration.GetProjectParent(reference.ParentScoping);
 
             //todo: Use code path analysis to ensure that we are really picking up the last assignment to the RHS.
             // is the reference referring to something else in scope that's a object?
             return declarationFinderProvider.DeclarationFinder.MatchName(expression.GetText())
                 .Any(decl => (decl.DeclarationType.HasFlag(DeclarationType.ClassModule) || Tokens.Object.Equals(decl.AsTypeName))
                 && AccessibilityCheck.IsAccessible(project, module, reference.ParentScoping, decl));
+        }
+
+        private static bool HasPotentiallyNonObjectParameterlessDefaultMember(ClassModuleDeclaration classModule)
+        {
+            var defaultMember = classModule?.DefaultMember;
+
+            if (defaultMember == null)
+            {
+                return false;
+            }
+
+            var parameters = (defaultMember as IParameterizedDeclaration)?.Parameters;
+            // assign declaration is an object without a default parameterless (or with all parameters optional) member - LHS needs a 'Set' keyword.
+            if (parameters != null && parameters.Any(p => !p.IsOptional))
+            {
+                return false;
+            }
+
+            var defaultMemberType = defaultMember.AsTypeDeclaration as ClassModuleDeclaration;
+            return defaultMemberType == null || HasPotentiallyNonObjectParameterlessDefaultMember(defaultMemberType);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableRequiresSetAssignmentEvaluator.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableRequiresSetAssignmentEvaluator.cs
@@ -96,8 +96,9 @@ namespace Rubberduck.Inspections
             var project = Declaration.GetProjectParent(reference.ParentScoping);
             var module = Declaration.GetModuleParent(reference.ParentScoping);
 
+            //Covers the case of a single variable on the RHS of the assignment.
             var simpleName = expression.GetDescendent<VBAParser.SimpleNameExprContext>();
-            if (simpleName != null)
+            if (simpleName != null && simpleName.GetText() == expression.GetText())
             {
                 return declarationFinderProvider.DeclarationFinder.MatchName(simpleName.identifier().GetText())
                     .Any(d => AccessibilityCheck.IsAccessible(project, module, reference.ParentScoping, d) && d.IsObject);

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableRequiresSetAssignmentEvaluator.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableRequiresSetAssignmentEvaluator.cs
@@ -59,7 +59,7 @@ namespace Rubberduck.Inspections
                 }
                 var parameters = (classModule.DefaultMember as IParameterizedDeclaration)?.Parameters;
                 // assign declaration is an object without a default parameterless (or with all parameters optional) member - LHS needs a 'Set' keyword.
-                return parameters != null && parameters.All(p => p.IsOptional);
+                return parameters != null && parameters.Any(p => !p.IsOptional);
             }
 
             // assigned declaration is a variant. we need to know about the RHS of the assignment.           

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -1178,7 +1178,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         }
 
         /// <summary>
-        /// Gets all identifier references in the specified module.
+        /// Gets all identifier references with the specified selection.
         /// </summary>
         public IEnumerable<IdentifierReference> IdentifierReferences(QualifiedSelection selection)
         {

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -1178,6 +1178,16 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         }
 
         /// <summary>
+        /// Gets all identifier references in the specified module.
+        /// </summary>
+        public IEnumerable<IdentifierReference> IdentifierReferences(QualifiedSelection selection)
+        {
+            return _referencesBySelection.TryGetValue(selection, out var value)
+                ? value
+                : Enumerable.Empty<IdentifierReference>();
+        }
+
+        /// <summary>
         /// Gets all identifier references in the specified member.
         /// </summary>
         public IEnumerable<IdentifierReference> IdentifierReferences(QualifiedMemberName member)

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -157,19 +157,6 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ObjectVariableNotSet_GivenVariantVariableAssignedRange_ReturnsResult()
-        {
-            var expectResultCount = 1;
-            var input =
-@"
-Private Sub TestSub(ByRef testParam As Variant)
-    testParam = Range(""A1:C1"")
-End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel.1.8.xml");
-        }
-
-        [Test]
-        [Category("Inspections")]
         public void ObjectVariableNotSet_GivenVariantVariableAssignedDeclaredRange_ReturnsResult()
         {
             var expectResultCount = 1;
@@ -498,7 +485,7 @@ Private Sub Test()
     bar.Add ""x"", ""x""
     foo = ""Test"" & bar.Item(""x"")
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, new[]{"VBA.4.2"});
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "VBA.4.2");
         }
 
         [Test]
@@ -517,7 +504,7 @@ Private Sub Test()
     bar = 42
     foo = bar
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, new[] { "VBA.4.2" });
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
         }
 
         [Test]

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -157,19 +157,6 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ObjectVariableNotSet_GivenVariantVariableAssignedDeclaredRange_ReturnsResult()
-        {
-            var expectResultCount = 1;
-            var input =
-@"
-Private Sub TestSub(ByRef testParam As Variant, target As Range)
-    testParam = target
-End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel.1.8.xml");
-        }
-
-        [Test]
-        [Category("Inspections")]
         public void ObjectVariableNotSet_GivenVariantVariableAssignedBaseType_ReturnsNoResult()
         {
             var expectResultCount = 0;
@@ -180,24 +167,6 @@ Private Sub Workbook_Open()
     target = ""A1""
 End Sub";
             AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
-        }
-
-        [Test]
-        [Category("Inspections")]
-        public void ObjectVariableNotSet_GivenObjectVariableNotSet_ReturnsResult()
-        {
-            var expectResultCount = 1;
-            var input =
-@"
-Private Sub Workbook_Open()
-    
-    Dim target As Range
-    target = Range(""A1"")
-    
-    target.Value = ""forgot something?""
-
-End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel.1.8.xml");
         }
 
         [Test]
@@ -490,7 +459,7 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ObjectVariableNotSet_SinlgeRHSVariableCaseRespectsDeclarationShadowing()
+        public void ObjectVariableNotSet_SingleRHSVariableCaseRespectsDeclarationShadowing()
         {
 
             var expectResultCount = 0;
@@ -505,6 +474,82 @@ Private Sub Test()
     foo = bar
 End Sub";
             AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ObjectVariableNotSet_SingleRHSVariableCaseRespectsDefaultMembers()
+        {
+            var expectResultCount = 0;
+            var input =
+                @"
+Private Sub Test()    
+    Dim foo As Range
+    Dim bar As Variant    
+    bar = foo
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel.1.8.xml");
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ObjectVariableNotSet_SingleRHSVariableCaseIdentifiesDefaultMembersNotReturningAnObject()
+        {
+            var expectResultCount = 1;
+            var input =
+                @"
+Private Sub Test()    
+    Dim foo As Recordset
+    Dim bar As Variant    
+    bar = foo
+End Sub";
+            //The default member of Recordset is Fields, which is an object.
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB.6.1");
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ObjectVariableNotSet_AssignmentToVarirableWithDefaultMemberReturningAnObject_OneResult()
+        {
+            var expectResultCount = 1;
+            var input =
+                @"
+Private Sub Test()    
+    Dim foo As Recordset
+    Dim bar As Variant    
+    foo = bar
+End Sub";
+            //The default member of Recordset is Fields, which is an object.
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB.6.1");
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ObjectVariableNotSet_NewExprWithNonObjectDefaultMember_NoResult()
+        {
+            var expectResultCount = 0;
+            var input =
+                @"
+Private Sub Test()    
+    Dim foo As Variant  
+    foo = New Connection
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB.6.1");
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ObjectVariableNotSet_NewExprWithObjectOnlyDefaultMember_OneResult()
+        {
+            var expectResultCount = 1;
+            var input =
+                @"
+Private Sub Test()    
+    Dim foo As Variant  
+    foo = New Recordset
+End Sub";
+            //The default member of Recordset is Fields, which is an object.
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB.6.1");
         }
 
         [Test]

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -485,6 +485,24 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
+        public void ObjectVariableNotSet_ComplexExpressionOnRHSWithMemberAccess_ReturnsNoResult()
+        {
+
+            var expectResultCount = 0;
+            var input =
+                @"
+Private Sub Test()
+    Dim foo As Variant
+    Dim bar As Collection
+    Set bar = New Collection
+    bar.Add ""x"", ""x""
+    foo = ""Test"" & bar.Item(""x"")
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, new[]{"VBA.4.2"});
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ObjectVariableNotSet_LSetOnUDT_ReturnsNoResult()
         {
 

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -503,6 +503,25 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
+        public void ObjectVariableNotSet_SinlgeRHSVariableCaseRespectsDeclarationShadowing()
+        {
+
+            var expectResultCount = 0;
+            var input =
+                @"
+Private bar As Collection
+
+Private Sub Test()
+    Dim foo As Variant
+    Dim bar As Long
+    bar = 42
+    foo = bar
+End Sub";
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, new[] { "VBA.4.2" });
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ObjectVariableNotSet_LSetOnUDT_ReturnsNoResult()
         {
 

--- a/RubberduckTests/QuickFixes/UseSetKeywordForObjectAssignmentQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/UseSetKeywordForObjectAssignmentQuickFixTests.cs
@@ -62,21 +62,13 @@ End Sub
         {
             var inputCode =
                 @"
-Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) As Range
-    If source Is Nothing Then
-        CombineRanges = toCombine 'no inspection result (but there should be one!)
-    Else
-        CombineRanges = Union(source, toCombine) 'no inspection result (but there should be one!)
-    End If
+Private Function ReturnObject(ByVal source As Object) As Object
+    ReturnObject = source
 End Function";
             var expectedCode =
                 @"
-Private Function CombineRanges(ByVal source As Range, ByVal toCombine As Range) As Range
-    If source Is Nothing Then
-        Set CombineRanges = toCombine 'no inspection result (but there should be one!)
-    Else
-        Set CombineRanges = Union(source, toCombine) 'no inspection result (but there should be one!)
-    End If
+Private Function ReturnObject(ByVal source As Object) As Object
+    Set ReturnObject = source
 End Function";
 
             var actualCode = ApplyQuickFixToAllInspectionResults(inputCode, state => new ObjectVariableNotSetInspection(state));


### PR DESCRIPTION
Closes #4037
Closes #4318

This PR should remove next to all false-positives for the `ObjectVariableNotSetInspection` not connected to indexed default member accesses. 

I opted not to err on the safe side for `NewExpr` because the legitimate cases are very rare and having false-negatives for simple qualified type expressions is worse from my point of view.  

A real fix is pending the implementation of an expression type derivation engine. 