### PR TITLE
Add missing attribute quickfix

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
@@ -42,6 +42,10 @@ namespace Rubberduck.Inspections.Concrete
 
         private static bool MissesCorrespondingAttribute(Declaration declaration, IAttributeAnnotation annotation)
         {
+            if (string.IsNullOrEmpty(annotation.Attribute))
+            {
+                return false;
+            }
             return declaration.DeclarationType.HasFlag(DeclarationType.Module)
                 ? !declaration.Attributes.HasAttributeFor(annotation)
                 : !declaration.Attributes.HasAttributeFor(annotation, declaration.IdentifierName);

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
@@ -1,87 +1,48 @@
 using System.Collections.Generic;
 using System.Linq;
-using Antlr4.Runtime;
 using Rubberduck.Inspections.Abstract;
 using Rubberduck.Inspections.Results;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Annotations;
-using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Inspections;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
-using Rubberduck.Parsing.VBA.Parsing;
 using Rubberduck.Resources.Inspections;
 
 namespace Rubberduck.Inspections.Concrete
 {
     [CannotAnnotate]
-    public sealed class MissingAttributeInspection : ParseTreeInspectionBase
+    public sealed class MissingAttributeInspection : InspectionBase
     {
         public MissingAttributeInspection(RubberduckParserState state)
             : base(state)
-        {
-            Listener = new MissingMemberAttributeListener(state);
-        }
-
-        public override CodeKind TargetKindOfCode => CodeKind.AttributesCode;
-
-        public override IInspectionListener Listener { get; }
+        {}
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
-            return Listener.Contexts.Select(context =>
+            var declarationsWithAttributeAnnotations = State.DeclarationFinder.AllUserDeclarations
+                .Where(declaration => declaration.Annotations.Any(annotation => annotation.AnnotationType.HasFlag(AnnotationType.Attribute)));
+            var results = new List<DeclarationInspectionResult>();
+            foreach (var declaration in declarationsWithAttributeAnnotations)
             {
-                var name = string.Format(InspectionResults.MissingAttributeInspection, context.MemberName.MemberName,
-                    ((VBAParser.AnnotationContext)context.Context).annotationName().GetText());
-                return new QualifiedContextInspectionResult(this, name, context);
-            });
-        }
-
-        public class MissingMemberAttributeListener : ParseTreeListeners.AttributeAnnotationListener
-        {
-            public MissingMemberAttributeListener(RubberduckParserState state) : base(state) { }
-
-            public override void ExitAnnotation(VBAParser.AnnotationContext context)
-            {
-                var annotationType = context.AnnotationType;
-
-                if (!annotationType.HasFlag(AnnotationType.Attribute))
+                foreach(var annotation in declaration.Annotations.Where(annotation => annotation.AnnotationType.HasFlag(AnnotationType.Attribute)))
                 {
-                    return;
-                }
-
-                var isMemberAnnotation = annotationType.HasFlag(AnnotationType.MemberAnnotation);
-                var isModuleScope = CurrentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Module);
-
-                if (isModuleScope && !isMemberAnnotation)
-                {
-                    // module-level annotation
-                    var module = State.DeclarationFinder.UserDeclarations(DeclarationType.Module).Single(m => m.QualifiedName.QualifiedModuleName.Equals(CurrentModuleName));
-                    if (!module.Attributes.HasAttributeFor(context.AnnotationType))
+                    if (MissesCorrespondingAttribute(declaration, annotation))
                     {
-                        AddContext(new QualifiedContext<ParserRuleContext>(CurrentModuleName, context));
+                        var description = string.Format(InspectionResults.MissingAttributeInspection, declaration.IdentifierName,
+                            annotation.AnnotationType.ToString());
+                        results.Add(new DeclarationInspectionResult(this, description, declaration, new QualifiedContext(declaration.QualifiedModuleName, annotation.Context), annotation));
                     }
-                }
-                else if (isMemberAnnotation)
-                {
-                    // member-level annotation is above the context for the first member in the module..
-                    if (isModuleScope)
-                    {
-                        CurrentScopeDeclaration = FirstMember;
-                    }
-
-                    var member = Members.Value.Single(m => m.Key.Equals(CurrentScopeDeclaration.QualifiedName.MemberName));
-                    if (!member.Value.Attributes.HasAttributeFor(context.AnnotationType, member.Key))
-                    {
-                        AddContext(new QualifiedContext<ParserRuleContext>(CurrentModuleName, context));
-                    }
-                }
-                else
-                {
-                    // annotation is illegal. ignore.
                 }
             }
+
+            return results;
+        }
+
+        private static bool MissesCorrespondingAttribute(Declaration declaration, IAnnotation annotation)
+        {
+            return !declaration.Attributes.HasAttributeFor(annotation.AnnotationType);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
@@ -42,7 +42,9 @@ namespace Rubberduck.Inspections.Concrete
 
         private static bool MissesCorrespondingAttribute(Declaration declaration, IAnnotation annotation)
         {
-            return !declaration.Attributes.HasAttributeFor(annotation.AnnotationType);
+            return declaration.DeclarationType.HasFlag(DeclarationType.Module)
+                ? !declaration.Attributes.HasAttributeFor(annotation.AnnotationType)
+                : !declaration.Attributes.HasAttributeFor(annotation.AnnotationType, declaration.IdentifierName);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
@@ -26,7 +26,7 @@ namespace Rubberduck.Inspections.Concrete
             var results = new List<DeclarationInspectionResult>();
             foreach (var declaration in declarationsWithAttributeAnnotations)
             {
-                foreach(var annotation in declaration.Annotations.Where(annotation => annotation.AnnotationType.HasFlag(AnnotationType.Attribute)))
+                foreach(var annotation in declaration.Annotations.OfType<IAttributeAnnotation>())
                 {
                     if (MissesCorrespondingAttribute(declaration, annotation))
                     {
@@ -40,11 +40,11 @@ namespace Rubberduck.Inspections.Concrete
             return results;
         }
 
-        private static bool MissesCorrespondingAttribute(Declaration declaration, IAnnotation annotation)
+        private static bool MissesCorrespondingAttribute(Declaration declaration, IAttributeAnnotation annotation)
         {
             return declaration.DeclarationType.HasFlag(DeclarationType.Module)
-                ? !declaration.Attributes.HasAttributeFor(annotation.AnnotationType)
-                : !declaration.Attributes.HasAttributeFor(annotation.AnnotationType, declaration.IdentifierName);
+                ? !declaration.Attributes.HasAttributeFor(annotation)
+                : !declaration.Attributes.HasAttributeFor(annotation, declaration.IdentifierName);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
@@ -32,7 +32,12 @@ namespace Rubberduck.Inspections.Concrete
                     {
                         var description = string.Format(InspectionResults.MissingAttributeInspection, declaration.IdentifierName,
                             annotation.AnnotationType.ToString());
-                        results.Add(new DeclarationInspectionResult(this, description, declaration, new QualifiedContext(declaration.QualifiedModuleName, annotation.Context), annotation));
+
+                        var result = new DeclarationInspectionResult(this, description, declaration,
+                            new QualifiedContext(declaration.QualifiedModuleName, annotation.Context));
+                        result.Properties.Annotation = annotation;
+
+                        results.Add(result);
                     }
                 }
             }

--- a/Rubberduck.CodeAnalysis/QuickFixes/AddMissingAttributeQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/AddMissingAttributeQuickFix.cs
@@ -1,0 +1,42 @@
+﻿using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
+
+namespace Rubberduck.Inspections.QuickFixes
+{
+    public sealed class AddMissingAttributeQuickFix : QuickFixBase
+    {
+        private readonly IAttributesUpdater _attributesUpdater; 
+
+        public AddMissingAttributeQuickFix(IAttributesUpdater attributesUpdater)
+            : base(typeof(MissingAttributeInspection))
+        {
+            _attributesUpdater = attributesUpdater;
+        }
+
+        public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
+        {
+            var declaration = result.Target;
+            IAttributeAnnotation annotation = result.Properties.Annotation;
+
+            var attributeName = declaration.DeclarationType.HasFlag(DeclarationType.Module)
+                ? annotation.Attribute
+                : $"{declaration.IdentifierName}.{annotation.Attribute}";
+
+            _attributesUpdater.AddAttribute(rewriteSession, declaration, attributeName, annotation.AttributeValues);
+        }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AddMissingAttributeQuickFix;
+
+        public override CodeKind TargetCodeKind => CodeKind.AttributesCode;
+
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+    }
+}

--- a/Rubberduck.Parsing/Annotations/AnnotationType.cs
+++ b/Rubberduck.Parsing/Annotations/AnnotationType.cs
@@ -64,7 +64,9 @@ namespace Rubberduck.Parsing.Annotations
         PredeclaredId = 1 << 16 | Attribute | ModuleAnnotation,
         [AttributeAnnotation("VB_Exposed", "True")]
         Exposed = 1 << 17 | Attribute | ModuleAnnotation,
-        Obsolete = 1 << 18 | MemberAnnotation | VariableAnnotation
+        Obsolete = 1 << 18 | MemberAnnotation | VariableAnnotation,
+        [AttributeAnnotation("VB_Description")]
+        ModuleDescription = 1 << 19 | Attribute | ModuleAnnotation
     }
 
     [AttributeUsage(AttributeTargets.Field)]

--- a/Rubberduck.Parsing/Annotations/AnnotationType.cs
+++ b/Rubberduck.Parsing/Annotations/AnnotationType.cs
@@ -66,7 +66,9 @@ namespace Rubberduck.Parsing.Annotations
         Exposed = 1 << 17 | Attribute | ModuleAnnotation,
         Obsolete = 1 << 18 | MemberAnnotation | VariableAnnotation,
         [AttributeAnnotation("VB_Description")]
-        ModuleDescription = 1 << 19 | Attribute | ModuleAnnotation
+        ModuleDescription = 1 << 19 | Attribute | ModuleAnnotation,
+        ModuleAttribute = 1 << 20 | Attribute | ModuleAnnotation,
+        MemberAttribute = 1 << 21 | Attribute | MemberAnnotation
     }
 
     [AttributeUsage(AttributeTargets.Field)]

--- a/Rubberduck.Parsing/Annotations/AttributeAnnotationBase.cs
+++ b/Rubberduck.Parsing/Annotations/AttributeAnnotationBase.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.Annotations
+{
+    public abstract class AttributeAnnotationBase : AnnotationBase, IAttributeAnnotation
+    {
+        protected AttributeAnnotationBase(AnnotationType annotationType, QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> attributeValues) 
+        :base(annotationType, qualifiedSelection, context)
+        {
+            AttributeValues = attributeValues;
+        }
+
+        public abstract string Attribute { get; }
+        public IReadOnlyList<string> AttributeValues { get; }
+    }
+}

--- a/Rubberduck.Parsing/Annotations/AttributeAnnotationBase.cs
+++ b/Rubberduck.Parsing/Annotations/AttributeAnnotationBase.cs
@@ -9,7 +9,7 @@ namespace Rubberduck.Parsing.Annotations
         protected AttributeAnnotationBase(AnnotationType annotationType, QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> attributeValues) 
         :base(annotationType, qualifiedSelection, context)
         {
-            AttributeValues = attributeValues;
+            AttributeValues = attributeValues ?? new List<string>();
         }
 
         public abstract string Attribute { get; }

--- a/Rubberduck.Parsing/Annotations/DefaultMemberAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/DefaultMemberAnnotation.cs
@@ -13,7 +13,7 @@ namespace Rubberduck.Parsing.Annotations
         public DefaultMemberAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
             : base(AnnotationType.DefaultMember, qualifiedSelection, context, new List<string> { "0" })
         {
-            Description = parameters.FirstOrDefault();
+            Description = parameters?.FirstOrDefault() ?? string.Empty;
         }
 
         public string Description { get; }

--- a/Rubberduck.Parsing/Annotations/DefaultMemberAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/DefaultMemberAnnotation.cs
@@ -8,15 +8,15 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Used for specifying a member's <c>VB_UserMemId</c> attribute value.
     /// </summary>
-    public sealed class DefaultMemberAnnotation : AnnotationBase, IAttributeAnnotation
+    public sealed class DefaultMemberAnnotation : AttributeAnnotationBase
     {
         public DefaultMemberAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.DefaultMember, qualifiedSelection, context)
+            : base(AnnotationType.DefaultMember, qualifiedSelection, context, new List<string> { "0" })
         {
             Description = parameters.FirstOrDefault();
         }
 
         public string Description { get; }
-        public string Attribute => "VB_UserMemId = 0";
+        public override string Attribute => "VB_UserMemId";
     }
 }

--- a/Rubberduck.Parsing/Annotations/DescriptionAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/DescriptionAnnotation.cs
@@ -11,7 +11,7 @@ namespace Rubberduck.Parsing.Annotations
     public sealed class DescriptionAnnotation : AttributeAnnotationBase
     {
         public DescriptionAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.Description, qualifiedSelection, context, parameters.Take(1).ToList())
+            : base(AnnotationType.Description, qualifiedSelection, context, parameters?.Take(1).ToList())
         {
             Description = AttributeValues?.FirstOrDefault();
             if ((Description?.StartsWith("\"") ?? false) && Description.EndsWith("\""))

--- a/Rubberduck.Parsing/Annotations/DescriptionAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/DescriptionAnnotation.cs
@@ -8,12 +8,12 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Used for specifying a member's <c>VB_Description</c> attribute.
     /// </summary>
-    public sealed class DescriptionAnnotation : AnnotationBase, IAttributeAnnotation
+    public sealed class DescriptionAnnotation : AttributeAnnotationBase
     {
         public DescriptionAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.Description, qualifiedSelection, context)
+            : base(AnnotationType.Description, qualifiedSelection, context, parameters.Take(1).ToList())
         {
-            Description = parameters?.FirstOrDefault();
+            Description = AttributeValues?.FirstOrDefault();
             if ((Description?.StartsWith("\"") ?? false) && Description.EndsWith("\""))
             {
                 // strip surrounding double quotes
@@ -22,6 +22,6 @@ namespace Rubberduck.Parsing.Annotations
         }
 
         public string Description { get; }
-        public string Attribute => $"VB_Description = \"{Description.Replace("\"", "\"\"")}\"";
+        public override string Attribute => "VB_Description";
     }
 }

--- a/Rubberduck.Parsing/Annotations/EnumeratorMemberAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/EnumeratorMemberAnnotation.cs
@@ -8,15 +8,12 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Used for specifying a member's <c>VB_UserMemId</c> attribute value.
     /// </summary>
-    public sealed class EnumeratorMemberAnnotation : AnnotationBase, IAttributeAnnotation
+    public sealed class EnumeratorMemberAnnotation : AttributeAnnotationBase
     {
         public EnumeratorMemberAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.Enumerator, qualifiedSelection, context)
-        {
-            Description = parameters.FirstOrDefault();
-        }
+            : base(AnnotationType.Enumerator, qualifiedSelection, context, new List<string> { "-4" })
+        {}
 
-        public string Description { get; }
-        public string Attribute => ".VB_UserMemId = -4";
+        public override string Attribute => "VB_UserMemId";
     }
 }

--- a/Rubberduck.Parsing/Annotations/ExposedModuleAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ExposedModuleAnnotation.cs
@@ -10,7 +10,7 @@ namespace Rubberduck.Parsing.Annotations
     public sealed class ExposedModuleAnnotation : AttributeAnnotationBase
     {
         public ExposedModuleAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.Exposed, qualifiedSelection, context, new List<string> { "True" })
+            : base(AnnotationType.Exposed, qualifiedSelection, context, new List<string> { Tokens.True })
         {
             
         }

--- a/Rubberduck.Parsing/Annotations/ExposedModuleAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ExposedModuleAnnotation.cs
@@ -7,14 +7,14 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Used for specifying a module's <c>VB_Exposed</c> attribute.
     /// </summary>
-    public sealed class ExposedModuleAnnotation : AnnotationBase, IAttributeAnnotation
+    public sealed class ExposedModuleAnnotation : AttributeAnnotationBase
     {
         public ExposedModuleAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.Exposed, qualifiedSelection, context)
+            : base(AnnotationType.Exposed, qualifiedSelection, context, new List<string> { "True" })
         {
             
         }
 
-        public string Attribute => "VB_Exposed = True";
+        public override string Attribute => "VB_Exposed";
     }
 }

--- a/Rubberduck.Parsing/Annotations/IAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/IAttributeAnnotation.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
+
 namespace Rubberduck.Parsing.Annotations
 {
-    public interface IAttributeAnnotation
+    public interface IAttributeAnnotation : IAnnotation
     {
         string Attribute { get; }
+        IReadOnlyList<string> AttributeValues { get; }
     }
 }

--- a/Rubberduck.Parsing/Annotations/MemberAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/MemberAttributeAnnotation.cs
@@ -8,9 +8,9 @@ namespace Rubberduck.Parsing.Annotations
     public class MemberAttributeAnnotation : AttributeAnnotationBase
     {
         public MemberAttributeAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> parameters)
-        :base(AnnotationType.MemberAttribute, qualifiedSelection, context, parameters.Skip(1).ToList())
+        :base(AnnotationType.MemberAttribute, qualifiedSelection, context, parameters?.Skip(1).ToList())
         {
-            Attribute = parameters.FirstOrDefault();
+            Attribute = parameters?.FirstOrDefault() ?? string.Empty;
         }
 
         public override string Attribute { get; }

--- a/Rubberduck.Parsing/Annotations/MemberAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/MemberAttributeAnnotation.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.Annotations
+{
+    public class MemberAttributeAnnotation : AttributeAnnotationBase
+    {
+        public MemberAttributeAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> parameters)
+        :base(AnnotationType.MemberAttribute, qualifiedSelection, context, parameters.Skip(1).ToList())
+        {
+            Attribute = parameters.FirstOrDefault();
+        }
+
+        public override string Attribute { get; }
+    }
+}

--- a/Rubberduck.Parsing/Annotations/ModuleAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ModuleAttributeAnnotation.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.Annotations
+{
+    public class ModuleAttributeAnnotation : AttributeAnnotationBase
+    {
+        public ModuleAttributeAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> paramaters) 
+        :base(AnnotationType.ModuleAttribute, qualifiedSelection, context, paramaters.Skip(1).ToList())
+        {
+            Attribute = paramaters.FirstOrDefault();
+        }
+
+        public override string Attribute { get; }
+    }
+}

--- a/Rubberduck.Parsing/Annotations/ModuleAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ModuleAttributeAnnotation.cs
@@ -8,9 +8,9 @@ namespace Rubberduck.Parsing.Annotations
     public class ModuleAttributeAnnotation : AttributeAnnotationBase
     {
         public ModuleAttributeAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> paramaters) 
-        :base(AnnotationType.ModuleAttribute, qualifiedSelection, context, paramaters.Skip(1).ToList())
+        :base(AnnotationType.ModuleAttribute, qualifiedSelection, context, paramaters?.Skip(1).ToList())
         {
-            Attribute = paramaters.FirstOrDefault();
+            Attribute = paramaters?.FirstOrDefault() ?? string.Empty;
         }
 
         public override string Attribute { get; }

--- a/Rubberduck.Parsing/Annotations/ModuleDescriptionAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ModuleDescriptionAnnotation.cs
@@ -11,7 +11,7 @@ namespace Rubberduck.Parsing.Annotations
     public sealed class ModuleDescriptionAnnotation : AttributeAnnotationBase
     {
         public ModuleDescriptionAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> attributeValues)
-            : base(AnnotationType.ModuleDescription, qualifiedSelection, context, attributeValues.Take(1).ToList())
+            : base(AnnotationType.ModuleDescription, qualifiedSelection, context, attributeValues?.Take(1).ToList())
         {
             Description = AttributeValues?.FirstOrDefault();
             if ((Description?.StartsWith("\"") ?? false) && Description.EndsWith("\""))

--- a/Rubberduck.Parsing/Annotations/ModuleDescriptionAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ModuleDescriptionAnnotation.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.Annotations
+{
+    /// <summary>
+    /// Used for specifying a module's <c>VB_Description</c> attribute.
+    /// </summary>
+    public sealed class ModuleDescriptionAnnotation : AnnotationBase, IAttributeAnnotation
+    {
+        public ModuleDescriptionAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
+            : base(AnnotationType.ModuleDescription, qualifiedSelection, context)
+        {
+            Description = parameters?.FirstOrDefault();
+            if ((Description?.StartsWith("\"") ?? false) && Description.EndsWith("\""))
+            {
+                // strip surrounding double quotes
+                Description = Description.Substring(1, Description.Length - 2);
+            }
+        }
+
+        public string Description { get; }
+        public string Attribute => $"VB_Description = \"{Description.Replace("\"", "\"\"")}\"";
+    }
+}

--- a/Rubberduck.Parsing/Annotations/ModuleDescriptionAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ModuleDescriptionAnnotation.cs
@@ -8,12 +8,12 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Used for specifying a module's <c>VB_Description</c> attribute.
     /// </summary>
-    public sealed class ModuleDescriptionAnnotation : AnnotationBase, IAttributeAnnotation
+    public sealed class ModuleDescriptionAnnotation : AttributeAnnotationBase
     {
-        public ModuleDescriptionAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.ModuleDescription, qualifiedSelection, context)
+        public ModuleDescriptionAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> attributeValues)
+            : base(AnnotationType.ModuleDescription, qualifiedSelection, context, attributeValues.Take(1).ToList())
         {
-            Description = parameters?.FirstOrDefault();
+            Description = AttributeValues?.FirstOrDefault();
             if ((Description?.StartsWith("\"") ?? false) && Description.EndsWith("\""))
             {
                 // strip surrounding double quotes
@@ -22,6 +22,7 @@ namespace Rubberduck.Parsing.Annotations
         }
 
         public string Description { get; }
-        public string Attribute => $"VB_Description = \"{Description.Replace("\"", "\"\"")}\"";
+
+        public override string Attribute => "VB_Description";
     }
 }

--- a/Rubberduck.Parsing/Annotations/PredeclaredIdAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/PredeclaredIdAnnotation.cs
@@ -10,7 +10,7 @@ namespace Rubberduck.Parsing.Annotations
     public sealed class PredeclaredIdAnnotation : AttributeAnnotationBase
     {
         public PredeclaredIdAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.PredeclaredId, qualifiedSelection, context, new List<string>{"True"})
+            : base(AnnotationType.PredeclaredId, qualifiedSelection, context, new List<string>{Tokens.True})
         {}
 
         public override string Attribute => "VB_PredeclaredId";

--- a/Rubberduck.Parsing/Annotations/PredeclaredIdAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/PredeclaredIdAnnotation.cs
@@ -7,14 +7,12 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Used for specifying a module's <c>VB_PredeclaredId</c> attribute.
     /// </summary>
-    public sealed class PredeclaredIdAnnotation : AnnotationBase, IAttributeAnnotation
+    public sealed class PredeclaredIdAnnotation : AttributeAnnotationBase
     {
         public PredeclaredIdAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IEnumerable<string> parameters)
-            : base(AnnotationType.PredeclaredId, qualifiedSelection, context)
-        {
-            
-        }
+            : base(AnnotationType.PredeclaredId, qualifiedSelection, context, new List<string>{"True"})
+        {}
 
-        public string Attribute => "VB_PredeclaredId = True";
+        public override string Attribute => "VB_PredeclaredId";
     }
 }

--- a/Rubberduck.Parsing/Annotations/VBAParserAnnotationFactory.cs
+++ b/Rubberduck.Parsing/Annotations/VBAParserAnnotationFactory.cs
@@ -50,7 +50,7 @@ namespace Rubberduck.Parsing.Annotations
                 return parameters;
             }
 
-        private IAnnotation CreateAnnotation(string annotationName, List<string> parameters,
+        private IAnnotation CreateAnnotation(string annotationName, IReadOnlyList<string> parameters,
             QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context)
         {
             if (_creators.TryGetValue(annotationName.ToUpperInvariant(), out var annotationClrType))

--- a/Rubberduck.Parsing/Annotations/VBAParserAnnotationFactory.cs
+++ b/Rubberduck.Parsing/Annotations/VBAParserAnnotationFactory.cs
@@ -30,6 +30,9 @@ namespace Rubberduck.Parsing.Annotations
             _creators.Add(AnnotationType.Enumerator.ToString().ToUpperInvariant(), typeof(EnumeratorMemberAnnotation));
             _creators.Add(AnnotationType.Exposed.ToString().ToUpperInvariant(), typeof (ExposedModuleAnnotation));
             _creators.Add(AnnotationType.Obsolete.ToString().ToUpperInvariant(), typeof(ObsoleteAnnotation));
+            _creators.Add(AnnotationType.ModuleAttribute.ToString().ToUpperInvariant(), typeof(ModuleAttributeAnnotation));
+            _creators.Add(AnnotationType.MemberAttribute.ToString().ToUpperInvariant(), typeof(MemberAttributeAnnotation));
+            _creators.Add(AnnotationType.ModuleDescription.ToString().ToUpperInvariant(), typeof(ModuleDescriptionAnnotation));
         }
 
         public IAnnotation Create(VBAParser.AnnotationContext context, QualifiedSelection qualifiedSelection)

--- a/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
+++ b/Rubberduck.Parsing/ComReflection/ReferencedDeclarationsCollector.cs
@@ -129,7 +129,7 @@ namespace Rubberduck.Parsing.ComReflection
             }
             if (module is IComTypeWithMembers members && members.IsExtensible)
             {
-                attributes.AddExtensibledClassAttribute();
+                attributes.AddExtensibleClassAttribute();
             }
             return attributes;
         }

--- a/Rubberduck.Parsing/ParserRuleContextExtensions.cs
+++ b/Rubberduck.Parsing/ParserRuleContextExtensions.cs
@@ -198,7 +198,7 @@ namespace Rubberduck.Parsing
         public static TContext GetDescendent<TContext>(this ParserRuleContext context) where TContext : ParserRuleContext
         {
             var descendents = GetDescendents<TContext>(context);
-            return descendents.FirstOrDefault();
+            return descendents.OrderBy(descendent => descendent.Start.TokenIndex).FirstOrDefault();
         }
 
         /// <summary>

--- a/Rubberduck.Parsing/Rewriter/AttributesRewriteSession.cs
+++ b/Rubberduck.Parsing/Rewriter/AttributesRewriteSession.cs
@@ -24,7 +24,7 @@ namespace Rubberduck.Parsing.Rewriter
         }
 
         protected override bool TryRewriteInternal()
-        {
+        {          
             //The suspension ensures that only one parse gets executed instead of two for each rewritten module.
             var result = _parseManager.OnSuspendParser(this, new[] {ParserState.Ready}, ExecuteAllRewriters);
             if(result != SuspensionResult.Completed)
@@ -38,9 +38,11 @@ namespace Rubberduck.Parsing.Rewriter
 
         private void ExecuteAllRewriters()
         {
-            foreach (var rewriter in CheckedOutModuleRewriters.Values)
+            foreach (var module in CheckedOutModuleRewriters.Keys)
             {
-                rewriter.Rewrite();
+                //We have to mark the modules explicitly as modified because attributes only changes do not alter the code pane code.
+                _parseManager.MarkAsModified(module);
+                CheckedOutModuleRewriters[module].Rewrite();
             }
         }
     }

--- a/Rubberduck.Parsing/Symbols/Attributes.cs
+++ b/Rubberduck.Parsing/Symbols/Attributes.cs
@@ -41,7 +41,8 @@ namespace Rubberduck.Parsing.Symbols
 
         public string Name { get; }
 
-        public IReadOnlyCollection<string> Values => _values.AsReadOnly();
+        //The order of the values matters for some attributes, e.g. VB_Ext_Key.
+        public IReadOnlyList<string> Values => _values.AsReadOnly();
 
         public bool HasValue(string value)
         {
@@ -52,7 +53,7 @@ namespace Rubberduck.Parsing.Symbols
         {
             return other != null 
                    && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) 
-                   && _values.Equals(other.Values);
+                   && _values.SequenceEqual(other.Values);
         }
 
         public override bool Equals(object obj)

--- a/Rubberduck.Parsing/Symbols/Attributes.cs
+++ b/Rubberduck.Parsing/Symbols/Attributes.cs
@@ -141,8 +141,8 @@ namespace Rubberduck.Parsing.Symbols
 
         public bool HasHiddenMemberAttribute(string identifierName, out AttributeNode attribute)
         {
-            attribute = this.SingleOrDefault(a => a.HasValue("-4") &&
-                a.Name.Equals($"{identifierName}.VB_UserMemId", StringComparison.OrdinalIgnoreCase));
+            attribute = this.SingleOrDefault(a => a.HasValue("40")
+                && a.Name.Equals($"{identifierName}.VB_UserMemId", StringComparison.OrdinalIgnoreCase));
             return attribute != null;
         }
 
@@ -158,6 +158,13 @@ namespace Rubberduck.Parsing.Symbols
         public void AddEvaluateMemberAttribute(string identifierName)
         {
             Add(new AttributeNode(identifierName + ".VB_UserMemId", new[] { "-5" }));
+        }
+
+        public bool HasEvaluateMemberAttribute(string identifierName, out AttributeNode attribute)
+        {
+            attribute = this.SingleOrDefault(a => a.HasValue("-5")
+                                                  && a.Name.Equals($"{identifierName}.VB_UserMemId", StringComparison.OrdinalIgnoreCase));
+            return attribute != null;
         }
 
         public void AddMemberDescriptionAttribute(string identifierName, string description)
@@ -176,7 +183,7 @@ namespace Rubberduck.Parsing.Symbols
         /// </summary>
         public void AddPredeclaredIdTypeAttribute()
         {
-            Add(new AttributeNode("VB_PredeclaredId", new[] {"True"}));
+            Add(new AttributeNode("VB_PredeclaredId", new[] {Tokens.True}));
         }
 
         public AttributeNode PredeclaredIdAttribute
@@ -197,7 +204,7 @@ namespace Rubberduck.Parsing.Symbols
 
         public bool HasPredeclaredIdAttribute(out AttributeNode attribute)
         {
-            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_PredeclaredId", StringComparison.OrdinalIgnoreCase) && a.HasValue("True"));
+            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_PredeclaredId", StringComparison.OrdinalIgnoreCase) && a.HasValue(Tokens.True));
             return attribute != null;
         }
 
@@ -206,23 +213,23 @@ namespace Rubberduck.Parsing.Symbols
         /// </summary>
         public void AddGlobalClassAttribute()
         {
-            Add(new AttributeNode("VB_GlobalNamespace", new[] {"True"}));
+            Add(new AttributeNode("VB_GlobalNamespace", new[] {Tokens.True}));
         }
 
         public bool HasGlobalAttribute(out AttributeNode attribute)
         {
-            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_GlobalNamespace", StringComparison.OrdinalIgnoreCase) && a.HasValue("True"));
+            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_GlobalNamespace", StringComparison.OrdinalIgnoreCase) && a.HasValue(Tokens.True));
             return attribute != null;
         }
 
         public void AddExposedClassAttribute()
         {
-            Add(new AttributeNode("VB_Exposed", new[] { "True" }));
+            Add(new AttributeNode("VB_Exposed", new[] { Tokens.True }));
         }
 
         public bool HasExposedAttribute(out AttributeNode attribute)
         {
-            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_Exposed", StringComparison.OrdinalIgnoreCase) && a.HasValue("True"));
+            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_Exposed", StringComparison.OrdinalIgnoreCase) && a.HasValue(Tokens.True));
             return attribute != null;
         }
 
@@ -231,12 +238,12 @@ namespace Rubberduck.Parsing.Symbols
         /// </summary>
         public void AddExtensibleClassAttribute()
         {
-            Add(new AttributeNode("VB_Customizable", new[] { "True" }));
+            Add(new AttributeNode("VB_Customizable", new[] { Tokens.True }));
         }
 
         public bool HasExtensibleAttribute(out AttributeNode attribute)
         {
-            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_Customizable", StringComparison.OrdinalIgnoreCase) && a.HasValue("True"));
+            attribute = this.SingleOrDefault(a => a.Name.Equals("VB_Customizable", StringComparison.OrdinalIgnoreCase) && a.HasValue(Tokens.True));
             return attribute != null;
         }
 

--- a/Rubberduck.Parsing/VBA/AttributesUpdater.cs
+++ b/Rubberduck.Parsing/VBA/AttributesUpdater.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA.Parsing;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public class AttributesUpdater : IAttributesUpdater
+    {
+        private readonly IParseTreeProvider _parseTreeProvider;
+
+        public AttributesUpdater(IParseTreeProvider parseTreeProvider)
+        {
+            _parseTreeProvider = parseTreeProvider;
+        }
+
+
+        public void AddAttribute(IRewriteSession rewriteSession, Declaration declaration, string attribute, IReadOnlyList<string> values)
+        {
+            Debug.Assert(rewriteSession.TargetCodeKind == CodeKind.AttributesCode);
+
+            //Attributes must have at least one value.
+            if (values == null || !values.Any())
+            {
+                return;
+            }
+
+            //VB_Ext_Key is special in that this attribute can be declared multiple times, but only once for each key.
+            if (attribute.ToUpperInvariant().EndsWith("VB_EXT_KEY"))
+            {
+                if (values.Count != 2)
+                {
+                    return;
+                }
+                //Is the key already defined as external key?
+                if(declaration.Attributes.Any(attrbt => attrbt.Name.Equals(attribute, StringComparison.OrdinalIgnoreCase)
+                                                        && attrbt.Values[0].Equals(values[0])))
+                {
+                    return;
+                }
+            }
+            else if (declaration.Attributes.HasAttribute(attribute))
+            {
+                return;
+            }
+
+            var codeToInsert = $"{Environment.NewLine}Attribute {attribute} ={AttributeValuesText(values)}";
+
+            var rewriter = rewriteSession.CheckOutModuleRewriter(declaration.QualifiedModuleName);
+            if (declaration.DeclarationType.HasFlag(DeclarationType.Module))
+            {
+                var moduleParseTree = (ParserRuleContext)_parseTreeProvider.GetParseTree(declaration.QualifiedModuleName, CodeKind.AttributesCode);
+                var lastModuleAttribute = moduleParseTree.GetDescendents<VBAParser.ModuleAttributesContext>()
+                    .Where(moduleAttributes => moduleAttributes.attributeStmt() != null)
+                    .SelectMany(moduleAttributes => moduleAttributes.attributeStmt())
+                    .OrderBy(moduleAttribute => moduleAttribute.stop.TokenIndex)
+                    .Last();
+                rewriter.InsertAfter(lastModuleAttribute.stop.TokenIndex, codeToInsert);
+            }
+            else
+            {
+                rewriter.InsertAfter(declaration.AttributesPassContext.Stop.TokenIndex, codeToInsert);
+            }
+        }
+
+        private static string AttributeValuesText(IEnumerable<string> attributeValues)
+        {
+            var builder = new StringBuilder();
+            foreach (var attributeValue in attributeValues)
+            {
+                builder.Append($" {attributeValue},");
+            }
+            //Remove trailing comma.
+            builder.Length--;
+            return builder.ToString();
+        }
+
+        public void RemoveAttribute(IRewriteSession rewriteSession, Declaration declaration, string attribute, IReadOnlyList<string> values = null)
+        {
+            Debug.Assert(rewriteSession.TargetCodeKind == CodeKind.AttributesCode);
+
+            var attributeNodes = ApplicableAttributeNodes(declaration, attribute, values);
+
+            if (!attributeNodes.Any())
+            {
+                return;
+            }
+
+            var rewriter = rewriteSession.CheckOutModuleRewriter(declaration.QualifiedModuleName);
+            RemoveNodes(rewriter, attributeNodes);
+        }
+
+        private static void RemoveNodes(IModuleRewriter rewriter, IEnumerable<AttributeNode> attributeNodes)
+        {
+            foreach (var node in attributeNodes)
+            {
+                var attributeContext = node.Context;
+                rewriter.Remove(attributeContext);
+                if (attributeContext.TryGetFollowingContext(out VBAParser.EndOfLineContext followingEndOfLine))
+                {
+                    rewriter.Remove(followingEndOfLine);
+                }
+                else if (attributeContext.TryGetPrecedingContext(out VBAParser.EndOfLineContext precedingEndOfLine))
+                {
+                    //We are on the last line. So, we must remove the preceding newline.
+                    rewriter.Remove(precedingEndOfLine);
+                }
+            }
+        }
+
+        private static IList<AttributeNode> ApplicableAttributeNodes(Declaration declaration, string attribute, IReadOnlyList<string> values = null)
+        {
+            var attributeNodes = declaration.Attributes.AttributeNodes(attribute);
+            if (values != null)
+            {
+                attributeNodes = attributeNodes.Where(node => node.Values.SequenceEqual(values));
+            }
+
+            return attributeNodes.ToList();
+        }
+
+        public void UpdateAttribute(IRewriteSession rewriteSession, Declaration declaration, string attribute, IReadOnlyList<string> newValues, IReadOnlyList<string> oldValues = null)
+        {
+            Debug.Assert(rewriteSession.TargetCodeKind == CodeKind.AttributesCode);
+
+            var attributeNodes = ApplicableAttributeNodes(declaration, attribute, oldValues);
+
+            if (!attributeNodes.Any())
+            {
+                return;
+            }
+
+            var rewriter = rewriteSession.CheckOutModuleRewriter(declaration.QualifiedModuleName);
+
+            var nodeToUpdate = attributeNodes[0];
+            UpdateAttributeValues(rewriter, nodeToUpdate, newValues);
+            RemoveNodes(rewriter, attributeNodes.Skip(1));
+        }
+
+        private static void UpdateAttributeValues(IModuleRewriter rewriter, AttributeNode nodeToUpdate, IEnumerable<string> values)
+        {
+            var statementContext = nodeToUpdate.Context;
+            var firstIndexToReplace = statementContext.EQ().Symbol.TokenIndex + 1;
+            var lastIndexToReplace = statementContext.stop.TokenIndex;
+            var replacementText = AttributeValuesText(values);
+
+            rewriter.Replace(new Interval(firstIndexToReplace, lastIndexToReplace), replacementText);
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/AttributesUpdater.cs
+++ b/Rubberduck.Parsing/VBA/AttributesUpdater.cs
@@ -63,12 +63,12 @@ namespace Rubberduck.Parsing.VBA
                 if (lastModuleAttribute == null)
                 {
                     //This should never happen for a real module.
-                    var codeToInsert = $"Attribute {attribute} ={AttributeValuesText(values)}{Environment.NewLine}";
+                    var codeToInsert = $"Attribute {attribute} = {AttributeValuesText(values)}{Environment.NewLine}";
                     rewriter.InsertBefore(0, codeToInsert);
                 }
                 else
                 {
-                    var codeToInsert = $"{Environment.NewLine}Attribute {attribute} ={AttributeValuesText(values)}";
+                    var codeToInsert = $"{Environment.NewLine}Attribute {attribute} = {AttributeValuesText(values)}";
                     rewriter.InsertAfter(lastModuleAttribute.stop.TokenIndex, codeToInsert);
                 }  
             }
@@ -78,12 +78,12 @@ namespace Rubberduck.Parsing.VBA
                 var firstEndOfLineInMember = attributesContext.GetDescendent<VBAParser.EndOfLineContext>();
                 if (firstEndOfLineInMember == null)
                 {
-                    var codeToInsert = $"{Environment.NewLine}Attribute {attribute} ={AttributeValuesText(values)}";
+                    var codeToInsert = $"{Environment.NewLine}Attribute {attribute} = {AttributeValuesText(values)}";
                     rewriter.InsertAfter(declaration.AttributesPassContext.Stop.TokenIndex, codeToInsert);
                 }
                 else
                 {
-                    var codeToInsert = $"Attribute {attribute} ={AttributeValuesText(values)}{Environment.NewLine}";
+                    var codeToInsert = $"Attribute {attribute} = {AttributeValuesText(values)}{Environment.NewLine}";
                     rewriter.InsertAfter(firstEndOfLineInMember.Stop.TokenIndex, codeToInsert);
                 }
             }
@@ -91,14 +91,7 @@ namespace Rubberduck.Parsing.VBA
 
         private static string AttributeValuesText(IEnumerable<string> attributeValues)
         {
-            var builder = new StringBuilder();
-            foreach (var attributeValue in attributeValues)
-            {
-                builder.Append($" {attributeValue},");
-            }
-            //Remove trailing comma.
-            builder.Length--;
-            return builder.ToString();
+            return string.Join(", ", attributeValues);
         }
 
         public void RemoveAttribute(IRewriteSession rewriteSession, Declaration declaration, string attribute, IReadOnlyList<string> values = null)
@@ -168,7 +161,7 @@ namespace Rubberduck.Parsing.VBA
             var statementContext = nodeToUpdate.Context;
             var firstIndexToReplace = statementContext.EQ().Symbol.TokenIndex + 1;
             var lastIndexToReplace = statementContext.stop.TokenIndex;
-            var replacementText = AttributeValuesText(values);
+            var replacementText = $" {AttributeValuesText(values)}";
 
             rewriter.Replace(new Interval(firstIndexToReplace, lastIndexToReplace), replacementText);
         }

--- a/Rubberduck.Parsing/VBA/AttributesUpdater.cs
+++ b/Rubberduck.Parsing/VBA/AttributesUpdater.cs
@@ -74,8 +74,18 @@ namespace Rubberduck.Parsing.VBA
             }
             else
             {
-                var codeToInsert = $"{Environment.NewLine}Attribute {attribute} ={AttributeValuesText(values)}";
-                rewriter.InsertAfter(declaration.AttributesPassContext.Stop.TokenIndex, codeToInsert);
+                ParserRuleContext attributesContext = declaration.AttributesPassContext;
+                var firstEndOfLineInMember = attributesContext.GetDescendent<VBAParser.EndOfLineContext>();
+                if (firstEndOfLineInMember == null)
+                {
+                    var codeToInsert = $"{Environment.NewLine}Attribute {attribute} ={AttributeValuesText(values)}";
+                    rewriter.InsertAfter(declaration.AttributesPassContext.Stop.TokenIndex, codeToInsert);
+                }
+                else
+                {
+                    var codeToInsert = $"Attribute {attribute} ={AttributeValuesText(values)}{Environment.NewLine}";
+                    rewriter.InsertAfter(firstEndOfLineInMember.Stop.TokenIndex, codeToInsert);
+                }
             }
         }
 

--- a/Rubberduck.Parsing/VBA/Extensions/ListExtensions.cs
+++ b/Rubberduck.Parsing/VBA/Extensions/ListExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Rubberduck.Parsing.VBA.Extensions
+{
+    public class ReadOnlyListWrapper<T> : IReadOnlyList<T>
+    {
+        private readonly IList<T> _list;
+        public ReadOnlyListWrapper(IList<T> list)
+        {
+            _list = list;
+        }
+
+        public int Count => _list.Count;
+        public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+        public T this[int index] => _list[index];
+    }
+
+    public static class ListExtensions
+    {
+        public static IReadOnlyList<T> AsReadOnly<T>(this IList<T> list)
+        {
+            return new ReadOnlyListWrapper<T>(list);
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/IAttributesUpdater.cs
+++ b/Rubberduck.Parsing/VBA/IAttributesUpdater.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public interface IAttributesUpdater
+    {
+        void AddAttribute(IRewriteSession rewriteSession, Declaration declaration, string attribute, IReadOnlyList<string> values);
+        void RemoveAttribute(IRewriteSession rewriteSession, Declaration declaration, string attribute, IReadOnlyList<string> values = null);
+        void UpdateAttribute(IRewriteSession rewriteSession, Declaration declaration, string attribute, IReadOnlyList<string> newValues, IReadOnlyList<string> oldValues = null);
+    }
+}

--- a/Rubberduck.Parsing/VBA/IParseManager.cs
+++ b/Rubberduck.Parsing/VBA/IParseManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.VBA
 {
@@ -10,5 +11,6 @@ namespace Rubberduck.Parsing.VBA
 
         void OnParseRequested(object requestor);
         SuspensionResult OnSuspendParser(object requestor, IEnumerable<ParserState> allowedRunStates, Action busyAction, int millisecondsTimeout = -1);
+        void MarkAsModified(QualifiedModuleName module);
     }
 }

--- a/Rubberduck.Parsing/VBA/ModuleState.cs
+++ b/Rubberduck.Parsing/VBA/ModuleState.cs
@@ -27,6 +27,8 @@ namespace Rubberduck.Parsing.VBA
         public IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext> MembersAllowingAttributes { get; private set; }
 
         public bool IsNew { get; private set; }
+        public bool IsMarkedAsModified { get; private set; }
+
 
         public ModuleState(ConcurrentDictionary<Declaration, byte> declarations)
         {
@@ -42,6 +44,7 @@ namespace Rubberduck.Parsing.VBA
             MembersAllowingAttributes = new Dictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext>();
 
             IsNew = true;
+            IsMarkedAsModified = false;
             State = ParserState.Pending;
         }
 
@@ -146,6 +149,11 @@ namespace Rubberduck.Parsing.VBA
         {
             AttributesTokenStream = attributesTokenStream;
             return this;
+        }
+
+        public void MarkAsModified()
+        {
+            IsMarkedAsModified = true;
         }
 
         private bool _isDisposed;

--- a/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
@@ -171,13 +171,6 @@ namespace Rubberduck.Parsing.VBA.Parsing
 
         private static void AddOrUpdateAttribute(Attributes attributes, string attributeName, VBAParser.AttributeStmtContext context)
         {
-            var attribute = attributes.SingleOrDefault(a => a.Name.Equals(attributeName, StringComparison.OrdinalIgnoreCase));
-            if (attribute != null)
-            {
-                attribute.AddContext(context);
-                return;
-            }
-
             attributes.Add(new AttributeNode(context));
         }
     }

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -1010,7 +1010,7 @@ namespace Rubberduck.Parsing.VBA
             if (_moduleStates.TryGetValue(key, out var moduleState))
             {
                 // existing/modified
-                return moduleState.IsNew || GetModuleContentHash(key) != moduleState.ModuleContentHashCode;
+                return moduleState.IsNew || moduleState.IsMarkedAsModified || GetModuleContentHash(key) != moduleState.ModuleContentHashCode;
             }
 
             // new
@@ -1021,6 +1021,14 @@ namespace Rubberduck.Parsing.VBA
         {
             var component = ProjectsProvider.Component(module);
             return QualifiedModuleName.GetContentHash(component);
+        }
+
+        public void MarkAsModified(QualifiedModuleName module)
+        {
+            if (_moduleStates.TryGetValue(module, out var moduleState))
+            {
+                moduleState.MarkAsModified();
+            }
         }
 
         public Declaration FindSelectedDeclaration(ICodePane activeCodePane)

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -68,7 +68,18 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AccessSheetUsingCodeNameQuickFix", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Refer to statically accessible sheet by its code name.
+        /// </summary>
+        public static string AddMissingAttributeQuickFix
+        {
+            get
+            {
+                return ResourceManager.GetString("AddMissingAttributeQuickFix", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Add explicit &apos;Step&apos; clause.
         /// </summary>

--- a/Rubberduck.Resources/Inspections/QuickFixes.de.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.de.resx
@@ -261,4 +261,7 @@
   <data name="IsMissingOnInappropriateArgumentQuickFix" xml:space="preserve">
     <value>'IsMissing'-Aufruf in Prüfung eines Standardwerts umschreiben.</value>
   </data>
+  <data name="AddMissingAttributeQuickFix" xml:space="preserve">
+    <value>Füge das fehlende Attribut hinzu.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.resx
@@ -261,4 +261,7 @@
   <data name="IsMissingOnInappropriateArgumentQuickFix" xml:space="preserve">
     <value>Change 'IsMissing' call to test for default value.</value>
   </data>
+  <data name="AddMissingAttributeQuickFix" xml:space="preserve">
+    <value>Add the missing attribute.</value>
+  </data>
 </root>

--- a/RubberduckTests/Grammar/AnnotationTests.cs
+++ b/RubberduckTests/Grammar/AnnotationTests.cs
@@ -118,6 +118,24 @@ namespace RubberduckTests.Grammar
         [Category("Grammar")]
         [Category("Annotations")]
         [Test]
+        public void ModuleAttributeAnnotation_TypeIsModuleAttribute()
+        {
+            var annotation = new ModuleAttributeAnnotation(new QualifiedSelection(), null, new[] { "Attribute", "Value" });
+            Assert.AreEqual(AnnotationType.ModuleAttribute, annotation.AnnotationType);
+        }
+
+        [Category("Grammar")]
+        [Category("Annotations")]
+        [Test]
+        public void MemberAttributeAnnotation_TypeIsMemberAttribute()
+        {
+            var annotation = new MemberAttributeAnnotation(new QualifiedSelection(), null, new[] { "Attribute", "Value" });
+            Assert.AreEqual(AnnotationType.MemberAttribute, annotation.AnnotationType);
+        }
+
+        [Category("Grammar")]
+        [Category("Annotations")]
+        [Test]
         public void DescriptionAnnotation_TypeIsDescription()
         {
             var annotation = new DescriptionAnnotation(new QualifiedSelection(), null, new[] { "Desc"});

--- a/RubberduckTests/Grammar/AnnotationTests.cs
+++ b/RubberduckTests/Grammar/AnnotationTests.cs
@@ -127,6 +127,15 @@ namespace RubberduckTests.Grammar
         [Category("Grammar")]
         [Category("Annotations")]
         [Test]
+        public void ModuleDescriptionAnnotation_TypeIsModuleDescription()
+        {
+            var annotation = new ModuleDescriptionAnnotation(new QualifiedSelection(), null, null);
+            Assert.AreEqual(AnnotationType.ModuleDescription, annotation.AnnotationType);
+        }
+
+        [Category("Grammar")]
+        [Category("Annotations")]
+        [Test]
         public void DefaultMemberAnnotation_TypeIsDefaultMember()
         {
             var annotation = new DefaultMemberAnnotation(new QualifiedSelection(), null, new[] { "param" });

--- a/RubberduckTests/Grammar/AnnotationTests.cs
+++ b/RubberduckTests/Grammar/AnnotationTests.cs
@@ -120,7 +120,7 @@ namespace RubberduckTests.Grammar
         [Test]
         public void DescriptionAnnotation_TypeIsDescription()
         {
-            var annotation = new DescriptionAnnotation(new QualifiedSelection(), null, null);
+            var annotation = new DescriptionAnnotation(new QualifiedSelection(), null, new[] { "Desc"});
             Assert.AreEqual(AnnotationType.Description, annotation.AnnotationType);
         }
 
@@ -129,7 +129,7 @@ namespace RubberduckTests.Grammar
         [Test]
         public void ModuleDescriptionAnnotation_TypeIsModuleDescription()
         {
-            var annotation = new ModuleDescriptionAnnotation(new QualifiedSelection(), null, null);
+            var annotation = new ModuleDescriptionAnnotation(new QualifiedSelection(), null, new[] { "Desc" });
             Assert.AreEqual(AnnotationType.ModuleDescription, annotation.AnnotationType);
         }
 

--- a/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
@@ -1,0 +1,358 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class MissingAttributeInspectionTests
+    {
+        [Test]
+        [Category("Inspections")]
+        public void NoAnnotation_NoResult()
+        {
+            const string inputCode =
+                @"Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""NotDesc""
+'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeAnnotationWithAttributeButWithoutKeyReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeAnnotationWithAttributeAndKeyReturnsNoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""OtherValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeAnnotationWithMissingArgumentsNoResult()
+        {
+            const string inputCode =
+                @"'@ModuleAttribute
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+Attribute Foo.VB_Description = ""NotDesc""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeAnnotationWithAttributeButWithoutKeyReturnsResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""Value""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeAnnotationWithAttributeAndKeyReturnsNoResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""OtherValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeAnnotationWithMissingArgumentsNoResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void DefaultMemberAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@DefaultMember
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void DefaultMemberAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"'@DefaultMember
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 42
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void EnumeratorAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@Enumerator
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void EnumeratorAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"'@Enumerator
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 42
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void DescriptionAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@Description ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void DescriptionAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"'@Description, ""Desc""
+Public Sub Foo()
+Attribute Foo.VB_Description = ""NotDesc""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleDescriptionAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@ModuleDescription ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleDescriptionAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""NotDesc""
+'@ModuleDescription ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void PredeclaredIdAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@PredeclaredId
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void PredeclaredIdAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_PredeclaredId = False
+'@PredeclaredId
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExposedAnnotationWithoutAttributeReturnsResult()
+        {
+            const string inputCode =
+                @"'@Exposed
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExposedAnnotationWithAttributeReturnsNoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Exposed = False
+'@Exposed
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+
+        private IEnumerable<IInspectionResult> InspectionResults(string inputCode)
+        {
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingAttributeInspection(state);
+                return inspection.GetInspectionResults(CancellationToken.None);
+            }
+        }
+    }
+}

--- a/RubberduckTests/PostProcessing/AttributesUpdaterTests.cs
+++ b/RubberduckTests/PostProcessing/AttributesUpdaterTests.cs
@@ -1,0 +1,778 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.PostProcessing
+{
+    [TestFixture]
+    public class AttributesUpdaterTests
+    {
+        [Test]
+        [Category("AttributesUpdater")]
+        public void AddAttributeAddsMemberAttributeBelowMember()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+Attribute Foo.VB_Description = ""The MyFunc Description""
+";
+            var attributeToAdd = "Foo.VB_Description";
+            var attributeValues = new List<string> {"\"The MyFunc Description\""};
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var fooDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Procedure)
+                    .First(decl => decl.IdentifierName == "Foo");
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.AddAttribute(rewriteSession, fooDeclaration, attributeToAdd, attributeValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void MultipleAddAttributeWorkForMembers()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+Attribute Foo.VB_Description = ""The MyFunc Description""
+Attribute Foo.VB_HelpID = 2
+";
+            var firstAttributeToAdd = "Foo.VB_Description";
+            var firstAttributeValues = new List<string> { "\"The MyFunc Description\"" };
+            var secondAttributeToAdd = "Foo.VB_HelpID";
+            var secondAttributeValues = new List<string> { "2" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var fooDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Procedure)
+                    .First(decl => decl.IdentifierName == "Foo");
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.AddAttribute(rewriteSession, fooDeclaration, firstAttributeToAdd, firstAttributeValues);
+                attributesUpdater.AddAttribute(rewriteSession, fooDeclaration, secondAttributeToAdd, secondAttributeValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void AddAttributeAddsModuleAttributeBelowLastModuleAttribute()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Exposed = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributeToAdd = "VB_Exposed";
+            var attributeValues = new List<string> { "False" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.AddAttribute(rewriteSession, moduleDeclaration, attributeToAdd, attributeValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void MultipleAddAttributeWorkForModules()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Exposed = False
+Attribute VB_Description = ""Module Description""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var firstAttributeToAdd = "VB_Exposed";
+            var firstAttributeValues = new List<string> { "False" };
+            var secondAttributeToAdd = "VB_Description";
+            var secondAttributeValues = new List<string> { "\"Module Description\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.AddAttribute(rewriteSession, moduleDeclaration, firstAttributeToAdd, firstAttributeValues);
+                attributesUpdater.AddAttribute(rewriteSession, moduleDeclaration, secondAttributeToAdd, secondAttributeValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void AddAttributeDoesNotAddAttributeAlreadyThere()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Exposed = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Exposed = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributeToAdd = "VB_Exposed";
+            var attributeValues = new List<string> { "True" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.AddAttribute(rewriteSession, moduleDeclaration, attributeToAdd, attributeValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void AddAttributeAddsVbExtKeyAttributeForDifferentKey()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributeToAdd = "VB_Ext_Key";
+            var attributeValues = new List<string> { "\"OtherKey\"", "\"Value\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.AddAttribute(rewriteSession, moduleDeclaration, attributeToAdd, attributeValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void AddAttributeDoesNotAddVbExtKeyAttributeForExistingKey()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributeToAdd = "VB_Ext_Key";
+            var attributeValues = new List<string> { "\"Key\"", "\"Value\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.AddAttribute(rewriteSession, moduleDeclaration, attributeToAdd, attributeValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void RemoveAttributeWithoutValuesSpecifiedRemovesAllEntriesForTheAttributeForModules()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "VB_Ext_Key";
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.RemoveAttribute(rewriteSession, moduleDeclaration, attributesToRemove);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void RemoveAttributeWithoutValuesSpecifiedRemovesAllEntriesForTheAttributeForMembers()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""Value""
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "Foo.VB_Ext_Key";
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var fooDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Procedure)
+                    .First(decl => decl.IdentifierName == "Foo");
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.RemoveAttribute(rewriteSession, fooDeclaration, attributesToRemove);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void RemoveAttributeWithValuesSpecifiedRemovesOnlyEntriesForTheAttributeWithSpecifiedValuesForModules()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "VB_Ext_Key";
+            var valuesToRemove = new List<string> { "\"Key\"", "\"Value\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.RemoveAttribute(rewriteSession, moduleDeclaration, attributesToRemove, valuesToRemove);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void RemoveAttributeWithValuesSpecifiedRemovesOnlyEntriesForTheAttributeWithSpecifiedValuesForMembers()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""Value""
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""Value""
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "Foo.VB_Ext_Key";
+            var valuesToRemove = new List<string> { "\"Key\"", "\"Value\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var fooDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Procedure)
+                    .First(decl => decl.IdentifierName == "Foo");
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.RemoveAttribute(rewriteSession, fooDeclaration, attributesToRemove, valuesToRemove);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void UpdateAttributeWithoutValuesSpecifiedUpdatesFirstEntryForTheAttributeAndRemovesTheRestForModules()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""AnotherKey"", ""AnotherValue""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "VB_Ext_Key";
+            var newValues = new List<string> { "\"AnotherKey\"", "\"AnotherValue\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.UpdateAttribute(rewriteSession, moduleDeclaration, attributesToRemove, newValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void UpdateAttributeWithoutValuesSpecifiedUpdatesFirstEntryForTheAttributeAndRemovesTheRestForMembers()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""Value""
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Ext_Key = ""AnotherKey"", ""AnotherValue""
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "Foo.VB_Ext_Key";
+            var newValues = new List<string> { "\"AnotherKey\"", "\"AnotherValue\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var fooDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Procedure)
+                    .First(decl => decl.IdentifierName == "Foo");
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.UpdateAttribute(rewriteSession, fooDeclaration, attributesToRemove, newValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void UpdateAttributeWithValuesSpecifiedUpdatesOnlyEntriesForTheAttributeWithSpecifiedValuesForModules()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""Key"", ""Value""
+Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Ext_Key = ""AnotherKey"", ""AnotherValue""
+Attribute VB_Ext_Key = ""OtherKey"", ""Value""
+Public Sub Foo(bar As String)
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "VB_Ext_Key";
+            var oldValues = new List<string> { "\"Key\"", "\"Value\"" };
+            var newValues = new List<string> { "\"AnotherKey\"", "\"AnotherValue\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var moduleDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .First();
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.UpdateAttribute(rewriteSession, moduleDeclaration, attributesToRemove, newValues, oldValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("AttributesUpdater")]
+        public void UpdateAttributeWithValuesSpecifiedUpdatesOnlyEntriesForTheAttributeWithSpecifiedValuesForMembers()
+        {
+            const string inputCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""Value""
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+
+            const string expectedCode =
+                @"VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = ""ClassKeys""
+Attribute VB_GlobalNameSpace = False
+Public Sub Foo(bar As String)
+Attribute Foo.VB_Ext_Key = ""AnotherKey"", ""AnotherValue""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""Value""
+Attribute Foo.VB_Description = ""Desc""
+    bar = vbNullString
+End Sub
+";
+            var attributesToRemove = "Foo.VB_Ext_Key";
+            var oldValues = new List<string> { "\"Key\"", "\"Value\"" };
+            var newValues = new List<string> { "\"AnotherKey\"", "\"AnotherValue\"" };
+
+            string actualCode;
+            var (component, rewriteSession, state) = TestSetup(inputCode);
+            using (state)
+            {
+                var fooDeclaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Procedure)
+                    .First(decl => decl.IdentifierName == "Foo");
+                var attributesUpdater = new AttributesUpdater(state);
+
+                attributesUpdater.UpdateAttribute(rewriteSession, fooDeclaration, attributesToRemove, newValues, oldValues);
+                rewriteSession.TryRewrite();
+
+                actualCode = component.CodeModule.Content();
+            }
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        private (IVBComponent component, IRewriteSession rewriteSession, RubberduckParserState state) TestSetup(string inputCode)
+        {
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component).Object;
+            var (state, rewritingManager) = MockParser.CreateAndParseWithRewritingManager(vbe);
+            return (component, rewritingManager.CheckOutAttributesSession(), state);
+        }
+    }
+}

--- a/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
@@ -1,0 +1,102 @@
+﻿using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Inspections.QuickFixes;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
+
+namespace RubberduckTests.QuickFixes
+{
+    [TestFixture]
+    public class AddMissingAttributeQuickFixTests : QuickFixTestBase
+    {
+        [Test]
+        [Category("QuickFixes")]
+        public void MissingModuleAttribute_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"Attribute VB_Description = ""Desc""
+'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MissingMemberAttribute_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub
+Attribute Foo.VB_Description = ""Desc""";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MissingModuleAttributeWithMultipleValues_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""Value""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MissingMemberAttributeWithMultipleValues_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        protected override IQuickFix QuickFix(RubberduckParserState state)
+        {
+            return new AddMissingAttributeQuickFix(new AttributesUpdater(state));
+        }
+    }
+}

--- a/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
@@ -44,9 +44,9 @@ End Sub";
             const string expectedCode =
                 @"'@MemberAttribute VB_Description, ""Desc""
 Public Sub Foo()
+Attribute Foo.VB_Description = ""Desc""
     Const const1 As Integer = 9
-End Sub
-Attribute Foo.VB_Description = ""Desc""";
+End Sub";
 
             var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
             Assert.AreEqual(expectedCode, actualCode);
@@ -86,9 +86,9 @@ End Sub";
             const string expectedCode =
                 @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
 Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""
     Const const1 As Integer = 9
-End Sub
-Attribute Foo.VB_Ext_Key = ""Key"", ""Value""";
+End Sub";
 
             var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
             Assert.AreEqual(expectedCode, actualCode);


### PR DESCRIPTION
This PR closes #4630 and closes #4626.

This PR adds the new `AddMissingAttributeQuickFix` for the `MissingAttributeInspection`. At its core is the `AttributesUpdater`, which provides methods to add, remove and update attributes, both on members and modules.

Moreover, this PR contains a complete rewrite of the `MissingAttributeInspection` that previously redid all the work already done regarding the annotations.

Furthermore, all attribute annotations now expose the attribute and the values in separate properties. This makes matching to attributes easier.

In addition, the matching behaviur t attributes has been changed. Whether there is an attribute fr a specific inspection now only depends on the attribute and not the vlaues, with one exception `VB_Ext_Key`, fr which the first vlaue , the key, is taken into account. As a consequence, an `@Expsed` annotation on a class module will never trigger the `MissingAttributeInspection`. That will be handeled by a future `AttributeValueOutOfSyncInspectin`.  

Finally, I added three new anntations: the `@ModuleDescription` annotation, which is module annotation corresponding to `@Description` for member;, the `@ModuleAttribute` annotation and the `@MemberAttribute` annotation. The latter two require at least two parameters. The first is the attribute name and the second the first value. These two allow attribute annotation synchronization for attributes for which we have ne dedicated annotation.

I tested this both fr module and member attributes in the VBE and it works.