### PR TITLE
Attribute value out of sync inspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
@@ -31,8 +31,11 @@ namespace Rubberduck.Inspections.Concrete
                 {
                     if (HasDifferingAttributeValues(declaration, annotation, out var attributeValues))
                     {
-                        var description = string.Format(InspectionResults.AttributeValueOutOfSyncInspection, declaration.IdentifierName,
-                            annotation.Attribute, string.Join(", ", annotation.AttributeValues), string.Join(", ", attributeValues));
+                        var description = string.Format(InspectionResults.AttributeValueOutOfSyncInspection, 
+                            annotation.Attribute, 
+                            string.Join(", ", attributeValues), 
+                            annotation.AnnotationType, 
+                            string.Join(", ", annotation.AttributeValues));
 
                         var result = new DeclarationInspectionResult(this, description, declaration,
                             new QualifiedContext(declaration.QualifiedModuleName, annotation.Context));

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
@@ -52,8 +52,8 @@ namespace Rubberduck.Inspections.Concrete
         private static bool HasDifferingAttributeValues(Declaration declaration, IAttributeAnnotation annotation, out IReadOnlyList<string> attributeValues)
         {
             var attributeNodes = declaration.DeclarationType.HasFlag(DeclarationType.Module)
-                                    ? declaration.Attributes.AttributeNodesFor(annotation).ToList()
-                                    : declaration.Attributes.AttributeNodesFor(annotation, declaration.IdentifierName).ToList();
+                                    ? declaration.Attributes.AttributeNodesFor(annotation)
+                                    : declaration.Attributes.AttributeNodesFor(annotation, declaration.IdentifierName);
 
             foreach (var attributeNode in attributeNodes)
             {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
@@ -34,8 +34,7 @@ namespace Rubberduck.Inspections.Concrete
                         var description = string.Format(InspectionResults.AttributeValueOutOfSyncInspection, 
                             annotation.Attribute, 
                             string.Join(", ", attributeValues), 
-                            annotation.AnnotationType, 
-                            string.Join(", ", annotation.AttributeValues));
+                            annotation.AnnotationType);
 
                         var result = new DeclarationInspectionResult(this, description, declaration,
                             new QualifiedContext(declaration.QualifiedModuleName, annotation.Context));

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Inspections;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+
+namespace Rubberduck.Inspections.Concrete
+{
+    [CannotAnnotate]
+    public sealed class AttributeValueOutOfSyncInspection : InspectionBase
+    {
+        public AttributeValueOutOfSyncInspection(RubberduckParserState state) 
+        :base(state)
+        {
+        }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            var declarationsWithAttributeAnnotations = State.DeclarationFinder.AllUserDeclarations
+                .Where(declaration => declaration.Annotations.Any(annotation => annotation.AnnotationType.HasFlag(AnnotationType.Attribute)));
+            var results = new List<DeclarationInspectionResult>();
+            foreach (var declaration in declarationsWithAttributeAnnotations)
+            {
+                foreach (var annotation in declaration.Annotations.OfType<IAttributeAnnotation>())
+                {
+                    if (HasDifferingAttributeValues(declaration, annotation, out var attributeValues))
+                    {
+                        var description = string.Format(InspectionResults.AttributeValueOutOfSyncInspection, declaration.IdentifierName,
+                            annotation.Attribute, string.Join(", ", annotation.AttributeValues), string.Join(", ", attributeValues));
+
+                        var result = new DeclarationInspectionResult(this, description, declaration,
+                            new QualifiedContext(declaration.QualifiedModuleName, annotation.Context));
+                        result.Properties.Annotation = annotation;
+                        result.Properties.AttributeValues = attributeValues;
+
+                        results.Add(result);
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        private static bool HasDifferingAttributeValues(Declaration declaration, IAttributeAnnotation annotation, out IReadOnlyList<string> attributeValues)
+        {
+            var attributeNodes = declaration.DeclarationType.HasFlag(DeclarationType.Module)
+                                    ? declaration.Attributes.AttributeNodesFor(annotation).ToList()
+                                    : declaration.Attributes.AttributeNodesFor(annotation, declaration.IdentifierName).ToList();
+
+            foreach (var attributeNode in attributeNodes)
+            {
+                var values = attributeNode.Values;
+                if (!annotation.AttributeValues.SequenceEqual(values))
+                {
+                    attributeValues = values;
+                    return true;
+                }
+            }
+            attributeValues = new List<string>();
+            return false;
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/QuickFixes/AdjustAttributeValuesQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/AdjustAttributeValuesQuickFix.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
+
+namespace Rubberduck.Inspections.QuickFixes
+{
+    public class AdjustAttributeValuesQuickFix : QuickFixBase
+    {
+        private readonly IAttributesUpdater _attributesUpdater;
+
+        public AdjustAttributeValuesQuickFix(IAttributesUpdater attributesUpdater)
+            : base(typeof(AttributeValueOutOfSyncInspection))
+        {
+            _attributesUpdater = attributesUpdater;
+        }
+
+        public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
+        {
+            var declaration = result.Target;
+            IAttributeAnnotation annotation = result.Properties.Annotation;
+            IReadOnlyList<string> attributeValues = result.Properties.AttributeValues;
+
+            var attributeName = declaration.DeclarationType.HasFlag(DeclarationType.Module)
+                ? annotation.Attribute
+                : $"{declaration.IdentifierName}.{annotation.Attribute}";
+
+            _attributesUpdater.UpdateAttribute(rewriteSession, declaration, attributeName, annotation.AttributeValues, attributeValues);
+        }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AdjustAttributeValuesQuickFix;
+
+        public override CodeKind TargetCodeKind => CodeKind.AttributesCode;
+
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+    }
+}

--- a/Rubberduck.Core/Properties/Settings.Designer.cs
+++ b/Rubberduck.Core/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Rubberduck.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -41,111 +41,113 @@ namespace Rubberduck.Properties {
             "Inspection Name=\"IllegalAnnotationInspection\" Severity=\"Error\" InspectionType=\"R" +
             "ubberduckOpportunities\" />\r\n    <CodeInspection Name=\"RedundantByRefModifierInsp" +
             "ection\" Severity=\"DoNotShow\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeIns" +
-            "pection Name=\"MissingAttributeInspection\" Severity=\"DoNotShow\" InspectionType=\"R" +
-            "ubberduckOpportunities\" />\r\n    <CodeInspection Name=\"MissingAnnotationArgumentI" +
-            "nspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInsp" +
-            "ection Name=\"ModuleScopeDimKeywordInspection\" Severity=\"Suggestion\" InspectionTy" +
-            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"MultilineParameterInspe" +
-            "ction\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues" +
-            "\" />\r\n    <CodeInspection Name=\"MultipleDeclarationsInspection\" Severity=\"Warnin" +
-            "g\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection " +
-            "Name=\"ObsoleteCallStatementInspection\" Severity=\"Suggestion\" InspectionType=\"Lan" +
-            "guageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteCommentSyntaxInspectio" +
-            "n\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIns" +
-            "pection Name=\"ObsoleteLetStatementInspection\" Severity=\"Suggestion\" InspectionTy" +
-            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"OptionBaseInspection\" S" +
-            "everity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <Cod" +
-            "eInspection Name=\"RedundantOptionInspection\" Severity=\"Hint\" InspectionType=\"Lan" +
-            "guageOpportunities\" />\r\n    <CodeInspection Name=\"OptionExplicitInspection\" Seve" +
-            "rity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Pr" +
-            "ocedureCanBeWrittenAsFunctionInspection\" Severity=\"Suggestion\" InspectionType=\"L" +
-            "anguageOpportunities\" />\r\n    <CodeInspection Name=\"ApplicationWorksheetFunction" +
-            "Inspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <Co" +
-            "deInspection Name=\"AssignedByValParameterInspection\" Severity=\"Warning\" Inspecti" +
-            "onType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"EmptyModuleInspection\" " +
-            "Severity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <Co" +
-            "deInspection Name=\"LineLabelNotUsedInspection\" Severity=\"Warning\" InspectionType" +
-            "=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"IntegerDataTypeInspection\" Se" +
-            "verity=\"Hint\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"S" +
-            "hadowedDeclarationInspection\" Severity=\"DoNotShow\" InspectionType=\"CodeQualityIs" +
-            "sues\" />\r\n    <CodeInspection Name=\"ConstantNotUsedInspection\" Severity=\"Warning" +
-            "\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"DefaultProjec" +
-            "tNameInspection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabi" +
-            "lityIssues\" />\r\n    <CodeInspection Name=\"EmptyCaseBlockInspection\" Severity=\"Wa" +
-            "rning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspect" +
-            "ion Name=\"EmptyDoWhileBlockInspection\" Severity=\"Suggestion\" InspectionType=\"Mai" +
-            "ntainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyElseBlockIn" +
-            "spection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues" +
-            "\" />\r\n    <CodeInspection Name=\"EmptyForEachBlockInspection\" Severity=\"Warning\" " +
-            "InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Nam" +
-            "e=\"EmptyForLoopBlockInspection\" Severity=\"Warning\" InspectionType=\"Maintainabili" +
-            "tyAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyIfBlockInspection\" Se" +
-            "verity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <C" +
-            "odeInspection Name=\"EmptyWhileWendBlockInspection\" Severity=\"Warning\" Inspection" +
-            "Type=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Encapsu" +
-            "latePublicFieldInspection\" Severity=\"Suggestion\" InspectionType=\"Maintainability" +
-            "AndReadabilityIssues\" />\r\n    <CodeInspection Name=\"HostSpecificExpressionInspec" +
-            "tion\" Severity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIns" +
-            "pection Name=\"HungarianNotationInspection\" Severity=\"Suggestion\" InspectionType=" +
-            "\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"ImplicitActi" +
-            "veSheetReferenceInspection\" Severity=\"Warning\" InspectionType=\"LanguageOpportuni" +
-            "ties\" />\r\n    <CodeInspection Name=\"ImplicitActiveWorkbookReferenceInspection\" S" +
-            "everity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection" +
-            " Name=\"ImplicitDefaultMemberAssignmentInspection\" Severity=\"Suggestion\" Inspecti" +
-            "onType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitPublicMembe" +
-            "rInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <Cod" +
-            "eInspection Name=\"ImplicitVariantReturnTypeInspection\" Severity=\"Hint\" Inspectio" +
-            "nType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"MemberNotOnInterface" +
-            "Inspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeI" +
-            "nspection Name=\"MoveFieldCloserToUsageInspection\" Severity=\"Hint\" InspectionType" +
-            "=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"NonReturnin" +
-            "gFunctionInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n   " +
-            " <CodeInspection Name=\"ObjectVariableNotSetInspection\" Severity=\"Error\" Inspecti" +
-            "onType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteGlobalInspectio" +
-            "n\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIns" +
-            "pection Name=\"ObsoleteTypeHintInspection\" Severity=\"Suggestion\" InspectionType=\"" +
-            "LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ParameterCanBeByValInspecti" +
-            "on\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" /" +
-            ">\r\n    <CodeInspection Name=\"ParameterNotUsedInspection\" Severity=\"Warning\" Insp" +
-            "ectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ProcedureNotUsedIns" +
-            "pection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInsp" +
-            "ection Name=\"SelfAssignedDeclarationInspection\" Severity=\"Suggestion\" Inspection" +
-            "Type=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UnassignedVariableUsageIn" +
-            "spection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspe" +
-            "ction Name=\"UndeclaredVariableInspection\" Severity=\"Error\" InspectionType=\"CodeQ" +
-            "ualityIssues\" />\r\n    <CodeInspection Name=\"UntypedFunctionUsageInspection\" Seve" +
-            "rity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=" +
-            "\"UseMeaningfulNameInspection\" Severity=\"Suggestion\" InspectionType=\"Maintainabil" +
-            "ityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"VariableNotAssignedInspec" +
-            "tion\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspect" +
-            "ion Name=\"VariableNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQual" +
-            "ityIssues\" />\r\n    <CodeInspection Name=\"VariableTypeNotDeclaredInspection\" Seve" +
-            "rity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Na" +
-            "me=\"WriteOnlyPropertyInspection\" Severity=\"Suggestion\" InspectionType=\"CodeQuali" +
-            "tyIssues\" />\r\n    <CodeInspection Name=\"DefTypeStatementInspection\" Severity=\"Su" +
-            "ggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"S" +
-            "tepIsNotSpecifiedInspection\" Severity=\"DoNotShow\" InspectionType=\"LanguageOpport" +
-            "unities\" />\r\n    <CodeInspection Name=\"StepOneIsRedundantInspection\" Severity=\"H" +
-            "int\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"SheetA" +
-            "ccessedUsingStringInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOppo" +
-            "rtunities\" />\r\n    <CodeInspection Name=\"ObsoleteMemberUsageInspection\" Severity" +
-            "=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeIns" +
-            "pection Name=\"ObsoleteCallingConventionInspection\" Severity=\"Warning\" Inspection" +
-            "Type=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"DuplicatedAnnotationInspe" +
-            "ction\" Severity=\"Error\" InspectionType=\"RubberduckOpportunities\" />\r\n    <CodeIn" +
-            "spection Name=\"ModuleWithoutFolderInspection\" Severity=\"Suggestion\" InspectionTy" +
-            "pe=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"OnLocalErrorInspectio" +
-            "n\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIns" +
-            "pection Name=\"IsMissingOnInappropriateArgumentInspection\" Severity=\"Warning\" Ins" +
-            "pectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"IsMissingWithNonAr" +
-            "gumentParameterInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\"" +
-            " />\r\n    <CodeInspection Name=\"AssignmentNotUsedInspection\" Severity=\"Suggestion" +
-            "\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UnderscoreInP" +
-            "ublicClassModuleMemberInspection\" Severity=\"Warning\" InspectionType=\"CodeQuality" +
-            "Issues\" />\r\n    <CodeInspection Name=\"ExcelUdfNameIsValidCellReferenceInspection" +
-            "\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n  </CodeInspections>" +
-            "\r\n  <WhitelistedIdentifiers />\r\n  <RunInspectionsOnSuccessfulParse>true</RunInsp" +
-            "ectionsOnSuccessfulParse>\r\n</CodeInspectionSettings>")]
+            "pection Name=\"MissingAttributeInspection\" Severity=\"Warning\" InspectionType=\"Rub" +
+            "berduckOpportunities\" />\r\n    <CodeInspection Name=\"AttributeValueOutOfSyncInspe" +
+            "ction\" Severity=\"Warning\" InspectionType=\"RubberduckOpportunities\" />\r\n    <Code" +
+            "Inspection Name=\"MissingAnnotationArgumentInspection\" Severity=\"Error\" Inspectio" +
+            "nType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ModuleScopeDimKeywordIns" +
+            "pection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <C" +
+            "odeInspection Name=\"MultilineParameterInspection\" Severity=\"Suggestion\" Inspecti" +
+            "onType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Multi" +
+            "pleDeclarationsInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAnd" +
+            "ReadabilityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteCallStatementInspection" +
+            "\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInsp" +
+            "ection Name=\"ObsoleteCommentSyntaxInspection\" Severity=\"Suggestion\" InspectionTy" +
+            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteLetStatementIns" +
+            "pection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <C" +
+            "odeInspection Name=\"OptionBaseInspection\" Severity=\"Hint\" InspectionType=\"Mainta" +
+            "inabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"RedundantOptionInsp" +
+            "ection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInsp" +
+            "ection Name=\"OptionExplicitInspection\" Severity=\"Error\" InspectionType=\"CodeQual" +
+            "ityIssues\" />\r\n    <CodeInspection Name=\"ProcedureCanBeWrittenAsFunctionInspecti" +
+            "on\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIn" +
+            "spection Name=\"ApplicationWorksheetFunctionInspection\" Severity=\"Suggestion\" Ins" +
+            "pectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"AssignedByValParam" +
+            "eterInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <C" +
+            "odeInspection Name=\"EmptyModuleInspection\" Severity=\"Hint\" InspectionType=\"Maint" +
+            "ainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"LineLabelNotUsedIn" +
+            "spection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeIns" +
+            "pection Name=\"IntegerDataTypeInspection\" Severity=\"Hint\" InspectionType=\"CodeQua" +
+            "lityIssues\" />\r\n    <CodeInspection Name=\"ShadowedDeclarationInspection\" Severit" +
+            "y=\"DoNotShow\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"C" +
+            "onstantNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" " +
+            "/>\r\n    <CodeInspection Name=\"DefaultProjectNameInspection\" Severity=\"Suggestion" +
+            "\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection N" +
+            "ame=\"EmptyCaseBlockInspection\" Severity=\"Warning\" InspectionType=\"Maintainabilit" +
+            "yAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyDoWhileBlockInspection" +
+            "\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r" +
+            "\n    <CodeInspection Name=\"EmptyElseBlockInspection\" Severity=\"Warning\" Inspecti" +
+            "onType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Empty" +
+            "ForEachBlockInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndRea" +
+            "dabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyForLoopBlockInspection\" Sever" +
+            "ity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <Code" +
+            "Inspection Name=\"EmptyIfBlockInspection\" Severity=\"Warning\" InspectionType=\"Main" +
+            "tainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyWhileWendBlo" +
+            "ckInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIs" +
+            "sues\" />\r\n    <CodeInspection Name=\"EncapsulatePublicFieldInspection\" Severity=\"" +
+            "Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeIn" +
+            "spection Name=\"HostSpecificExpressionInspection\" Severity=\"Warning\" InspectionTy" +
+            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"HungarianNotationInspec" +
+            "tion\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\"" +
+            " />\r\n    <CodeInspection Name=\"ImplicitActiveSheetReferenceInspection\" Severity=" +
+            "\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"I" +
+            "mplicitActiveWorkbookReferenceInspection\" Severity=\"Warning\" InspectionType=\"Lan" +
+            "guageOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitDefaultMemberAssignmen" +
+            "tInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n  " +
+            "  <CodeInspection Name=\"ImplicitPublicMemberInspection\" Severity=\"Hint\" Inspecti" +
+            "onType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitVariantRetu" +
+            "rnTypeInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n   " +
+            " <CodeInspection Name=\"MemberNotOnInterfaceInspection\" Severity=\"Warning\" Inspec" +
+            "tionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"MoveFieldCloserToUsag" +
+            "eInspection\" Severity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues" +
+            "\" />\r\n    <CodeInspection Name=\"NonReturningFunctionInspection\" Severity=\"Error\"" +
+            " InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ObjectVariable" +
+            "NotSetInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <C" +
+            "odeInspection Name=\"ObsoleteGlobalInspection\" Severity=\"Suggestion\" InspectionTy" +
+            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteTypeHintInspect" +
+            "ion\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeI" +
+            "nspection Name=\"ParameterCanBeByValInspection\" Severity=\"Suggestion\" InspectionT" +
+            "ype=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Paramete" +
+            "rNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n  " +
+            "  <CodeInspection Name=\"ProcedureNotUsedInspection\" Severity=\"Warning\" Inspectio" +
+            "nType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"SelfAssignedDeclarationI" +
+            "nspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <Cod" +
+            "eInspection Name=\"UnassignedVariableUsageInspection\" Severity=\"Error\" Inspection" +
+            "Type=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UndeclaredVariableInspect" +
+            "ion\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection" +
+            " Name=\"UntypedFunctionUsageInspection\" Severity=\"Hint\" InspectionType=\"LanguageO" +
+            "pportunities\" />\r\n    <CodeInspection Name=\"UseMeaningfulNameInspection\" Severit" +
+            "y=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <Cod" +
+            "eInspection Name=\"VariableNotAssignedInspection\" Severity=\"Warning\" InspectionTy" +
+            "pe=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"VariableNotUsedInspection\" " +
+            "Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Na" +
+            "me=\"VariableTypeNotDeclaredInspection\" Severity=\"Warning\" InspectionType=\"Langua" +
+            "geOpportunities\" />\r\n    <CodeInspection Name=\"WriteOnlyPropertyInspection\" Seve" +
+            "rity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Nam" +
+            "e=\"DefTypeStatementInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpp" +
+            "ortunities\" />\r\n    <CodeInspection Name=\"StepIsNotSpecifiedInspection\" Severity" +
+            "=\"DoNotShow\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name" +
+            "=\"StepOneIsRedundantInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportun" +
+            "ities\" />\r\n    <CodeInspection Name=\"SheetAccessedUsingStringInspection\" Severit" +
+            "y=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Na" +
+            "me=\"ObsoleteMemberUsageInspection\" Severity=\"Warning\" InspectionType=\"Maintainab" +
+            "ilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteCallingConventi" +
+            "onInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <Cod" +
+            "eInspection Name=\"DuplicatedAnnotationInspection\" Severity=\"Error\" InspectionTyp" +
+            "e=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"ModuleWithoutFolderIns" +
+            "pection\" Severity=\"Suggestion\" InspectionType=\"RubberduckOpportunities\" />\r\n    " +
+            "<CodeInspection Name=\"OnLocalErrorInspection\" Severity=\"Suggestion\" InspectionTy" +
+            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"IsMissingOnInappropriat" +
+            "eArgumentInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n " +
+            "   <CodeInspection Name=\"IsMissingWithNonArgumentParameterInspection\" Severity=\"" +
+            "Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Assign" +
+            "mentNotUsedInspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" " +
+            "/>\r\n    <CodeInspection Name=\"UnderscoreInPublicClassModuleMemberInspection\" Sev" +
+            "erity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=" +
+            "\"ExcelUdfNameIsValidCellReferenceInspection\" Severity=\"Warning\" InspectionType=\"" +
+            "CodeQualityIssues\" />\r\n  </CodeInspections>\r\n  <WhitelistedIdentifiers />\r\n  <Ru" +
+            "nInspectionsOnSuccessfulParse>true</RunInspectionsOnSuccessfulParse>\r\n</CodeInsp" +
+            "ectionSettings>")]
         public global::Rubberduck.Settings.CodeInspectionSettings CodeInspectionSettings {
             get {
                 return ((global::Rubberduck.Settings.CodeInspectionSettings)(this["CodeInspectionSettings"]));

--- a/Rubberduck.Core/Properties/Settings.settings
+++ b/Rubberduck.Core/Properties/Settings.settings
@@ -15,7 +15,8 @@
     &lt;CodeInspection Name="FunctionReturnValueNotUsedInspection" Severity="Warning" InspectionType="CodeQualityIssues" /&gt;
     &lt;CodeInspection Name="IllegalAnnotationInspection" Severity="Error" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="RedundantByRefModifierInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" /&gt;
-    &lt;CodeInspection Name="MissingAttributeInspection" Severity="DoNotShow" InspectionType="RubberduckOpportunities" /&gt;
+    &lt;CodeInspection Name="MissingAttributeInspection" Severity="Warning" InspectionType="RubberduckOpportunities" /&gt;
+    &lt;CodeInspection Name="AttributeValueOutOfSyncInspection" Severity="Warning" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="MissingAnnotationArgumentInspection" Severity="Error" InspectionType="CodeQualityIssues" /&gt;
     &lt;CodeInspection Name="ModuleScopeDimKeywordInspection" Severity="Suggestion" InspectionType="LanguageOpportunities" /&gt;
     &lt;CodeInspection Name="MultilineParameterInspection" Severity="Suggestion" InspectionType="MaintainabilityAndReadabilityIssues" /&gt;

--- a/Rubberduck.Core/app.config
+++ b/Rubberduck.Core/app.config
@@ -39,7 +39,9 @@
                 InspectionType="RubberduckOpportunities" />
               <CodeInspection Name="RedundantByRefModifierInspection" Severity="DoNotShow"
                 InspectionType="CodeQualityIssues" />
-              <CodeInspection Name="MissingAttributeInspection" Severity="DoNotShow"
+              <CodeInspection Name="MissingAttributeInspection" Severity="Warning"
+                InspectionType="RubberduckOpportunities" />
+              <CodeInspection Name="AttributeOutOfSyncInspection" Severity="Warning"
                 InspectionType="RubberduckOpportunities" />
               <CodeInspection Name="MissingAnnotationArgumentInspection" Severity="Error"
                 InspectionType="CodeQualityIssues" />

--- a/Rubberduck.Parsing/Annotations/AnnotationType.cs
+++ b/Rubberduck.Parsing/Annotations/AnnotationType.cs
@@ -69,7 +69,7 @@ namespace Rubberduck.Parsing.Annotations
         [AttributeAnnotation("VB_Description")]
         ModuleDescription = 1 << 19 | Attribute | ModuleAnnotation,
         ModuleAttribute = 1 << 20 | Attribute | ModuleAnnotation,
-        MemberAttribute = 1 << 21 | Attribute | MemberAnnotation
+        MemberAttribute = 1 << 21 | Attribute | MemberAnnotation | VariableAnnotation
     }
 
     [AttributeUsage(AttributeTargets.Field)]

--- a/Rubberduck.Parsing/Annotations/AnnotationType.cs
+++ b/Rubberduck.Parsing/Annotations/AnnotationType.cs
@@ -5,6 +5,7 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Member names are 
     /// </summary>
+    [Flags]
     public enum AnnotationType
     {
         /// <summary>

--- a/Rubberduck.Parsing/Annotations/ModuleAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ModuleAttributeAnnotation.cs
@@ -7,10 +7,10 @@ namespace Rubberduck.Parsing.Annotations
 {
     public class ModuleAttributeAnnotation : AttributeAnnotationBase
     {
-        public ModuleAttributeAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> paramaters) 
-        :base(AnnotationType.ModuleAttribute, qualifiedSelection, context, paramaters?.Skip(1).ToList())
+        public ModuleAttributeAnnotation(QualifiedSelection qualifiedSelection, VBAParser.AnnotationContext context, IReadOnlyList<string> parameters) 
+        :base(AnnotationType.ModuleAttribute, qualifiedSelection, context, parameters?.Skip(1).ToList())
         {
-            Attribute = paramaters?.FirstOrDefault() ?? string.Empty;
+            Attribute = parameters?.FirstOrDefault() ?? string.Empty;
         }
 
         public override string Attribute { get; }

--- a/Rubberduck.Parsing/Symbols/Attributes.cs
+++ b/Rubberduck.Parsing/Symbols/Attributes.cs
@@ -126,13 +126,13 @@ namespace Rubberduck.Parsing.Symbols
 
         public void AddHiddenMemberAttribute(string identifierName)
         {
-            Add(new AttributeNode(identifierName + ".VB_UserMemId", new[] {"40"}));
+            Add(new AttributeNode(identifierName + ".VB_MemberFlags", new[] {"40"}));
         }
 
         public bool HasHiddenMemberAttribute(string identifierName, out AttributeNode attribute)
         {
             attribute = this.SingleOrDefault(a => a.HasValue("40")
-                && a.Name.Equals($"{identifierName}.VB_UserMemId", StringComparison.OrdinalIgnoreCase));
+                && a.Name.Equals($"{identifierName}.VB_MemberFlags", StringComparison.OrdinalIgnoreCase));
             return attribute != null;
         }
 

--- a/Rubberduck.Parsing/Symbols/Attributes.cs
+++ b/Rubberduck.Parsing/Symbols/Attributes.cs
@@ -77,9 +77,14 @@ namespace Rubberduck.Parsing.Symbols
     {
         public bool HasAttributeFor(IAttributeAnnotation annotation, string memberName = null)
         {
+            return AttributeNodesFor(annotation, memberName).Any();
+        }
+
+        public IEnumerable<AttributeNode> AttributeNodesFor(IAttributeAnnotation annotation, string memberName = null)
+        {
             if (!annotation.AnnotationType.HasFlag(AnnotationType.Attribute))
             {
-                return false;
+                return Enumerable.Empty<AttributeNode>();
             }
 
             var attributeName = memberName != null
@@ -89,26 +94,11 @@ namespace Rubberduck.Parsing.Symbols
             //VB_Ext_Key annotation depend on the defined key for identity.
             if (annotation.Attribute.Equals("VB_Ext_Key", StringComparison.OrdinalIgnoreCase))
             {
-                return this.Any(a => a.Name.Equals(attributeName, StringComparison.OrdinalIgnoreCase) 
+                return this.Where(a => a.Name.Equals(attributeName, StringComparison.OrdinalIgnoreCase)
                                      && a.Values[0] == annotation.AttributeValues[0]);
             }
 
-            return this.Any(a => a.Name.Equals(attributeName, StringComparison.OrdinalIgnoreCase));
-        }
-
-        public bool HasAttributeWithMatchingValueFor(IAttributeAnnotation annotation, string memberName = null)
-        {
-            if (!annotation.AnnotationType.HasFlag(AnnotationType.Attribute))
-            {
-                return false;
-            }
-
-            var attributeName = memberName != null
-                ? $"{memberName}.{annotation.Attribute}"
-                : annotation.Attribute;
-
-            return this.Any(a => a.Name.Equals(attributeName, StringComparison.OrdinalIgnoreCase)
-                                 && a.Values.SequenceEqual(annotation.AttributeValues));
+            return this.Where(a => a.Name.Equals(attributeName, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -86,7 +86,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
+        /// </summary>
+        public static string AttributeValueOutOfSyncInspection
+        {
+            get {
+                return ResourceManager.GetString("AttributeValueOutOfSyncInspection", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to A member is assigned True/False in different branches of an if statement with no other statements in the conditional. Use the condition directly to the member instead..
         /// </summary>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
@@ -358,4 +358,7 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   <data name="ExcelUdfNameIsValidCellReferenceInspection" xml:space="preserve">
     <value>Funktionen, die für EXCEL als benutzerdefinierte Funktionen sichtbar sind, werden einen '#REF!'-Fehler erzeugen, wenn sie in einem Arbeitsblatt verwendet werden, in dem ihr Name dem einer korrekten Zellreferenz entspricht. Wenn die Funktion als benutzerdefinierte Funktion gedacht ist, muss sie umbenannt werden. Wenn die Funktion nicht als benutzerdefinierte Funktion gedacht ist, sollte sie 'Private' deklariert oder aus einem Standardmodul herausgenommen werden.</value>
   </data>
+  <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
+    <value>Eine Rubberduck-Annotation wurde für ein Modul oder Element festgelegt, aber das zugehörige Attribut hat einen anderen Wert. Die Modul-Attribute und Annotationen sollten synchronisiert werden.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -358,4 +358,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="ExcelUdfNameIsValidCellReferenceInspection" xml:space="preserve">
     <value>Functions that are visible to Excel as User-Defined Functions will return a '#REF!' error when used on a Worksheet if they match the name of a valid cell reference. If the function is intended to be used as a UDF, it must be renamed. If the function is not intended to be used as a UDF, it should be scoped as 'Private' or moved out of a standard Module.</value>
   </data>
+  <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
+    <value>A Rubberduck annotation is specified for a module or member, but the corresponding attribute has a different value. Module attributes and annotations need to be synchronized.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -86,7 +86,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Assignment is not used.
+        /// </summary>
+        public static string AttributeValueOutOfSyncInspection
+        {
+            get {
+                return ResourceManager.GetString("AttributeValueOutOfSyncInspection", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal assignment in conditional.
         /// </summary>

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -357,4 +357,7 @@
   <data name="ExcelUdfNameIsValidCellReferenceInspection" xml:space="preserve">
     <value>Funktion wird von EXCEL-Zellreferenz verdeckt</value>
   </data>
+  <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
+    <value>Wert stimmt nicht überein zwischen Attribut und Annotation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -357,4 +357,7 @@
   <data name="ExcelUdfNameIsValidCellReferenceInspection" xml:space="preserve">
     <value>Function is hidden by Excel cell reference</value>
   </data>
+  <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
+    <value>Value does not match between attribute and annotation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -95,7 +95,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
+        /// </summary>
+        public static string AttributeValueOutOfSyncInspection
+        {
+            get {
+                return ResourceManager.GetString("AttributeValueOutOfSyncInspection", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal &apos;{0}&apos; assigned in conditional..
         /// </summary>

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -374,4 +374,7 @@
   <data name="ExcelUdfNameIsValidCellReferenceInspection" xml:space="preserve">
     <value>'{0}' wird von einem EXCEL-Zellverweis verdeckt.</value>
   </data>
+  <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
+    <value>Die Wert(e) des {0}-Attributs ({1}) passen nicht zur {2}-Annotation.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -389,4 +389,8 @@
     <value>'{0}' is hidden by a valid Excel cell reference.</value>
     <comment>{0} Function name</comment>
   </data>
+  <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
+    <value>The attribute value(s) for attribute {0} ({1}) are out of sync with the {2} annotation. </value>
+    <comment>{0} attribute name, {1} attribute values, {2} annotation name</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -74,8 +74,7 @@ namespace Rubberduck.Resources.Inspections {
         /// </summary>
         public static string AddMissingAttributeQuickFix
         {
-            get
-            {
+            get {
                 return ResourceManager.GetString("AddMissingAttributeQuickFix", resourceCulture);
             }
         }
@@ -88,7 +87,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AddStepOneQuickFix", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Add explicit &apos;Step&apos; clause.
+        /// </summary>
+        public static string AdjustAttributeValuesQuickFix
+        {
+            get {
+                return ResourceManager.GetString("AdjustAttributeValuesQuickFix", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use early-bound Application.WorksheetFunction method..
         /// </summary>

--- a/Rubberduck.Resources/Inspections/QuickFixes.de.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.de.resx
@@ -262,6 +262,9 @@
     <value>'IsMissing'-Aufruf in Prüfung eines Standardwerts umschreiben.</value>
   </data>
   <data name="AddMissingAttributeQuickFix" xml:space="preserve">
-    <value>Füge das fehlende Attribut hinzu.</value>
+    <value>Fehlendes Attribut hinzufügen</value>
+  </data>
+  <data name="AdjustAttributeValuesQuickFix" xml:space="preserve">
+    <value>Attributwert(e) anpassen</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.resx
@@ -262,6 +262,9 @@
     <value>Change 'IsMissing' call to test for default value.</value>
   </data>
   <data name="AddMissingAttributeQuickFix" xml:space="preserve">
-    <value>Add the missing attribute.</value>
+    <value>Add missing attribute</value>
+  </data>
+  <data name="AdjustAttributeValuesQuickFix" xml:space="preserve">
+    <value>Adjust attribute value(s)</value>
   </data>
 </root>

--- a/RubberduckTests/Inspections/AttributeValueOutOfSyncInspectionTests.cs
+++ b/RubberduckTests/Inspections/AttributeValueOutOfSyncInspectionTests.cs
@@ -1,0 +1,206 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Inspections.Abstract;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    public class AttributeValueOutOfSyncInspectionTests
+    {
+        [Test]
+        [Category("Inspections")]
+        public void NoAnnotation_NoResult()
+        {
+            const string inputCode =
+                @"Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeWithOtherValueReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Exposed = False
+'@ModuleAttribute VB_Exposed, True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeWithSameValue_NoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Exposed = True
+'@ModuleAttribute VB_Exposed, True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeWithOtherKey_NoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""OtherKey"", ""SomeValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeWithSameKeyButOtherValueReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""OtherValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeWithSameKeyAndValue_NoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""Value""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithOtherValueReturnsResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_UserMemId, -4
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 40
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithSameValue_NoResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_UserMemId, -4
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = -4
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeWithOtherKey_NoResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""SomeValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeWithSameKeyButOtherValueReturnsResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""OtherValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeWithSameKeyAndValue_NoResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ResultContainsAnnotationAndAttributeValues()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_UserMemId, -4
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 40
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            var inspectionResult = inspectionResults.First();
+            Assert.AreEqual(AnnotationType.MemberAttribute, inspectionResult.Properties.Annotation.AnnotationType);
+            Assert.AreEqual("VB_UserMemId", inspectionResult.Properties.Annotation.Attribute);
+            Assert.AreEqual("-4", inspectionResult.Properties.Annotation.AttributeValues[0]);
+            Assert.AreEqual("40", inspectionResult.Properties.AttributeValues[0]);
+        }
+
+        private IEnumerable<IInspectionResult> InspectionResults(string inputCode)
+        {
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new AttributeValueOutOfSyncInspection(state);
+                return inspection.GetInspectionResults(CancellationToken.None);
+            }
+        }
+    }
+}

--- a/RubberduckTests/QuickFixes/AdjustAttributeValuesQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AdjustAttributeValuesQuickFixTests.cs
@@ -1,0 +1,109 @@
+﻿using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Inspections.QuickFixes;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
+
+namespace RubberduckTests.QuickFixes
+{
+    public class AdjustAttributeValuesQuickFixTests : QuickFixTestBase
+    {
+        [Test]
+        [Category("QuickFixes")]
+        public void ModuleAttributeOutOfSync_QuickFixWorks()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""NotDesc""
+'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"Attribute VB_Description = ""Desc""
+'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new AttributeValueOutOfSyncInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void VbExtKeyModuleAttributeOutOfSync_QuickFixWorks()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""NotValue""
+Attribute VB_Ext_Key = ""OtherKey"", ""OtherValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""Value""
+Attribute VB_Ext_Key = ""OtherKey"", ""OtherValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new AttributeValueOutOfSyncInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MemberAttributeOutOfSync_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+Attribute Foo.VB_Description = ""NotDesc""
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+Attribute Foo.VB_Description = ""Desc""
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new AttributeValueOutOfSyncInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void VbExtKeyMemberAttributeOutOfSync_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""NotValue""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""OtherValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""Value""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""OtherValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new AttributeValueOutOfSyncInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        protected override IQuickFix QuickFix(RubberduckParserState state)
+        {
+            return new AdjustAttributeValuesQuickFix(new AttributesUpdater(state));
+        }
+    }
+}


### PR DESCRIPTION
This PR is the next step after PR #4641 and based on that PR.

This PR introduces the new `AttributeValueOutOfSyncInspection` along with the corresponding `AdjustAttributeValuesQuickFix`.

The inspection finds all instances of attribute annotations for which there is a corresponding attribute, but the value(s) do not match. So, it covers the empty spot of the `MissingAttributeInspection`. In particular, it deals with the `@PredeclaredId` and `@Exposed` annotations for which the corresponding attribute always exists in class modules.

The `AdjustAttributeValuesQuickFix` does exactly what the name suggests. 

I verified that this works in the VBE using the example of the `@PredeclaredId` annotation.