### PR TITLE
Reimplement missing annotation inspections

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AttributeValueOutOfSyncInspection.cs
@@ -9,6 +9,7 @@ using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace Rubberduck.Inspections.Concrete
 {
@@ -25,7 +26,7 @@ namespace Rubberduck.Inspections.Concrete
             var declarationsWithAttributeAnnotations = State.DeclarationFinder.AllUserDeclarations
                 .Where(declaration => declaration.Annotations.Any(annotation => annotation.AnnotationType.HasFlag(AnnotationType.Attribute)));
             var results = new List<DeclarationInspectionResult>();
-            foreach (var declaration in declarationsWithAttributeAnnotations)
+            foreach (var declaration in declarationsWithAttributeAnnotations.Where(decl => decl.QualifiedModuleName.ComponentType != ComponentType.Document))
             {
                 foreach (var annotation in declaration.Annotations.OfType<IAttributeAnnotation>())
                 {
@@ -39,6 +40,7 @@ namespace Rubberduck.Inspections.Concrete
                         var result = new DeclarationInspectionResult(this, description, declaration,
                             new QualifiedContext(declaration.QualifiedModuleName, annotation.Context));
                         result.Properties.Annotation = annotation;
+                        result.Properties.AttributeName = annotation.Attribute;
                         result.Properties.AttributeValues = attributeValues;
 
                         results.Add(result);

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/IllegalAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/IllegalAnnotationInspection.cs
@@ -8,7 +8,9 @@ using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Resources.Inspections;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.Parsing.VBA.Extensions;
+using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace Rubberduck.Inspections.Concrete
 {
@@ -24,9 +26,12 @@ namespace Rubberduck.Inspections.Concrete
             var identifierReferences = State.DeclarationFinder.AllIdentifierReferences().ToList();
             var annotations = State.AllAnnotations;
 
-            var illegalAnnotations = UnboundAnnotations(annotations, userDeclarations, identifierReferences)
+            var unboundAnnotations = UnboundAnnotations(annotations, userDeclarations, identifierReferences)
                 .Where(annotation => !annotation.AnnotationType.HasFlag(AnnotationType.GeneralAnnotation)
-                                        || annotation.AnnotatedLine == null);
+                                     || annotation.AnnotatedLine == null);
+            var attributeAnnotationsInDocuments = AttributeAnnotationsInDocuments(userDeclarations);
+
+            var illegalAnnotations = unboundAnnotations.Concat(attributeAnnotationsInDocuments).ToHashSet();
 
             return illegalAnnotations.Select(annotation => 
                 new QualifiedContextInspectionResult(
@@ -35,7 +40,7 @@ namespace Rubberduck.Inspections.Concrete
                     new QualifiedContext(annotation.QualifiedSelection.QualifiedName, annotation.Context)));
         }
 
-        private static ICollection<IAnnotation> UnboundAnnotations(IEnumerable<IAnnotation> annotations, IEnumerable<Declaration> userDeclarations, IEnumerable<IdentifierReference> identifierReferences)
+        private static IEnumerable<IAnnotation> UnboundAnnotations(IEnumerable<IAnnotation> annotations, IEnumerable<Declaration> userDeclarations, IEnumerable<IdentifierReference> identifierReferences)
         {
             var boundAnnotationsSelections = userDeclarations
                 .SelectMany(declaration => declaration.Annotations)
@@ -44,6 +49,13 @@ namespace Rubberduck.Inspections.Concrete
                 .ToHashSet();
             
             return annotations.Where(annotation => !boundAnnotationsSelections.Contains(annotation.QualifiedSelection)).ToList();
+        }
+
+        private static IEnumerable<IAnnotation> AttributeAnnotationsInDocuments(IEnumerable<Declaration> userDeclarations)
+        {
+            var declarationsInDocuments = userDeclarations
+                .Where(declaration => declaration.QualifiedModuleName.ComponentType == ComponentType.Document);
+            return declarationsInDocuments.SelectMany(doc => doc.Annotations).OfType<IAttributeAnnotation>();
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
@@ -9,6 +9,7 @@ using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace Rubberduck.Inspections.Concrete
 {
@@ -24,7 +25,7 @@ namespace Rubberduck.Inspections.Concrete
             var declarationsWithAttributeAnnotations = State.DeclarationFinder.AllUserDeclarations
                 .Where(declaration => declaration.Annotations.Any(annotation => annotation.AnnotationType.HasFlag(AnnotationType.Attribute)));
             var results = new List<DeclarationInspectionResult>();
-            foreach (var declaration in declarationsWithAttributeAnnotations)
+            foreach (var declaration in declarationsWithAttributeAnnotations.Where(decl => decl.QualifiedModuleName.ComponentType != ComponentType.Document))
             {
                 foreach(var annotation in declaration.Annotations.OfType<IAttributeAnnotation>())
                 {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingMemberAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingMemberAnnotationInspection.cs
@@ -40,7 +40,7 @@ namespace Rubberduck.Inspections.Concrete
                         var description = string.Format(InspectionResults.MissingMemberAnnotationInspection, 
                             declaration.IdentifierName,
                             attributeBaseName,
-                            attribute.Values);
+                            string.Join(", ", attribute.Values));
 
                         var result = new DeclarationInspectionResult(this, description, declaration,
                             new QualifiedContext(declaration.QualifiedModuleName, declaration.Context));

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingMemberAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingMemberAnnotationInspection.cs
@@ -10,7 +10,7 @@ using Rubberduck.Parsing.VBA;
 using Rubberduck.Resources.Inspections;
 using Rubberduck.VBEditor.SafeComWrappers;
 
-namespace Rubberduck.Inspections.Inspections.Concrete
+namespace Rubberduck.Inspections.Concrete
 {
     public sealed class MissingMemberAnnotationInspection : InspectionBase
     {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingMemberAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingMemberAnnotationInspection.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor.SafeComWrappers;
+
+namespace Rubberduck.Inspections.Inspections.Concrete
+{
+    public sealed class MissingMemberAnnotationInspection : InspectionBase
+    {
+        public MissingMemberAnnotationInspection(RubberduckParserState state) 
+        :base(state)
+        {}
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            var memberDeclarationsWithAttributes = State.DeclarationFinder.AllUserDeclarations
+                .Where(decl => !decl.DeclarationType.HasFlag(DeclarationType.Module)
+                                && decl.Attributes.Any());
+
+            var declarationsToInspect = memberDeclarationsWithAttributes
+                .Where(decl => decl.QualifiedModuleName.ComponentType != ComponentType.Document
+                               && !IsIgnoringInspectionResultFor(decl, AnnotationName));
+
+            var results = new List<DeclarationInspectionResult>();
+            foreach (var declaration in declarationsToInspect)
+            {
+                foreach (var attribute in declaration.Attributes)
+                {
+                    if (MissesCorrespondingMemberAnnotation(declaration, attribute))
+                    {
+                        var attributeBaseName = AttributeBaseName(declaration, attribute);
+
+                        var description = string.Format(InspectionResults.MissingMemberAnnotationInspection, 
+                            declaration.IdentifierName,
+                            attributeBaseName,
+                            attribute.Values);
+
+                        var result = new DeclarationInspectionResult(this, description, declaration,
+                            new QualifiedContext(declaration.QualifiedModuleName, declaration.Context));
+                        result.Properties.AttributeName = attributeBaseName;
+                        result.Properties.AttributeValues = attribute.Values;
+
+                        results.Add(result);
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        private static bool MissesCorrespondingMemberAnnotation(Declaration declaration, AttributeNode attribute)
+        {
+            if (string.IsNullOrEmpty(attribute.Name) || declaration.DeclarationType.HasFlag(DeclarationType.Module))
+            {
+                return false;
+            }
+
+            var attributeBaseName = AttributeBaseName(declaration, attribute);
+
+            //VB_Ext_Key attributes are special in that identity also depends on the first value, the key.
+            if (attributeBaseName == "VB_Ext_Key")
+            {
+                return !declaration.Annotations.OfType<IAttributeAnnotation>()
+                    .Any(annotation => annotation.Attribute.Equals("VB_Ext_Key") && attribute.Values[0].Equals(annotation.AttributeValues[0]));
+            }
+
+            return !declaration.Annotations.OfType<IAttributeAnnotation>()
+                .Any(annotation => annotation.Attribute.Equals(attributeBaseName));
+        }
+
+        private static string AttributeBaseName(Declaration declaration, AttributeNode attribute)
+        {
+            var attributeName = attribute.Name;
+            return attributeName.StartsWith($"{declaration.IdentifierName}.") 
+                ? attributeName.Substring(declaration.IdentifierName.Length + 1) 
+                : attributeName;
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingModuleAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingModuleAnnotationInspection.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor.SafeComWrappers;
+
+namespace Rubberduck.Inspections.Inspections.Concrete
+{
+    public sealed class MissingModuleAnnotationInspection : InspectionBase
+    {
+        public MissingModuleAnnotationInspection(RubberduckParserState state) 
+        :base(state)
+        {}
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            var moduleDeclarationsWithAttributes = State.DeclarationFinder
+                .UserDeclarations(DeclarationType.Module)
+                .Where(decl => decl.Attributes.Any());
+
+            var declarationsToInspect = moduleDeclarationsWithAttributes
+                .Where(decl => decl.QualifiedModuleName.ComponentType != ComponentType.Document
+                               && !IsIgnoringInspectionResultFor(decl, AnnotationName));
+
+            var results = new List<DeclarationInspectionResult>();
+            foreach (var declaration in declarationsToInspect)
+            {
+                foreach (var attribute in declaration.Attributes)
+                {
+                    if (IsDefaultAttribute(declaration, attribute))
+                    {
+                        continue;
+                    }
+
+                    if (MissesCorrespondingModuleAnnotation(declaration, attribute))
+                    {
+                        var description = string.Format(InspectionResults.MissingMemberAnnotationInspection,
+                            declaration.IdentifierName,
+                            attribute.Name,
+                            attribute.Values);
+
+                        var result = new DeclarationInspectionResult(this, description, declaration,
+                            new QualifiedContext(declaration.QualifiedModuleName, declaration.Context));
+                        result.Properties.AttributeName = attribute.Name;
+                        result.Properties.AttributeValues = attribute.Values;
+
+                        results.Add(result);
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        private static bool IsDefaultAttribute(Declaration declaration, AttributeNode attribute)
+        {
+            switch (attribute.Name)
+            {
+                case "VB_Name":
+                    return true;
+                case "VB_GlobalNameSpace":
+                    return declaration.DeclarationType.HasFlag(DeclarationType.ClassModule) 
+                        && attribute.Values[0].Equals(Tokens.False);
+                case "VB_Exposed":
+                    return declaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
+                           && attribute.Values[0].Equals(Tokens.False);
+                case "VB_Creatable":
+                    return declaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
+                           && attribute.Values[0].Equals(Tokens.False);
+                case "VB_PredeclaredId":
+                    return (declaration.QualifiedModuleName.ComponentType == ComponentType.ClassModule
+                                && attribute.Values[0].Equals(Tokens.False))
+                            || (declaration.QualifiedModuleName.ComponentType == ComponentType.UserForm
+                                && attribute.Values[0].Equals(Tokens.True));
+                default:
+                    return false;
+            }
+        }
+
+        private static bool MissesCorrespondingModuleAnnotation(Declaration declaration, AttributeNode attribute)
+        {
+            if (string.IsNullOrEmpty(attribute.Name) || !declaration.DeclarationType.HasFlag(DeclarationType.Module))
+            {
+                return false;
+            }
+
+            //VB_Ext_Key attributes are special in that identity also depends on the first value, the key.
+            if (attribute.Name == "VB_Ext_Key")
+            {
+                return !declaration.Annotations.OfType<IAttributeAnnotation>()
+                    .Any(annotation => annotation.Attribute.Equals("VB_Ext_Key") && attribute.Values[0].Equals(annotation.AttributeValues[0]));
+            }
+
+            return !declaration.Annotations.OfType<IAttributeAnnotation>()
+                .Any(annotation => annotation.Attribute.Equals(attribute.Name));
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingModuleAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingModuleAnnotationInspection.cs
@@ -11,7 +11,7 @@ using Rubberduck.Parsing.VBA;
 using Rubberduck.Resources.Inspections;
 using Rubberduck.VBEditor.SafeComWrappers;
 
-namespace Rubberduck.Inspections.Inspections.Concrete
+namespace Rubberduck.Inspections.Concrete
 {
     public sealed class MissingModuleAnnotationInspection : InspectionBase
     {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingModuleAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingModuleAnnotationInspection.cs
@@ -44,7 +44,7 @@ namespace Rubberduck.Inspections.Concrete
                         var description = string.Format(InspectionResults.MissingMemberAnnotationInspection,
                             declaration.IdentifierName,
                             attribute.Name,
-                            attribute.Values);
+                            string.Join(", ", attribute.Values));
 
                         var result = new DeclarationInspectionResult(this, description, declaration,
                             new QualifiedContext(declaration.QualifiedModuleName, declaration.Context));

--- a/Rubberduck.CodeAnalysis/QuickFixes/RemoveAttributeQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/RemoveAttributeQuickFix.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
+
+namespace Rubberduck.Inspections.QuickFixes
+{
+    public class RemoveAttributeQuickFix : QuickFixBase
+    {
+        private readonly IAttributesUpdater _attributesUpdater;
+
+        public RemoveAttributeQuickFix(IAttributesUpdater attributesUpdater)
+        :base(typeof(AttributeValueOutOfSyncInspection))
+        {
+            _attributesUpdater = attributesUpdater;
+        }
+
+        public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
+        {
+            var declaration = result.Target;
+            string attributeBaseName = result.Properties.AttributeName; 
+            IReadOnlyList<string> attributeValues = result.Properties.AttributeValues;
+
+            var attributeName = declaration.DeclarationType.HasFlag(DeclarationType.Module)
+                ? attributeBaseName
+                : $"{declaration.IdentifierName}.{attributeBaseName}";
+
+            _attributesUpdater.RemoveAttribute(rewriteSession, declaration, attributeName, attributeValues);
+        }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.RemoveAttributeQuickFix;
+
+        public override CodeKind TargetCodeKind => CodeKind.AttributesCode;
+
+        public override bool CanFixInProcedure => false;
+        public override bool CanFixInModule => false;
+        public override bool CanFixInProject => false;
+    }
+}

--- a/Rubberduck.Core/Properties/Settings.Designer.cs
+++ b/Rubberduck.Core/Properties/Settings.Designer.cs
@@ -42,112 +42,113 @@ namespace Rubberduck.Properties {
             "ubberduckOpportunities\" />\r\n    <CodeInspection Name=\"RedundantByRefModifierInsp" +
             "ection\" Severity=\"DoNotShow\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeIns" +
             "pection Name=\"MissingAttributeInspection\" Severity=\"Warning\" InspectionType=\"Rub" +
-            "berduckOpportunities\" />\r\n    <CodeInspection Name=\"AttributeValueOutOfSyncInspe" +
-            "ction\" Severity=\"Warning\" InspectionType=\"RubberduckOpportunities\" />\r\n    <Code" +
-            "Inspection Name=\"MissingAnnotationArgumentInspection\" Severity=\"Error\" Inspectio" +
-            "nType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ModuleScopeDimKeywordIns" +
-            "pection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <C" +
-            "odeInspection Name=\"MultilineParameterInspection\" Severity=\"Suggestion\" Inspecti" +
-            "onType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Multi" +
-            "pleDeclarationsInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAnd" +
-            "ReadabilityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteCallStatementInspection" +
-            "\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInsp" +
-            "ection Name=\"ObsoleteCommentSyntaxInspection\" Severity=\"Suggestion\" InspectionTy" +
-            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteLetStatementIns" +
-            "pection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <C" +
-            "odeInspection Name=\"OptionBaseInspection\" Severity=\"Hint\" InspectionType=\"Mainta" +
-            "inabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"RedundantOptionInsp" +
-            "ection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInsp" +
-            "ection Name=\"OptionExplicitInspection\" Severity=\"Error\" InspectionType=\"CodeQual" +
-            "ityIssues\" />\r\n    <CodeInspection Name=\"ProcedureCanBeWrittenAsFunctionInspecti" +
-            "on\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIn" +
-            "spection Name=\"ApplicationWorksheetFunctionInspection\" Severity=\"Suggestion\" Ins" +
-            "pectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"AssignedByValParam" +
-            "eterInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <C" +
-            "odeInspection Name=\"EmptyModuleInspection\" Severity=\"Hint\" InspectionType=\"Maint" +
-            "ainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"LineLabelNotUsedIn" +
-            "spection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeIns" +
-            "pection Name=\"IntegerDataTypeInspection\" Severity=\"Hint\" InspectionType=\"CodeQua" +
-            "lityIssues\" />\r\n    <CodeInspection Name=\"ShadowedDeclarationInspection\" Severit" +
-            "y=\"DoNotShow\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"C" +
-            "onstantNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" " +
-            "/>\r\n    <CodeInspection Name=\"DefaultProjectNameInspection\" Severity=\"Suggestion" +
-            "\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection N" +
-            "ame=\"EmptyCaseBlockInspection\" Severity=\"Warning\" InspectionType=\"Maintainabilit" +
-            "yAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyDoWhileBlockInspection" +
-            "\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r" +
-            "\n    <CodeInspection Name=\"EmptyElseBlockInspection\" Severity=\"Warning\" Inspecti" +
-            "onType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Empty" +
-            "ForEachBlockInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndRea" +
-            "dabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyForLoopBlockInspection\" Sever" +
+            "berduckOpportunities\" />\r\n    <CodeInspection Name=\"MissingMemberAnnotationInspe" +
+            "ction\" Severity=\"Suggestion\" InspectionType=\"RubberduckOpportunities\" />\r\n    <C" +
+            "odeInspection Name=\"AttributeValueOutOfSyncInspection\" Severity=\"Warning\" Inspec" +
+            "tionType=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"MissingAnnotati" +
+            "onArgumentInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n  " +
+            "  <CodeInspection Name=\"ModuleScopeDimKeywordInspection\" Severity=\"Suggestion\" I" +
+            "nspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"MultilinePar" +
+            "ameterInspection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadab" +
+            "ilityIssues\" />\r\n    <CodeInspection Name=\"MultipleDeclarationsInspection\" Sever" +
             "ity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <Code" +
-            "Inspection Name=\"EmptyIfBlockInspection\" Severity=\"Warning\" InspectionType=\"Main" +
-            "tainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyWhileWendBlo" +
-            "ckInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIs" +
-            "sues\" />\r\n    <CodeInspection Name=\"EncapsulatePublicFieldInspection\" Severity=\"" +
-            "Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeIn" +
-            "spection Name=\"HostSpecificExpressionInspection\" Severity=\"Warning\" InspectionTy" +
-            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"HungarianNotationInspec" +
-            "tion\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\"" +
-            " />\r\n    <CodeInspection Name=\"ImplicitActiveSheetReferenceInspection\" Severity=" +
-            "\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"I" +
-            "mplicitActiveWorkbookReferenceInspection\" Severity=\"Warning\" InspectionType=\"Lan" +
-            "guageOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitDefaultMemberAssignmen" +
-            "tInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n  " +
-            "  <CodeInspection Name=\"ImplicitPublicMemberInspection\" Severity=\"Hint\" Inspecti" +
-            "onType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitVariantRetu" +
-            "rnTypeInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n   " +
-            " <CodeInspection Name=\"MemberNotOnInterfaceInspection\" Severity=\"Warning\" Inspec" +
-            "tionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"MoveFieldCloserToUsag" +
-            "eInspection\" Severity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues" +
-            "\" />\r\n    <CodeInspection Name=\"NonReturningFunctionInspection\" Severity=\"Error\"" +
-            " InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ObjectVariable" +
-            "NotSetInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <C" +
-            "odeInspection Name=\"ObsoleteGlobalInspection\" Severity=\"Suggestion\" InspectionTy" +
-            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteTypeHintInspect" +
-            "ion\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeI" +
-            "nspection Name=\"ParameterCanBeByValInspection\" Severity=\"Suggestion\" InspectionT" +
-            "ype=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Paramete" +
-            "rNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n  " +
-            "  <CodeInspection Name=\"ProcedureNotUsedInspection\" Severity=\"Warning\" Inspectio" +
-            "nType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"SelfAssignedDeclarationI" +
-            "nspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <Cod" +
-            "eInspection Name=\"UnassignedVariableUsageInspection\" Severity=\"Error\" Inspection" +
-            "Type=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UndeclaredVariableInspect" +
-            "ion\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection" +
-            " Name=\"UntypedFunctionUsageInspection\" Severity=\"Hint\" InspectionType=\"LanguageO" +
-            "pportunities\" />\r\n    <CodeInspection Name=\"UseMeaningfulNameInspection\" Severit" +
-            "y=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <Cod" +
-            "eInspection Name=\"VariableNotAssignedInspection\" Severity=\"Warning\" InspectionTy" +
-            "pe=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"VariableNotUsedInspection\" " +
-            "Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Na" +
-            "me=\"VariableTypeNotDeclaredInspection\" Severity=\"Warning\" InspectionType=\"Langua" +
-            "geOpportunities\" />\r\n    <CodeInspection Name=\"WriteOnlyPropertyInspection\" Seve" +
-            "rity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Nam" +
-            "e=\"DefTypeStatementInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpp" +
-            "ortunities\" />\r\n    <CodeInspection Name=\"StepIsNotSpecifiedInspection\" Severity" +
-            "=\"DoNotShow\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name" +
-            "=\"StepOneIsRedundantInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportun" +
-            "ities\" />\r\n    <CodeInspection Name=\"SheetAccessedUsingStringInspection\" Severit" +
-            "y=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Na" +
-            "me=\"ObsoleteMemberUsageInspection\" Severity=\"Warning\" InspectionType=\"Maintainab" +
-            "ilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteCallingConventi" +
-            "onInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <Cod" +
-            "eInspection Name=\"DuplicatedAnnotationInspection\" Severity=\"Error\" InspectionTyp" +
-            "e=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"ModuleWithoutFolderIns" +
-            "pection\" Severity=\"Suggestion\" InspectionType=\"RubberduckOpportunities\" />\r\n    " +
-            "<CodeInspection Name=\"OnLocalErrorInspection\" Severity=\"Suggestion\" InspectionTy" +
-            "pe=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"IsMissingOnInappropriat" +
-            "eArgumentInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n " +
-            "   <CodeInspection Name=\"IsMissingWithNonArgumentParameterInspection\" Severity=\"" +
-            "Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Assign" +
-            "mentNotUsedInspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" " +
-            "/>\r\n    <CodeInspection Name=\"UnderscoreInPublicClassModuleMemberInspection\" Sev" +
-            "erity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=" +
-            "\"ExcelUdfNameIsValidCellReferenceInspection\" Severity=\"Warning\" InspectionType=\"" +
-            "CodeQualityIssues\" />\r\n  </CodeInspections>\r\n  <WhitelistedIdentifiers />\r\n  <Ru" +
-            "nInspectionsOnSuccessfulParse>true</RunInspectionsOnSuccessfulParse>\r\n</CodeInsp" +
-            "ectionSettings>")]
+            "Inspection Name=\"ObsoleteCallStatementInspection\" Severity=\"Suggestion\" Inspecti" +
+            "onType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteCommentSynt" +
+            "axInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n " +
+            "   <CodeInspection Name=\"ObsoleteLetStatementInspection\" Severity=\"Suggestion\" I" +
+            "nspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"OptionBaseIn" +
+            "spection\" Severity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues\" /" +
+            ">\r\n    <CodeInspection Name=\"RedundantOptionInspection\" Severity=\"Hint\" Inspecti" +
+            "onType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"OptionExplicitInspe" +
+            "ction\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspecti" +
+            "on Name=\"ProcedureCanBeWrittenAsFunctionInspection\" Severity=\"Suggestion\" Inspec" +
+            "tionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ApplicationWorksh" +
+            "eetFunctionInspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" " +
+            "/>\r\n    <CodeInspection Name=\"AssignedByValParameterInspection\" Severity=\"Warnin" +
+            "g\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"EmptyModuleI" +
+            "nspection\" Severity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues\" " +
+            "/>\r\n    <CodeInspection Name=\"LineLabelNotUsedInspection\" Severity=\"Warning\" Ins" +
+            "pectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"IntegerDataTypeIns" +
+            "pection\" Severity=\"Hint\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspect" +
+            "ion Name=\"ShadowedDeclarationInspection\" Severity=\"DoNotShow\" InspectionType=\"Co" +
+            "deQualityIssues\" />\r\n    <CodeInspection Name=\"ConstantNotUsedInspection\" Severi" +
+            "ty=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"De" +
+            "faultProjectNameInspection\" Severity=\"Suggestion\" InspectionType=\"Maintainabilit" +
+            "yAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyCaseBlockInspection\" S" +
+            "everity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <" +
+            "CodeInspection Name=\"EmptyDoWhileBlockInspection\" Severity=\"Suggestion\" Inspecti" +
+            "onType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Empty" +
+            "ElseBlockInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadab" +
+            "ilityIssues\" />\r\n    <CodeInspection Name=\"EmptyForEachBlockInspection\" Severity" +
+            "=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeIns" +
+            "pection Name=\"EmptyForLoopBlockInspection\" Severity=\"Warning\" InspectionType=\"Ma" +
+            "intainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyIfBlockIns" +
+            "pection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\"" +
+            " />\r\n    <CodeInspection Name=\"EmptyWhileWendBlockInspection\" Severity=\"Warning\"" +
+            " InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Na" +
+            "me=\"EncapsulatePublicFieldInspection\" Severity=\"Suggestion\" InspectionType=\"Main" +
+            "tainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"HostSpecificExpre" +
+            "ssionInspection\" Severity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n " +
+            "   <CodeInspection Name=\"HungarianNotationInspection\" Severity=\"Suggestion\" Insp" +
+            "ectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"I" +
+            "mplicitActiveSheetReferenceInspection\" Severity=\"Warning\" InspectionType=\"Langua" +
+            "geOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitActiveWorkbookReferenceIn" +
+            "spection\" Severity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <Cod" +
+            "eInspection Name=\"ImplicitDefaultMemberAssignmentInspection\" Severity=\"Suggestio" +
+            "n\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"Implicit" +
+            "PublicMemberInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" /" +
+            ">\r\n    <CodeInspection Name=\"ImplicitVariantReturnTypeInspection\" Severity=\"Hint" +
+            "\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"MemberNot" +
+            "OnInterfaceInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r" +
+            "\n    <CodeInspection Name=\"MoveFieldCloserToUsageInspection\" Severity=\"Hint\" Ins" +
+            "pectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"" +
+            "NonReturningFunctionInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssu" +
+            "es\" />\r\n    <CodeInspection Name=\"ObjectVariableNotSetInspection\" Severity=\"Erro" +
+            "r\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteGlob" +
+            "alInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n " +
+            "   <CodeInspection Name=\"ObsoleteTypeHintInspection\" Severity=\"Suggestion\" Inspe" +
+            "ctionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ParameterCanBeBy" +
+            "ValInspection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabili" +
+            "tyIssues\" />\r\n    <CodeInspection Name=\"ParameterNotUsedInspection\" Severity=\"Wa" +
+            "rning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Procedur" +
+            "eNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n  " +
+            "  <CodeInspection Name=\"SelfAssignedDeclarationInspection\" Severity=\"Suggestion\"" +
+            " InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UnassignedVari" +
+            "ableUsageInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n   " +
+            " <CodeInspection Name=\"UndeclaredVariableInspection\" Severity=\"Error\" Inspection" +
+            "Type=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UntypedFunctionUsageInspe" +
+            "ction\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspe" +
+            "ction Name=\"UseMeaningfulNameInspection\" Severity=\"Suggestion\" InspectionType=\"M" +
+            "aintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"VariableNotAss" +
+            "ignedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <" +
+            "CodeInspection Name=\"VariableNotUsedInspection\" Severity=\"Warning\" InspectionTyp" +
+            "e=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"VariableTypeNotDeclaredInspe" +
+            "ction\" Severity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIn" +
+            "spection Name=\"WriteOnlyPropertyInspection\" Severity=\"Suggestion\" InspectionType" +
+            "=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"DefTypeStatementInspection\" S" +
+            "everity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspect" +
+            "ion Name=\"StepIsNotSpecifiedInspection\" Severity=\"DoNotShow\" InspectionType=\"Lan" +
+            "guageOpportunities\" />\r\n    <CodeInspection Name=\"StepOneIsRedundantInspection\" " +
+            "Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection N" +
+            "ame=\"SheetAccessedUsingStringInspection\" Severity=\"Suggestion\" InspectionType=\"L" +
+            "anguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteMemberUsageInspectio" +
+            "n\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n " +
+            "   <CodeInspection Name=\"ObsoleteCallingConventionInspection\" Severity=\"Warning\"" +
+            " InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"DuplicatedAnno" +
+            "tationInspection\" Severity=\"Error\" InspectionType=\"RubberduckOpportunities\" />\r\n" +
+            "    <CodeInspection Name=\"ModuleWithoutFolderInspection\" Severity=\"Suggestion\" I" +
+            "nspectionType=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"OnLocalErr" +
+            "orInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n " +
+            "   <CodeInspection Name=\"IsMissingOnInappropriateArgumentInspection\" Severity=\"W" +
+            "arning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"IsMissi" +
+            "ngWithNonArgumentParameterInspection\" Severity=\"Warning\" InspectionType=\"CodeQua" +
+            "lityIssues\" />\r\n    <CodeInspection Name=\"AssignmentNotUsedInspection\" Severity=" +
+            "\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Un" +
+            "derscoreInPublicClassModuleMemberInspection\" Severity=\"Warning\" InspectionType=\"" +
+            "CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ExcelUdfNameIsValidCellReferenc" +
+            "eInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n  </CodeI" +
+            "nspections>\r\n  <WhitelistedIdentifiers />\r\n  <RunInspectionsOnSuccessfulParse>tr" +
+            "ue</RunInspectionsOnSuccessfulParse>\r\n</CodeInspectionSettings>")]
         public global::Rubberduck.Settings.CodeInspectionSettings CodeInspectionSettings {
             get {
                 return ((global::Rubberduck.Settings.CodeInspectionSettings)(this["CodeInspectionSettings"]));

--- a/Rubberduck.Core/Properties/Settings.Designer.cs
+++ b/Rubberduck.Core/Properties/Settings.Designer.cs
@@ -44,111 +44,113 @@ namespace Rubberduck.Properties {
             "pection Name=\"MissingAttributeInspection\" Severity=\"Warning\" InspectionType=\"Rub" +
             "berduckOpportunities\" />\r\n    <CodeInspection Name=\"MissingMemberAnnotationInspe" +
             "ction\" Severity=\"Suggestion\" InspectionType=\"RubberduckOpportunities\" />\r\n    <C" +
-            "odeInspection Name=\"AttributeValueOutOfSyncInspection\" Severity=\"Warning\" Inspec" +
-            "tionType=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"MissingAnnotati" +
-            "onArgumentInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n  " +
-            "  <CodeInspection Name=\"ModuleScopeDimKeywordInspection\" Severity=\"Suggestion\" I" +
-            "nspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"MultilinePar" +
-            "ameterInspection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadab" +
-            "ilityIssues\" />\r\n    <CodeInspection Name=\"MultipleDeclarationsInspection\" Sever" +
-            "ity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <Code" +
-            "Inspection Name=\"ObsoleteCallStatementInspection\" Severity=\"Suggestion\" Inspecti" +
-            "onType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteCommentSynt" +
-            "axInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n " +
-            "   <CodeInspection Name=\"ObsoleteLetStatementInspection\" Severity=\"Suggestion\" I" +
-            "nspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"OptionBaseIn" +
-            "spection\" Severity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues\" /" +
-            ">\r\n    <CodeInspection Name=\"RedundantOptionInspection\" Severity=\"Hint\" Inspecti" +
-            "onType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"OptionExplicitInspe" +
-            "ction\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspecti" +
-            "on Name=\"ProcedureCanBeWrittenAsFunctionInspection\" Severity=\"Suggestion\" Inspec" +
-            "tionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ApplicationWorksh" +
-            "eetFunctionInspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" " +
-            "/>\r\n    <CodeInspection Name=\"AssignedByValParameterInspection\" Severity=\"Warnin" +
-            "g\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"EmptyModuleI" +
-            "nspection\" Severity=\"Hint\" InspectionType=\"MaintainabilityAndReadabilityIssues\" " +
-            "/>\r\n    <CodeInspection Name=\"LineLabelNotUsedInspection\" Severity=\"Warning\" Ins" +
-            "pectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"IntegerDataTypeIns" +
-            "pection\" Severity=\"Hint\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspect" +
-            "ion Name=\"ShadowedDeclarationInspection\" Severity=\"DoNotShow\" InspectionType=\"Co" +
-            "deQualityIssues\" />\r\n    <CodeInspection Name=\"ConstantNotUsedInspection\" Severi" +
-            "ty=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"De" +
-            "faultProjectNameInspection\" Severity=\"Suggestion\" InspectionType=\"Maintainabilit" +
-            "yAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyCaseBlockInspection\" S" +
-            "everity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <" +
-            "CodeInspection Name=\"EmptyDoWhileBlockInspection\" Severity=\"Suggestion\" Inspecti" +
-            "onType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Empty" +
-            "ElseBlockInspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadab" +
-            "ilityIssues\" />\r\n    <CodeInspection Name=\"EmptyForEachBlockInspection\" Severity" +
-            "=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeIns" +
-            "pection Name=\"EmptyForLoopBlockInspection\" Severity=\"Warning\" InspectionType=\"Ma" +
-            "intainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyIfBlockIns" +
-            "pection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\"" +
-            " />\r\n    <CodeInspection Name=\"EmptyWhileWendBlockInspection\" Severity=\"Warning\"" +
-            " InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Na" +
-            "me=\"EncapsulatePublicFieldInspection\" Severity=\"Suggestion\" InspectionType=\"Main" +
-            "tainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"HostSpecificExpre" +
-            "ssionInspection\" Severity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n " +
-            "   <CodeInspection Name=\"HungarianNotationInspection\" Severity=\"Suggestion\" Insp" +
-            "ectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"I" +
-            "mplicitActiveSheetReferenceInspection\" Severity=\"Warning\" InspectionType=\"Langua" +
-            "geOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitActiveWorkbookReferenceIn" +
-            "spection\" Severity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <Cod" +
-            "eInspection Name=\"ImplicitDefaultMemberAssignmentInspection\" Severity=\"Suggestio" +
-            "n\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"Implicit" +
-            "PublicMemberInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" /" +
-            ">\r\n    <CodeInspection Name=\"ImplicitVariantReturnTypeInspection\" Severity=\"Hint" +
-            "\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"MemberNot" +
-            "OnInterfaceInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r" +
-            "\n    <CodeInspection Name=\"MoveFieldCloserToUsageInspection\" Severity=\"Hint\" Ins" +
-            "pectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"" +
-            "NonReturningFunctionInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssu" +
-            "es\" />\r\n    <CodeInspection Name=\"ObjectVariableNotSetInspection\" Severity=\"Erro" +
-            "r\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteGlob" +
-            "alInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n " +
-            "   <CodeInspection Name=\"ObsoleteTypeHintInspection\" Severity=\"Suggestion\" Inspe" +
-            "ctionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ParameterCanBeBy" +
-            "ValInspection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabili" +
-            "tyIssues\" />\r\n    <CodeInspection Name=\"ParameterNotUsedInspection\" Severity=\"Wa" +
-            "rning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Procedur" +
-            "eNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n  " +
-            "  <CodeInspection Name=\"SelfAssignedDeclarationInspection\" Severity=\"Suggestion\"" +
-            " InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UnassignedVari" +
-            "ableUsageInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n   " +
-            " <CodeInspection Name=\"UndeclaredVariableInspection\" Severity=\"Error\" Inspection" +
-            "Type=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"UntypedFunctionUsageInspe" +
-            "ction\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspe" +
-            "ction Name=\"UseMeaningfulNameInspection\" Severity=\"Suggestion\" InspectionType=\"M" +
-            "aintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"VariableNotAss" +
-            "ignedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <" +
-            "CodeInspection Name=\"VariableNotUsedInspection\" Severity=\"Warning\" InspectionTyp" +
-            "e=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"VariableTypeNotDeclaredInspe" +
+            "odeInspection Name=\"MissingModuleAnnotationInspection\" Severity=\"Suggestion\" Ins" +
+            "pectionType=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"AttributeVal" +
+            "ueOutOfSyncInspection\" Severity=\"Warning\" InspectionType=\"RubberduckOpportunitie" +
+            "s\" />\r\n    <CodeInspection Name=\"MissingAnnotationArgumentInspection\" Severity=\"" +
+            "Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ModuleSc" +
+            "opeDimKeywordInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportuni" +
+            "ties\" />\r\n    <CodeInspection Name=\"MultilineParameterInspection\" Severity=\"Sugg" +
+            "estion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspec" +
+            "tion Name=\"MultipleDeclarationsInspection\" Severity=\"Warning\" InspectionType=\"Ma" +
+            "intainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"ObsoleteCallSta" +
+            "tementInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" /" +
+            ">\r\n    <CodeInspection Name=\"ObsoleteCommentSyntaxInspection\" Severity=\"Suggesti" +
+            "on\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"Obsolet" +
+            "eLetStatementInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportuni" +
+            "ties\" />\r\n    <CodeInspection Name=\"OptionBaseInspection\" Severity=\"Hint\" Inspec" +
+            "tionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Red" +
+            "undantOptionInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" /" +
+            ">\r\n    <CodeInspection Name=\"OptionExplicitInspection\" Severity=\"Error\" Inspecti" +
+            "onType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ProcedureCanBeWrittenAs" +
+            "FunctionInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\"" +
+            " />\r\n    <CodeInspection Name=\"ApplicationWorksheetFunctionInspection\" Severity=" +
+            "\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"As" +
+            "signedByValParameterInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIs" +
+            "sues\" />\r\n    <CodeInspection Name=\"EmptyModuleInspection\" Severity=\"Hint\" Inspe" +
+            "ctionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Li" +
+            "neLabelNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" " +
+            "/>\r\n    <CodeInspection Name=\"IntegerDataTypeInspection\" Severity=\"Hint\" Inspect" +
+            "ionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ShadowedDeclarationIns" +
+            "pection\" Severity=\"DoNotShow\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeIn" +
+            "spection Name=\"ConstantNotUsedInspection\" Severity=\"Warning\" InspectionType=\"Cod" +
+            "eQualityIssues\" />\r\n    <CodeInspection Name=\"DefaultProjectNameInspection\" Seve" +
+            "rity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <" +
+            "CodeInspection Name=\"EmptyCaseBlockInspection\" Severity=\"Warning\" InspectionType" +
+            "=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyDoWhil" +
+            "eBlockInspection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadab" +
+            "ilityIssues\" />\r\n    <CodeInspection Name=\"EmptyElseBlockInspection\" Severity=\"W" +
+            "arning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspec" +
+            "tion Name=\"EmptyForEachBlockInspection\" Severity=\"Warning\" InspectionType=\"Maint" +
+            "ainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EmptyForLoopBlockI" +
+            "nspection\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssue" +
+            "s\" />\r\n    <CodeInspection Name=\"EmptyIfBlockInspection\" Severity=\"Warning\" Insp" +
+            "ectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"E" +
+            "mptyWhileWendBlockInspection\" Severity=\"Warning\" InspectionType=\"Maintainability" +
+            "AndReadabilityIssues\" />\r\n    <CodeInspection Name=\"EncapsulatePublicFieldInspec" +
+            "tion\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssues\"" +
+            " />\r\n    <CodeInspection Name=\"HostSpecificExpressionInspection\" Severity=\"Warni" +
+            "ng\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"Hungari" +
+            "anNotationInspection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndRe" +
+            "adabilityIssues\" />\r\n    <CodeInspection Name=\"ImplicitActiveSheetReferenceInspe" +
             "ction\" Severity=\"Warning\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeIn" +
-            "spection Name=\"WriteOnlyPropertyInspection\" Severity=\"Suggestion\" InspectionType" +
-            "=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"DefTypeStatementInspection\" S" +
-            "everity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspect" +
-            "ion Name=\"StepIsNotSpecifiedInspection\" Severity=\"DoNotShow\" InspectionType=\"Lan" +
-            "guageOpportunities\" />\r\n    <CodeInspection Name=\"StepOneIsRedundantInspection\" " +
-            "Severity=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection N" +
-            "ame=\"SheetAccessedUsingStringInspection\" Severity=\"Suggestion\" InspectionType=\"L" +
-            "anguageOpportunities\" />\r\n    <CodeInspection Name=\"ObsoleteMemberUsageInspectio" +
-            "n\" Severity=\"Warning\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n " +
-            "   <CodeInspection Name=\"ObsoleteCallingConventionInspection\" Severity=\"Warning\"" +
-            " InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"DuplicatedAnno" +
-            "tationInspection\" Severity=\"Error\" InspectionType=\"RubberduckOpportunities\" />\r\n" +
-            "    <CodeInspection Name=\"ModuleWithoutFolderInspection\" Severity=\"Suggestion\" I" +
-            "nspectionType=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"OnLocalErr" +
-            "orInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n " +
-            "   <CodeInspection Name=\"IsMissingOnInappropriateArgumentInspection\" Severity=\"W" +
-            "arning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"IsMissi" +
-            "ngWithNonArgumentParameterInspection\" Severity=\"Warning\" InspectionType=\"CodeQua" +
-            "lityIssues\" />\r\n    <CodeInspection Name=\"AssignmentNotUsedInspection\" Severity=" +
-            "\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Un" +
-            "derscoreInPublicClassModuleMemberInspection\" Severity=\"Warning\" InspectionType=\"" +
-            "CodeQualityIssues\" />\r\n    <CodeInspection Name=\"ExcelUdfNameIsValidCellReferenc" +
-            "eInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n  </CodeI" +
-            "nspections>\r\n  <WhitelistedIdentifiers />\r\n  <RunInspectionsOnSuccessfulParse>tr" +
-            "ue</RunInspectionsOnSuccessfulParse>\r\n</CodeInspectionSettings>")]
+            "spection Name=\"ImplicitActiveWorkbookReferenceInspection\" Severity=\"Warning\" Ins" +
+            "pectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"ImplicitDefaul" +
+            "tMemberAssignmentInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOppor" +
+            "tunities\" />\r\n    <CodeInspection Name=\"ImplicitPublicMemberInspection\" Severity" +
+            "=\"Hint\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"Imp" +
+            "licitVariantReturnTypeInspection\" Severity=\"Hint\" InspectionType=\"LanguageOpport" +
+            "unities\" />\r\n    <CodeInspection Name=\"MemberNotOnInterfaceInspection\" Severity=" +
+            "\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"MoveF" +
+            "ieldCloserToUsageInspection\" Severity=\"Hint\" InspectionType=\"MaintainabilityAndR" +
+            "eadabilityIssues\" />\r\n    <CodeInspection Name=\"NonReturningFunctionInspection\" " +
+            "Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name" +
+            "=\"ObjectVariableNotSetInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIs" +
+            "sues\" />\r\n    <CodeInspection Name=\"ObsoleteGlobalInspection\" Severity=\"Suggesti" +
+            "on\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"Obsolet" +
+            "eTypeHintInspection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities" +
+            "\" />\r\n    <CodeInspection Name=\"ParameterCanBeByValInspection\" Severity=\"Suggest" +
+            "ion\" InspectionType=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspectio" +
+            "n Name=\"ParameterNotUsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQuali" +
+            "tyIssues\" />\r\n    <CodeInspection Name=\"ProcedureNotUsedInspection\" Severity=\"Wa" +
+            "rning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"SelfAssi" +
+            "gnedDeclarationInspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssu" +
+            "es\" />\r\n    <CodeInspection Name=\"UnassignedVariableUsageInspection\" Severity=\"E" +
+            "rror\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"Undeclare" +
+            "dVariableInspection\" Severity=\"Error\" InspectionType=\"CodeQualityIssues\" />\r\n   " +
+            " <CodeInspection Name=\"UntypedFunctionUsageInspection\" Severity=\"Hint\" Inspectio" +
+            "nType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"UseMeaningfulNameIns" +
+            "pection\" Severity=\"Suggestion\" InspectionType=\"MaintainabilityAndReadabilityIssu" +
+            "es\" />\r\n    <CodeInspection Name=\"VariableNotAssignedInspection\" Severity=\"Warni" +
+            "ng\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspection Name=\"VariableNot" +
+            "UsedInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <C" +
+            "odeInspection Name=\"VariableTypeNotDeclaredInspection\" Severity=\"Warning\" Inspec" +
+            "tionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"WriteOnlyProperty" +
+            "Inspection\" Severity=\"Suggestion\" InspectionType=\"CodeQualityIssues\" />\r\n    <Co" +
+            "deInspection Name=\"DefTypeStatementInspection\" Severity=\"Suggestion\" InspectionT" +
+            "ype=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"StepIsNotSpecifiedInsp" +
+            "ection\" Severity=\"DoNotShow\" InspectionType=\"LanguageOpportunities\" />\r\n    <Cod" +
+            "eInspection Name=\"StepOneIsRedundantInspection\" Severity=\"Hint\" InspectionType=\"" +
+            "LanguageOpportunities\" />\r\n    <CodeInspection Name=\"SheetAccessedUsingStringIns" +
+            "pection\" Severity=\"Suggestion\" InspectionType=\"LanguageOpportunities\" />\r\n    <C" +
+            "odeInspection Name=\"ObsoleteMemberUsageInspection\" Severity=\"Warning\" Inspection" +
+            "Type=\"MaintainabilityAndReadabilityIssues\" />\r\n    <CodeInspection Name=\"Obsolet" +
+            "eCallingConventionInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssu" +
+            "es\" />\r\n    <CodeInspection Name=\"DuplicatedAnnotationInspection\" Severity=\"Erro" +
+            "r\" InspectionType=\"RubberduckOpportunities\" />\r\n    <CodeInspection Name=\"Module" +
+            "WithoutFolderInspection\" Severity=\"Suggestion\" InspectionType=\"RubberduckOpportu" +
+            "nities\" />\r\n    <CodeInspection Name=\"OnLocalErrorInspection\" Severity=\"Suggesti" +
+            "on\" InspectionType=\"LanguageOpportunities\" />\r\n    <CodeInspection Name=\"IsMissi" +
+            "ngOnInappropriateArgumentInspection\" Severity=\"Warning\" InspectionType=\"CodeQual" +
+            "ityIssues\" />\r\n    <CodeInspection Name=\"IsMissingWithNonArgumentParameterInspec" +
+            "tion\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <CodeInspect" +
+            "ion Name=\"AssignmentNotUsedInspection\" Severity=\"Suggestion\" InspectionType=\"Cod" +
+            "eQualityIssues\" />\r\n    <CodeInspection Name=\"UnderscoreInPublicClassModuleMembe" +
+            "rInspection\" Severity=\"Warning\" InspectionType=\"CodeQualityIssues\" />\r\n    <Code" +
+            "Inspection Name=\"ExcelUdfNameIsValidCellReferenceInspection\" Severity=\"Warning\" " +
+            "InspectionType=\"CodeQualityIssues\" />\r\n  </CodeInspections>\r\n  <WhitelistedIdent" +
+            "ifiers />\r\n  <RunInspectionsOnSuccessfulParse>true</RunInspectionsOnSuccessfulPa" +
+            "rse>\r\n</CodeInspectionSettings>")]
         public global::Rubberduck.Settings.CodeInspectionSettings CodeInspectionSettings {
             get {
                 return ((global::Rubberduck.Settings.CodeInspectionSettings)(this["CodeInspectionSettings"]));

--- a/Rubberduck.Core/Properties/Settings.settings
+++ b/Rubberduck.Core/Properties/Settings.settings
@@ -17,6 +17,7 @@
     &lt;CodeInspection Name="RedundantByRefModifierInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" /&gt;
     &lt;CodeInspection Name="MissingAttributeInspection" Severity="Warning" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="MissingMemberAnnotationInspection" Severity="Suggestion" InspectionType="RubberduckOpportunities" /&gt;
+    &lt;CodeInspection Name="MissingModuleAnnotationInspection" Severity="Suggestion" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="AttributeValueOutOfSyncInspection" Severity="Warning" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="MissingAnnotationArgumentInspection" Severity="Error" InspectionType="CodeQualityIssues" /&gt;
     &lt;CodeInspection Name="ModuleScopeDimKeywordInspection" Severity="Suggestion" InspectionType="LanguageOpportunities" /&gt;

--- a/Rubberduck.Core/Properties/Settings.settings
+++ b/Rubberduck.Core/Properties/Settings.settings
@@ -16,6 +16,7 @@
     &lt;CodeInspection Name="IllegalAnnotationInspection" Severity="Error" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="RedundantByRefModifierInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" /&gt;
     &lt;CodeInspection Name="MissingAttributeInspection" Severity="Warning" InspectionType="RubberduckOpportunities" /&gt;
+    &lt;CodeInspection Name="MissingMemberAnnotationInspection" Severity="Suggestion" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="AttributeValueOutOfSyncInspection" Severity="Warning" InspectionType="RubberduckOpportunities" /&gt;
     &lt;CodeInspection Name="MissingAnnotationArgumentInspection" Severity="Error" InspectionType="CodeQualityIssues" /&gt;
     &lt;CodeInspection Name="ModuleScopeDimKeywordInspection" Severity="Suggestion" InspectionType="LanguageOpportunities" /&gt;

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -395,15 +395,6 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
-        /// </summary>
-        public static string MissingAnnotationInspection {
-            get {
-                return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A Rubberduck annotation is specified for a module or member, but the corresponding attribute isn&apos;t present. Module attributes and annotations need to be synchronized..
         /// </summary>
         public static string MissingAttributeInspection {
@@ -419,6 +410,16 @@ namespace Rubberduck.Resources.Inspections {
         {
             get {
                 return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
+        /// </summary>
+        public static string MissingModuleAnnotationInspection
+        {
+            get {
+                return ResourceManager.GetString("MissingModuleAnnotationInspection", resourceCulture);
             }
         }
 

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -411,7 +411,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
+        /// </summary>
+        public static string MissingMemberAnnotationInspection
+        {
+            get {
+                return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Public&apos; keyword can only be used at module level; its counterpart &apos;Private&apos; can also only be used at module level. &apos;Dim&apos; however, can be used to declare both procedure and module scope variables. For consistency, it would be preferable to reserve &apos;Dim&apos; for locals, and thus to use &apos;Private&apos; instead of &apos;Dim&apos; at module level..
         /// </summary>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.cs.resx
@@ -310,9 +310,6 @@ Jestliže může být parametr prázdný, ignorujte výsledek této inspekce; p�
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>Anotace Rubberducku je specifikována pro modul nebo člen, ale příslušný atribut není přítomen. Atributy modulu a anotace je třeba synchronizovat.</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Atributy modulu a člena se ve VBE nezobrazují. Přidáním anotace uděláte tyto atributy explicitnější a Rubberduck může držet anotace a atributy synchronizovány.</value>
-  </data>
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Anotace, která má být specifikována na úrovni modulu, nemůže být použita k anotaci členů; anotace, které mají být členy anotací, nemohou být použity na úrovni modulu; anotace modulu a členů mohou být specifikovány pouze jednou.</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
@@ -361,4 +361,7 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
     <value>Eine Rubberduck-Annotation wurde für ein Modul oder Element festgelegt, aber das zugehörige Attribut hat einen anderen Wert. Die Modul-Attribute und Annotationen sollten synchronisiert werden.</value>
   </data>
+  <data name="MissingMemberAnnotationInspection" xml:space="preserve">
+    <value>Elementattribute werden von der VBE nicht angezeigt. Durch das hinzufügen einer Annotation werden diese Attribute deutlicher. Außerdem kann Rubberduck die Annotationen und Attribute synchronisieren.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
@@ -247,9 +247,6 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   <data name="OptionBaseZeroInspection" xml:space="preserve">
     <value>Dies ist die Standardeinstellung, sie muss nicht spezifiziert werden.</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Modul- und Elementattribute werden von der VBE nicht angezeigt. Durch das hinzufügen einer Annotation werden diese Attribute deutlicher. Außerdem kann Rubberduck die Annotationen und Attribute synchronisieren.</value>
-  </data>
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Eine Annotation für die Modulebene kann nicht verwendet werden, um Elemente zu annotieren; Eine Annotation für Elemente kann auf Modulebene nicht verwendet werden; Modul- und Elementannotationen sollten nur einmal spezifiziert werden.</value>
   </data>
@@ -363,5 +360,8 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   </data>
   <data name="MissingMemberAnnotationInspection" xml:space="preserve">
     <value>Elementattribute werden von der VBE nicht angezeigt. Durch das hinzufügen einer Annotation werden diese Attribute deutlicher. Außerdem kann Rubberduck die Annotationen und Attribute synchronisieren.</value>
+  </data>
+  <data name="MissingModuleAnnotationInspection" xml:space="preserve">
+    <value>Modulattribute werden von der VBE nicht angezeigt. Durch das hinzufügen einer Annotation werden diese Attribute deutlicher. Außerdem kann Rubberduck die Annotationen und Attribute synchronisieren.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.fr.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.fr.resx
@@ -250,9 +250,6 @@ Si le paramètre peut être nul, ignorer ce résultat; passer une valeur nulle �
   <data name="ShadowedDeclarationInspection" xml:space="preserve">
     <value>Deux déclarations ont le même nom dans le même espace-nom: une seule d'entre elles peut être utilisée.</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Les attributs du module et de ses membres n'apparaissent pas dans l'éditeur. En ajoutant une annotation, vous rendez ces attributs plus explicite, et Rubberduck peut synchroniser annotations et attributs.</value>
-  </data>
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Une annotation devant être spécifiée au niveau du module ne peut être utilisée pour annoter de membres; les annotations devant être spécifiées au niveau des membres du module, ne peuvent être utilisées au niveau du module; toutes les annotations ne devrait être spécifiées qu'une seule fois par module/membre.</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -361,4 +361,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
     <value>A Rubberduck annotation is specified for a module or member, but the corresponding attribute has a different value. Module attributes and annotations need to be synchronized.</value>
   </data>
+  <data name="MissingMemberAnnotationInspection" xml:space="preserve">
+    <value>Member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -253,9 +253,6 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>An annotation meant to be specified at module level cannot be used to annotate members; annotations meant to be annotate members cannot be used at module level.</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized.</value>
-  </data>
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>A Rubberduck annotation is specified for a module or member, but the corresponding attribute isn't present. Module attributes and annotations need to be synchronized.</value>
   </data>
@@ -363,5 +360,8 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   </data>
   <data name="MissingMemberAnnotationInspection" xml:space="preserve">
     <value>Member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized.</value>
+  </data>
+  <data name="MissingModuleAnnotationInspection" xml:space="preserve">
+    <value>Module attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -395,15 +395,6 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Missing annotation.
-        /// </summary>
-        public static string MissingAnnotationInspection {
-            get {
-                return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Missing attribute.
         /// </summary>
         public static string MissingAttributeInspection {
@@ -419,6 +410,17 @@ namespace Rubberduck.Resources.Inspections {
         {
             get {
                 return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Missing annotation.
+        /// </summary>
+        public static string MissingModuleAnnotationInspection
+        {
+            get
+            {
+                return ResourceManager.GetString("MissingModuleAnnotationInspection", resourceCulture);
             }
         }
 

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -411,7 +411,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Missing annotation.
+        /// </summary>
+        public static string MissingMemberAnnotationInspection
+        {
+            get {
+                return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use of &apos;Dim&apos; keyword at module level.
         /// </summary>

--- a/Rubberduck.Resources/Inspections/InspectionNames.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.cs.resx
@@ -252,9 +252,6 @@
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Ilegální anotace</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Chybějící anotace</value>
-  </data>
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>Chybějící atribut</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -360,4 +360,7 @@
   <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
     <value>Wert stimmt nicht überein zwischen Attribut und Annotation</value>
   </data>
+  <data name="MissingMemberAnnotationInspection" xml:space="preserve">
+    <value>Fehlende Elementannotation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -258,9 +258,6 @@
   <data name="ImplicitByRefModifierInspection" xml:space="preserve">
     <value>Implizite Referenzübergabe</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Fehlende Annotation</value>
-  </data>
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Illegale Annotation</value>
   </data>
@@ -362,5 +359,8 @@
   </data>
   <data name="MissingMemberAnnotationInspection" xml:space="preserve">
     <value>Fehlende Elementannotation</value>
+  </data>
+  <data name="MissingModuleAnnotationInspection" xml:space="preserve">
+    <value>Fehlende Modulannotation</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.fr.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.fr.resx
@@ -267,9 +267,6 @@
   <data name="ImplicitByRefModifierInspection" xml:space="preserve">
     <value>Paramètre ByRef implicite</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Annotation manquante</value>
-  </data>
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Annotation illégale</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -252,9 +252,6 @@
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Illegal annotation</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Missing annotation</value>
-  </data>
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>Missing attribute</value>
   </data>
@@ -362,5 +359,8 @@
   </data>
   <data name="MissingMemberAnnotationInspection" xml:space="preserve">
     <value>Missing member annotation</value>
+  </data>
+  <data name="MissingModuleAnnotationInspection" xml:space="preserve">
+    <value>Missing module annotation</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -360,4 +360,7 @@
   <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
     <value>Value does not match between attribute and annotation</value>
   </data>
+  <data name="MissingMemberAnnotationInspection" xml:space="preserve">
+    <value>Missing member annotation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -429,7 +429,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; attribute, but no corresponding annotation..
+        /// </summary>
+        public static string MissingMemberAnnotationInspection
+        {
+            get {
+                return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Module-level variable &apos;{0}&apos; is declared with the &apos;Dim&apos; keyword..
         /// </summary>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -413,15 +413,6 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; attribute, but no corresponding annotation..
-        /// </summary>
-        public static string MissingAnnotationInspection {
-            get {
-                return ResourceManager.GetString("MissingAnnotationInspection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; annotation, but no corresponding attribute..
         /// </summary>
         public static string MissingAttributeInspection {
@@ -437,6 +428,16 @@ namespace Rubberduck.Resources.Inspections {
         {
             get {
                 return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; attribute, but no corresponding annotation..
+        /// </summary>
+        public static string MissingModuleAnnotationInspection
+        {
+            get {
+                return ResourceManager.GetString("MissingModuleAnnotationInspection", resourceCulture);
             }
         }
 

--- a/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
@@ -252,9 +252,6 @@
   <data name="IllegalAnnotationInspection" xml:space="preserve">
     <value>Anotace '{0}' je v tomto kontextu ilegální.</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Modul nebo člen '{0}' má atribut '{1}', avšak žádnou korespondující anotaci</value>
-  </data>
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>Modul nebo člen '{0}' má '{1}' anotaci, ale žádný korespondující atribut</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -266,9 +266,6 @@
   <data name="RedundantOptionInspection" xml:space="preserve">
     <value>'{0}' hat keine Auswirkung.</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Modul oder Element '{0}' hat ein '{1}' Attribut, aber keine zugehörige Annotation.</value>
-  </data>
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>Modul oder Element '{0}' hat eine '{1}' Annotation, aber das zugehörige Attribut fehlt.</value>
   </data>
@@ -379,5 +376,8 @@
   </data>
   <data name="MissingMemberAnnotationInspection" xml:space="preserve">
     <value>Element '{0}' hat ein '{1}' Attribut mit Wert(en) '{2}', aber keine zugehörige Annotation.</value>
+  </data>
+  <data name="MissingModuleAnnotationInspection" xml:space="preserve">
+    <value>Modul '{0}' hat ein '{1}' Attribut mit Wert(en) '{2}', aber keine zugehörige Annotation.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -377,4 +377,7 @@
   <data name="AttributeValueOutOfSyncInspection" xml:space="preserve">
     <value>Die Wert(e) des {0}-Attributs ({1}) passen nicht zur {2}-Annotation.</value>
   </data>
+  <data name="MissingMemberAnnotationInspection" xml:space="preserve">
+    <value>Element '{0}' hat ein '{1}' Attribut mit Wert(en) '{2}', aber keine zugehörige Annotation.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.fr.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.fr.resx
@@ -297,9 +297,6 @@
   <data name="RedundantOptionInspection" xml:space="preserve">
     <value>'{0}' n'a aucun effet</value>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Le module ou membre '{0}' a un attribut '{1}', mais pas l'annotation correspondante</value>
-  </data>
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>Le module ou membre '{0}' a l'annotation '{1}', mais pas l'attribut correspondant</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -260,10 +260,6 @@
     <value>Annotation '{0}' is illegal in this context.</value>
     <comment>{0} annotation name</comment>
   </data>
-  <data name="MissingAnnotationInspection" xml:space="preserve">
-    <value>Module or member '{0}' has a '{1}' attribute, but no corresponding annotation.</value>
-    <comment>{0} module/member; {1} specified attribute</comment>
-  </data>
   <data name="MissingAttributeInspection" xml:space="preserve">
     <value>Module or member '{0}' has a '{1}' annotation, but no corresponding attribute.</value>
     <comment>{0} module/member; {1} specified annotation</comment>
@@ -396,5 +392,9 @@
   <data name="MissingMemberAnnotationInspection" xml:space="preserve">
     <value>Member '{0}' has a '{1}' attribute with value(s) '{2}', but no corresponding annotation.</value>
     <comment>{0} member; {1} specified attribute; {2} specified values</comment>
+  </data>
+  <data name="MissingModuleAnnotationInspection" xml:space="preserve">
+    <value>Module '{0}' has a '{1}' attribute with value(s) '{2}', but no corresponding annotation.</value>
+    <comment>{0} module; {1} specified attribute; {2} specified values</comment>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -393,4 +393,8 @@
     <value>The attribute value(s) for attribute {0} ({1}) are out of sync with the {2} annotation. </value>
     <comment>{0} attribute name, {1} attribute values, {2} annotation name</comment>
   </data>
+  <data name="MissingMemberAnnotationInspection" xml:space="preserve">
+    <value>Member '{0}' has a '{1}' attribute with value(s) '{2}', but no corresponding annotation.</value>
+    <comment>{0} member; {1} specified attribute; {2} specified values</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -277,7 +277,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("RedundantByRefModifierQuickFix", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Remove comment.
+        /// </summary>
+        public static string RemoveAttributeQuickFix
+        {
+            get {
+                return ResourceManager.GetString("RemoveAttributeQuickFix", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Remove comment.
         /// </summary>

--- a/Rubberduck.Resources/Inspections/QuickFixes.de.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.de.resx
@@ -267,4 +267,7 @@
   <data name="AdjustAttributeValuesQuickFix" xml:space="preserve">
     <value>Attributwert(e) anpassen</value>
   </data>
+  <data name="RemoveAttributeQuickFix" xml:space="preserve">
+    <value>Attribut entfernen</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.resx
@@ -267,4 +267,7 @@
   <data name="AdjustAttributeValuesQuickFix" xml:space="preserve">
     <value>Adjust attribute value(s)</value>
   </data>
+  <data name="RemoveAttributeQuickFix" xml:space="preserve">
+    <value>Remove attribute</value>
+  </data>
 </root>

--- a/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
+++ b/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
@@ -948,6 +948,45 @@ Implements IWorkbookData
 
         [Test]
         [Category("Inspections")]
+        public void ModuleAttributeAnnotationInDocumentReturnsResult()
+        {
+            const string inputCode = @"
+'@ModuleAttribute VB_Description, ""Desc""
+
+";
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.Document, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeAnnotationInDocumentReturnsResult()
+        {
+            const string inputCode = @"
+'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+End Sub
+";
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.Document, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new IllegalAnnotationInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void InspectionName()
         {
             const string inspectionName = "IllegalAnnotationInspection";

--- a/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using NUnit.Framework;
 using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
@@ -36,6 +37,20 @@ End Sub";
 
             var inspectionResults = InspectionResults(inputCode);
             Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeAnnotationWithoutAttributeInDocumentModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.Document);
+            Assert.AreEqual(0, inspectionResults.Count());
         }
 
         [Test]
@@ -109,6 +124,20 @@ End Sub";
 
             var inspectionResults = InspectionResults(inputCode);
             Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeAnnotationWithoutAttributeInDomcumentModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Description, ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.Document);
+            Assert.AreEqual(0, inspectionResults.Count());
         }
 
         [Test]
@@ -345,9 +374,9 @@ End Sub";
         }
 
 
-        private IEnumerable<IInspectionResult> InspectionResults(string inputCode)
+        private IEnumerable<IInspectionResult> InspectionResults(string inputCode, ComponentType componentType = ComponentType.StandardModule)
         {
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, componentType, out _);
             using (var state = MockParser.CreateAndParse(vbe.Object))
             {
                 var inspection = new MissingAttributeInspection(state);

--- a/RubberduckTests/Inspections/MissingMemberAnnotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingMemberAnnotationInspectionTests.cs
@@ -1,0 +1,199 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using Rubberduck.Inspections.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class MissingMemberAnnotationInspectionTests
+    {
+        [Test]
+        [Category("Inspections")]
+        public void NoAttribute_NoResult()
+        {
+            const string inputCode =
+                @"Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void NoMemberAttribute_NoResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithoutAnnotationReturnsResult()
+        {
+            const string inputCode =
+                @"
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = -4
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithOtherValueDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_UserMemId, -4
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 40
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithoutAnnotationInDocumentModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 40
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.Document);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeWithOtherKeyReturnsResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""SomeValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeWithOtherKeyInDocumentModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""SomeValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.Document);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyMemberAttributeWithSameKeyDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""SomeValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithoutAnnotationAndIgnoreDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"'@Ignore MissingMemberAnnotation
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = -4
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithoutAnnotationAndIgnoreModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"'@IgnoreModule MissingMemberAnnotation
+Public Sub Bar()
+End Sub
+
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = -4
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void InspectionResultContainsAttributeBaseNameAndValues()
+        {
+            const string inputCode =
+                @"
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = -4
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            var expectedAttributeName = "VB_UserMemId";
+            var expectedAttributeValues = new List<string>{"-4"};
+
+            var inspectionResult = inspectionResults.Single();
+            var actualAttributeBaseName = inspectionResult.Properties.AttributeName;
+            var actualAttributeValues = inspectionResult.Properties.AttributeValues;
+
+            Assert.AreEqual(expectedAttributeName, actualAttributeBaseName);
+            Assert.AreEqual(expectedAttributeValues.Count, actualAttributeValues.Count);
+            Assert.AreEqual(expectedAttributeValues[0], actualAttributeValues[0]);
+        }
+
+        private IEnumerable<IInspectionResult> InspectionResults(string inputCode, ComponentType componentType = ComponentType.StandardModule)
+        {
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, componentType, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingMemberAnnotationInspection(state);
+                return inspection.GetInspectionResults(CancellationToken.None);
+            }
+        }
+    }
+}

--- a/RubberduckTests/Inspections/MissingMemberAnnotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingMemberAnnotationInspectionTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
-using Rubberduck.Inspections.Inspections.Concrete;
+using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;

--- a/RubberduckTests/Inspections/MissingModuleAnnotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingModuleAnnotationInspectionTests.cs
@@ -1,0 +1,447 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using Rubberduck.Inspections.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class MissingModuleAnnotationInspectionTests
+    {
+        [Test]
+        [Category("Inspections")]
+        public void NoAttribute_NoResult()
+        {
+            const string inputCode =
+                @"Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void NoModuleAttribute_NoResult()
+        {
+            const string inputCode =
+                @"
+Public Sub Foo()
+Attribute Foo.VB_Description = ""Desc""
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeWithoutAnnotationReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeWithOtherValueDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""NotDesc""
+'@ModuleAttribute VB_Description, ""Desc""
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 40
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ModuleAttributeWithoutAnnotationInDocumentModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""Desc""
+Public Sub Foo()
+Attribute Foo.VB_UserMemId = 40
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.Document);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeWithOtherKeyReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""OtherKey"", ""SomeValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeWithOtherKeyInDocumentModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""OtherKey"", ""SomeValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.Document);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VbExtKeyModuleAttributeWithSameKeyDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""SomeValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeWithoutAnnotationAndIgnoreModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""Desc""
+'@IgnoreModule MissingModuleAnnotation
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void NameAttributeInStandardModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Name = ""SomeName""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.StandardModule);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void NameAttributeInClassModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Name = ""SomeName""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void NameAttributeInUserFormDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Name = ""SomeName""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void GlobalNameSpaceAttributeWithValueFalseInClassModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_GlobalNameSpace = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void GlobalNameSpaceAttributeWithValueFalseInUserFormModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_GlobalNameSpace = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void GlobalNameSpaceAttributeWithValueTrueInClassModuleReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_GlobalNameSpace = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void GlobalNameSpaceAttributeWithValueTrueInUserFormReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_GlobalNameSpace = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExposedAttributeWithValueFalseInClassModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Exposed = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExposedAttributeWithValueFalseInUserFormModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Exposed = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExposedAttributeWithValueTrueInClassModuleReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Exposed = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExposedAttributeWithValueTrueInUserFormReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Exposed = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void CreatableAttributeWithValueFalseInClassModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Creatable = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void CreatableAttributeWithValueFalseInUserFormModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Creatable = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void CreatableAttributeWithValueTrueInClassModuleReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Creatable = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void CreatableAttributeWithValueTrueInUserFormReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_Creatable = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void PredeclaredIdAttributeWithValueFalseInClassModuleDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_PredeclaredId = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void PredeclaredIdAttributeWithValueFalseInUserFormModuleReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_PredeclaredId = False
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void PredeclaredIdAttributeWithValueTrueInClassModuleReturnsResult()
+        {
+            const string inputCode =
+                @"Attribute VB_PredeclaredId = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.ClassModule);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void PredeclaredIdAttributeWithValueTrueInUserFormDoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Attribute VB_PredeclaredId = True
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode, ComponentType.UserForm);
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void InspectionResultContainsAttributeNameAndValues()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var inspectionResults = InspectionResults(inputCode);
+            var expectedAttributeName = "VB_Description";
+            var expectedAttributeValues = new List<string> { "\"Desc\"" };
+
+            var inspectionResult = inspectionResults.Single();
+            var actualAttributeBaseName = inspectionResult.Properties.AttributeName;
+            var actualAttributeValues = inspectionResult.Properties.AttributeValues;
+
+            Assert.AreEqual(expectedAttributeName, actualAttributeBaseName);
+            Assert.AreEqual(expectedAttributeValues.Count, actualAttributeValues.Count);
+            Assert.AreEqual(expectedAttributeValues[0], actualAttributeValues[0]);
+        }
+
+        private IEnumerable<IInspectionResult> InspectionResults(string inputCode, ComponentType componentType = ComponentType.StandardModule)
+        {
+            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, componentType, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new MissingModuleAnnotationInspection(state);
+                return inspection.GetInspectionResults(CancellationToken.None);
+            }
+        }
+    }
+}

--- a/RubberduckTests/Inspections/MissingModuleAnnotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingModuleAnnotationInspectionTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
-using Rubberduck.Inspections.Inspections.Concrete;
+using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;

--- a/RubberduckTests/QuickFixes/RemoveAttributeQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/RemoveAttributeQuickFixTests.cs
@@ -1,0 +1,104 @@
+﻿using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Inspections.QuickFixes;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
+
+namespace RubberduckTests.QuickFixes
+{
+    [TestFixture]
+    public class RemoveAttributeQuickFixTests : QuickFixTestBase
+    {
+        [Test]
+        [Category("QuickFixes")]
+        public void ModuleAttributeWithoutAnnotation_QuickFixWorks()
+        {
+            const string inputCode =
+                @"Attribute VB_Description = ""Desc""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingModuleAnnotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void VbExtKeyModuleAttributeWithoutAnnotationForOneKey_QuickFixWorks()
+        {
+            const string inputCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""NotValue""
+Attribute VB_Ext_Key = ""OtherKey"", ""OtherValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"Attribute VB_Ext_Key = ""Key"", ""NotValue""
+'@ModuleAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingModuleAnnotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MemberAttributeWithoutAnnotation_QuickFixWorks()
+        {
+            const string inputCode =
+                @"
+Public Sub Foo()
+Attribute Foo.VB_Description = ""NotDesc""
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"
+Public Sub Foo()
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingMemberAnnotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void VbExtKeyMemberAttributeWithoutAnnotationForOneKey_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""NotValue""
+Attribute Foo.VB_Ext_Key = ""OtherKey"", ""OtherValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            const string expectedCode =
+                @"'@MemberAttribute VB_Ext_Key, ""Key"", ""Value""
+Public Sub Foo()
+Attribute Foo.VB_Ext_Key = ""Key"", ""NotValue""
+    Const const1 As Integer = 9
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingMemberAnnotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        protected override IQuickFix QuickFix(RubberduckParserState state)
+        {
+            return new RemoveAttributeQuickFix(new AttributesUpdater(state));
+        }
+    }
+}


### PR DESCRIPTION
This PR reimplements the `MissingAnnotationInspection` as two separate inspections, `MissingModuleAnnotationInspection` and `MissingMemberAnnotationInspection`. This split allows to ignore missing member annotations both on a separate basis and a module basis.

The `MissingModuleAnnotationInspection` is set up not to return a result for the default attribute (values) for standard modules, class modules and user forms. 

This PR also includes the `RemoveAttributeQuickFix` that does what it suggests. This allows to remove a non-default value for a default attribute in a class module or user form, e.g. after removing an `@Exposed` annotation, This quickfix can be used to remove the `VB_Exposed = True` attribute, which resets it to the default `VB_Exposed = False`.

Moreover, attribute annotations are now illegal in document modules and ignored there by the three attribute inspections. We simply cannot do anything about attributes in document modules and we really shouldn't. 