### PR TITLE
Some small fixes from 4686

### DIFF
--- a/Rubberduck.CodeAnalysis/CodePathAnalysis/Walker.cs
+++ b/Rubberduck.CodeAnalysis/CodePathAnalysis/Walker.cs
@@ -5,7 +5,6 @@ using Rubberduck.Parsing.Symbols;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Antlr4.Runtime;
 
 namespace Rubberduck.Inspections.CodePathAnalysis
 {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
@@ -6,6 +6,7 @@ using Rubberduck.Inspections.CodePathAnalysis;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Inspections.CodePathAnalysis.Extensions;
 using System.Linq;
+using Rubberduck.Inspections.CodePathAnalysis.Nodes;
 using Rubberduck.Inspections.Results;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Grammar;
@@ -30,7 +31,15 @@ namespace Rubberduck.Inspections.Concrete
             var nodes = new List<IdentifierReference>();
             foreach (var variable in variables)
             {
-                var tree = _walker.GenerateTree(variable.ParentScopeDeclaration.Context, variable);
+                var parentScopeDeclaration = variable.ParentScopeDeclaration;
+
+                if (parentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Module))
+                {
+                    continue;
+                }
+
+                var tree = _walker.GenerateTree(parentScopeDeclaration.Context, variable);
+
 
                 nodes.AddRange(tree.GetIdentifierReferences());
             }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ModuleWithoutFolderInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ModuleWithoutFolderInspection.cs
@@ -13,8 +13,7 @@ namespace Rubberduck.Inspections.Concrete
     {
         public ModuleWithoutFolderInspection(RubberduckParserState state)
             : base(state)
-        {
-        }
+        {}
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
@@ -22,7 +21,9 @@ namespace Rubberduck.Inspections.Concrete
                 .Where(w => w.Annotations.All(a => a.AnnotationType != AnnotationType.Folder))
                 .ToList();
 
-            return modulesWithoutFolderAnnotation.Select(declaration =>
+            return modulesWithoutFolderAnnotation
+                .Where(declaration => !IsIgnoringInspectionResultFor(declaration, AnnotationName))
+                .Select(declaration =>
                 new DeclarationInspectionResult(this, string.Format(InspectionResults.ModuleWithoutFolderInspection, declaration.IdentifierName), declaration));
         }
     }

--- a/RubberduckTests/Inspections/ModuleWithoutFolderInspectionTests.cs
+++ b/RubberduckTests/Inspections/ModuleWithoutFolderInspectionTests.cs
@@ -46,7 +46,7 @@ Option Explicit";
         [Category("Inspections")]
         public void Module_NonFolderAnnotation()
         {
-            const string inputCode = @"'@IgnoreModule
+            const string inputCode = @"'@PredeclaredId
 Option Explicit";
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
@@ -56,6 +56,23 @@ Option Explicit";
                 var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
 
                 Assert.AreEqual(1, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void Module_NoFolderAnnotation_IgnoreWorks()
+        {
+            const string inputCode = @"'@IgnoreModule ModuleWithoutFolder
+Option Explicit";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ModuleWithoutFolderInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any());
             }
         }
     }


### PR DESCRIPTION
These are the last two commits from PR #4686

I have extracted them because they fix two small unrelated issues whose fix should go into the next release.

This PR closes #4653

The problem was that the `AssignmentNotUsedInspection also considered module variable, whose `ParentScopingDeclaration` is a module declaration and, thus, has a `null` context.
Now, member variables are no longer considered because the inspection only seems to make sense for local variables.

This PR also makes the `MissingFolderAnnotationInspection` actually ignore modules with an `@IgnoreModule` annotation for this inspection.