### PR TITLE
4655 key not found exception

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
@@ -41,14 +41,6 @@ namespace Rubberduck.Inspections.Concrete
                 .Concat(builtinHandlers)
                 .Concat(userDeclarations.Where(item => item.IsWithEvents)));
 
-            bool HasArgumentReferencesWithIsAssignmentFlagged(QualifiedContext<ParserRuleContext> context)
-                => contextLookup.TryGetValue(context.Context.GetChild<VBAParser.ArgContext>(), out Declaration decl)
-                    ? decl.References.Any(rf => rf.IsAssignment) : false;
-
-            Declaration GetSubStmtParentDeclaration(QualifiedContext<ParserRuleContext> context)
-                => contextLookup.TryGetValue((VBAParser.SubStmtContext)context.Context.Parent, out Declaration decl)
-                    ? decl : null;
-
             return Listener.Contexts
                 .Where(context => context.Context.Parent is VBAParser.SubStmtContext
                                     && HasArgumentReferencesWithIsAssignmentFlagged(context))
@@ -62,6 +54,20 @@ namespace Rubberduck.Inspections.Concrete
                 .Select(result => new DeclarationInspectionResult(this,
                     string.Format(InspectionResults.ProcedureCanBeWrittenAsFunctionInspection, result.IdentifierName),
                     result));
+
+            bool HasArgumentReferencesWithIsAssignmentFlagged(QualifiedContext<ParserRuleContext> context)
+            {
+                return contextLookup.TryGetValue(context.Context.GetChild<VBAParser.ArgContext>(), out Declaration decl)
+                    ? decl.References.Any(rf => rf.IsAssignment)
+                        : false;
+            }
+
+            Declaration GetSubStmtParentDeclaration(QualifiedContext<ParserRuleContext> context)
+            {
+                return contextLookup.TryGetValue(context.Context.Parent as VBAParser.SubStmtContext, out Declaration decl)
+                    ? decl
+                        : null;
+            }
         }
 
         public class SingleByRefParamArgListListener : VBAParserBaseListener, IInspectionListener

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
@@ -26,7 +26,7 @@ namespace Rubberduck.Inspections.Concrete
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
-            if (Listener.Contexts.Count == 0)
+            if (!Listener.Contexts.Any())
             {
                 return Enumerable.Empty<IInspectionResult>();
             }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
@@ -26,6 +26,11 @@ namespace Rubberduck.Inspections.Concrete
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
+            if (Listener.Contexts.Count == 0)
+            {
+                return Enumerable.Empty<IInspectionResult>();
+            }
+
             var userDeclarations = UserDeclarations.ToList();
             var builtinHandlers = State.DeclarationFinder.FindEventHandlers().ToList();
 

--- a/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
@@ -12,28 +12,6 @@ namespace RubberduckTests.Inspections
     {
         [Test]
         [Category("Inspections")]
-        public void ProcedureShouldBeFunction_NoArgCase_NoResults()
-        {
-            const string inputCode =
-@"
-Private foo As Long
-Private Sub Foo()
-    foo = 42
-End Sub";
-
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(0, inspectionResults.Count());
-            }
-        }
-
-        [Test]
-        [Category("Inspections")]
         public void ProcedureShouldBeFunction_ReturnsResult()
         {
             const string inputCode =

--- a/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureShouldBeFunctionInspectionTests.cs
@@ -12,6 +12,28 @@ namespace RubberduckTests.Inspections
     {
         [Test]
         [Category("Inspections")]
+        public void ProcedureShouldBeFunction_NoArgCase_NoResults()
+        {
+            const string inputCode =
+@"
+Private foo As Long
+Private Sub Foo()
+    foo = 42
+End Sub";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ProcedureCanBeWrittenAsFunctionInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ProcedureShouldBeFunction_ReturnsResult()
         {
             const string inputCode =


### PR DESCRIPTION
Closes #4655 

Added `TryGetValue()` where the inspection accessed a dictionary using the key without verification checks.  Since I could not determine a specific use case that caused the missing key issue, adding protection to accessing the dictionary may be all that is/was needed to clear the issue.