### PR TITLE
Stop rewriting dirty modules

### DIFF
--- a/Rubberduck.CodeAnalysis/QuickFixes/IQuickFixFailureNotifier.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/IQuickFixFailureNotifier.cs
@@ -1,0 +1,9 @@
+﻿using Rubberduck.Parsing.Rewriter;
+
+namespace Rubberduck.Inspections.QuickFixes
+{
+    public interface IQuickFixFailureNotifier
+    {
+        void NotifyQuickFixExecutionFailure(RewriteSessionState sessionState);
+    }
+}

--- a/Rubberduck.CodeAnalysis/QuickFixes/QuickFixFailureNotifier.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/QuickFixFailureNotifier.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Rubberduck.Interaction;
+using Rubberduck.Parsing.Rewriter;
+
+namespace Rubberduck.Inspections.QuickFixes
+{
+    public class QuickFixFailureNotifier : IQuickFixFailureNotifier
+    {
+        private readonly IMessageBox _messageBox;
+
+        public QuickFixFailureNotifier(IMessageBox messageBox)
+        {
+            _messageBox = messageBox;
+        }
+
+        public void NotifyQuickFixExecutionFailure(RewriteSessionState sessionState)
+        {
+            var message = FailureMessage(sessionState);
+            var caption = Resources.Inspections.QuickFixes.ApplyQuickFixFailedCaption;
+
+            _messageBox.NotifyWarn(message, caption);
+        }
+
+        private static string FailureMessage(RewriteSessionState sessionState)
+        {
+            var baseFailureMessage = Resources.Inspections.QuickFixes.ApplyQuickFixesFailedMessage;
+            var failureReasonMessage = FailureReasonMessage(sessionState);
+            var message = string.IsNullOrEmpty(failureReasonMessage)
+                ? baseFailureMessage
+                : $"{baseFailureMessage}{Environment.NewLine}{Environment.NewLine}{failureReasonMessage}";
+            return message;
+        }
+
+        private static string FailureReasonMessage(RewriteSessionState sessionState)
+        {
+            switch (sessionState)
+            {
+                case RewriteSessionState.StaleParseTree:
+                    return Resources.Inspections.QuickFixes.StaleModuleFailureReason;
+                default:
+                    return string.Empty;
+            }
+        }
+    }
+}

--- a/Rubberduck.Interaction/Input/IMessageBox.cs
+++ b/Rubberduck.Interaction/Input/IMessageBox.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Forms = System.Windows.Forms;
+﻿using Forms = System.Windows.Forms;
 
 namespace Rubberduck.Interaction
 {

--- a/Rubberduck.Parsing/Rewriter/IRewriteSession.cs
+++ b/Rubberduck.Parsing/Rewriter/IRewriteSession.cs
@@ -7,8 +7,15 @@ namespace Rubberduck.Parsing.Rewriter
     {
         IModuleRewriter CheckOutModuleRewriter(QualifiedModuleName module);
         bool TryRewrite();
-        bool IsInvalidated { get; }
-        void Invalidate();
+        RewriteSessionState Status { get; set; }
         CodeKind TargetCodeKind { get; }
+    }
+
+    public enum RewriteSessionState
+    {
+        Valid,
+        RewriteApplied,
+        OtherSessionsRewriteApplied,
+        StaleParseTree
     }
 }

--- a/Rubberduck.Parsing/Rewriter/RewritingManager.cs
+++ b/Rubberduck.Parsing/Rewriter/RewritingManager.cs
@@ -50,6 +50,8 @@ namespace Rubberduck.Parsing.Rewriter
                     return false;
                 }
 
+                rewriteSession.Status = RewriteSessionState.RewriteApplied;
+
                 InvalidateAllSessionsInternal();
                 return true;
             }
@@ -80,13 +82,13 @@ namespace Rubberduck.Parsing.Rewriter
         {
             foreach (var rewriteSession in _activeCodePaneSessions)
             {
-                rewriteSession.Invalidate();
+                rewriteSession.Status = RewriteSessionState.OtherSessionsRewriteApplied;
             }
             _activeCodePaneSessions.Clear();
 
             foreach (var rewriteSession in _activeAttributesSessions)
             {
-                rewriteSession.Invalidate();
+                rewriteSession.Status = RewriteSessionState.OtherSessionsRewriteApplied;
             }
             _activeAttributesSessions.Clear();
         }

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -126,6 +126,26 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionQuickFix", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use early-bound Application.WorksheetFunction method..
+        /// </summary>
+        public static string ApplyQuickFixFailedCaption
+        {
+            get {
+                return ResourceManager.GetString("ApplyQuickFixFailedCaption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use early-bound Application.WorksheetFunction method..
+        /// </summary>
+        public static string ApplyQuickFixesFailedMessage
+        {
+            get {
+                return ResourceManager.GetString("ApplyQuickFixesFailedMessage", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Create and use a local copy of the parameter.
@@ -506,7 +526,17 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("SplitMultipleDeclarationsQuickFix", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Separate multiple declarations into multiple instructions.
+        /// </summary>
+        public static string StaleModuleFailureReason
+        {
+            get {
+                return ResourceManager.GetString("StaleModuleFailureReason", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Synchronize attributes/annotations in module.
         /// </summary>

--- a/Rubberduck.Resources/Inspections/QuickFixes.de.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.de.resx
@@ -279,4 +279,13 @@
   <data name="AddAttributeAnnotationQuickFix" xml:space="preserve">
     <value>Attributannotation hinzufügen</value>
   </data>
+  <data name="ApplyQuickFixesFailedMessage" xml:space="preserve">
+    <value>Die Ausführen des Quickfixes ist fehlgeschlagen. </value>
+  </data>
+  <data name="StaleModuleFailureReason" xml:space="preserve">
+    <value>Ein betroffenes Module wurde seit dem letzten Parse modifiziert.</value>
+  </data>
+  <data name="ApplyQuickFixFailedCaption" xml:space="preserve">
+    <value>Quickfixausführung fehlgeschlagen</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.resx
@@ -279,4 +279,13 @@
   <data name="AddAttributeAnnotationQuickFix" xml:space="preserve">
     <value>Add attribute annotation</value>
   </data>
+  <data name="ApplyQuickFixesFailedMessage" xml:space="preserve">
+    <value>Failed to apply the quick fix.</value>
+  </data>
+  <data name="StaleModuleFailureReason" xml:space="preserve">
+    <value>An affected module has been modified since the last parse.</value>
+  </data>
+  <data name="ApplyQuickFixFailedCaption" xml:space="preserve">
+    <value>Quick Fix Application Failure</value>
+  </data>
 </root>

--- a/RubberduckTests/Rewriter/AttributesRewriteSessionTests.cs
+++ b/RubberduckTests/Rewriter/AttributesRewriteSessionTests.cs
@@ -89,9 +89,9 @@ namespace RubberduckTests.Rewriter
             Assert.AreEqual(CodeKind.AttributesCode, rewriteSession.TargetCodeKind);
         }
 
-        protected override IRewriteSession RewriteSession(IParseManager parseManager, Func<IRewriteSession, bool> rewritingAllowed, out MockRewriterProvider mockProvider)
+        protected override IRewriteSession RewriteSession(IParseManager parseManager, Func<IRewriteSession, bool> rewritingAllowed, out MockRewriterProvider mockProvider, bool rewritersAreDirty = false)
         {
-            mockProvider = new MockRewriterProvider();
+            mockProvider = new MockRewriterProvider(rewritersAreDirty);
             return new AttributesRewriteSession(parseManager, mockProvider, rewritingAllowed);
         }
     }

--- a/RubberduckTests/Rewriter/CodePaneRewriteSessionTests.cs
+++ b/RubberduckTests/Rewriter/CodePaneRewriteSessionTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Moq;
 using NUnit.Framework;
 using Rubberduck.Parsing.Rewriter;
@@ -41,7 +40,7 @@ namespace RubberduckTests.Rewriter
             var module = new QualifiedModuleName("TestProject", string.Empty, "TestModule");
             var otherModule = new QualifiedModuleName("TestProject", string.Empty, "OtherTestModule");
             rewriteSession.CheckOutModuleRewriter(module);
-            rewriteSession.Invalidate();
+            rewriteSession.Status = RewriteSessionState.OtherSessionsRewriteApplied;
             rewriteSession.CheckOutModuleRewriter(otherModule);
 
             rewriteSession.TryRewrite();
@@ -99,9 +98,9 @@ namespace RubberduckTests.Rewriter
             Assert.AreEqual(CodeKind.CodePaneCode, rewriteSession.TargetCodeKind);
         }
 
-        protected override IRewriteSession RewriteSession(IParseManager parseManager, Func<IRewriteSession, bool> rewritingAllowed, out MockRewriterProvider mockProvider)
+        protected override IRewriteSession RewriteSession(IParseManager parseManager, Func<IRewriteSession, bool> rewritingAllowed, out MockRewriterProvider mockProvider, bool rewritersAreDirty = false)
         {
-            mockProvider = new MockRewriterProvider();
+            mockProvider = new MockRewriterProvider(rewritersAreDirty);
             return new CodePaneRewriteSession(parseManager, mockProvider, rewritingAllowed);
         }
     }

--- a/RubberduckTests/Rewriter/RewriteManagerTests.cs
+++ b/RubberduckTests/Rewriter/RewriteManagerTests.cs
@@ -17,7 +17,7 @@ namespace RubberduckTests.Rewriter
         {
             var rewritingManager = RewritingManager(out _);
             var codePaneSession = rewritingManager.CheckOutCodePaneSession();
-            Assert.IsFalse(codePaneSession.IsInvalidated);
+            Assert.AreEqual(RewriteSessionState.Valid, codePaneSession.Status);
         }
 
 
@@ -27,13 +27,13 @@ namespace RubberduckTests.Rewriter
         {
             var rewritingManager = RewritingManager(out _);
             var attributesSession = rewritingManager.CheckOutAttributesSession();
-            Assert.IsFalse(attributesSession.IsInvalidated);
+            Assert.AreEqual(RewriteSessionState.Valid, attributesSession.Status);
         }
 
 
         [Test]
         [Category("Rewriter")]
-        public void InvalidateAllSessionsCallsInvalidateOnAllActiveSessions()
+        public void InvalidateAllSessionsSetsTheStatusToOtherSessionsRewriteAppliedForAllActiveSessions()
         {
             var rewritingManager = RewritingManager(out var mockFactory);
             rewritingManager.CheckOutCodePaneSession();
@@ -45,13 +45,43 @@ namespace RubberduckTests.Rewriter
 
             foreach (var mockSession in mockFactory.RequestedCodePaneSessions().Concat(mockFactory.RequestedAttributesSessions()))
             {
-                mockSession.Verify(m => m.Invalidate(), Times.Once);
+                mockSession.VerifySet(m => m.Status = RewriteSessionState.OtherSessionsRewriteApplied, Times.Once);
             }
         }
 
         [Test]
         [Category("Rewriter")]
-        public void CallingTheRewritingAllowedCallbackFromAnActiveCodePaneSessionCallsInvalidateOnAllActiveSessions()
+        public void CallingTheRewritingAllowedCallbackFromAnActiveCodePaneSessionSetsItsStatusToRewriteApplied()
+        {
+            var rewritingManager = RewritingManager(out var mockFactory);
+            var codePaneSession = rewritingManager.CheckOutCodePaneSession();
+            rewritingManager.CheckOutAttributesSession();
+            rewritingManager.CheckOutCodePaneSession();
+            rewritingManager.CheckOutAttributesSession();
+
+            codePaneSession.TryRewrite();
+
+            Assert.AreEqual(RewriteSessionState.RewriteApplied, codePaneSession.Status);
+        }
+
+        [Test]
+        [Category("Rewriter")]
+        public void CallingTheRewritingAllowedCallbackFromAnActiveAttributesSessionSetsItsStatusToRewriteApplied()
+        {
+            var rewritingManager = RewritingManager(out var mockFactory);
+            rewritingManager.CheckOutCodePaneSession();
+            var attributesSession = rewritingManager.CheckOutAttributesSession();
+            rewritingManager.CheckOutCodePaneSession();
+            rewritingManager.CheckOutAttributesSession();
+
+            attributesSession.TryRewrite();
+
+            Assert.AreEqual(RewriteSessionState.RewriteApplied, attributesSession.Status);
+        }
+
+        [Test]
+        [Category("Rewriter")]
+        public void CallingTheRewritingAllowedCallbackFromAnActiveCodePaneSessionSetsTheStatusToOtherSessionsRewriteAppliedForAllActiveSessions()
         {
             var rewritingManager = RewritingManager(out var mockFactory);
             var codePaneSession = rewritingManager.CheckOutCodePaneSession();
@@ -63,13 +93,13 @@ namespace RubberduckTests.Rewriter
 
             foreach (var mockSession in mockFactory.RequestedCodePaneSessions().Concat(mockFactory.RequestedAttributesSessions()))
             {
-                mockSession.Verify(m => m.Invalidate(), Times.Once);
+                mockSession.VerifySet(m => m.Status = RewriteSessionState.OtherSessionsRewriteApplied, Times.Once);
             }
         }
 
         [Test]
         [Category("Rewriter")]
-        public void CallingTheRewritingAllowedCallbackFromAnActiveAttributesSessionCallsInvalidateOnAllActiveSessions()
+        public void CallingTheRewritingAllowedCallbackFromAnActiveAttributesSessionSetsTheStatusToOtherSessionsRewriteAppliedForAllActiveSessions()
         {
             var rewritingManager = RewritingManager(out var mockFactory);
             rewritingManager.CheckOutCodePaneSession();
@@ -81,17 +111,98 @@ namespace RubberduckTests.Rewriter
 
             foreach (var mockSession in mockFactory.RequestedCodePaneSessions().Concat(mockFactory.RequestedAttributesSessions()))
             {
-                mockSession.Verify(m => m.Invalidate(), Times.Once);
+                mockSession.VerifySet(m => m.Status = RewriteSessionState.OtherSessionsRewriteApplied, Times.Once);
             }
         }
 
         [Test]
         [Category("Rewriter")]
-        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveCodePaneSessionDoesNotCallInvalidateOnAnyActiveSession_InactiveDueToRewrite()
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveCodePaneSessionDoesNotSetItsStatusToRewriteApplied_InactiveDueToInvalidateAll()
+        {
+            var rewritingManager = RewritingManager(out var mockFactory);
+            var codePaneSession = rewritingManager.CheckOutCodePaneSession();
+
+            rewritingManager.InvalidateAllSessions();
+
+            rewritingManager.CheckOutCodePaneSession();
+            rewritingManager.CheckOutAttributesSession();
+
+            codePaneSession.TryRewrite();
+
+            var mockSession = mockFactory.RequestedCodePaneSessions()
+                .First(mockedSession => codePaneSession.Equals(mockedSession.Object));
+
+            mockSession.VerifySet(m => m.Status = RewriteSessionState.RewriteApplied, Times.Never);
+        }
+
+        [Test]
+        [Category("Rewriter")]
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveAttributesSessionDoesNotSetItsStatusToRewriteApplied_InactiveDueToInvalidateAll()
+        {
+            var rewritingManager = RewritingManager(out var mockFactory);
+            var attributesSession = rewritingManager.CheckOutAttributesSession();
+
+            rewritingManager.InvalidateAllSessions();
+
+            rewritingManager.CheckOutCodePaneSession();
+            rewritingManager.CheckOutAttributesSession();
+
+            attributesSession.TryRewrite();
+
+            var mockSession = mockFactory.RequestedAttributesSessions()
+                .First(mockedSession => attributesSession == mockedSession.Object);
+
+            mockSession.VerifySet(m => m.Status = RewriteSessionState.RewriteApplied, Times.Never);
+        }
+
+        [Test]
+        [Category("Rewriter")]
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveCodePaneSessionDoesNotSetItsStatusToRewriteApplied_InactiveDueToRewrite()
         {
             var rewritingManager = RewritingManager(out var mockFactory);
             var codePaneSession = rewritingManager.CheckOutCodePaneSession();
             var attributesSession = rewritingManager.CheckOutAttributesSession();
+
+            attributesSession.TryRewrite();
+
+            rewritingManager.CheckOutCodePaneSession();
+            rewritingManager.CheckOutAttributesSession();
+
+            codePaneSession.TryRewrite();
+
+            var mockSession = mockFactory.RequestedCodePaneSessions()
+                .First(mockedSession => codePaneSession == mockedSession.Object);
+
+            mockSession.VerifySet(m => m.Status = RewriteSessionState.RewriteApplied, Times.Never);
+        }
+
+        [Test]
+        [Category("Rewriter")]
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveAttributesSessionDoesNotSetItsStatusToRewriteApplied_InactiveDueToRewrite()
+        {
+            var rewritingManager = RewritingManager(out var mockFactory);
+            var codePaneSession = rewritingManager.CheckOutCodePaneSession();
+            var attributesSession = rewritingManager.CheckOutAttributesSession();
+
+            codePaneSession.TryRewrite();
+
+            rewritingManager.CheckOutCodePaneSession();
+            rewritingManager.CheckOutAttributesSession();
+
+            attributesSession.TryRewrite();
+
+            var mockSession = mockFactory.RequestedAttributesSessions()
+                .First(mockedSession => attributesSession.Equals(mockedSession.Object));
+
+            mockSession.VerifySet(m => m.Status = RewriteSessionState.RewriteApplied, Times.Never);
+        }
+
+        [Test]
+        [Category("Rewriter")]
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveCodePaneSessionDoesNotSetTheStatusToOtherSessionsRewriteAppliedForAnyActiveSession_InactiveDueToInvalidateAll()
+        {
+            var rewritingManager = RewritingManager(out var mockFactory);
+            var codePaneSession = rewritingManager.CheckOutCodePaneSession();
 
             rewritingManager.InvalidateAllSessions();
 
@@ -102,18 +213,17 @@ namespace RubberduckTests.Rewriter
 
             foreach (var mockSession in mockFactory.RequestedCodePaneSessions()
                 .Concat(mockFactory.RequestedAttributesSessions())
-                .Where(session => session.Object != codePaneSession && session.Object != attributesSession))
+                .Where(session => session.Object != codePaneSession))
             {
-                mockSession.Verify(m => m.Invalidate(), Times.Never);
+                mockSession.VerifySet(m => m.Status = RewriteSessionState.OtherSessionsRewriteApplied, Times.Never);
             }
         }
 
         [Test]
         [Category("Rewriter")]
-        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveAttributesSessionDoesNotCallInvalidateOnAnyActiveSession_InactiveDueToRewrite()
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveAttributesSessionDoesNotSetTheStatusToOtherSessionsRewriteAppliedForAnyActiveSession_InactiveDueToInvalidateAll()
         {
             var rewritingManager = RewritingManager(out var mockFactory);
-            var codePaneSession = rewritingManager.CheckOutCodePaneSession();
             var attributesSession = rewritingManager.CheckOutAttributesSession();
 
             rewritingManager.InvalidateAllSessions();
@@ -121,19 +231,19 @@ namespace RubberduckTests.Rewriter
             rewritingManager.CheckOutCodePaneSession();
             rewritingManager.CheckOutAttributesSession();
 
-            codePaneSession.TryRewrite();
+            attributesSession.TryRewrite();
 
             foreach (var mockSession in mockFactory.RequestedCodePaneSessions()
                 .Concat(mockFactory.RequestedAttributesSessions())
-                .Where(session => session.Object != codePaneSession && session.Object != attributesSession))
+                .Where(session => session.Object != attributesSession))
             {
-                mockSession.Verify(m => m.Invalidate(), Times.Never);
+                mockSession.VerifySet(m => m.Status = RewriteSessionState.OtherSessionsRewriteApplied, Times.Never);
             }
         }
 
         [Test]
         [Category("Rewriter")]
-        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveCodePaneSessionDoesNotCallInvalidateOnAnyActiveSession_InactiveDueToInvalidateAll()
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveCodePaneSessionDoesNotSetTheStatusToOtherSessionsRewriteAppliedForAnyActiveSession_InactiveDueToRewrite()
         {
             var rewritingManager = RewritingManager(out var mockFactory);
             var codePaneSession = rewritingManager.CheckOutCodePaneSession();
@@ -150,13 +260,13 @@ namespace RubberduckTests.Rewriter
                 .Concat(mockFactory.RequestedAttributesSessions())
                 .Where(session => session.Object != codePaneSession && session.Object != attributesSession))
             {
-                mockSession.Verify(m => m.Invalidate(), Times.Never);
+                mockSession.VerifySet(m => m.Status = RewriteSessionState.OtherSessionsRewriteApplied, Times.Never);
             }
         }
 
         [Test]
         [Category("Rewriter")]
-        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveAttributesSessionDoesNotCallInvalidateOnAnyActiveSession_InactiveDueToInvalidateAll()
+        public void CallingTheRewritingAllowedCallbackFromANoLongerActiveAttributesSessionDoesNotSetTheStatusToOtherSessionsRewriteAppliedForAnyActiveSession_InactiveDueToRewrite()
         {
             var rewritingManager = RewritingManager(out var mockFactory);
             var codePaneSession = rewritingManager.CheckOutCodePaneSession();
@@ -173,7 +283,7 @@ namespace RubberduckTests.Rewriter
                 .Concat(mockFactory.RequestedAttributesSessions())
                 .Where( session => session.Object != codePaneSession && session.Object != attributesSession))
             {
-                mockSession.Verify(m => m.Invalidate(), Times.Never);
+                mockSession.VerifySet(m => m.Status = RewriteSessionState.OtherSessionsRewriteApplied, Times.Never);
             }
         }
 
@@ -210,9 +320,17 @@ namespace RubberduckTests.Rewriter
         {
             var mockSession = new Mock<IRewriteSession>();
             mockSession.Setup(m => m.TryRewrite()).Callback(() => rewritingAllowed.Invoke(mockSession.Object));
-            var isInvalidated = false;
-            mockSession.Setup(m => m.IsInvalidated).Returns(() => isInvalidated);
-            mockSession.Setup(m => m.Invalidate()).Callback(() => isInvalidated = true);
+            var status = RewriteSessionState.Valid;
+            mockSession.SetupGet(m => m.Status).Returns(status);
+            mockSession.SetupSet(m => m.Status = It.IsAny<RewriteSessionState>())
+                .Callback<RewriteSessionState>( value =>
+                {
+                    if (status == RewriteSessionState.Valid)
+                    {
+                        status = value;
+                        mockSession.SetupGet(m => m.Status).Returns(status);
+                    }
+                }); 
             mockSession.Setup(m => m.TargetCodeKind).Returns(targetCodeKind);
 
             return mockSession;


### PR DESCRIPTION
This PR closes  #4688

After this PR, whenever a rewrite session checks out a rewriter that is already dirt, i.e. whose underlying parse tree is stale, the rewrite session invalidates itself. This causes any subsequent call to `TryRewrite` to fail.

In order to communicate the reason for the failure better, I changed the boolean property `IsInvalidated` to a property `Status` returning an enum value. This property can be set once to another value than `Valid` in order to invalidate the rewriter. Afterwards, all attempts to set the property are ignored. Thus, for any invalid session it shows the original reason for the invalidation.

Using this information, I added a notification mechanism to the `QuickFixProvider` informing about any failure to apply a rewriter. Currently, onlyfor a failure due to a stale parse tree the reason for the failure is presented to the user.