### PR TITLE
Invalidate inspection results after parsing

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/InspectionBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/InspectionBase.cs
@@ -166,5 +166,10 @@ namespace Rubberduck.Inspections.Abstract
             _logger.Trace("Intercepted invocation of '{0}.{1}' ran for {2}ms", GetType().Name, nameof(DoGetInspectionResults), _stopwatch.ElapsedMilliseconds);
             return result;
         }
+
+        public virtual bool ChangesInvalidateResult(IInspectionResult result, ICollection<QualifiedModuleName> modifiedModules)
+        {
+            return true;
+        }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/InspectionResultBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/InspectionResultBase.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using Antlr4.Runtime;
 using Rubberduck.Common;
 using Rubberduck.Parsing.Inspections;
@@ -38,6 +39,12 @@ namespace Rubberduck.Inspections.Abstract
         public ParserRuleContext Context { get; }
         public Declaration Target { get; }
         public dynamic Properties { get; }
+
+        public virtual bool ChangesInvalidateResult(ICollection<QualifiedModuleName> modifiedModules)
+        {
+            return modifiedModules.Contains(QualifiedName) 
+                   || Inspection.ChangesInvalidateResult(this, modifiedModules);
+        }
 
         /// <summary>
         /// Gets the information needed to select the target instruction in the VBE.

--- a/Rubberduck.CodeAnalysis/Inspections/Results/DeclarationInspectionResult.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Results/DeclarationInspectionResult.cs
@@ -1,4 +1,5 @@
-﻿using Rubberduck.Inspections.Abstract;
+﻿using System.Collections.Generic;
+using Rubberduck.Inspections.Abstract;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Symbols;
@@ -6,7 +7,7 @@ using Rubberduck.VBEditor;
 
 namespace Rubberduck.Inspections.Results
 {
-    internal class DeclarationInspectionResult : InspectionResultBase
+    public class DeclarationInspectionResult : InspectionResultBase
     {
         public DeclarationInspectionResult(IInspection inspection, string description, Declaration target, QualifiedContext context = null, dynamic properties = null) :
             base(inspection,
@@ -30,6 +31,12 @@ namespace Rubberduck.Inspections.Results
             return target.DeclarationType.HasFlag(DeclarationType.Member)
                 ? target.QualifiedName
                 : GetQualifiedMemberName(target.ParentDeclaration);
+        }
+
+        public override bool ChangesInvalidateResult(ICollection<QualifiedModuleName> modifiedModules)
+        {
+            return modifiedModules.Contains(Target.QualifiedModuleName)
+                   || base.ChangesInvalidateResult(modifiedModules);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Results/IdentifierReferenceInspectionResult.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Results/IdentifierReferenceInspectionResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Rubberduck.Inspections.Abstract;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Inspections.Abstract;
@@ -8,24 +9,30 @@ using Rubberduck.VBEditor;
 
 namespace Rubberduck.Inspections.Results
 {
-    internal class IdentifierReferenceInspectionResult : InspectionResultBase
+    public class IdentifierReferenceInspectionResult : InspectionResultBase
     {
-        public IdentifierReferenceInspectionResult(IInspection inspection, string description, RubberduckParserState state, IdentifierReference reference, dynamic properties = null) :
+        public IdentifierReferenceInspectionResult(IInspection inspection, string description, IDeclarationFinderProvider declarationFinderProvider, IdentifierReference reference, dynamic properties = null) :
             base(inspection,
                  description,
                  reference.QualifiedModuleName,
                  reference.Context,
                  reference.Declaration,
                  new QualifiedSelection(reference.QualifiedModuleName, reference.Context.GetSelection()),
-                 GetQualifiedMemberName(state, reference),
+                 GetQualifiedMemberName(declarationFinderProvider, reference),
                  (object)properties)
         {
         }
 
-        private static QualifiedMemberName? GetQualifiedMemberName(RubberduckParserState state, IdentifierReference reference)
+        private static QualifiedMemberName? GetQualifiedMemberName(IDeclarationFinderProvider declarationFinderProvider, IdentifierReference reference)
         {
-            var members = state.DeclarationFinder.Members(reference.QualifiedModuleName);
+            var members = declarationFinderProvider.DeclarationFinder.Members(reference.QualifiedModuleName);
             return members.SingleOrDefault(m => reference.Context.IsDescendentOf(m.Context))?.QualifiedName;
+        }
+
+        public override bool ChangesInvalidateResult(ICollection<QualifiedModuleName> modifiedModules)
+        {
+            return modifiedModules.Contains(Target.QualifiedModuleName)
+                || base.ChangesInvalidateResult(modifiedModules);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Results/QualifiedContextInspectionResult.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Results/QualifiedContextInspectionResult.cs
@@ -5,7 +5,7 @@ using Rubberduck.VBEditor;
 
 namespace Rubberduck.Inspections.Results
 {
-    internal class QualifiedContextInspectionResult : InspectionResultBase
+    public class QualifiedContextInspectionResult : InspectionResultBase
     {
         public QualifiedContextInspectionResult(IInspection inspection, string description, QualifiedContext context, dynamic properties = null) :
             base(inspection,
@@ -16,7 +16,6 @@ namespace Rubberduck.Inspections.Results
                  new QualifiedSelection(context.ModuleName, context.Context.GetSelection()),
                  context.MemberName,
                  (object)properties)
-        {
-        }
+        {}
     }
 }

--- a/Rubberduck.Core/UI/Inspections/AggregateInspectionResult.cs
+++ b/Rubberduck.Core/UI/Inspections/AggregateInspectionResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Antlr4.Runtime;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Symbols;
@@ -28,6 +29,8 @@ namespace Rubberduck.UI.Inspections
         public ParserRuleContext Context => _result.Context;
 
         public dynamic Properties => throw new InvalidOperationException();
+
+        public virtual bool ChangesInvalidateResult(ICollection<QualifiedModuleName> modifiedModules) => true;
 
         public int CompareTo(IInspectionResult other)
         {

--- a/Rubberduck.Parsing/Inspections/Abstract/IInspection.cs
+++ b/Rubberduck.Parsing/Inspections/Abstract/IInspection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.Inspections.Abstract
 {
@@ -15,5 +16,10 @@ namespace Rubberduck.Parsing.Inspections.Abstract
         /// <param name="token"></param>
         /// <returns>Returns inspection results, if any.</returns>
         IEnumerable<IInspectionResult> GetInspectionResults(CancellationToken token);
+
+        /// <summary>
+        /// Specifies whether an inspection result is deemed invalid after the specified modules have changed.
+        /// </summary>
+        bool ChangesInvalidateResult(IInspectionResult result, ICollection<QualifiedModuleName> modifiedModules);
     }
 }

--- a/Rubberduck.Parsing/Inspections/Abstract/IInspectionResult.cs
+++ b/Rubberduck.Parsing/Inspections/Abstract/IInspectionResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Antlr4.Runtime;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.VBEditor;
@@ -14,5 +15,6 @@ namespace Rubberduck.Parsing.Inspections.Abstract
         Declaration Target { get; }
         ParserRuleContext Context { get; }
         dynamic Properties { get; }
+        bool ChangesInvalidateResult(ICollection<QualifiedModuleName> modifiedModules);
     }
 }

--- a/RubberduckTests/Inspections/InspectionResultTests.cs
+++ b/RubberduckTests/Inspections/InspectionResultTests.cs
@@ -1,0 +1,201 @@
+﻿using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.UI.Inspections;
+using Rubberduck.VBEditor;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class InspectionResultTests
+    {
+        [Test]
+        public void InspectionResultsAreDeemedInvalidatedIfTheModuleWithTheirQualifiedModuleNameHasBeenModified()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(false);
+
+            var module = new QualifiedModuleName("project", string.Empty,"module");
+            var context = new QualifiedContext(module, null);
+            var modifiedModules = new HashSet<QualifiedModuleName>{module};
+
+            var inspectionResult = new QualifiedContextInspectionResult(inspectionMock.Object, string.Empty, context);
+
+            Assert.IsTrue(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+
+        [Test]
+        public void InspectionResultsAreDeemedInvalidatedIfTheInspectionDeemsThemInvalidated()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(true);
+
+            var module = new QualifiedModuleName("project", string.Empty, "module");
+            var context = new QualifiedContext(module, null);
+            var modifiedModules = new HashSet<QualifiedModuleName>();
+
+            var inspectionResult = new QualifiedContextInspectionResult(inspectionMock.Object, string.Empty, context);
+
+            Assert.IsTrue(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+
+        [Test]
+        public void QualifiedContextInspectionResultsAreNotDeemedInvalidatedIfNeitherTheInspectionDeemsThemInvalidatedNorTheirQualifiedModuleNameGetsModified()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(false);
+
+            var module = new QualifiedModuleName("project", string.Empty, "module");
+            var otherModule = new QualifiedModuleName("project", string.Empty, "otherModule");
+            var context = new QualifiedContext(module, null);
+            var modifiedModules = new HashSet<QualifiedModuleName>{ otherModule };
+
+            var inspectionResult = new QualifiedContextInspectionResult(inspectionMock.Object, string.Empty, context);
+
+            Assert.IsFalse(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+
+        [Test]
+        public void DeclarationInspectionResultsAreDeemedInvalidatedIfTheirTargetsModuleGetsModified()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(false);
+
+            var module = new QualifiedModuleName("project", string.Empty, "module");
+            var declarationModule = new QualifiedModuleName("project", string.Empty, "declarationModule");
+            var declarationMemberName = new QualifiedMemberName(declarationModule, "test");
+            var context = new QualifiedContext(module, null);
+            var declaration = new Declaration(declarationMemberName, null, string.Empty, string.Empty, string.Empty, false, false,
+                Accessibility.Public, DeclarationType.Constant, null, null, default, false, null);
+            var modifiedModules = new HashSet<QualifiedModuleName>{declarationModule};
+            
+            var inspectionResult = new DeclarationInspectionResult(inspectionMock.Object, string.Empty, declaration, context);
+
+            Assert.IsTrue(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+
+        [Test]
+        public void DeclarationInspectionResultsAreNotDeemedInvalidatedIfNeitherTheInspectionDeemsThemInvalidatedNorTheirModuleNorThatOfTheTargetGetModified()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(false);
+
+            var module = new QualifiedModuleName("project", string.Empty, "module");
+            var declarationModule = new QualifiedModuleName("project", string.Empty, "declarationModule");
+            var otherModule = new QualifiedModuleName("project", string.Empty, "otherModule");
+            var declarationMemberName = new QualifiedMemberName(declarationModule, "test");
+            var context = new QualifiedContext(module, null);
+            var declaration = new Declaration(declarationMemberName, null, string.Empty, string.Empty, string.Empty, false, false,
+                Accessibility.Public, DeclarationType.Constant, null, null, default, false, null);
+            var modifiedModules = new HashSet<QualifiedModuleName> { otherModule };
+
+            var inspectionResult = new DeclarationInspectionResult(inspectionMock.Object, string.Empty, declaration, context);
+
+            Assert.IsFalse(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+
+        [Test]
+        public void IdentifierRefereneceInspectionResultsAreDeemedInvalidatedIfTheModuleOfTheirReferencedDeclarationGetsModified()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(false);
+
+            var module = new QualifiedModuleName("project", string.Empty, "module");
+            var declarationModule = new QualifiedModuleName("project", string.Empty, "declarationModule");
+            var declarationMemberName = new QualifiedMemberName(declarationModule, "test");
+            var declaration = new Declaration(declarationMemberName, null, string.Empty, string.Empty, string.Empty, false, false,
+                Accessibility.Public, DeclarationType.Constant, null, null, default, false, null);
+            var identifierReference = new IdentifierReference(module, null, null, "test", default, null, declaration);
+            var modifiedModules = new HashSet<QualifiedModuleName> { declarationModule };
+
+            var declarationFinderProviderMock = new Mock<IDeclarationFinderProvider>();
+            var declaratioFinder = new DeclarationFinder(new List<Declaration>(), new List<IAnnotation>(),
+                new List<UnboundMemberDeclaration>());
+            declarationFinderProviderMock.SetupGet(m => m.DeclarationFinder).Returns(declaratioFinder);
+            var inspectionResult = new IdentifierReferenceInspectionResult(inspectionMock.Object, string.Empty, declarationFinderProviderMock.Object, identifierReference);
+
+            Assert.IsTrue(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+
+        [Test]
+        public void IdentifierReferenceInspectionResultsAreNotDeemedInvalidatedIfNeitherTheInspectionDeemsThemInvalidatedNorTheirModuleNorThatOfTheReferencedDeclarationGetModified()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(false);
+
+            var module = new QualifiedModuleName("project", string.Empty, "module");
+            var declarationModule = new QualifiedModuleName("project", string.Empty, "declarationModule");
+            var otherModule = new QualifiedModuleName("project", string.Empty, "otherModule");
+            var declarationMemberName = new QualifiedMemberName(declarationModule, "test");
+            var declaration = new Declaration(declarationMemberName, null, string.Empty, string.Empty, string.Empty, false, false,
+                Accessibility.Public, DeclarationType.Constant, null, null, default, false, null);
+
+            var identifierReference = new IdentifierReference(module, null, null, "test", default, null, declaration); 
+            var modifiedModules = new HashSet<QualifiedModuleName> { otherModule };
+
+            var declarationFinderProviderMock = new Mock<IDeclarationFinderProvider>();
+            var declaratioFinder = new DeclarationFinder(new List<Declaration>(), new List<IAnnotation>(),
+                new List<UnboundMemberDeclaration>());
+            declarationFinderProviderMock.SetupGet(m => m.DeclarationFinder).Returns(declaratioFinder);
+            var inspectionResult = new IdentifierReferenceInspectionResult(inspectionMock.Object, string.Empty, declarationFinderProviderMock.Object, identifierReference);
+
+            Assert.IsFalse(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+
+        [Test]
+        public void AggregateInspectionResultsAreAlwaysDeemedInvalidated()
+        {
+            var inspectionMock = new Mock<IInspection>();
+            inspectionMock
+                .Setup(m =>
+                    m.ChangesInvalidateResult(It.IsAny<IInspectionResult>(),
+                        It.IsAny<ICollection<QualifiedModuleName>>()))
+                .Returns(false);
+
+            var module = new QualifiedModuleName("project", string.Empty, "module");
+            var otherModule = new QualifiedModuleName("project", string.Empty, "otherModule");
+            var context = new QualifiedContext(module, null);
+            var modifiedModules = new HashSet<QualifiedModuleName> { otherModule };
+
+            var baseInspectionResult = new QualifiedContextInspectionResult(inspectionMock.Object, string.Empty, context);
+            var inspectionResult = new AggregateInspectionResult(baseInspectionResult, 42);
+
+            Assert.IsTrue(inspectionResult.ChangesInvalidateResult(modifiedModules));
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #2023

This PR introduces the base framework for inspection result invalidation. Each inspection result now has a member `ChangedInvalidateResult` taking the modified modules and returning whether the result got invalidated by the changes. 

The base implementation checks whether the module on the inspection result got modified. If not, it asks the inspection whether it thinks that the result is stale. `DeclarationInspectionResults` and `IdentifierInspectionResults` also take the module of the corresponding declaraion into account. `AggregateInspectionResults` are always considered stale as there is no information about the contents.

For the inspections, the check whether a result is stale defaults to true. If anything else is desired, the corresponding virtual method on `InspectionBase` has to be overriden. (This effectively deems all results stale at the moment.)

In the `InspectionViewModel` now all reults deemed atale get removed after a parse, provided the inspections do not run; running the inspections removes all results anyway. Consequently, when automatically running the inspections is deactivated, the stale results no longer remain in the view. This prevents the execution of quickfixes on stale data.

Currently, all existing modules are considered modified. To change that, the parsed modules would have to find their way into the state changed handler somehow. (This will not be part of this PR.) 

