### PR TITLE
Fixes 4964 (installing with no menu showing)

### DIFF
--- a/Rubberduck.Main/Extension.cs
+++ b/Rubberduck.Main/Extension.cs
@@ -134,69 +134,71 @@ namespace Rubberduck
 
         private void InitializeAddIn()
         {
-            if (_isInitialized)
-            {
-                // The add-in is already initialized. See:
-                // The strange case of the add-in initialized twice
-                // http://msmvps.com/blogs/carlosq/archive/2013/02/14/the-strange-case-of-the-add-in-initialized-twice.aspx
-                return;
-            }
-
-            var configLoader = new XmlPersistanceService<GeneralSettings>
-            {
-                FilePath =
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                        "Rubberduck", "rubberduck.config")
-            };
-            var configProvider = new GeneralConfigProvider(configLoader);
-            
-            _initialSettings = configProvider.Create();
-            if (_initialSettings != null)
-            {
-                try
-                {
-                    var cultureInfo = CultureInfo.GetCultureInfo(_initialSettings.Language.Code);
-                    Dispatcher.CurrentDispatcher.Thread.CurrentUICulture = cultureInfo;
-                }
-                catch (CultureNotFoundException)
-                {
-                }
-                try
-                {
-                    if (_initialSettings.SetDpiUnaware)
-                    {
-                        SHCore.SetProcessDpiAwareness(PROCESS_DPI_AWARENESS.Process_DPI_Unaware);
-                    }
-                }
-                catch (Exception)
-                {
-                    Debug.Assert(false, "Could not set DPI awareness.");
-                }
-            }
-            else
-            {
-                Debug.Assert(false, "Settings could not be initialized.");
-            }
-
             Splash splash = null;
-            if (_initialSettings.CanShowSplash)
-            {
-                splash = new Splash
-                {
-                    // note: IVersionCheck.CurrentVersion could return this string.
-                    Version = $"version {Assembly.GetExecutingAssembly().GetName().Version}"
-                };
-                splash.Show();
-                splash.Refresh();
-            }
-
             try
             {
+                if (_isInitialized)
+                {
+                    // The add-in is already initialized. See:
+                    // The strange case of the add-in initialized twice
+                    // http://msmvps.com/blogs/carlosq/archive/2013/02/14/the-strange-case-of-the-add-in-initialized-twice.aspx
+                    return;
+                }
+
+                var configLoader = new XmlPersistanceService<GeneralSettings>
+                {
+                    FilePath =
+                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                            "Rubberduck", "rubberduck.config")
+                };
+                var configProvider = new GeneralConfigProvider(configLoader);
+
+                _initialSettings = configProvider.Create();
+                if (_initialSettings != null)
+                {
+                    try
+                    {
+                        var cultureInfo = CultureInfo.GetCultureInfo(_initialSettings.Language.Code);
+                        Dispatcher.CurrentDispatcher.Thread.CurrentUICulture = cultureInfo;
+                    }
+                    catch (CultureNotFoundException)
+                    {
+                    }
+
+                    try
+                    {
+                        if (_initialSettings.SetDpiUnaware)
+                        {
+                            SHCore.SetProcessDpiAwareness(PROCESS_DPI_AWARENESS.Process_DPI_Unaware);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        Debug.Assert(false, "Could not set DPI awareness.");
+                    }
+                }
+                else
+                {
+                    Debug.Assert(false, "Settings could not be initialized.");
+                }
+
+                if (_initialSettings?.CanShowSplash ?? false)
+                {
+                    splash = new Splash
+                    {
+                        // note: IVersionCheck.CurrentVersion could return this string.
+                        Version = $"version {Assembly.GetExecutingAssembly().GetName().Version}"
+                    };
+                    splash.Show();
+                    splash.Refresh();
+                }
+
                 Startup();
             }
             catch (Win32Exception)
             {
-                System.Windows.Forms.MessageBox.Show(Resources.RubberduckUI.RubberduckReloadFailure_Message, RubberduckUI.RubberduckReloadFailure_Title,
+                System.Windows.Forms.MessageBox.Show(Resources.RubberduckUI.RubberduckReloadFailure_Message,
+                    RubberduckUI.RubberduckReloadFailure_Title,
                     MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
             catch (Exception exception)
@@ -211,8 +213,8 @@ namespace Rubberduck
                     RubberduckUI.RubberduckLoadFailure, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             finally
-            {                
-                splash?.Dispose();                
+            {
+                splash?.Dispose();
             }
         }
 

--- a/Rubberduck.SettingsProvider/XmlPersistanceService.cs
+++ b/Rubberduck.SettingsProvider/XmlPersistanceService.cs
@@ -19,6 +19,10 @@ namespace Rubberduck.SettingsProvider
 
             var doc = GetConfigurationDoc(FilePath);
             var node = GetNodeByName(doc, typeof(T).Name);
+            if (node == null)
+            {
+                return FailedLoadReturnValue();
+            }
 
             using (var reader = node.CreateReader())
             {

--- a/RubberduckTests/Settings/GeneralSettingsTests.cs
+++ b/RubberduckTests/Settings/GeneralSettingsTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using Rubberduck.VBEditor.VbeRuntime.Settings;
 using System;
 using Rubberduck.Interaction;
+using Rubberduck.SettingsProvider;
 
 namespace RubberduckTests.Settings
 {
@@ -154,14 +155,22 @@ namespace RubberduckTests.Settings
             Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.AutoSavePeriod, viewModel.AutoSavePeriod);
         }
 
-        //[Category("Settings")]
-        //[Test]
-        //public void DelimiterIsSetInCtor()
-        //{
-        //    var defaultConfig = GetDefaultConfig();
-        //    var viewModel = new GeneralSettingsViewModel(defaultConfig, GetOperatingSystemMock().Object);
+        [Category("Settings")]
+        [Test]
+        public void UserSettingsLoadedUsingDefaultWhenMissingFile()
+        {
+            // For this test, we need to use the actual object. Fortunately, the path is virtual, so we
+            // can override that property and force it to use an non-existent path to prove that settings
+            // will be still created using defaults without the file present. 
+            var persisterMock = new Mock<XmlPersistanceService<GeneralSettings>>();
+            persisterMock.Setup(x => x.FilePath).Returns("C:\\some\\non\\existent\\path\\rubberduck");
+            persisterMock.CallBase = true;
+            var configProvider = new GeneralConfigProvider(persisterMock.Object);
 
-        //    Assert.AreEqual(defaultConfig.UserSettings.GeneralSettings.Delimiter, (char)viewModel.Delimiter);
-        //}
+            var settings = configProvider.Create();
+            var defaultSettings = configProvider.CreateDefaults();
+
+            Assert.AreEqual(defaultSettings, settings);
+        }
     }
 }


### PR DESCRIPTION
Closes #4694 
Closes #4668

Also adds an unit test to prove that the default settings will be loaded even if the file is missing. Also, the `InitializeAddIn` is now completely wrapped in the try/catch to ensure that if exception are thrown anywhere else, we will get an error message and logs rather than just silently loading a non-working instance.