### PR TITLE
Fix ParameterCanBeByValInspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/NonReturningFunctionInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/NonReturningFunctionInspection.cs
@@ -51,7 +51,7 @@ namespace Rubberduck.Inspections.Concrete
         private bool IsAssignedByRefArgument(Declaration enclosingProcedure, IdentifierReference reference)
         {
             var argExpression = reference.Context.GetAncestor<VBAParser.ArgumentExpressionContext>();
-            var parameter = State.DeclarationFinder.FindParameterFromArgument(argExpression, enclosingProcedure);
+            var parameter = State.DeclarationFinder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, enclosingProcedure);
 
             // note: not recursive, by design.
             return parameter != null

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
@@ -108,9 +108,7 @@ namespace Rubberduck.Inspections.Concrete
                     for (var i = 0; i < implementationParameters.Count; i++)
                     {
                         parameterCanBeChangedToBeByVal[i] = parameterCanBeChangedToBeByVal[i]
-                                                            && !IsPotentiallyUsedAsByRefParameter(implementationParameters[i]) 
-                                                            && ((VBAParser.ArgContext)implementationParameters[i].Context).BYVAL() == null 
-                                                            && !implementationParameters[i].References.Any(reference => reference.IsAssignment);
+                                                            && CanBeChangedToBePassedByValIndividually(implementationParameters[i]);
                     }
                 }
 
@@ -153,9 +151,7 @@ namespace Rubberduck.Inspections.Concrete
                     for (var i = 0; i < handlerParameters.Count; i++)
                     {
                         parameterCanBeChangedToBeByVal[i] = parameterCanBeChangedToBeByVal[i] 
-                                                            && !IsPotentiallyUsedAsByRefParameter(handlerParameters[i]) 
-                                                            && ((VBAParser.ArgContext)handlerParameters[i].Context).BYVAL() == null 
-                                                            && !handlerParameters[i].References.Any(reference => reference.IsAssignment);
+                                                            && CanBeChangedToBePassedByValIndividually(handlerParameters[i]);
                     }
                 }
 

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
@@ -95,7 +95,7 @@ namespace Rubberduck.Inspections.Concrete
                     continue;
                 }
 
-                var parameterCanBeChangedToBeByVal = interfaceParameters.Select(parameter => parameter.IsByRef).ToList();
+                var parameterCanBeChangedToBeByVal = interfaceParameters.Select(parameter => CanBeChangedToBePassedByValIndividually(parameter)).ToList();
 
                 var implementingMembers = State.DeclarationFinder.FindInterfaceImplementationMembers(memberDeclaration);
                 foreach (var implementingMember in implementingMembers)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
@@ -1,14 +1,17 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Rubberduck.Common;
 using Rubberduck.Inspections.Abstract;
 using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Resources.Inspections;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Extensions;
 
 namespace Rubberduck.Inspections.Concrete
 {
@@ -19,132 +22,175 @@ namespace Rubberduck.Inspections.Concrete
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
-            var declarations = UserDeclarations.ToArray();
-            var issues = new List<IInspectionResult>();
+            var parameters = State.DeclarationFinder
+                .UserDeclarations(DeclarationType.Parameter)
+                .OfType<ParameterDeclaration>().ToList();
+            var parametersThatCanBeChangedToBePassedByVal = new List<ParameterDeclaration>();
 
-            var interfaceDeclarationMembers = State.DeclarationFinder.FindAllInterfaceMembers().ToArray();
-            var interfaceScopes = State.DeclarationFinder.FindAllInterfaceImplementingMembers().Concat(interfaceDeclarationMembers).Select(s => s.Scope).ToArray();
+            var interfaceDeclarationMembers = State.DeclarationFinder.FindAllInterfaceMembers().ToList();
+            var interfaceScopeDeclarations = State.DeclarationFinder
+                .FindAllInterfaceImplementingMembers()
+                .Concat(interfaceDeclarationMembers)
+                .ToHashSet();
 
-            issues.AddRange(GetResults(declarations, interfaceDeclarationMembers));
+            parametersThatCanBeChangedToBePassedByVal.AddRange(InterFaceMembersThatCanBeChangedToBePassedByVal(interfaceDeclarationMembers));
 
-            var eventMembers = declarations.Where(item => item.DeclarationType == DeclarationType.Event).ToArray();
-            var formEventHandlerScopes = State.FindFormEventHandlers().Select(handler => handler.Scope).ToArray();
-            var eventHandlerScopes = State.DeclarationFinder.FindEventHandlers().Concat(declarations.FindUserEventHandlers()).Select(e => e.Scope).ToArray();
-            var eventScopes = eventMembers.Select(s => s.Scope)
-                .Concat(formEventHandlerScopes)
-                .Concat(eventHandlerScopes)
-                .ToArray();
+            var eventMembers = State.DeclarationFinder.UserDeclarations(DeclarationType.Event).ToList();
+            var formEventHandlerScopeDeclarations = State.FindFormEventHandlers();
+            var eventHandlerScopeDeclarations = State.DeclarationFinder.FindEventHandlers().Concat(parameters.FindUserEventHandlers());
+            var eventScopeDeclarations = eventMembers
+                .Concat(formEventHandlerScopeDeclarations)
+                .Concat(eventHandlerScopeDeclarations)
+                .ToHashSet();
 
-            issues.AddRange(GetResults(declarations, eventMembers));
+            parametersThatCanBeChangedToBePassedByVal.AddRange(EventMembersThatCanBeChangedToBePassedByVal(eventMembers));
 
-            var declareScopes = declarations.Where(item =>
-                    item.DeclarationType == DeclarationType.LibraryFunction
-                    || item.DeclarationType == DeclarationType.LibraryProcedure)
-                .Select(e => e.Scope)
-                .ToArray();
-            
-            issues.AddRange(declarations.OfType<ParameterDeclaration>()
-                .Where(declaration => IsIssue(declaration, declarations, declareScopes, eventScopes, interfaceScopes))
-                .Select(issue => new DeclarationInspectionResult(this, string.Format(InspectionResults.ParameterCanBeByValInspection, issue.IdentifierName), issue)));
+            parametersThatCanBeChangedToBePassedByVal
+                .AddRange(parameters.Where(parameter => CanBeChangedToBePassedByVal(parameter, eventScopeDeclarations, interfaceScopeDeclarations)));
 
-            return issues;
+            return parametersThatCanBeChangedToBePassedByVal
+                .Where(parameter => !IsIgnoringInspectionResultFor(parameter, AnnotationName))
+                .Select(parameter => new DeclarationInspectionResult(this, string.Format(InspectionResults.ParameterCanBeByValInspection, parameter.IdentifierName), parameter));
         }
 
-        private bool IsIssue(ParameterDeclaration declaration, Declaration[] userDeclarations, string[] declareScopes, string[] eventScopes, string[] interfaceScopes)
+        private bool CanBeChangedToBePassedByVal(ParameterDeclaration parameter, HashSet<Declaration> eventScopeDeclarations, HashSet<Declaration> interfaceScopeDeclarations)
         {
-            var isIssue = 
-                !declaration.IsArray
-                && !declaration.IsParamArray
-                && (declaration.IsByRef || declaration.IsImplicitByRef)
-                && (declaration.AsTypeDeclaration == null || declaration.AsTypeDeclaration.DeclarationType != DeclarationType.ClassModule && declaration.AsTypeDeclaration.DeclarationType != DeclarationType.UserDefinedType && declaration.AsTypeDeclaration.DeclarationType != DeclarationType.Enumeration)
-                && !declareScopes.Contains(declaration.ParentScope)
-                && !eventScopes.Contains(declaration.ParentScope)
-                && !interfaceScopes.Contains(declaration.ParentScope)
-                && !IsUsedAsByRefParam(userDeclarations, declaration)
-                && (!declaration.References.Any() || !declaration.References.Any(reference => reference.IsAssignment));
+            var enclosingMember = parameter.ParentScopeDeclaration;
+            var isIssue = !interfaceScopeDeclarations.Contains(enclosingMember)
+                          && !eventScopeDeclarations.Contains(enclosingMember)
+                          && CanBeChangedToBePassedByValIndividually(parameter);
             return isIssue;
         }
 
-        private IEnumerable<IInspectionResult> GetResults(Declaration[] declarations, Declaration[] declarationMembers)
+        private bool CanBeChangedToBePassedByValIndividually(ParameterDeclaration parameter)
         {
-            foreach (var declaration in declarationMembers)
+            var canPossiblyBeChangedToBePassedByVal =
+                !parameter.IsArray
+                && !parameter.IsParamArray
+                && (parameter.IsByRef || parameter.IsImplicitByRef)
+                && !IsParameterOfDeclaredLibraryFunction(parameter)
+                && (parameter.AsTypeDeclaration == null 
+                    || (parameter.AsTypeDeclaration.DeclarationType != DeclarationType.ClassModule 
+                        && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.UserDefinedType 
+                        && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.Enumeration))
+                && !parameter.References.Any(reference => reference.IsAssignment)
+                && !IsPotentiallyUsedAsByRefParameter(parameter);
+            return canPossiblyBeChangedToBePassedByVal;
+        }
+
+        private static bool IsParameterOfDeclaredLibraryFunction(ParameterDeclaration parameter)
+        {
+            var parentMember = parameter.ParentScopeDeclaration;
+            return parentMember.DeclarationType == DeclarationType.LibraryFunction
+                   || parentMember.DeclarationType == DeclarationType.LibraryProcedure;
+        }
+
+        private IEnumerable<ParameterDeclaration> InterFaceMembersThatCanBeChangedToBePassedByVal(List<Declaration> interfaceMembers)
+        {
+            foreach (var memberDeclaration in interfaceMembers.OfType<ModuleBodyElementDeclaration>())
             {
-                var declarationParameters = declarations.OfType<ParameterDeclaration>()
-                    .Where(d => Equals(d.ParentDeclaration, declaration))
-                    .OrderBy(o => o.Selection.StartLine)
-                    .ThenBy(t => t.Selection.StartColumn)
-                    .ToList();
-
-                if (!declarationParameters.Any()) { continue; }
-                var parametersAreByRef = declarationParameters.Select(s => true).ToList();
-
-                var members = declarationMembers.Any(a => a.DeclarationType == DeclarationType.Event)
-                    ? declarations.FindHandlersForEvent(declaration).Select(s => s.Item2).ToList()
-                    : State.DeclarationFinder.FindInterfaceImplementationMembers(declaration).Cast<Declaration>().ToList();
-
-                foreach (var member in members)
+                var interfaceParameters = memberDeclaration.Parameters.ToList();
+                if (!interfaceParameters.Any())
                 {
-                    var parameters = declarations.OfType<ParameterDeclaration>()
-                        .Where(d => Equals(d.ParentDeclaration, member))
-                        .OrderBy(o => o.Selection.StartLine)
-                        .ThenBy(t => t.Selection.StartColumn)
-                        .ToList();
+                    continue;
+                }
+
+                var parameterCanBeChangedToBeByVal = interfaceParameters.Select(parameter => parameter.IsByRef).ToList();
+
+                var implementingMembers = State.DeclarationFinder.FindInterfaceImplementationMembers(memberDeclaration);
+                foreach (var implementingMember in implementingMembers)
+                {
+                    var implementationParameters = implementingMember.Parameters.ToList();
 
                     //If you hit this assert, reopen https://github.com/rubberduck-vba/Rubberduck/issues/3906
-                    Debug.Assert(parametersAreByRef.Count == parameters.Count);
+                    Debug.Assert(parameterCanBeChangedToBeByVal.Count == implementationParameters.Count);
 
-                    for (var i = 0; i < parameters.Count; i++)
+                    for (var i = 0; i < implementationParameters.Count; i++)
                     {
-                        parametersAreByRef[i] = parametersAreByRef[i] &&
-                                                !IsUsedAsByRefParam(declarations, parameters[i]) &&
-                                                ((VBAParser.ArgContext) parameters[i].Context).BYVAL() == null &&
-                                                !parameters[i].References.Any(reference => reference.IsAssignment);
+                        parameterCanBeChangedToBeByVal[i] = parameterCanBeChangedToBeByVal[i]
+                                                            && !IsPotentiallyUsedAsByRefParameter(implementationParameters[i]) 
+                                                            && ((VBAParser.ArgContext)implementationParameters[i].Context).BYVAL() == null 
+                                                            && !implementationParameters[i].References.Any(reference => reference.IsAssignment);
                     }
                 }
 
-                for (var i = 0; i < declarationParameters.Count; i++)
+                for (var i = 0; i < parameterCanBeChangedToBeByVal.Count; i++)
                 {
-                    if (parametersAreByRef[i])
+                    if (parameterCanBeChangedToBeByVal[i])
                     {
-                        yield return new DeclarationInspectionResult(this,
-                                                          string.Format(InspectionResults.ParameterCanBeByValInspection, declarationParameters[i].IdentifierName),
-                                                          declarationParameters[i]);
+                        yield return interfaceParameters[i];
                     }
                 }
             }
         }
 
-        private static bool IsUsedAsByRefParam(IEnumerable<Declaration> declarations, Declaration parameter)
+        private IEnumerable<ParameterDeclaration> EventMembersThatCanBeChangedToBePassedByVal(IEnumerable<Declaration> eventMembers)
         {
-            // find the procedure calls in the procedure of the parameter.
-            // note: works harder than it needs to when procedure has more than a single procedure call...
-            //       ...but caching [declarations] would be a memory leak
-            var items = declarations as List<Declaration> ?? declarations.ToList();
-
-            var procedureCalls = items.Where(item => item.DeclarationType.HasFlag(DeclarationType.Member))
-                .SelectMany(member => member.References.Where(reference => reference.ParentScoping.Equals(parameter.ParentScopeDeclaration)))
-                .GroupBy(call => call.Declaration)
-                .ToList(); // only check a procedure once. its declaration doesn't change if it's called 20 times anyway.
-
-            foreach (var item in procedureCalls)
+            foreach (var memberDeclaration in eventMembers)
             {
-                var calledProcedureArgs = items
-                    .Where(arg => arg.DeclarationType == DeclarationType.Parameter && arg.ParentScope == item.Key.Scope)
-                    .OrderBy(arg => arg.Selection.StartLine)
-                    .ThenBy(arg => arg.Selection.StartColumn)
-                    .ToArray();
-
-                foreach (var declaration in calledProcedureArgs)
+                var eventParameters = (memberDeclaration as IParameterizedDeclaration)?.Parameters.ToList();
+                if (!eventParameters?.Any() ?? false)
                 {
-                    if (((VBAParser.ArgContext) declaration.Context).BYVAL() != null)
-                    {
-                        continue;
-                    }
+                    continue;
+                }
 
-                    if (declaration.References.Any(reference => reference.IsAssignment))
+                var parameterCanBeChangedToBeByVal = eventParameters.Select(parameter => parameter.IsByRef).ToList();
+
+                //todo: Find a better way to find the handlers.
+                var eventHandlers = State.DeclarationFinder
+                    .AllUserDeclarations
+                    .FindHandlersForEvent(memberDeclaration)
+                    .Select(s => s.Item2)
+                    .ToList();
+
+                foreach (var eventHandler in eventHandlers.OfType<IParameterizedDeclaration>())
+                {
+                    var handlerParameters = eventHandler.Parameters.ToList();
+
+                    //If you hit this assert, reopen https://github.com/rubberduck-vba/Rubberduck/issues/3906
+                    Debug.Assert(parameterCanBeChangedToBeByVal.Count == handlerParameters.Count);
+
+                    for (var i = 0; i < handlerParameters.Count; i++)
                     {
-                        return true;
+                        parameterCanBeChangedToBeByVal[i] = parameterCanBeChangedToBeByVal[i] 
+                                                            && !IsPotentiallyUsedAsByRefParameter(handlerParameters[i]) 
+                                                            && ((VBAParser.ArgContext)handlerParameters[i].Context).BYVAL() == null 
+                                                            && !handlerParameters[i].References.Any(reference => reference.IsAssignment);
                     }
+                }
+
+                for (var i = 0; i < parameterCanBeChangedToBeByVal.Count; i++)
+                {
+                    if (parameterCanBeChangedToBeByVal[i])
+                    {
+                        yield return eventParameters[i];
+                    }
+                }
+            }
+        }
+
+        private bool IsPotentiallyUsedAsByRefParameter(ParameterDeclaration parameter)
+        {
+            //The condition on the text of the argument context excludes the cases where the argument is either passed explicitly by value 
+            //or used inside a non-trivial expression, e.g. an arithmetic expression.
+            var argumentsBeingTheParameter = parameter.References
+                .Select(reference => reference.Context.GetAncestor<VBAParser.ArgumentExpressionContext>())
+                .Where(context => context != null && context.GetText().Equals(parameter.IdentifierName, StringComparison.OrdinalIgnoreCase));
+
+            foreach (var argument in argumentsBeingTheParameter)
+            {
+                var parameterCorrespondingToArgument = State.DeclarationFinder
+                    .FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argument, parameter.QualifiedModuleName);
+
+                if (parameterCorrespondingToArgument == null)
+                {
+                    //We have no idea what parameter it is passed to ar argument. So, we have to err on the safe side and assume it is passed by reference.
+                    return true;
+                }
+
+                if (parameterCorrespondingToArgument.IsByRef)
+                {
+                    return true;
                 }
             }
 

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnassignedVariableUsageInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnassignedVariableUsageInspection.cs
@@ -54,7 +54,7 @@ namespace Rubberduck.Inspections.Concrete
         private bool IsAssignedByRefArgument(Declaration enclosingProcedure, IdentifierReference reference)
         {
             var argExpression = reference.Context.GetAncestor<VBAParser.ArgumentExpressionContext>();
-            var parameter = State.DeclarationFinder.FindParameterFromArgument(argExpression, enclosingProcedure);
+            var parameter = State.DeclarationFinder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, enclosingProcedure);
 
             // note: not recursive, by design.
             return parameter != null

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
@@ -37,7 +37,7 @@ namespace Rubberduck.Inspections.Concrete
         private bool IsAssignedByRefArgument(Declaration enclosingProcedure, IdentifierReference reference)
         {
             var argExpression = reference.Context.GetAncestor<VBAParser.ArgumentExpressionContext>();
-            var parameter = State.DeclarationFinder.FindParameterFromArgument(argExpression, enclosingProcedure);
+            var parameter = State.DeclarationFinder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, enclosingProcedure);
 
             // note: not recursive, by design.
             return parameter != null

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Antlr4.Runtime;
 using NLog;
 using Rubberduck.Parsing.Annotations;
@@ -542,46 +543,34 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                 : Enumerable.Empty<Declaration>();
         }
 
-        public ParameterDeclaration FindParameterFromArgument(VBAParser.ArgumentExpressionContext argExpression, Declaration enclosingProcedure)
+        public ParameterDeclaration FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(VBAParser.ArgumentExpressionContext argumentExpression, Declaration enclosingProcedure)
         {
-            if (argExpression  == null || 
-                argExpression.GetDescendent<VBAParser.ParenthesizedExprContext>() != null || 
-                argExpression.BYVAL() != null)
+            return FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argumentExpression, enclosingProcedure.QualifiedModuleName);
+        }
+
+        public ParameterDeclaration FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(VBAParser.ArgumentExpressionContext argumentExpression, QualifiedModuleName module)
+        {
+            //todo: Rename after making it work for more general cases.
+
+            if (argumentExpression  == null 
+                || argumentExpression.GetDescendent<VBAParser.ParenthesizedExprContext>() != null 
+                || argumentExpression.BYVAL() != null)
             {
-                // not an argument, or argument is parenthesized and thus passed ByVal
+                // not a simple argument, or argument is parenthesized and thus passed ByVal
                 return null;
             }
 
-            var callStmt = argExpression.GetAncestor<VBAParser.CallStmtContext>();
-
-            var identifier = callStmt?
-                .GetDescendent<VBAParser.LExpressionContext>()
-                .GetDescendents<VBAParser.IdentifierContext>()
-                .LastOrDefault();
-
-            if (identifier == null)
+            var callingNonDefaultMember = CallingNonDefaultMember(argumentExpression, module);
+            if (callingNonDefaultMember == null)
             {
-                // if we don't know what we're calling, we can't dig any further
+                // Either we could not resolve the call or there is a default member call involved. 
                 return null;
             }
 
-            var selection = new QualifiedSelection(enclosingProcedure.QualifiedModuleName, identifier.GetSelection());
-            if (!_referencesBySelection.TryGetValue(selection, out var matches))
-            {
-                return null;
-            }
-
-            var procedure = matches.SingleOrDefault()?.Declaration;
-            if (procedure?.ParentScopeDeclaration is ClassModuleDeclaration)
-            {
-                // we can't know that the member is on the class' default interface
-                return null;
-            }
-
-            var parameters = Parameters(procedure);
+            var parameters = Parameters(callingNonDefaultMember);
 
             ParameterDeclaration parameter;
-            var namedArg = argExpression.GetAncestor<VBAParser.NamedArgumentContext>();
+            var namedArg = argumentExpression.GetAncestor<VBAParser.NamedArgumentContext>();
             if (namedArg != null)
             {
                 // argument is named: we're lucky
@@ -591,11 +580,11 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             else
             {
                 // argument is positional: work out its index
-                var argList = callStmt.GetDescendent<VBAParser.ArgumentListContext>();
-                var args = argList.GetDescendents<VBAParser.PositionalArgumentContext>().ToArray();
+                var argumentList = argumentExpression.GetAncestor<VBAParser.ArgumentListContext>();
+                var arguments = argumentList.GetDescendents<VBAParser.PositionalArgumentContext>().ToArray();
 
-                var parameterIndex = args
-                    .Select((param, index) => param.GetDescendent<VBAParser.ArgumentExpressionContext>() == argExpression ? (param, index) : (null, -1))
+                var parameterIndex = arguments
+                    .Select((param, index) => param.GetDescendent<VBAParser.ArgumentExpressionContext>() == argumentExpression ? (param, index) : (null, -1))
                     .SingleOrDefault(item => item.param != null).index;
 
                 parameter = parameters
@@ -605,6 +594,74 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             }
 
             return parameter;
+        }
+
+        private ModuleBodyElementDeclaration CallingNonDefaultMember(VBAParser.ArgumentExpressionContext argumentExpression, QualifiedModuleName module)
+        {
+            //todo: Make this work for default member calls.
+
+            var argumentList = argumentExpression.GetAncestor<VBAParser.ArgumentListContext>();
+            var cannotHaveDefaultMemberCall = false;
+
+            ParserRuleContext callingExpression;
+            switch (argumentList.Parent)
+            {
+                case VBAParser.CallStmtContext callStmt:
+                    cannotHaveDefaultMemberCall = true;
+                    callingExpression = callStmt.lExpression();
+                    break;
+                case VBAParser.IndexExprContext indexExpr:
+                    callingExpression = indexExpr.lExpression();
+                    break;
+                case VBAParser.WhitespaceIndexExprContext indexExpr:
+                    callingExpression = indexExpr.lExpression();
+                    break;
+                default:
+                    //This should never happen.
+                    return null;
+            }
+
+            VBAParser.IdentifierContext callingIdentifier;
+            if (cannotHaveDefaultMemberCall)
+            {
+                callingIdentifier = callingExpression
+                    .GetDescendents<VBAParser.IdentifierContext>()
+                    .LastOrDefault();
+            }
+            else
+            {
+                switch (callingExpression)
+                {
+                    case VBAParser.SimpleNameExprContext simpleName:
+                        callingIdentifier = simpleName.identifier();
+                        break;
+                    case VBAParser.MemberAccessExprContext memberAccess:
+                        callingIdentifier = memberAccess
+                            .GetDescendents<VBAParser.IdentifierContext>()
+                            .LastOrDefault();
+                        break;
+                    case VBAParser.WithMemberAccessExprContext memberAccess:
+                        callingIdentifier = memberAccess
+                            .GetDescendents<VBAParser.IdentifierContext>()
+                            .LastOrDefault();
+                        break;
+                    default:
+                        //This is only possible in case of a default member access.
+                        return null;
+                }
+            }
+
+            if (callingIdentifier == null)
+            {
+                return null;
+            }
+
+            var referencedMember = IdentifierReferences(callingIdentifier, module)
+                .Select(reference => reference.Declaration)
+                .OfType<ModuleBodyElementDeclaration>()
+                .FirstOrDefault();
+
+            return referencedMember;
         }
 
         private string ToNormalizedName(string name)
@@ -1251,6 +1308,16 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             return _referencesByModule.TryGetValue(module, out var value)
                 ? value
                 : Enumerable.Empty<IdentifierReference>();
+        }
+
+        /// <summary>
+        /// Gets all identifier references for an IdentifierContext.
+        /// </summary>
+        public IEnumerable<IdentifierReference> IdentifierReferences(VBAParser.IdentifierContext identifierContext, QualifiedModuleName module)
+        {
+            var qualifiedSelection = new QualifiedSelection(module, identifierContext.GetSelection());
+            return IdentifierReferences(qualifiedSelection)
+                .Where(identifierReference => identifierReference.IdentifierName.Equals(identifierContext.GetText()));
         }
 
         /// <summary>

--- a/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
@@ -589,7 +589,7 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_SingleParamAssignedTo()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamAssignedTo_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -627,7 +627,40 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethod()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamAssignedTo_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Sub DoSomething(ByRef a As Integer)
+    a = 42
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any());
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethod_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -668,7 +701,43 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethodExplicitlyByVal()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethod_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Sub DoSomething(ByRef a As Integer)
+    DoSomethingElse a
+End Sub
+
+Private Sub DoSomethingElse(ByRef bar As Integer)
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any(result => result.Target.IdentifierName.Equals("a")));
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethodExplicitlyByVal_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -709,7 +778,42 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethodPartOfExpression()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethodExplicitlyByVal_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Sub DoSomething(ByRef a As Integer)
+    DoSomethingElse (a)
+End Sub
+
+Private Sub DoSomethingElse(ByRef bar As Integer)
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer)
+End Sub";
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count(result => result.Target.IdentifierName.Equals("a")));
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethodPartOfExpression_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -750,7 +854,43 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEvent()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamUsedByRefMethodPartOfExpression_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Sub DoSomething(ByRef a As Integer)
+    DoSomethingElse a + 42
+End Sub
+
+Private Sub DoSomethingElse(ByRef bar As Integer)
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count(result => result.Target.IdentifierName.Equals("a")));
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEvent_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -790,7 +930,42 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEventExplicitlyByVal()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEvent_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Event Bar(ByRef foo As Integer)
+
+Public Sub DoSomething(ByRef a As Integer)
+    RaiseEvent Bar(a)
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.IsFalse(inspectionResults.Any(result => result.Target.IdentifierName.Equals("a")));
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEventExplicitlyByVal_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -830,7 +1005,42 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEventPartOfExpression()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEventExplicitlyByVal_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Event Bar(ByRef foo As Integer)
+
+Public Sub DoSomething(ByRef a As Integer)
+    RaiseEvent Bar(ByVal a)
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count(result => result.Target.IdentifierName.Equals("a")));
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEventPartOfExpression_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -870,7 +1080,42 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ParameterCanBeByVal_InterfaceMember_MultipleParams_OneCanBeByVal()
+        public void ParameterCanBeByVal_InterfaceMember_SingleParamByRefEventPartOfExpression_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Event Bar(ByRef foo As Integer)
+
+Public Sub DoSomething(ByRef a As Integer)
+    RaiseEvent Bar(a + 15)
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual(1, inspectionResults.Count(result => result.Target.IdentifierName.Equals("a")));
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_MultipleParams_OneCanBeByVal_InImplementation()
         {
             //Input
             const string inputCode1 =
@@ -893,6 +1138,39 @@ End Sub";
                 .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
                 .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
                 .AddComponent("Class2", ComponentType.ClassModule, inputCode3)
+                .Build();
+            var vbe = builder.AddProject(project).Build();
+
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual("a", inspectionResults.Single().Target.IdentifierName);
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ParameterCanBeByVal_InterfaceMember_MultipleParams_OneCanBeByVal_InInterface()
+        {
+            //Input
+            const string inputCode1 =
+                @"Public Sub DoSomething(ByRef a As Integer, ByRef b As Integer)
+    b = 42
+End Sub";
+            const string inputCode2 =
+                @"Implements IClass1
+
+Private Sub IClass1_DoSomething(ByRef a As Integer, ByRef b As Integer)
+End Sub";
+
+            var builder = new MockVbeBuilder();
+            var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
+                .AddComponent("IClass1", ComponentType.ClassModule, inputCode1)
+                .AddComponent("Class1", ComponentType.ClassModule, inputCode2)
+                .AddComponent("Class2", ComponentType.ClassModule, inputCode2)
                 .Build();
             var vbe = builder.AddProject(project).Build();
 

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -1245,7 +1245,7 @@ End Sub
 
                 var enclosing = declarations.FirstOrDefault(decl => decl.IdentifierName.Equals("Bar"));
                 var context = enclosing?.Context.GetDescendent<VBAParser.ArgumentExpressionContext>();
-                var actual = state.DeclarationFinder.FindParameterFromArgument(context, enclosing);
+                var actual = state.DeclarationFinder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(context, enclosing);
 
                 Assert.AreEqual(expected, actual);
             }


### PR DESCRIPTION
This PR closes #4719.

This is a redesign of the `ParameterCanBeByValInspection`, which was implemented in a confusing way.

Now, the parts for interfaces and events use the same base logic to determin whether a parameter of an individual member could be passed by value. This logic also has been redesigned heavily. Now, it really looks at the references to the parameter and evaluates whether these references correspond to assignments or ByRef parameters.

This PR also fixes that the inspection ignored that in VBA an implemented interface can have an implementation of its own.