### PR TITLE
Introduce the ISelectionService

### DIFF
--- a/Rubberduck.VBEEditor/Utility/ISelectionService.cs
+++ b/Rubberduck.VBEEditor/Utility/ISelectionService.cs
@@ -1,0 +1,12 @@
+﻿namespace Rubberduck.VBEditor.Utility
+{
+    public interface ISelectionService
+    {
+        QualifiedSelection? ActiveSelection();
+        Selection? Selection(QualifiedModuleName module);
+        bool TryActivate(QualifiedModuleName module);
+        bool TrySetActiveSelection(QualifiedSelection selection);
+        bool TrySetSelection(QualifiedModuleName module, Selection selection);
+        bool TrySetSelection(QualifiedSelection selection);
+    }
+}

--- a/Rubberduck.VBEEditor/Utility/SelectionService.cs
+++ b/Rubberduck.VBEEditor/Utility/SelectionService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NLog;
 using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
@@ -8,6 +9,8 @@ namespace Rubberduck.VBEditor.Utility
     {
         private readonly IProjectsProvider _projectsProvider;
         private readonly IVBE _vbe;
+
+        private Logger _logger = LogManager.GetCurrentClassLogger();
 
         public SelectionService(IVBE vbe, IProjectsProvider projectsProvider)
         {
@@ -57,8 +60,9 @@ namespace Rubberduck.VBEditor.Utility
 
                 return true;
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                _logger.Debug(exception, $"Failed to activate the code pane of module {module}.");
                 return false;
             }
         }
@@ -99,8 +103,9 @@ namespace Rubberduck.VBEditor.Utility
 
                 return true;
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                _logger.Debug(exception, $"Failed to set the selection of module {module} to {selection}.");
                 return false;
             }
         }

--- a/Rubberduck.VBEEditor/Utility/SelectionService.cs
+++ b/Rubberduck.VBEEditor/Utility/SelectionService.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Rubberduck.VBEditor.ComManagement;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.Utility
+{
+    public class SelectionService : ISelectionService
+    {
+        private readonly IProjectsProvider _projectsProvider;
+        private readonly IVBE _vbe;
+
+        public SelectionService(IVBE vbe, IProjectsProvider projectsProvider)
+        {
+            _vbe = vbe;
+            _projectsProvider = projectsProvider;
+        }
+
+
+        public QualifiedSelection? ActiveSelection()
+        {
+            using (var activeCodePane = _vbe.ActiveCodePane)
+            {
+                return activeCodePane?.GetQualifiedSelection();
+            }
+        }
+
+        public Selection? Selection(QualifiedModuleName module)
+        {
+            var component = _projectsProvider.Component(module);
+            if (component == null)
+            {
+                return null;
+            }
+
+            using (var codeModule = component.CodeModule)
+            using (var codePane = codeModule.CodePane)
+            {
+                return codePane.Selection;
+            }
+        }
+
+        public bool TryActivate(QualifiedModuleName module)
+        {
+            try
+            {
+                var component = _projectsProvider.Component(module);
+                if (component == null)
+                {
+                    return false;
+                }
+
+                using (var codeModule = component.CodeModule)
+                using(var codePane = codeModule.CodePane)
+                {
+                    _vbe.ActiveCodePane = codePane;
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public bool TrySetActiveSelection(QualifiedSelection selection)
+        {
+            var activeCodePane = _vbe.ActiveCodePane;
+
+            if (!TryActivate(selection.QualifiedName))
+            {
+                return false;
+            }
+
+            if (!TrySetSelection(selection))
+            {
+                TryActivate(activeCodePane.QualifiedModuleName);
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool TrySetSelection(QualifiedModuleName module, Selection selection)
+        {
+            try
+            {
+                var component = _projectsProvider.Component(module);
+                if (component == null)
+                {
+                    return false;
+                }
+
+                using (var codeModule = component.CodeModule)
+                using (var codePane = codeModule.CodePane)
+                {
+                    codePane.Selection = selection;
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public bool TrySetSelection(QualifiedSelection selection)
+        {
+            return TrySetSelection(selection.QualifiedName, selection.Selection);
+        }
+    }
+}

--- a/RubberduckTests/VBEditor/Utility/SelectionServiceTests.cs
+++ b/RubberduckTests/VBEditor/Utility/SelectionServiceTests.cs
@@ -1,0 +1,447 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Moq;
+using NUnit.Framework;
+using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.ComManagement;
+using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using Rubberduck.VBEditor.Utility;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.VBEditor.Utility
+{
+    [TestFixture]
+    public class SelectionServiceTests
+    {
+        [Test]
+        public void NoCodePaneOpen_ActiveSelectionReturnsNull()
+        {
+            var vbe = new Mock<IVBE>().Object;
+            var projectsProvider = new Mock<IProjectsProvider>().Object;
+
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var activeSelection = selectionService.ActiveSelection();
+            
+            Assert.IsNull(activeSelection);
+        }
+
+        [Test]
+        public void CodePaneOpen_ActiveSelectionReturnsSelectionOfActiveCodePane()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("activeModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", string.Empty)
+            }).Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            var selection = new Selection(2, 1);
+
+            activeCodePane.Selection = selection;
+            vbe.ActiveCodePane = activeCodePane;
+
+            var projectsProvider = new Mock<IProjectsProvider>().Object;
+
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var expectedActiveSelection = vbe.GetActiveSelection();
+            var actualActiveSelection = selectionService.ActiveSelection();
+
+            Assert.AreEqual(expectedActiveSelection, actualActiveSelection);
+        }
+
+        [Test]
+        public void ComponentExists_SelectionReturnsSelection()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("someModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", string.Empty)
+            }).Object;
+            var someCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("someModule")).CodeModule.CodePane;
+            var selection = new Selection(2, 1);
+            someCodePane.Selection = selection;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var module = someCodePane.QualifiedModuleName;
+
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var expectedSelection = someCodePane.Selection;
+            var actualSelection = selectionService.Selection(module);
+
+            Assert.AreEqual(expectedSelection, actualSelection);
+        }
+
+        [Test]
+        public void ComponentDoesNotExist_SelectionReturnsNull()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("someModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", string.Empty)
+            }).Object;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var module = new QualifiedModuleName("test", string.Empty, "yetAnotherModule");
+
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var actualSelection = selectionService.Selection(module);
+
+            Assert.IsNull(actualSelection);
+        }
+
+        [Test]
+        public void ComponentExists_TryActiveActivatesComponentAndReturnsTrue()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("activeModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", string.Empty)
+            }).Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            vbe.ActiveCodePane = activeCodePane;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var otherModule = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("otherModule")).QualifiedModuleName;
+            var success = selectionService.TryActivate(otherModule);
+
+            var expectedActiveModule = otherModule;
+            var actualActiveModule = vbe.ActiveCodePane.QualifiedModuleName;
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(expectedActiveModule, actualActiveModule);
+        }
+
+        [Test]
+        public void ComponentDoesNotExist_TryActiveDoesNotChangeTheActiveModuleAndReturnsFalse()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("activeModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", string.Empty)
+            }).Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            vbe.ActiveCodePane = activeCodePane;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var nonExistentModule = new QualifiedModuleName("test", string.Empty, "nonExistentModule");
+            var success = selectionService.TryActivate(nonExistentModule);
+
+            var expectedActiveModule = activeCodePane.QualifiedModuleName;
+            var actualActiveModule = vbe.ActiveCodePane.QualifiedModuleName;
+
+            Assert.IsFalse(success);
+            Assert.AreEqual(expectedActiveModule, actualActiveModule);
+        }
+
+        [Test]
+        public void VbeThrowsExceptionOnActivation_TryActiveDoesNotChangeTheActiveModuleAndReturnsFalse()
+        {
+            var vbeMock = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("activeModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", string.Empty)
+            });
+            var vbe = vbeMock.Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            vbe.ActiveCodePane = activeCodePane;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var otherCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("otherModule")).CodeModule.CodePane;
+            var otherModule = otherCodePane.QualifiedModuleName;
+            vbeMock.SetupSet(m => m.ActiveCodePane = otherCodePane).Callback(() => throw new COMException());
+
+            var success = selectionService.TryActivate(otherModule);
+
+            var expectedActiveModule = activeCodePane.QualifiedModuleName;
+            var actualActiveModule = vbe.ActiveCodePane.QualifiedModuleName;
+
+            Assert.IsFalse(success);
+            Assert.AreEqual(expectedActiveModule, actualActiveModule);
+        }
+
+        [Test]
+        public void ComponentExists_TrySetActiveSelectionSetsActiveSelectionAndReturnsTrue()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("activeModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}")
+            }).Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            var activeSelection = new Selection(2, 1);
+            activeCodePane.Selection = activeSelection;
+            vbe.ActiveCodePane = activeCodePane;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var otherModule = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("otherModule")).QualifiedModuleName;
+            var newSelection = new Selection(3, 1);
+            var newQualifiedSelection = new QualifiedSelection(otherModule, newSelection);
+
+            var success = selectionService.TrySetActiveSelection(newQualifiedSelection);
+
+            var expectedActiveModule = otherModule;
+            var actualActiveModule = vbe.ActiveCodePane.QualifiedModuleName;
+            var actualSelection = vbe.ActiveCodePane.Selection;
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(expectedActiveModule, actualActiveModule);
+            Assert.AreEqual(newSelection, actualSelection);
+        }
+
+        [Test]
+        public void ComponentDoesNotExist_TrySetActiveSelectionDoesNotChangeTheActiveSelectionAndReturnsFalse()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("activeModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}")
+            }).Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            var activeSelection = new Selection(2, 1);
+            activeCodePane.Selection = activeSelection;
+            vbe.ActiveCodePane = activeCodePane;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var nonExistentModule = new QualifiedModuleName("test", string.Empty, "nonExistentModule");
+            var newSelection = new Selection(3, 1);
+            var newQualifiedSelection = new QualifiedSelection(nonExistentModule, newSelection);
+
+            var success = selectionService.TrySetActiveSelection(newQualifiedSelection);
+
+            var expectedActiveModule = activeCodePane.QualifiedModuleName;
+            var actualActiveModule = vbe.ActiveCodePane.QualifiedModuleName;
+            var actualSelection = vbe.ActiveCodePane.Selection;
+
+            Assert.IsFalse(success);
+            Assert.AreEqual(expectedActiveModule, actualActiveModule);
+            Assert.AreEqual(activeSelection, actualSelection);
+        }
+
+        [Test]
+        public void VbeThrowsExceptionOnComponentActivation_TrySetActiveSelectionDoesNotChangeTheActiveSelectionAndReturnsFalse()
+        {
+            var vbeMock = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("activeModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}")
+            });
+            var vbe = vbeMock.Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            var activeSelection = new Selection(2, 1);
+            activeCodePane.Selection = activeSelection;
+            vbe.ActiveCodePane = activeCodePane;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var otherCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("otherModule")).CodeModule.CodePane;
+            var otherModule = otherCodePane.QualifiedModuleName;
+            var newSelection = new Selection(3, 1);
+            var newQualifiedSelection = new QualifiedSelection(otherModule, newSelection);
+            vbeMock.SetupSet(m => m.ActiveCodePane = otherCodePane).Callback(() => throw new COMException());
+
+            var success = selectionService.TrySetActiveSelection(newQualifiedSelection);
+
+            var expectedActiveModule = activeCodePane.QualifiedModuleName;
+            var actualActiveModule = vbe.ActiveCodePane.QualifiedModuleName;
+            var actualSelection = vbe.ActiveCodePane.Selection;
+
+            Assert.IsFalse(success);
+            Assert.AreEqual(expectedActiveModule, actualActiveModule);
+            Assert.AreEqual(activeSelection, actualSelection);
+        }
+
+        [Test]
+        public void SomeCodePaneOpen_ThrowsExceptionOnSelectionChange_TrySetActiveSelectionDoesNotChangeTheActiveCodePaneAndReturnsFalse()
+        {
+            var vbeBuilder = new MockVbeBuilder();
+            var activeSelection = new Selection(2, 1);
+            var projectBuilder = vbeBuilder.ProjectBuilder("test", ProjectProtection.Unprotected)
+                .AddComponent("activeModule", ComponentType.StandardModule, $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}", activeSelection)
+                .AddComponent("otherModule", ComponentType.StandardModule, $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}");
+
+            var vbe = projectBuilder.AddProjectToVbeBuilder().Build().Object;
+            var activeCodePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("activeModule")).CodeModule.CodePane;
+            vbe.ActiveCodePane = activeCodePane;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var otherCodeModuleMock = projectBuilder.MockCodeModules.Single(mock => mock.Object.Name.Equals("otherModule"));
+            var otherPaneMock = new Mock<ICodePane>();
+            otherPaneMock.SetupSet(m => m.Selection = It.IsAny<Selection>()).Callback(() => throw new COMException());
+            otherCodeModuleMock.SetupGet(m => m.CodePane).Returns(otherPaneMock.Object);
+            var otherModule = otherCodeModuleMock.Object.QualifiedModuleName;
+            var newSelection = new Selection(3, 1);
+            var newQualifiedSelection = new QualifiedSelection(otherModule, newSelection);
+
+            var success = selectionService.TrySetActiveSelection(newQualifiedSelection);
+
+            var expectedActiveModule = activeCodePane.QualifiedModuleName;
+            var actualActiveModule = vbe.ActiveCodePane.QualifiedModuleName;
+            var actualSelection = vbe.ActiveCodePane.Selection;
+
+            Assert.IsFalse(success);
+            Assert.AreEqual(expectedActiveModule, actualActiveModule);
+            Assert.AreEqual(activeSelection, actualSelection); ;
+        }
+
+        [Test]
+        public void ComponentExists_TrySetSelectionSetsSelectionOfModuleAndReturnsTrue()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("someModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}")
+            }).Object;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var somePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("someModule")).CodeModule.CodePane;
+            var someModule = somePane.QualifiedModuleName;
+            var newSelection = new Selection(3, 1);
+
+            var success = selectionService.TrySetSelection(someModule, newSelection);
+
+            var actualSelection = somePane.Selection;
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(newSelection, actualSelection);
+        }
+
+        [Test]
+        public void ComponentDoesNotExist_TrySetSelectionReturnsFalse()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("someModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}")
+            }).Object;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var nonExistentModule = new QualifiedModuleName("test", string.Empty, "nonExistentModule");
+            var newSelection = new Selection(3, 1);
+
+            var success = selectionService.TrySetSelection(nonExistentModule, newSelection);
+
+            Assert.IsFalse(success);
+        }
+
+        [Test]
+        public void ThrowsExceptionOnSelectionChange_TrySetSelectionReturnsFalse()
+        {
+            var vbeBuilder = new MockVbeBuilder();
+            var oldSelection = new Selection(2, 1);
+            var projectBuilder = vbeBuilder.ProjectBuilder("test", ProjectProtection.Unprotected)
+                .AddComponent("someModule", ComponentType.StandardModule, $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}", oldSelection)
+                .AddComponent("otherModule", ComponentType.StandardModule, $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}");
+
+            var vbe = projectBuilder.AddProjectToVbeBuilder().Build().Object;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var someCodeModuleMock = projectBuilder.MockCodeModules.Single(mock => mock.Object.Name.Equals("someModule"));
+            var somePaneMock = new Mock<ICodePane>();
+            somePaneMock.SetupSet(m => m.Selection = It.IsAny<Selection>()).Callback(() => throw new COMException());
+            someCodeModuleMock.SetupGet(m => m.CodePane).Returns(somePaneMock.Object);
+            var someModule = someCodeModuleMock.Object.QualifiedModuleName;
+            var newSelection = new Selection(3, 1);
+
+            var success = selectionService.TrySetSelection(someModule, newSelection);
+
+            Assert.IsFalse(success);
+        }
+
+        [Test]
+        public void ComponentExists_TrySetSelectionSetsSelectionOfModuleAndReturnsTrue_QualifiedSelesction()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("someModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}")
+            }).Object;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var somePane = vbe.VBProjects.Single().VBComponents.Single(comp => comp.Name.Equals("someModule")).CodeModule.CodePane;
+            var someModule = somePane.QualifiedModuleName;
+            var newSelection = new Selection(3, 1);
+            var newQualifiedSelection = new QualifiedSelection(someModule, newSelection);
+
+            var success = selectionService.TrySetSelection(newQualifiedSelection);
+
+            var actualSelection = somePane.Selection;
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(newSelection, actualSelection);
+        }
+
+        [Test]
+        public void ComponentDoesNotExist_TrySetSelectionReturnsFalse_QualifiedSelesction()
+        {
+            var vbe = MockVbeBuilder.BuildFromStdModules(new[]
+            {
+                ("someModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}"),
+                ("otherModule", $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}")
+            }).Object;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var nonExistentModule = new QualifiedModuleName("test", string.Empty, "nonExistentModule");
+            var newSelection = new Selection(3, 1);
+            var newQualifiedSelection = new QualifiedSelection(nonExistentModule, newSelection);
+
+            var success = selectionService.TrySetSelection(newQualifiedSelection);
+
+            Assert.IsFalse(success);
+        }
+
+        [Test]
+        public void ThrowsExceptionOnSelectionChange_TrySetSelectionReturnsFalse_QualifiedSelesction()
+        {
+            var vbeBuilder = new MockVbeBuilder();
+            var oldSelection = new Selection(2, 1);
+            var projectBuilder = vbeBuilder.ProjectBuilder("test", ProjectProtection.Unprotected)
+                .AddComponent("someModule", ComponentType.StandardModule, $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}", oldSelection)
+                .AddComponent("otherModule", ComponentType.StandardModule, $"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}");
+
+            var vbe = projectBuilder.AddProjectToVbeBuilder().Build().Object;
+            var projectsProvider = new ProjectsRepository(vbe);
+            projectsProvider.Refresh();
+            var selectionService = new SelectionService(vbe, projectsProvider);
+
+            var someCodeModuleMock = projectBuilder.MockCodeModules.Single(mock => mock.Object.Name.Equals("someModule"));
+            var somePaneMock = new Mock<ICodePane>();
+            somePaneMock.SetupSet(m => m.Selection = It.IsAny<Selection>()).Callback(() => throw new COMException());
+            someCodeModuleMock.SetupGet(m => m.CodePane).Returns(somePaneMock.Object);
+            var someModule = someCodeModuleMock.Object.QualifiedModuleName;
+            var newSelection = new Selection(3, 1);
+            var newQualifiedSelection = new QualifiedSelection(someModule, newSelection);
+
+            var success = selectionService.TrySetSelection(newQualifiedSelection);
+
+            Assert.IsFalse(success);
+        }
+    }
+} 


### PR DESCRIPTION
This service provides access to the active selection and selection of individual modules without involving COM wrappers directly; the interface only uses QMNs and selections.

It is currently not used anywhere. Future PRs might change that.