### PR TITLE
Last minute fixes.

### DIFF
--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -102,8 +102,8 @@ namespace Rubberduck.Navigation.CodeExplorer
                     return;
                 }
 
-                _selectedItem = value;
                 ExpandToNode(value);
+                _selectedItem = value;
 
                 OnPropertyChanged();
 
@@ -434,12 +434,12 @@ namespace Rubberduck.Navigation.CodeExplorer
         {
             while (true)
             {
+                node = node.Parent;
                 if (node == null)
                 {
                     return;
                 }
                 node.IsExpanded = true;
-                node = node.Parent;
             }
         }
 

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -337,10 +337,10 @@
     <value>'On Local Error'-Direktive</value>
   </data>
   <data name="IsMissingOnInappropriateArgumentInspection" xml:space="preserve">
-    <value>Unpassende Verwendung der 'IsMissing'-Funktion</value>
+    <value>Unpassende Verwendung der 'IsMissing'-Funktion - Parameter ist nicht vom Typ Variant</value>
   </data>
   <data name="IsMissingWithNonArgumentParameterInspection" xml:space="preserve">
-    <value>Unpassende Verwendung der 'IsMissing'-Funktion</value>
+    <value>Unpassende Verwendung der 'IsMissing'-Funktion - Lokale Variable kann nie fehlen</value>
   </data>
   <data name="AssignmentNotUsedInspection" xml:space="preserve">
     <value>Zuweisung wird nie gelesen</value>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -337,10 +337,10 @@
     <value>On Local Error statement</value>
   </data>
   <data name="IsMissingOnInappropriateArgumentInspection" xml:space="preserve">
-    <value>Inappropriate use of 'IsMissing' function</value>
+    <value>Inappropriate use of 'IsMissing' - Parameter is not 'Variant'</value>
   </data>
   <data name="IsMissingWithNonArgumentParameterInspection" xml:space="preserve">
-    <value>Inappropriate use of 'IsMissing' function</value>
+    <value>Inappropriate use of 'IsMissing' - Parameter is local variable</value>
   </data>
   <data name="AssignmentNotUsedInspection" xml:space="preserve">
     <value>Assignment is not used</value>

--- a/RubberduckTests/Inspections/GeneralInspectionTests.cs
+++ b/RubberduckTests/Inspections/GeneralInspectionTests.cs
@@ -54,6 +54,18 @@ namespace RubberduckTests.Inspections
 
         [Test]
         [Category("Inspections")]
+        public void InspectionNameStringsAreUnique()
+        {
+            var inspections = typeof(InspectionBase).Assembly.GetTypes()
+                .Where(type => GetAllBaseTypes(type).Contains(typeof(InspectionBase)) && !type.IsAbstract)
+                .Select(i => i.Name)
+                .ToList();
+
+            Assert.AreEqual(inspections.Count, inspections.Distinct().Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void InspectionMetaStringsExist()
         {
             var inspections = typeof(InspectionBase).Assembly.GetTypes()


### PR DESCRIPTION
Distinguish between IsMissing inspection names (closes #4740).

This also tweaks the expansion of nodes in the CE to not expand on single-click.