### PR TITLE
Fix regression on Add/Remove References Apply.

### DIFF
--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesModel.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using Rubberduck.AddRemoveReferences;
 using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
 using Rubberduck.Settings;
 
 namespace Rubberduck.UI.AddRemoveReferences
@@ -11,6 +12,7 @@ namespace Rubberduck.UI.AddRemoveReferences
     public interface IAddRemoveReferencesModel
     {
         string HostApplication { get; }
+        RubberduckParserState State { get; }
         ReferenceSettings Settings { get; set; }
         ProjectDeclaration Project { get; set; }
         List<ReferenceModel> References { get; set; }
@@ -21,8 +23,9 @@ namespace Rubberduck.UI.AddRemoveReferences
     {
         private static readonly string Host = Path.GetFileName(Application.ExecutablePath).ToUpperInvariant();
 
-        public AddRemoveReferencesModel(ProjectDeclaration project, IEnumerable<ReferenceModel> references, ReferenceSettings settings)
+        public AddRemoveReferencesModel(RubberduckParserState state, ProjectDeclaration project, IEnumerable<ReferenceModel> references, ReferenceSettings settings)
         {
+            State = state;
             Settings = settings;
             Project = project;
             References = references.ToList();
@@ -37,6 +40,8 @@ namespace Rubberduck.UI.AddRemoveReferences
         }
 
         public string HostApplication => Host;
+
+        public RubberduckParserState State { get; }
 
         public ReferenceSettings Settings { get; set; }
 

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesPresenterFactory.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesPresenterFactory.cs
@@ -118,7 +118,7 @@ namespace Rubberduck.UI.AddRemoveReferences
                 }
 
                 var settings = _settings.Create();
-                model = new AddRemoveReferencesModel(project, models.Values, settings);
+                model = new AddRemoveReferencesModel(_state, project, models.Values, settings);
                 if (AddRemoveReferencesViewModel.HostHasProjects)
                 {
                     model.References.AddRange(GetUserProjectFolderModels(model.Settings).Where(proj =>

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesViewModel.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesViewModel.cs
@@ -76,7 +76,7 @@ namespace Rubberduck.UI.AddRemoveReferences
         }
 
         public event EventHandler<DialogResult> OnWindowClosed;
-        private void CloseWindowOk() => OnWindowClosed?.Invoke(this, DialogResult.OK);
+        private void CloseWindowOk() => OnWindowClosed?.Invoke(this, IsProjectDirty ? DialogResult.OK : DialogResult.Cancel);
         private void CloseWindowCancel() => OnWindowClosed?.Invoke(this, DialogResult.Cancel);
 
         private readonly List<(int?, ReferenceInfo)> _clean;
@@ -300,6 +300,11 @@ namespace Rubberduck.UI.AddRemoveReferences
             }
             
             Model.State.OnParseRequested(this);
+
+            _clean.Clear();
+            _clean.AddRange(new List<(int?, ReferenceInfo)>(_project.Select(reference => (reference.Priority, reference.ToReferenceInfo()))));
+            IsProjectDirty = false;
+
             AvailableReferences.Refresh();
             ProjectReferences.Refresh();
         }

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesViewModel.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesViewModel.cs
@@ -9,6 +9,7 @@ using System.Windows.Data;
 using System.Windows.Forms;
 using NLog;
 using Rubberduck.AddRemoveReferences;
+using Rubberduck.Parsing.VBA;
 using Rubberduck.Resources;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor;
@@ -110,7 +111,7 @@ namespace Rubberduck.UI.AddRemoveReferences
            
             OkCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), _ => CloseWindowOk());
             CancelCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), _ => CloseWindowCancel());
-            ApplyCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteApplyCommand);
+            ApplyCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteApplyCommand, ApplyCanExecute);
         }
 
         public string ProjectCaption => string.IsNullOrEmpty(Model?.Project?.IdentifierName)
@@ -292,14 +293,20 @@ namespace Rubberduck.UI.AddRemoveReferences
         /// <param name="parameter">Ignored</param>
         private void ExecuteApplyCommand(object parameter)
         {
-            var changed = _reconciler.ReconcileReferences(Model, _available.ToList());
+            var changed = _reconciler.ReconcileReferences(Model, _project.ToList());
             foreach (var reference in changed.Where(reference => !_project.Contains(reference)).ToList())
             {
                 _project.Add(reference);
             }
             
+            Model.State.OnParseRequested(this);
             AvailableReferences.Refresh();
             ProjectReferences.Refresh();
+        }
+
+        private bool ApplyCanExecute(object parameter)
+        {
+            return Model.State.Status == ParserState.Ready;
         }
 
         /// <summary>

--- a/RubberduckTests/AddRemoveReferences/AddRemoveReferencesSetup.cs
+++ b/RubberduckTests/AddRemoveReferences/AddRemoveReferencesSetup.cs
@@ -257,7 +257,7 @@ namespace RubberduckTests.AddRemoveReferences
                 allReferences.AddRange(projects);
             }
 
-            var model = new AddRemoveReferencesModel(declaration, allReferences, settings);
+            var model = new AddRemoveReferencesModel(null, declaration, allReferences, settings);
             var reconciler = ArrangeReferenceReconciler(settings, out _, out libraryProvider);
             browserFactory = new Mock<IFileSystemBrowserFactory>();
 

--- a/RubberduckTests/AddRemoveReferences/AddRemoveReferencesViewModelTests.cs
+++ b/RubberduckTests/AddRemoveReferences/AddRemoveReferencesViewModelTests.cs
@@ -133,7 +133,7 @@ namespace RubberduckTests.AddRemoveReferences
         {
             var declaration = AddRemoveReferencesSetup.ArrangeMocksAndGetProject();
             var settings = AddRemoveReferencesSetup.GetNonDefaultReferenceSettings();
-            var model = new AddRemoveReferencesModel(declaration, SearchReferencesList, settings);
+            var model = new AddRemoveReferencesModel(null, declaration, SearchReferencesList, settings);
             var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler(settings);
 
             var viewModel = new AddRemoveReferencesViewModel(model, reconciler, new Mock<IFileSystemBrowserFactory>().Object);


### PR DESCRIPTION
Force a reparse on Apply - this apparently wasn't propagating the VBE events because the dialog is modal.