### PR TITLE
Fix mock setup and rename test setup

### DIFF
--- a/RubberduckTests/Mocks/MockProjectBuilder.cs
+++ b/RubberduckTests/Mocks/MockProjectBuilder.cs
@@ -321,12 +321,6 @@ namespace RubberduckTests.Mocks
             result.Setup(m => m.AddFromFile(It.IsAny<string>()));
 
             codePane.SetupGet(m => m.CodeModule).Returns(() => result.Object);
-            codePane.SetupSet(p => p.Selection)
-                .Callback(setValue =>
-                {
-                    codePane.Setup(p => p.GetQualifiedSelection()).Returns(new QualifiedSelection(new QualifiedModuleName(component.Object), setValue));
-                    codePane.SetupGet(p => p.Selection).Returns(setValue);
-                });
             return result;
         }
 

--- a/RubberduckTests/Mocks/MockVbeBuilder.cs
+++ b/RubberduckTests/Mocks/MockVbeBuilder.cs
@@ -82,9 +82,6 @@ namespace RubberduckTests.Mocks
             foreach (var component in _projects.SelectMany(vbProject => vbProject.VBComponents))
             {
                 _codePanes.Add(component.CodeModule.CodePane);
-                {
-                    _vbe.Setup(v => v.ActiveCodePane).Returns(component.CodeModule.CodePane);
-                }
             }
 
             _vbe.SetupGet(vbe => vbe.ActiveVBProject).Returns(project.Object);

--- a/RubberduckTests/Refactoring/Rename/RenameTestExecution.cs
+++ b/RubberduckTests/Refactoring/Rename/RenameTestExecution.cs
@@ -77,7 +77,7 @@ namespace RubberduckTests.Refactoring.Rename
             tdo.MsgBox.Setup(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(tdo.MsgBoxReturn == ConfirmationOutcome.Yes);
             
             var activeIndex = renameTMDs.FindIndex(tmd => tmd.Input_WithFauxCursor != string.Empty);
-            tdo.VBE = tdo.VBE ?? BuildProject(tdo.ProjectName, tdo.ModuleTestSetupDefs, activeIndex);
+            tdo.VBE = tdo.VBE ?? BuildProject(tdo.ProjectName, tdo.ModuleTestSetupDefs, activeIndex, tdo.UseLibraries);
             tdo.AdditionalSetup?.Invoke(tdo);
             (tdo.ParserState, tdo.RewritingManager) = MockParser.CreateAndParseWithRewritingManager(tdo.VBE);
 

--- a/RubberduckTests/Refactoring/Rename/RenameTests.cs
+++ b/RubberduckTests/Refactoring/Rename/RenameTests.cs
@@ -2,20 +2,13 @@ using System.Linq;
 using NUnit.Framework;
 using Moq;
 using Rubberduck.Parsing.Symbols;
-using Rubberduck.Refactorings;
 using Rubberduck.Refactorings.Rename;
 using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using RubberduckTests.Mocks;
-using System.Collections.Generic;
-using Rubberduck.Parsing.VBA;
 using Rubberduck.UI.Refactorings.Rename;
 using Rubberduck.Interaction;
-using Rubberduck.Common;
-using Rubberduck.UI.Refactorings;
-using RubberduckTests.Refactoring.MockIoC;
-using Rubberduck.Parsing.Rewriter;
 
 using static RubberduckTests.Refactoring.Rename.RenameTestExecution;
 


### PR DESCRIPTION
The mock setup has been broken in the refactoring dialog PR #4072.
The rename test setup never used the UseLibraries property. Thus, tests relying on it failed.