### PR TITLE
Implement ThunderCode inspections

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/KeywordsUsedAsMemberInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/KeywordsUsedAsMemberInspection.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+
+namespace Rubberduck.Inspections.Inspections.Concrete.ThunderCode
+{
+    public class KeywordsUsedAsMemberInspection : InspectionBase
+    {
+        public KeywordsUsedAsMemberInspection(RubberduckParserState state) : base(state) { }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            return State.DeclarationFinder.UserDeclarations(DeclarationType.UserDefinedTypeMember)
+                .Concat(State.DeclarationFinder.UserDeclarations(DeclarationType.EnumerationMember))
+                .Where(m => ReservedKeywords.Any(k => 
+                    k.ToLowerInvariant().Equals(
+                        m.IdentifierName.Trim().TrimStart('[').TrimEnd(']').ToLowerInvariant())))
+                .Select(m => new DeclarationInspectionResult(
+                    this,
+                    InspectionResults.KeywordsUsedAsMemberInspection.
+                        ThunderCodeFormat(m.IdentifierName),
+                    m
+                ));
+        }
+
+        // MS-VBAL 3.3.5.2 Reserved Identifiers and IDENTIFIER
+        private static IEnumerable<string> ReservedKeywords = new []
+        {
+            /*
+Statement-keyword = "Call" / "Case" /"Close" / "Const"/ "Declare" / "DefBool" / "DefByte" / 
+                    "DefCur" / "DefDate" / "DefDbl" / "DefInt" / "DefLng" / "DefLngLng" / 
+                    "DefLngPtr" / "DefObj" / "DefSng" / "DefStr" / "DefVar" / "Dim" / "Do" / 
+                    "Else" / "ElseIf" / "End" / "EndIf" /  "Enum" / "Erase" / "Event" / 
+                    "Exit" / "For" / "Friend" / "Function" / "Get" / "Global" / "GoSub" / 
+                    "GoTo" / "If" / "Implements"/ "Input" / "Let" / "Lock" / "Loop" / 
+                    "LSet"/ "Next" / "On" / "Open" / "Option" / "Print" / "Private" / 
+                    "Public" / "Put" / "RaiseEvent" / "ReDim" / "Resume" / "Return" / 
+                    "RSet" / "Seek" / "Select" / "Set" / "Static" / "Stop" / "Sub" / 
+                    "Type" / "Unlock" / "Wend" / "While" / "With" / "Write" 
+                    */
+                    
+            Tokens.Call,
+            Tokens.Case,
+            Tokens.Close,
+            Tokens.Const,
+            Tokens.Declare,
+            "DefBool",
+            "DefByte",
+            "DefCur",
+            "DefDate",
+            "DefDbl",
+            "DefInt",
+            "DefLng",
+            "DefLngLng",
+            "DefLngPtr",
+            "DefObj",
+            "DefSng",
+            "DefStr",
+            "DefVar",
+            Tokens.Dim,
+            Tokens.Do,
+            Tokens.Else,
+            Tokens.ElseIf,
+            Tokens.End,
+            "EndIf",
+            Tokens.Enum,
+            "Erase",
+            "Event",
+            Tokens.Exit,
+            Tokens.For,
+            Tokens.Friend,
+            Tokens.Function,
+            Tokens.Get,
+            Tokens.Global,
+            Tokens.GoSub,
+            Tokens.GoTo,
+            Tokens.If,
+            Tokens.Implements,
+            Tokens.Input,
+            Tokens.Let,
+            "Lock",
+            Tokens.Loop,
+            "LSet",
+            Tokens.Next,
+            Tokens.On,
+            Tokens.Open,
+            Tokens.Option,
+            Tokens.Print,
+            Tokens.Private,
+            Tokens.Public,
+            Tokens.Put,
+            "RaiseEvent",
+            Tokens.ReDim,
+            Tokens.Resume,
+            Tokens.Return,
+            "RSet",
+            "Seek",
+            Tokens.Select,
+            Tokens.Set,
+            Tokens.Static,
+            Tokens.Stop,
+            Tokens.Sub,
+            Tokens.Type,
+            "Unlock",
+            Tokens.Wend,
+            Tokens.While,
+            Tokens.With,
+            Tokens.Write,
+
+            /*
+rem-keyword = "Rem" marker-keyword = "Any" / "As"/ "ByRef" / "ByVal "/"Case" / "Each" / 
+              "Else" /"In"/ "New" / "Shared" / "Until" / "WithEvents" / "Write" / "Optional" / 
+              "ParamArray" / "Preserve" / "Spc" / "Tab" / "Then" / "To" 
+            */
+            
+            Tokens.Any,
+            Tokens.As,
+            Tokens.ByRef,
+            Tokens.ByVal,
+            Tokens.Case,
+            Tokens.Each,
+            Tokens.In,
+            Tokens.New,
+            "Shared",
+            Tokens.Until,
+            "WithEvents",
+            Tokens.Optional,
+            Tokens.ParamArray,
+            Tokens.Preserve,
+            Tokens.Spc,
+            "Tab",
+            Tokens.Then,
+            Tokens.To,
+
+            /*
+operator-identifier = "AddressOf" / "And" / "Eqv" / "Imp" / "Is" / "Like" / "New" / "Mod" / 
+                      "Not" / "Or" / "TypeOf" / "Xor"
+             */
+            
+            Tokens.AddressOf,
+            Tokens.And,
+            Tokens.Eqv,
+            Tokens.Imp,
+            Tokens.Is,
+            Tokens.Like,
+            Tokens.Mod,
+            Tokens.Not,
+            Tokens.Or,
+            Tokens.TypeOf,
+            Tokens.XOr
+        };
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/LineContinuationBetweenKeywordsInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/LineContinuationBetweenKeywordsInspection.cs
@@ -1,0 +1,161 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Inspections.Inspections.Concrete.ThunderCode
+{
+    /// <summary>
+    /// Note that the inspection only checks a subset of possible "evil" line continatuions
+    /// for both simplicity and performance reasons. Exahustive inspection would likely take
+    /// too much effort. 
+    /// </summary>
+    public class LineContinuationBetweenKeywordsInspection : ParseTreeInspectionBase
+    {
+        public LineContinuationBetweenKeywordsInspection(RubberduckParserState state) : base(state)
+        {
+            Listener = new LineContinuationBetweenKeywordsListener();
+        }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            return Listener.Contexts.Select(c => new QualifiedContextInspectionResult(
+                this,
+                InspectionResults.LineContinuationBetweenKeywordsInspection.
+                    ThunderCodeFormat(),
+                c));
+        }
+
+        public override IInspectionListener Listener { get; }
+
+        public class LineContinuationBetweenKeywordsListener : VBAParserBaseListener, IInspectionListener
+        {
+            private readonly List<QualifiedContext<ParserRuleContext>> _contexts = new List<QualifiedContext<ParserRuleContext>>();
+
+            public IReadOnlyList<QualifiedContext<ParserRuleContext>> Contexts => _contexts;
+
+            public void ClearContexts()
+            {
+                _contexts.Clear();
+            }
+
+            public QualifiedModuleName CurrentModuleName { get; set; }
+
+            public override void EnterSubStmt(VBAParser.SubStmtContext context)
+            {
+                CheckContext(context, context.END_SUB());
+                base.EnterSubStmt(context);
+            }
+
+            public override void EnterFunctionStmt(VBAParser.FunctionStmtContext context)
+            {
+                CheckContext(context, context.END_FUNCTION());
+                base.EnterFunctionStmt(context);
+            }
+
+            public override void EnterPropertyGetStmt(VBAParser.PropertyGetStmtContext context)
+            {
+                CheckContext(context, context.PROPERTY_GET());
+                CheckContext(context, context.END_PROPERTY());
+                base.EnterPropertyGetStmt(context);
+            }
+
+            public override void EnterPropertyLetStmt(VBAParser.PropertyLetStmtContext context)
+            {
+                CheckContext(context, context.PROPERTY_LET());
+                CheckContext(context, context.END_PROPERTY());
+                base.EnterPropertyLetStmt(context);
+            }
+
+            public override void EnterPropertySetStmt(VBAParser.PropertySetStmtContext context)
+            {
+                CheckContext(context, context.PROPERTY_SET());
+                CheckContext(context, context.END_PROPERTY());
+                base.EnterPropertySetStmt(context);
+            }
+
+            public override void EnterSelectCaseStmt(VBAParser.SelectCaseStmtContext context)
+            {
+                CheckContext(context, context.END_SELECT());
+                base.EnterSelectCaseStmt(context);
+            }
+
+            public override void EnterWithStmt(VBAParser.WithStmtContext context)
+            {
+                CheckContext(context, context.END_WITH());
+                base.EnterWithStmt(context);
+            }
+
+            public override void EnterExitStmt(VBAParser.ExitStmtContext context)
+            {
+                CheckContext(context, context.EXIT_DO());
+                CheckContext(context, context.EXIT_FOR());
+                CheckContext(context, context.EXIT_FUNCTION());
+                CheckContext(context, context.EXIT_PROPERTY());
+                CheckContext(context, context.EXIT_SUB());
+                base.EnterExitStmt(context);
+            }
+
+            public override void EnterOnErrorStmt(VBAParser.OnErrorStmtContext context)
+            {
+                CheckContext(context, context.ON_ERROR());
+                CheckContext(context, context.ON_LOCAL_ERROR());
+                base.EnterOnErrorStmt(context);
+            }
+
+            public override void EnterOptionBaseStmt(VBAParser.OptionBaseStmtContext context)
+            {
+                CheckContext(context, context.OPTION_BASE());
+                base.EnterOptionBaseStmt(context);
+            }
+
+            public override void EnterOptionCompareStmt(VBAParser.OptionCompareStmtContext context)
+            {
+                CheckContext(context, context.OPTION_COMPARE());
+                base.EnterOptionCompareStmt(context);
+            }
+
+            public override void EnterOptionExplicitStmt(VBAParser.OptionExplicitStmtContext context)
+            {
+                CheckContext(context, context.OPTION_EXPLICIT());
+                base.EnterOptionExplicitStmt(context);
+            }
+
+            public override void EnterOptionPrivateModuleStmt(VBAParser.OptionPrivateModuleStmtContext context)
+            {
+                CheckContext(context, context.OPTION_PRIVATE_MODULE());
+                base.EnterOptionPrivateModuleStmt(context);
+            }
+
+            public override void EnterEnumerationStmt(VBAParser.EnumerationStmtContext context)
+            {
+                CheckContext(context, context.END_ENUM());
+                base.EnterEnumerationStmt(context);
+            }
+
+            public override void EnterUdtDeclaration(VBAParser.UdtDeclarationContext context)
+            {
+                CheckContext(context, context.END_TYPE());
+                base.EnterUdtDeclaration(context);
+            }
+
+
+
+            private void CheckContext(ParserRuleContext context, IParseTree subTreeToExamine)
+            {
+                if (subTreeToExamine?.GetText().Contains("_") ?? false)
+                {
+                    _contexts.Add(new QualifiedContext<ParserRuleContext>(CurrentModuleName, context));
+                }
+            }
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/NegativeLineNumberInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/NegativeLineNumberInspection.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Inspections.Inspections.Concrete.ThunderCode
+{
+    public class NegativeLineNumberInspection : ParseTreeInspectionBase
+    {
+        public NegativeLineNumberInspection(RubberduckParserState state) : base(state)
+        {
+            Listener = new NegativeLineNumberKeywordsListener();
+        }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            return Listener.Contexts.Select(c => new QualifiedContextInspectionResult(
+                this,
+                
+                InspectionResults.NegativeLineNumberInspection.
+                    ThunderCodeFormat(),
+                c));
+        }
+
+        public override IInspectionListener Listener { get; }
+
+        public class NegativeLineNumberKeywordsListener : VBAParserBaseListener, IInspectionListener
+        {
+            private readonly List<QualifiedContext<ParserRuleContext>> _contexts = new List<QualifiedContext<ParserRuleContext>>();
+
+            public IReadOnlyList<QualifiedContext<ParserRuleContext>> Contexts => _contexts;
+
+            public void ClearContexts()
+            {
+                _contexts.Clear();
+            }
+
+            public QualifiedModuleName CurrentModuleName { get; set; }
+
+            public override void EnterOnErrorStmt(VBAParser.OnErrorStmtContext context)
+            {
+                CheckContext(context, context.expression());
+                base.EnterOnErrorStmt(context);
+            }
+
+            public override void EnterGoToStmt(VBAParser.GoToStmtContext context)
+            {
+                CheckContext(context, context.expression());
+                base.EnterGoToStmt(context);
+            }
+
+            public override void EnterLineNumberLabel(VBAParser.LineNumberLabelContext context)
+            {
+                CheckContext(context, context);
+                base.EnterLineNumberLabel(context);
+            }
+
+            private void CheckContext(ParserRuleContext context, IParseTree expression)
+            {
+                var target = expression?.GetText().Trim() ?? string.Empty;
+                if (target.StartsWith("-") && int.TryParse(target.Substring(1), out _))
+                {
+                    _contexts.Add(new QualifiedContext<ParserRuleContext>(CurrentModuleName, context));
+                }
+            }
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/NonBreakingSpaceIdentifierInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/NonBreakingSpaceIdentifierInspection.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+
+namespace Rubberduck.Inspections.Inspections.Concrete.ThunderCode
+{
+    public class NonBreakingSpaceIdentifierInspection : InspectionBase
+    {
+        private const string Nbsp = "\u00A0";
+
+        public NonBreakingSpaceIdentifierInspection(RubberduckParserState state) : base(state) { }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            return State.DeclarationFinder.AllUserDeclarations
+                .Where(d => d.IdentifierName.Contains(Nbsp))
+                .Select(d => new DeclarationInspectionResult(
+                    this, 
+                    InspectionResults.NonBreakingSpaceIdentifierInspection.
+                        ThunderCodeFormat(d.IdentifierName), 
+                    d));
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/OnErrorGoToMinusOneInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/OnErrorGoToMinusOneInspection.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Inspections.Inspections.Concrete.ThunderCode
+{
+    public class OnErrorGoToMinusOneInspection : ParseTreeInspectionBase
+    {
+        public OnErrorGoToMinusOneInspection(RubberduckParserState state) : base(state)
+        {
+            Listener = new OnErrorGoToMinusOneListener();
+        }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            return Listener.Contexts.Select(c => new QualifiedContextInspectionResult(
+                this,
+
+                InspectionResults.OnErrorGoToMinusOneInspection.
+                    ThunderCodeFormat(),
+                c));
+        }
+
+        public override IInspectionListener Listener { get; }
+
+        public class OnErrorGoToMinusOneListener : VBAParserBaseListener, IInspectionListener
+        {
+            private readonly List<QualifiedContext<ParserRuleContext>> _contexts = new List<QualifiedContext<ParserRuleContext>>();
+
+            public IReadOnlyList<QualifiedContext<ParserRuleContext>> Contexts => _contexts;
+
+            public void ClearContexts()
+            {
+                _contexts.Clear();
+            }
+
+            public QualifiedModuleName CurrentModuleName { get; set; }
+
+            public override void EnterOnErrorStmt(VBAParser.OnErrorStmtContext context)
+            {
+                CheckContext(context, context.expression());
+                base.EnterOnErrorStmt(context);
+            }
+            
+            private void CheckContext(ParserRuleContext context, IParseTree expression)
+            {
+                var target = expression?.GetText().Trim() ?? string.Empty;
+                if (target.StartsWith("-") && int.TryParse(target.Substring(1), out var result) && result == 1)
+                {
+                    _contexts.Add(new QualifiedContext<ParserRuleContext>(CurrentModuleName, context));
+                }
+            }
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/ThunderCodeFormatExtension.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ThunderCode/ThunderCodeFormatExtension.cs
@@ -1,0 +1,12 @@
+﻿using Rubberduck.Resources.Inspections;
+
+namespace Rubberduck.Inspections.Inspections.Concrete.ThunderCode
+{
+    public static class ThunderCodeFormatExtension
+    {
+        public static string ThunderCodeFormat(this string inspectionBase, params object[] args)
+        {
+            return string.Format(InspectionResults.ThunderCode_Base, string.Format(inspectionBase, args));
+        }
+    }
+}

--- a/Rubberduck.Parsing/Grammar/VBALexer.g4
+++ b/Rubberduck.Parsing/Grammar/VBALexer.g4
@@ -111,7 +111,7 @@ EACH : E A C H;
 ELSE : E L S E;
 ELSEIF : E L S E I F;
 EMPTY : E M P T Y;
-// Apparently END_ENUM don't allow line continuations (in the VB editor)
+// Apparently END_ENUM doesn't allow line continuations (in the VB editor)
 END_ENUM : E N D WS+ E N U M;
 END_FUNCTION : E N D (WS | LINE_CONTINUATION)+ F U N C T I O N;
 // We allow "EndIf" without the whitespace as well for the preprocessor.

--- a/Rubberduck.Parsing/Grammar/VBALexer.g4
+++ b/Rubberduck.Parsing/Grammar/VBALexer.g4
@@ -111,7 +111,7 @@ EACH : E A C H;
 ELSE : E L S E;
 ELSEIF : E L S E I F;
 EMPTY : E M P T Y;
-// Apparently END_ENUM and END_TYPE don't allow line continuations (in the VB editor)
+// Apparently END_ENUM don't allow line continuations (in the VB editor)
 END_ENUM : E N D WS+ E N U M;
 END_FUNCTION : E N D (WS | LINE_CONTINUATION)+ F U N C T I O N;
 // We allow "EndIf" without the whitespace as well for the preprocessor.
@@ -120,7 +120,7 @@ ENDPROPERTY : E N D P R O P E R T Y; //Used in module configurations.
 END_PROPERTY : E N D (WS | LINE_CONTINUATION)+ P R O P E R T Y;
 END_SELECT : E N D (WS | LINE_CONTINUATION)+ S E L E C T;
 END_SUB : E N D (WS | LINE_CONTINUATION)+ S U B;
-END_TYPE : E N D WS+ T Y P E;
+END_TYPE : E N D (WS | LINE_CONTINUATION)+ T Y P E;
 END_WITH : E N D (WS | LINE_CONTINUATION)+ W I T H;
 END : E N D;
 ENUM : E N U M;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -622,7 +622,10 @@ standaloneLineNumberLabel :
     lineNumberLabel whiteSpace? COLON
     | lineNumberLabel;
 combinedLabels : lineNumberLabel whiteSpace identifierStatementLabel;
-lineNumberLabel : numberLiteral;
+// Technically, the negative numbers are illegal but VBE can prettify a
+// &HFFFFFFFF into a -1 which becomes a legal line number. Editing the same
+// line subsequently then breaks it. 
+lineNumberLabel : MINUS? numberLiteral; 
 
 numberLiteral : HEXLITERAL | OCTLITERAL | FLOATLITERAL | INTEGERLITERAL;
 

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
@@ -59,7 +59,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -69,7 +69,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -79,7 +79,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -89,7 +89,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -99,7 +99,17 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        public static System.Drawing.Bitmap BrokenReference {
+            get {
+                object obj = ResourceManager.GetObject("BrokenReference", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Add.
         /// </summary>
@@ -155,20 +165,20 @@ namespace Rubberduck.Resources.CodeExplorer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Predeclared Class module (.cls).
-        /// </summary>
-        public static string CodeExplorer_AddPredeclaredClassModuleText {
-            get {
-                return ResourceManager.GetString("CodeExplorer_AddPredeclaredClassModuleText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Standard module (.bas).
         /// </summary>
         public static string CodeExplorer_AddStdModuleText {
             get {
                 return ResourceManager.GetString("CodeExplorer_AddStdModuleText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Templates.
+        /// </summary>
+        public static string CodeExplorer_AddTemplatesSubMenu {
+            get {
+                return ResourceManager.GetString("CodeExplorer_AddTemplatesSubMenu", resourceCulture);
             }
         }
         
@@ -288,16 +298,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorer_ExportAll", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Font Size.
-        /// </summary>
-        public static string CodeExplorer_FontSizeToolTip {
-            get {
-                return ResourceManager.GetString("CodeExplorer_FontSizeToolTip", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Find All Implementations....
         /// </summary>
@@ -313,6 +314,15 @@ namespace Rubberduck.Resources.CodeExplorer {
         public static string CodeExplorer_FindAllReferencesText {
             get {
                 return ResourceManager.GetString("CodeExplorer_FindAllReferencesText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Font Size.
+        /// </summary>
+        public static string CodeExplorer_FontSizeToolTip {
+            get {
+                return ResourceManager.GetString("CodeExplorer_FontSizeToolTip", resourceCulture);
             }
         }
         
@@ -333,7 +343,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorer_Indent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Library References.
         /// </summary>
@@ -342,7 +352,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorer_LibraryReferences", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Na&amp;vigate.
         /// </summary>
@@ -405,7 +415,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorer_Print", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Project References.
         /// </summary>
@@ -415,7 +425,6 @@ namespace Rubberduck.Resources.CodeExplorer {
             }
         }
         
-
         /// <summary>
         ///   Looks up a localized string similar to R&amp;efresh.
         /// </summary>
@@ -469,7 +478,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorer_SearchPlaceholder", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Set as start up.
         /// </summary>
@@ -541,7 +550,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorer_SortStyle_ByType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Sync with code pane.
         /// </summary>
@@ -550,7 +559,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorer_SyncCodePaneToolTip", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Code Explorer.
         /// </summary>
@@ -568,17 +577,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("CodeExplorerDockablePresenter_ParseStarted", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        public static System.Drawing.Bitmap BrokenReference {
-            get {
-                object obj = ResourceManager.GetObject("BrokenReference", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -656,7 +655,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("ExportBeforeRemove_Prompt", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error exporting &apos;{0}&apos;.
         /// </summary>
@@ -665,7 +664,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("ExportError_Caption", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -695,7 +694,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -705,7 +704,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -715,7 +714,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -725,7 +724,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -735,7 +734,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -745,7 +744,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -785,7 +784,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -795,7 +794,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -805,7 +804,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -815,7 +814,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -825,7 +824,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -835,7 +834,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -855,7 +854,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
- 
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -865,7 +864,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -875,7 +874,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -885,7 +884,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -895,7 +894,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -905,7 +904,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
- 
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -929,15 +928,13 @@ namespace Rubberduck.Resources.CodeExplorer {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
-        public static System.Drawing.Bitmap Reference
-        {
-            get
-            {
+        public static System.Drawing.Bitmap Reference {
+            get {
                 object obj = ResourceManager.GetObject("Reference", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error removing &apos;{0}&apos;.
         /// </summary>
@@ -946,7 +943,7 @@ namespace Rubberduck.Resources.CodeExplorer {
                 return ResourceManager.GetString("RemoveError_Caption", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -86,17 +86,16 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
+        ///   Looks up a localized string similar to A Rubberduck annotation is specified for a module or member, but the corresponding attribute has a different value. Module attributes and annotations need to be synchronized..
         /// </summary>
-        public static string AttributeValueOutOfSyncInspection
-        {
+        public static string AttributeValueOutOfSyncInspection {
             get {
                 return ResourceManager.GetString("AttributeValueOutOfSyncInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A member is assigned True/False in different branches of an if statement with no other statements in the conditional. Use the condition directly to the member instead..
         /// </summary>
@@ -242,7 +241,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Functions that are visible to Excel as User-Defined Functions will return a &apos;#REF&apos; error when used on a Worksheet if they match the name of a valid cell reference. If the function is intended to be used as a UDF, it must be renamed. If the function is not intended to be used as a UDF, it should be scoped as &apos;Private&apos; or moved out of a standard Module..
+        ///   Looks up a localized string similar to Functions that are visible to Excel as User-Defined Functions will return a &apos;#REF!&apos; error when used on a Worksheet if they match the name of a valid cell reference. If the function is intended to be used as a UDF, it must be renamed. If the function is not intended to be used as a UDF, it should be scoped as &apos;Private&apos; or moved out of a standard Module..
         /// </summary>
         public static string ExcelUdfNameIsValidCellReferenceInspection {
             get {
@@ -368,6 +367,24 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A keyword is being used as a member in either an enumeration or an user defined type. That can lead to ambiguous resolution. Consider renaming the member..
+        /// </summary>
+        public static string KeywordsUsedAsMemberInspection {
+            get {
+                return ResourceManager.GetString("KeywordsUsedAsMemberInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There are line continuations between keywords. There is no good reason to put it there; consider removing them altogether.
+        /// </summary>
+        public static string LineContinuationBetweenKeywordsInspection {
+            get {
+                return ResourceManager.GetString("LineContinuationBetweenKeywordsInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A line label that is never jumpted to (&apos;GoTo&apos;, &apos;Resume&apos;, ...), serves no purpose. Consider removing it..
         /// </summary>
         public static string LineLabelNotUsedInspection {
@@ -402,27 +419,25 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
+        ///   Looks up a localized string similar to Member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
         /// </summary>
-        public static string MissingMemberAnnotationInspection
-        {
+        public static string MissingMemberAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Module and member attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
+        ///   Looks up a localized string similar to Module attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized..
         /// </summary>
-        public static string MissingModuleAnnotationInspection
-        {
+        public static string MissingModuleAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingModuleAnnotationInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;Public&apos; keyword can only be used at module level; its counterpart &apos;Private&apos; can also only be used at module level. &apos;Dim&apos; however, can be used to declare both procedure and module scope variables. For consistency, it would be preferable to reserve &apos;Dim&apos; for locals, and thus to use &apos;Private&apos; instead of &apos;Dim&apos; at module level..
         /// </summary>
@@ -469,6 +484,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The identiifer contains a non-breaking space which looks very much like just an ordinary space, which obfsucates the code and makes for a confusing experience. Consider using visible characters for the identifiers..
+        /// </summary>
+        public static string NonBreakingSpaceIdentifierInspection {
+            get {
+                return ResourceManager.GetString("NonBreakingSpaceIdentifierInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This is likely a bug. The return value of a function or property getter must be assigned before exiting, otherwise the program will not be working with expected results. If a function has no meaningful return value, consider declaring it as a &apos;Sub&apos; procedure instead..
         /// </summary>
         public static string NonReturningFunctionInspection {
@@ -487,7 +511,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows implementations of Visual Basic only support the StdCall calling convention, and use of of the CDecl calling convention is only supported in Macintosh versions of VBA. Use of this keyword in Windows will result in runtime error 49 - &apos;Bad DLL calling convention&apos;. If this procedure is only intended to be used on Macintosh hosts, it should be conditionally compiled..
+        ///   Looks up a localized string similar to Windows implementations of Visual Basic only support the StdCall calling convention. The CDecl calling convention is only supported in Macintosh versions of VBA. Use of this keyword in Windows will result in runtime error 49 - &apos;Bad DLL calling convention&apos;. If this procedure is only intended to be used on Macintosh hosts, it should be conditionally compiled..
         /// </summary>
         public static string ObsoleteCallingConventionInspection {
             get {
@@ -559,7 +583,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to On Local Error exists only for compatibility with previous versions of Visual Basic, and all Errors are treated as Local regardless of the Error statement. Use of this keyword inaccurately gives the impression that there is a distinction between types of error handling when there is not..
+        ///   Looks up a localized string similar to On Local Error exists only for compatibility with previous versions of Visual Basic, and all Errors are treated as Local regardless of the On Local Error statement. Use of this keyword inaccurately gives the impression that there is a distinction between types of error handling when there is not..
         /// </summary>
         public static string OnLocalErrorInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -484,6 +484,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Negative line numbers are actually input as hex literal and then prettified by VBE. Editing the line again will cause it to turn red since negative line numbers are in fact illegal..
+        /// </summary>
+        public static string NegativeLineNumberInspection {
+            get {
+                return ResourceManager.GetString("NegativeLineNumberInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The identiifer contains a non-breaking space which looks very much like just an ordinary space, which obfsucates the code and makes for a confusing experience. Consider using visible characters for the identifiers..
         /// </summary>
         public static string NonBreakingSpaceIdentifierInspection {
@@ -579,6 +588,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to While this is legal, this is poorly documented &quot;feature&quot; that means something different -- the error state is also cleared in addition to disabling any error handling. However, this can be ambiguous as a negative line label of -1 may end up as a target and excessively complex error handling usually indicates a need of refactoring the procedure..
+        /// </summary>
+        public static string OnErrorGoToMinusOneInspection {
+            get {
+                return ResourceManager.GetString("OnErrorGoToMinusOneInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -364,4 +364,13 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="MissingModuleAnnotationInspection" xml:space="preserve">
     <value>Module attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized.</value>
   </data>
+  <data name="KeywordsUsedAsMemberInspection" xml:space="preserve">
+    <value>A keyword is being used as a member in either an enumeration or an user defined type. That can lead to ambiguous resolution. Condier renaming.</value>
+  </data>
+  <data name="LineContinuationBetweenKeywordsInspection" xml:space="preserve">
+    <value>There are line continuations between keywords. There is no good reason to put it there; consider removing them altogether</value>
+  </data>
+  <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
+    <value>The identiifer contains a non-breaking space which looks very much like just an ordinary space, which obfsucates the code and makes for a confusing experience. Consider using only latin characters for the identifiers.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -373,4 +373,10 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
     <value>The identiifer contains a non-breaking space which looks very much like just an ordinary space, which obfsucates the code and makes for a confusing experience. Consider using visible characters for the identifiers.</value>
   </data>
+  <data name="NegativeLineNumberInspection" xml:space="preserve">
+    <value>Negative line numbers are actually input as hex literal and then prettified by VBE. Editing the line again will cause it to turn red since negative line numbers are in fact illegal.</value>
+  </data>
+  <data name="OnErrorGoToMinusOneInspection" xml:space="preserve">
+    <value>While this is legal, this is poorly documented "feature" that means something different -- the error state is also cleared in addition to disabling any error handling. However, this can be ambiguous as a negative line label of -1 may end up as a target and excessively complex error handling usually indicates a need of refactoring the procedure.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -365,12 +365,12 @@ If the parameter can be null, ignore this inspection result; passing a null valu
     <value>Module attributes are not displayed in the VBE. By adding an annotation, you make these attributes more explicit, and Rubberduck can keep annotations and attributes synchronized.</value>
   </data>
   <data name="KeywordsUsedAsMemberInspection" xml:space="preserve">
-    <value>A keyword is being used as a member in either an enumeration or an user defined type. That can lead to ambiguous resolution. Condier renaming.</value>
+    <value>A keyword is being used as a member in either an enumeration or an user defined type. That can lead to ambiguous resolution. Consider renaming the member.</value>
   </data>
   <data name="LineContinuationBetweenKeywordsInspection" xml:space="preserve">
     <value>There are line continuations between keywords. There is no good reason to put it there; consider removing them altogether</value>
   </data>
   <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
-    <value>The identiifer contains a non-breaking space which looks very much like just an ordinary space, which obfsucates the code and makes for a confusing experience. Consider using only latin characters for the identifiers.</value>
+    <value>The identiifer contains a non-breaking space which looks very much like just an ordinary space, which obfsucates the code and makes for a confusing experience. Consider using visible characters for the identifiers.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -486,6 +486,15 @@ namespace Rubberduck.Resources.Inspections {
         /// <summary>
         ///   Looks up a localized string similar to ThunderCode!.
         /// </summary>
+        public static string NegativeLineNumberInspection {
+            get {
+                return ResourceManager.GetString("NegativeLineNumberInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ThunderCode!.
+        /// </summary>
         public static string NonBreakingSpaceIdentifierInspection {
             get {
                 return ResourceManager.GetString("NonBreakingSpaceIdentifierInspection", resourceCulture);
@@ -579,6 +588,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ThunderCode!.
+        /// </summary>
+        public static string OnErrorGoToMinusOneInspection {
+            get {
+                return ResourceManager.GetString("OnErrorGoToMinusOneInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -86,17 +86,16 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Assignment is not used.
+        ///   Looks up a localized string similar to Value does not match between attribute and annotation.
         /// </summary>
-        public static string AttributeValueOutOfSyncInspection
-        {
+        public static string AttributeValueOutOfSyncInspection {
             get {
                 return ResourceManager.GetString("AttributeValueOutOfSyncInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal assignment in conditional.
         /// </summary>
@@ -350,7 +349,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; function.
+        ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; - Parameter is not &apos;Variant&apos;.
         /// </summary>
         public static string IsMissingOnInappropriateArgumentInspection {
             get {
@@ -359,11 +358,29 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; function.
+        ///   Looks up a localized string similar to Inappropriate use of &apos;IsMissing&apos; - Parameter is local variable.
         /// </summary>
         public static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ThunderCode!.
+        /// </summary>
+        public static string KeywordsUsedAsMemberInspection {
+            get {
+                return ResourceManager.GetString("KeywordsUsedAsMemberInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ThunderCode!.
+        /// </summary>
+        public static string LineContinuationBetweenKeywordsInspection {
+            get {
+                return ResourceManager.GetString("LineContinuationBetweenKeywordsInspection", resourceCulture);
             }
         }
         
@@ -402,28 +419,25 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Missing annotation.
+        ///   Looks up a localized string similar to Missing member annotation.
         /// </summary>
-        public static string MissingMemberAnnotationInspection
-        {
+        public static string MissingMemberAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Missing annotation.
+        ///   Looks up a localized string similar to Missing module annotation.
         /// </summary>
-        public static string MissingModuleAnnotationInspection
-        {
-            get
-            {
+        public static string MissingModuleAnnotationInspection {
+            get {
                 return ResourceManager.GetString("MissingModuleAnnotationInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use of &apos;Dim&apos; keyword at module level.
         /// </summary>
@@ -470,6 +484,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ThunderCode!.
+        /// </summary>
+        public static string NonBreakingSpaceIdentifierInspection {
+            get {
+                return ResourceManager.GetString("NonBreakingSpaceIdentifierInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Non-returning function or property getter.
         /// </summary>
         public static string NonReturningFunctionInspection {
@@ -488,7 +511,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use of obsolete &apos;CDecl&apos; calling convention.
+        ///   Looks up a localized string similar to Use of &apos;CDecl&apos; calling convention on Windows.
         /// </summary>
         public static string ObsoleteCallingConventionInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -363,4 +363,13 @@
   <data name="MissingModuleAnnotationInspection" xml:space="preserve">
     <value>Missing module annotation</value>
   </data>
+  <data name="KeywordsUsedAsMemberInspection" xml:space="preserve">
+    <value>ThunderCode!</value>
+  </data>
+  <data name="LineContinuationBetweenKeywordsInspection" xml:space="preserve">
+    <value>ThunderCode!</value>
+  </data>
+  <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
+    <value>ThunderCode!</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -372,4 +372,10 @@
   <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
     <value>ThunderCode!</value>
   </data>
+  <data name="NegativeLineNumberInspection" xml:space="preserve">
+    <value>ThunderCode!</value>
+  </data>
+  <data name="OnErrorGoToMinusOneInspection" xml:space="preserve">
+    <value>ThunderCode!</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -95,17 +95,16 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AssignmentNotUsedInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to An assignment is immediately overridden by another assignment or is never referenced..
+        ///   Looks up a localized string similar to The attribute value(s) for attribute {0} ({1}) are out of sync with the {2} annotation. .
         /// </summary>
-        public static string AttributeValueOutOfSyncInspection
-        {
+        public static string AttributeValueOutOfSyncInspection {
             get {
                 return ResourceManager.GetString("AttributeValueOutOfSyncInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Boolean literal &apos;{0}&apos; assigned in conditional..
         /// </summary>
@@ -377,11 +376,29 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;IsMissing&apos; is passed an expresssion that is not an argument to the enclosing procedure..
+        ///   Looks up a localized string similar to &apos;IsMissing&apos; is passed an expression that is not an argument to the enclosing procedure..
         /// </summary>
         public static string IsMissingWithNonArgumentParameterInspection {
             get {
                 return ResourceManager.GetString("IsMissingWithNonArgumentParameterInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Keyword used as an identifier for the member {0}.
+        /// </summary>
+        public static string KeywordsUsedAsMemberInspection {
+            get {
+                return ResourceManager.GetString("KeywordsUsedAsMemberInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line continuation(s) in unexpected places. .
+        /// </summary>
+        public static string LineContinuationBetweenKeywordsInspection {
+            get {
+                return ResourceManager.GetString("LineContinuationBetweenKeywordsInspection", resourceCulture);
             }
         }
         
@@ -420,27 +437,25 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("MissingAttributeInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; attribute, but no corresponding annotation..
+        ///   Looks up a localized string similar to Member &apos;{0}&apos; has a &apos;{1}&apos; attribute with value(s) &apos;{2}&apos;, but no corresponding annotation..
         /// </summary>
-        public static string MissingMemberAnnotationInspection
-        {
+        public static string MissingMemberAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingMemberAnnotationInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Module or member &apos;{0}&apos; has a &apos;{1}&apos; attribute, but no corresponding annotation..
+        ///   Looks up a localized string similar to Module &apos;{0}&apos; has a &apos;{1}&apos; attribute with value(s) &apos;{2}&apos;, but no corresponding annotation..
         /// </summary>
-        public static string MissingModuleAnnotationInspection
-        {
+        public static string MissingModuleAnnotationInspection {
             get {
                 return ResourceManager.GetString("MissingModuleAnnotationInspection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Module-level variable &apos;{0}&apos; is declared with the &apos;Dim&apos; keyword..
         /// </summary>
@@ -483,6 +498,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string MultipleDeclarationsInspection {
             get {
                 return ResourceManager.GetString("MultipleDeclarationsInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-breaking space encountered in identifier {0}.
+        /// </summary>
+        public static string NonBreakingSpaceIdentifierInspection {
+            get {
+                return ResourceManager.GetString("NonBreakingSpaceIdentifierInspection", resourceCulture);
             }
         }
         
@@ -717,6 +741,18 @@ namespace Rubberduck.Resources.Inspections {
         public static string StopKeywordInspection {
             get {
                 return ResourceManager.GetString("StopKeywordInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}
+        ///Andrew &quot;ThunderFrame&quot; Jackson would be proud! 
+        ///You&apos;re seeing this inspection result because there&apos;s no way that&apos;s real code and you&apos;re just pushing the limits of Rubberduck&apos;s parsing and resolving capabilities, right? ...RIGHT? 
+        ///In memoriam, 1972-2018.
+        /// </summary>
+        public static string ThunderCode_Base {
+            get {
+                return ResourceManager.GetString("ThunderCode_Base", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -502,6 +502,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Negative line number encountered.
+        /// </summary>
+        public static string NegativeLineNumberInspection {
+            get {
+                return ResourceManager.GetString("NegativeLineNumberInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Non-breaking space encountered in identifier &apos;{0}&apos;.
         /// </summary>
         public static string NonBreakingSpaceIdentifierInspection {
@@ -597,6 +606,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string ObsoleteTypeHintInspection {
             get {
                 return ResourceManager.GetString("ObsoleteTypeHintInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to On Error GoTo -1 encountered.
+        /// </summary>
+        public static string OnErrorGoToMinusOneInspection {
+            get {
+                return ResourceManager.GetString("OnErrorGoToMinusOneInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -385,7 +385,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Keyword used as an identifier for the member {0}.
+        ///   Looks up a localized string similar to Keyword used as an identifier for the member &apos;{0}&apos;.
         /// </summary>
         public static string KeywordsUsedAsMemberInspection {
             get {
@@ -502,7 +502,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Non-breaking space encountered in identifier {0}.
+        ///   Looks up a localized string similar to Non-breaking space encountered in identifier &apos;{0}&apos;.
         /// </summary>
         public static string NonBreakingSpaceIdentifierInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -397,4 +397,22 @@
     <value>Module '{0}' has a '{1}' attribute with value(s) '{2}', but no corresponding annotation.</value>
     <comment>{0} module; {1} specified attribute; {2} specified values</comment>
   </data>
+  <data name="KeywordsUsedAsMemberInspection" xml:space="preserve">
+    <value>Keyword used as an identifier for the member {0}</value>
+    <comment>{0} Member name</comment>
+  </data>
+  <data name="LineContinuationBetweenKeywordsInspection" xml:space="preserve">
+    <value>Line continuation(s) in unexpected places. </value>
+  </data>
+  <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
+    <value>Non-breaking space encountered in identifier {0}</value>
+    <comment>{0} Identifier</comment>
+  </data>
+  <data name="ThunderCode_Base" xml:space="preserve">
+    <value>{0}
+Andrew "ThunderFrame" Jackson would be proud! 
+You're seeing this inspection result because there's no way that's real code and you're just pushing the limits of Rubberduck's parsing and resolving capabilities, right? ...RIGHT? 
+In memoriam, 1972-2018</value>
+    <comment>{0} ThunderCode inspection description</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -398,14 +398,14 @@
     <comment>{0} module; {1} specified attribute; {2} specified values</comment>
   </data>
   <data name="KeywordsUsedAsMemberInspection" xml:space="preserve">
-    <value>Keyword used as an identifier for the member {0}</value>
+    <value>Keyword used as an identifier for the member '{0}'</value>
     <comment>{0} Member name</comment>
   </data>
   <data name="LineContinuationBetweenKeywordsInspection" xml:space="preserve">
     <value>Line continuation(s) in unexpected places. </value>
   </data>
   <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
-    <value>Non-breaking space encountered in identifier {0}</value>
+    <value>Non-breaking space encountered in identifier '{0}'</value>
     <comment>{0} Identifier</comment>
   </data>
   <data name="ThunderCode_Base" xml:space="preserve">

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -415,4 +415,10 @@ You're seeing this inspection result because there's no way that's real code and
 In memoriam, 1972-2018</value>
     <comment>{0} ThunderCode inspection description</comment>
   </data>
+  <data name="NegativeLineNumberInspection" xml:space="preserve">
+    <value>Negative line number encountered</value>
+  </data>
+  <data name="OnErrorGoToMinusOneInspection" xml:space="preserve">
+    <value>On Error GoTo -1 encountered</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionsUI.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionsUI.Designer.cs
@@ -59,7 +59,7 @@ namespace Rubberduck.Resources.Inspections {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Filter.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("CodeInspection_Filter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Code Quality Issues.
         /// </summary>
@@ -196,7 +196,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Column.
         /// </summary>
@@ -205,7 +205,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ExportColumnHeader_Column", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Component.
         /// </summary>
@@ -214,7 +214,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ExportColumnHeader_Component", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Issue.
         /// </summary>
@@ -223,7 +223,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ExportColumnHeader_Issue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Line.
         /// </summary>
@@ -232,7 +232,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ExportColumnHeader_Line", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Project.
         /// </summary>
@@ -241,7 +241,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ExportColumnHeader_Project", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Type.
         /// </summary>
@@ -250,7 +250,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ExportColumnHeader_Type", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -260,7 +260,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -280,7 +280,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -290,7 +290,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Declaration.
         /// </summary>
@@ -317,7 +317,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("Inspections_Usage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
@@ -327,27 +327,7 @@ namespace Rubberduck.Resources.Inspections {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        public static System.Drawing.Bitmap severity {
-            get {
-                object obj = ResourceManager.GetObject("severity", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        public static System.Drawing.Bitmap type {
-            get {
-                object obj = ResourceManager.GetObject("type", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0}: {1} - {2} {3}.{4}, line {5}.
         /// </summary>
@@ -390,6 +370,26 @@ namespace Rubberduck.Resources.Inspections {
         public static string QuickFix_ThisProject {
             get {
                 return ResourceManager.GetString("QuickFix_ThisProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        public static System.Drawing.Bitmap severity {
+            get {
+                object obj = ResourceManager.GetObject("severity", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        public static System.Drawing.Bitmap type {
+            get {
+                object obj = ResourceManager.GetObject("type", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
             }
         }
     }

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -68,27 +68,25 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AccessSheetUsingCodeNameQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Refer to statically accessible sheet by its code name.
+        ///   Looks up a localized string similar to Add attribute annotation.
         /// </summary>
-        public static string AddAttributeAnnotationQuickFix
-        {
+        public static string AddAttributeAnnotationQuickFix {
             get {
                 return ResourceManager.GetString("AddAttributeAnnotationQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Refer to statically accessible sheet by its code name.
+        ///   Looks up a localized string similar to Add missing attribute.
         /// </summary>
-        public static string AddMissingAttributeQuickFix
-        {
+        public static string AddMissingAttributeQuickFix {
             get {
                 return ResourceManager.GetString("AddMissingAttributeQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add explicit &apos;Step&apos; clause.
         /// </summary>
@@ -97,27 +95,25 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("AddStepOneQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Add explicit &apos;Step&apos; clause.
+        ///   Looks up a localized string similar to Adjust attribute annotation.
         /// </summary>
-        public static string AdjustAttributeAnnotationQuickFix
-        {
+        public static string AdjustAttributeAnnotationQuickFix {
             get {
                 return ResourceManager.GetString("AdjustAttributeAnnotationQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Add explicit &apos;Step&apos; clause.
+        ///   Looks up a localized string similar to Adjust attribute value(s).
         /// </summary>
-        public static string AdjustAttributeValuesQuickFix
-        {
+        public static string AdjustAttributeValuesQuickFix {
             get {
                 return ResourceManager.GetString("AdjustAttributeValuesQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use early-bound Application.WorksheetFunction method..
         /// </summary>
@@ -126,24 +122,22 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("ApplicationWorksheetFunctionQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Use early-bound Application.WorksheetFunction method..
+        ///   Looks up a localized string similar to Failed to apply the quick fix..
         /// </summary>
-        public static string ApplyQuickFixFailedCaption
-        {
-            get {
-                return ResourceManager.GetString("ApplyQuickFixFailedCaption", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Use early-bound Application.WorksheetFunction method..
-        /// </summary>
-        public static string ApplyQuickFixesFailedMessage
-        {
+        public static string ApplyQuickFixesFailedMessage {
             get {
                 return ResourceManager.GetString("ApplyQuickFixesFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Quick Fix Application Failure.
+        /// </summary>
+        public static string ApplyQuickFixFailedCaption {
+            get {
+                return ResourceManager.GetString("ApplyQuickFixFailedCaption", resourceCulture);
             }
         }
         
@@ -317,27 +311,25 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("RedundantByRefModifierQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Remove comment.
+        ///   Looks up a localized string similar to Remove annotation.
         /// </summary>
-        public static string RemoveAnnotationQuickFix
-        {
+        public static string RemoveAnnotationQuickFix {
             get {
                 return ResourceManager.GetString("RemoveAnnotationQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Remove comment.
+        ///   Looks up a localized string similar to Remove attribute.
         /// </summary>
-        public static string RemoveAttributeQuickFix
-        {
+        public static string RemoveAttributeQuickFix {
             get {
                 return ResourceManager.GetString("RemoveAttributeQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remove comment.
         /// </summary>
@@ -526,17 +518,16 @@ namespace Rubberduck.Resources.Inspections {
                 return ResourceManager.GetString("SplitMultipleDeclarationsQuickFix", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Separate multiple declarations into multiple instructions.
+        ///   Looks up a localized string similar to An affected module has been modified since the last parse..
         /// </summary>
-        public static string StaleModuleFailureReason
-        {
+        public static string StaleModuleFailureReason {
             get {
                 return ResourceManager.GetString("StaleModuleFailureReason", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Synchronize attributes/annotations in module.
         /// </summary>

--- a/Rubberduck.Resources/Menus/RubberduckMenus.Designer.cs
+++ b/Rubberduck.Resources/Menus/RubberduckMenus.Designer.cs
@@ -59,7 +59,7 @@ namespace Rubberduck.Resources.Menus {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add/Remove References....
         /// </summary>
@@ -68,7 +68,7 @@ namespace Rubberduck.Resources.Menus {
                 return ResourceManager.GetString("AddRemoveReferences", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Find all references....
         /// </summary>
@@ -95,7 +95,7 @@ namespace Rubberduck.Resources.Menus {
                 return ResourceManager.GetString("ContextMenu_GoToImplementation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Run selected test.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Rubberduck.Resources.Menus {
                 return ResourceManager.GetString("ContextMenu_RunSelectedTest", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Run tests in module.
         /// </summary>
@@ -113,7 +113,7 @@ namespace Rubberduck.Resources.Menus {
                 return ResourceManager.GetString("ContextMenu_RunSelectedTestModule", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Re&amp;name.
         /// </summary>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -22,6 +22,11 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Inspections\InspectionInfo.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>InspectionInfo.resx</DependentUpon>
+    </Compile>
     <Compile Update="Inspections\InspectionNames.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -39,6 +44,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Update="Inspections\InspectionInfo.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>InspectionInfo.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Update="Inspections\InspectionNames.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>InspectionNames.Designer.cs</LastGenOutput>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -22,6 +22,16 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Inspections\InspectionNames.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>InspectionNames.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Inspections\InspectionResults.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>InspectionResults.resx</DependentUpon>
+    </Compile>
     <Compile Update="RubberduckUI.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -29,6 +39,14 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Update="Inspections\InspectionNames.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>InspectionNames.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Inspections\InspectionResults.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>InspectionResults.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Update="RubberduckUI.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>RubberduckUI.Designer.cs</LastGenOutput>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -13,11 +13,13 @@
     <Resource Include="**\*.txt" Exclude="$(IntermediateOutputPath)\**" />
   </ItemGroup>
   <ItemGroup>
-    <Resource Update="**\*.resx">
+    <EmbeddedResource Update="**\*.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>$([System.String]::Copy('%(FileName)')).Designer.cs</LastGenOutput>
-    </Resource>
+    </EmbeddedResource>
     <Compile Update="**\*.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
       <DependentUpon>$([System.String]::Copy('%(Filename)').Replace('.Designer', '')).resx</DependentUpon>
     </Compile>
   </ItemGroup>
@@ -37,11 +39,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>InspectionResults.resx</DependentUpon>
     </Compile>
-    <Compile Update="RubberduckUI.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>RubberduckUI.resx</DependentUpon>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Inspections\InspectionInfo.resx">
@@ -55,10 +52,6 @@
     <EmbeddedResource Update="Inspections\InspectionResults.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>InspectionResults.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="RubberduckUI.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>RubberduckUI.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Rubberduck.Resources/Settings/SettingsUI.Designer.cs
+++ b/Rubberduck.Resources/Settings/SettingsUI.Designer.cs
@@ -257,7 +257,7 @@ namespace Rubberduck.Resources.Settings {
                 return ResourceManager.GetString("PageHeader_InspectionSettings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reference Settings.
         /// </summary>
@@ -266,7 +266,7 @@ namespace Rubberduck.Resources.Settings {
                 return ResourceManager.GetString("PageHeader_ReferenceSettings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Todo Settings.
         /// </summary>
@@ -329,7 +329,7 @@ namespace Rubberduck.Resources.Settings {
                 return ResourceManager.GetString("PageInstructions_InspectionSettings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Configure settings for adding and removing references..
         /// </summary>
@@ -338,7 +338,7 @@ namespace Rubberduck.Resources.Settings {
                 return ResourceManager.GetString("PageInstructions_ReferenceSettings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Configure markers to be recognized in comments..
         /// </summary>

--- a/Rubberduck.Resources/Settings/ToDoExplorerPage.Designer.cs
+++ b/Rubberduck.Resources/Settings/ToDoExplorerPage.Designer.cs
@@ -70,15 +70,6 @@ namespace Rubberduck.Resources.Settings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Text.
-        /// </summary>
-        public static string TodoSettings_Text {
-            get {
-                return ResourceManager.GetString("TodoSettings_Text", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Text:.
         /// </summary>
         public static string TodoSettings_TextLabel {

--- a/Rubberduck.Resources/Settings/UnitTestingPage.Designer.cs
+++ b/Rubberduck.Resources/Settings/UnitTestingPage.Designer.cs
@@ -94,8 +94,8 @@ namespace Rubberduck.Resources.Settings {
             get {
                 return ResourceManager.GetString("UnitTestSettings_BindingMode", resourceCulture);
             }
-        }      
-
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Dual binding.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Rubberduck.Resources.Settings {
                 return ResourceManager.GetString("UnitTestSettings_DualBinding", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Early binding.
         /// </summary>

--- a/Rubberduck.Resources/Templates.Designer.cs
+++ b/Rubberduck.Resources/Templates.Designer.cs
@@ -80,7 +80,8 @@ namespace Rubberduck.Resources {
         ///Attribute VB_Exposed = False
         ///Attribute VB_Ext_KEY = &quot;Rubberduck&quot;, &quot;Predeclared Class Module&quot;
         ///
-        ///Option Explicit.
+        ///Option Explicit
+        ///&apos;@PredeclaredId.
         /// </summary>
         public static string PredeclaredClassModule_Code {
             get {
@@ -89,7 +90,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adds a class mdoule that is predeclared and thus can be used without newing it up..
+        ///   Looks up a localized string similar to Adds a class module that is predeclared and thus can be used without first creating a new instance..
         /// </summary>
         public static string PredeclaredClassModule_Description {
             get {

--- a/Rubberduck.Resources/ToDoExplorer/ToDoExplorerUI.Designer.cs
+++ b/Rubberduck.Resources/ToDoExplorer/ToDoExplorerUI.Designer.cs
@@ -126,29 +126,11 @@ namespace Rubberduck.Resources.ToDoExplorer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO Explorer.
-        /// </summary>
-        public static string TodoSettings_Caption {
-            get {
-                return ResourceManager.GetString("TodoSettings_Caption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Text.
         /// </summary>
         public static string TodoSettings_Text {
             get {
                 return ResourceManager.GetString("TodoSettings_Text", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Text:.
-        /// </summary>
-        public static string TodoSettings_TextLabel {
-            get {
-                return ResourceManager.GetString("TodoSettings_TextLabel", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/UnitTesting/TestExplorer.Designer.cs
+++ b/Rubberduck.Resources/UnitTesting/TestExplorer.Designer.cs
@@ -106,14 +106,14 @@ namespace Rubberduck.Resources.UnitTesting {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Category Name.
+        ///   Looks up a localized string similar to Category.
         /// </summary>
         public static string TestExplorer_CategoryName {
             get {
                 return ResourceManager.GetString("TestExplorer_CategoryName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Run all tests.
         /// </summary>
@@ -122,7 +122,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_ContextMenuRunAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Run all tests in group.
         /// </summary>
@@ -131,7 +131,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_ContextMenuRunGroup", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Run selected tests.
         /// </summary>
@@ -140,7 +140,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_ContextMenuRunSelected", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Run single test.
         /// </summary>
@@ -149,7 +149,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_ContextMenuRunSingle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Duration.
         /// </summary>
@@ -203,7 +203,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_QualifiedModuleName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reset all test results.
         /// </summary>
@@ -275,7 +275,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_RunMenuPassedTests", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Selected Tests.
         /// </summary>
@@ -311,8 +311,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_TestNumberPassed", resourceCulture);
             }
         }
-
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Total Duration.
         /// </summary>
@@ -321,7 +320,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorer_TotalDuration", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uncategorized.
         /// </summary>
@@ -348,7 +347,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestExplorerWindow_Caption", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to hr.
         /// </summary>
@@ -357,7 +356,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_DurationHour", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ms.
         /// </summary>
@@ -366,7 +365,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_DurationMillisecond", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to min.
         /// </summary>
@@ -375,7 +374,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_DurationMinute", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to sec.
         /// </summary>
@@ -384,7 +383,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_DurationSecond", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed.
         /// </summary>
@@ -411,7 +410,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_Inconclusive", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} of {1} Tests Run (Total Run Time: {2:g}).
         /// </summary>
@@ -420,7 +419,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_RunSummaryFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Spectacular Failure.
         /// </summary>
@@ -429,7 +428,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_SpectacularFail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Succeeded.
         /// </summary>
@@ -438,7 +437,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_Succeeded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Summary:.
         /// </summary>
@@ -447,7 +446,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_SummaryCaption", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
@@ -456,7 +455,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("TestOutcome_Unknown", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Act.
         /// </summary>
@@ -465,7 +464,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_Act", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Arrange.
         /// </summary>
@@ -474,7 +473,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_Arrange", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Assert.
         /// </summary>
@@ -483,7 +482,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_Assert", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to TestMethod.
         /// </summary>
@@ -492,7 +491,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_BaseName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Change to expected error number.
         /// </summary>
@@ -510,7 +509,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_ErrorNotRaised", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ExpectedError.
         /// </summary>
@@ -519,7 +518,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_ExpectedError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ModuleCleanup.
         /// </summary>
@@ -528,7 +527,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_ModuleCleanupMethod", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ModuleInitialize.
         /// </summary>
@@ -537,7 +536,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_ModuleInitializeMethod", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Test raised an error.
         /// </summary>
@@ -555,16 +554,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_Rename", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to TestInitialize.
-        /// </summary>
-        public static string UnitTest_NewMethod_TestInitializeMethod {
-            get {
-                return ResourceManager.GetString("UnitTest_NewMethod_TestInitializeMethod", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to TestCleanup.
         /// </summary>
@@ -573,7 +563,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_TestCleanupMethod", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to TestExit.
         /// </summary>
@@ -582,7 +572,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_TestExitLabel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to TestFail.
         /// </summary>
@@ -591,7 +581,16 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewMethod_TestFailLabel", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TestInitialize.
+        /// </summary>
+        public static string UnitTest_NewMethod_TestInitializeMethod {
+            get {
+                return ResourceManager.GetString("UnitTest_NewMethod_TestInitializeMethod", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to TestModule.
         /// </summary>
@@ -600,7 +599,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewModule_BaseName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Tests.
         /// </summary>
@@ -609,7 +608,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewModule_DefaultFolder", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to LateBind.
         /// </summary>
@@ -618,7 +617,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewModule_LateBindConstant", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to LateBindTests.
         /// </summary>
@@ -627,7 +626,7 @@ namespace Rubberduck.Resources.UnitTesting {
                 return ResourceManager.GetString("UnitTest_NewModule_LateBindDirective", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to this method runs after every test in the module.
         /// </summary>

--- a/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
+++ b/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using Rubberduck.Inspections.Inspections.Concrete.ThunderCode;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections.ThunderCode
+{
+    [TestFixture]
+    [Category("Inspections")]
+    [Category("ThunderCode")]
+    public class ThunderCodeInspectionTests
+    {
+        [Test]
+        [TestCase(1, "Public Sub foo\u00A0bar()" + @"
+End Sub")]
+        [TestCase(0, @"Public Sub foo()
+End Sub")]
+        [TestCase(0, @"Public Sub foo bar()
+End Sub")]
+        public void NonBreakingSpaceIdentifier_ReturnsResult(int expectedCount, string inputCode)
+        {
+            var func = new Func<RubberduckParserState, IInspection>(state =>
+                new NonBreakingSpaceIdentifierInspection(state));
+            ThunderCatsGo(func, inputCode, expectedCount);
+        }
+
+        [Test]
+        [TestCase(2, @"Do")]
+        [TestCase(2, @"Loop")]
+        [TestCase(2, @"For")]
+        [TestCase(2, @"Next")]
+        [TestCase(0, @"Foo")]
+        [TestCase(0, @"Bar")]
+        [TestCase(0, @"ForNext")]
+        [TestCase(0, @"Fur")]
+        public void KeywordsUsedAsMember_ReturnsResult(int expectedCount, string inputVariable)
+        {
+            var inputCode = $@"Private Type HeeHaw
+  {inputVariable} As Variant
+End Type
+
+Private Enum HawHaw
+  [{inputVariable}] = 1
+End Enum";
+
+            var func = new Func<RubberduckParserState, IInspection>(state =>
+                new KeywordsUsedAsMemberInspection(state));
+            ThunderCatsGo(func, inputCode, expectedCount);
+        }
+
+        // NOTE: the inspection only covers trivial cases and is not exhaustive
+        // For that reason, some of test cases which the evil continuations exists
+        // may still pass without any results. To cover them all would likely be too
+        // expensie.
+        [Test]
+        [TestCase(1, @"Private Sub Foo()
+End _
+Sub")]
+        [TestCase(0, @"Private _
+Sub Foo
+End Sub")]
+        [TestCase(1, @"Private Function Foo() As Boolean
+End _
+ _
+Function")]
+        [TestCase(0, @"Private _
+ _
+Function Foo() As Boolean
+End Function")]
+        [TestCase(1, @"Private Property _
+Get Foo() As String
+End Property")]
+        [TestCase(0, @"Private Property Get Foo() As String
+Foo = _
+ 23
+End Property")]
+        [TestCase(1, @"Private Property Get Foo() As String
+Foo = 23
+End _
+Property")]
+        [TestCase(0, @"Private Property Let Foo(NewValue As String)
+  Bar = NewValue
+End Property")]
+        [TestCase(1, @"Private Property Let Foo(NewValue As String)
+  Bar = NewValue
+End _
+Property")]
+        [TestCase(2, @"Private Property _
+Let Foo(NewValue As String)
+  Bar = NewValue
+End _
+Property")]
+        [TestCase(1, @"Option _
+Explicit")]
+        [TestCase(0, @"Option Explicit")]
+        [TestCase(1, @"Option Explicit
+Option _
+Base 1")]
+        [TestCase(0, @"Option Explicit
+Option Base 1")]
+        [TestCase(1, @"Public Type foo
+  bar As Variant
+End _
+Type")]
+        [TestCase(0, @"Public Type foo
+  bar _ 
+  As _
+  Variant
+End Type")]
+        [TestCase(1, @"Public Enum foo
+  bar = 1
+End _
+Enum", Ignore = "Enum does not allow line continuations")]
+        [TestCase(0, @"Public Enum bar
+  foo =  1
+End Enum")]
+        [TestCase(1, @"Private Sub Foo()
+  On _
+Error GoTo 0
+End Sub")]
+        [TestCase(0, @"Private Sub Foo()
+  On Error GoTo 0
+End Sub")]
+        [TestCase(0, @"Private Sub Foo()
+  On Local Error GoTo 0
+End Sub")]
+        [TestCase(1, @"Private Sub Foo()
+  On _ 
+Local Error GoTo 0
+End Sub")]
+        [TestCase(0, @"Private Sub Foo()
+  For i = 0 to 3
+    Exit For
+  Next
+End Sub")]
+        [TestCase(1, @"Private Sub Foo()
+  For i = 0 to 3
+    Exit _ 
+For
+  Next
+End Sub")]
+        public void EvilLineContinuation_ReturnResults(int expectedCount, string inputCode)
+        {
+            var func = new Func<RubberduckParserState, IInspection>(state =>
+                new LineContinuationBetweenKeywordsInspection(state));
+            ThunderCatsGo(func, inputCode, expectedCount);
+        }
+
+        private void ThunderCatsGo(Func<RubberduckParserState, IInspection> inspectionFunction, string inputCode, int expectedCount)
+        {
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = inspectionFunction(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var actualResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                Assert.AreEqual(expectedCount, actualResults.Count());
+            }
+        }
+    }
+}

--- a/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
+++ b/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
@@ -150,7 +150,91 @@ End Sub")]
             ThunderCatsGo(func, inputCode, expectedCount);
         }
 
-        private void ThunderCatsGo(Func<RubberduckParserState, IInspection> inspectionFunction, string inputCode, int expectedCount)
+        [Test]
+        [TestCase(0,@"Public Sub Gogo()
+GoTo 1
+1:
+End Sub")]
+        [TestCase(0, @"Public Sub Gogo()
+GoTo 1
+1
+End Sub")]
+        [TestCase(1, @"Public Sub Gogo()
+-1:
+End Sub")]
+        [TestCase(1, @"Public Sub Gogo()
+-1
+End Sub")]
+        [TestCase(1, @"Public Sub Gogo()
+GoTo 1
+1
+-1:
+End Sub")]
+        [TestCase(2, @"Public Sub Gogo()
+GoTo -1
+1
+-1:
+End Sub")]
+        [TestCase(2, @"Public Sub Gogo()
+GoTo -1
+1:
+-1
+End Sub")]
+        [TestCase(2, @"Public Sub Gogo()
+GoTo -5
+1
+-5:
+End Sub")]
+        public void NegativeLineNumberLabel_ReturnResults(int expectedCount, string inputCode)
+        {
+            var func = new Func<RubberduckParserState, IInspection>(state =>
+                new NegativeLineNumberInspection(state));
+            ThunderCatsGo(func, inputCode, expectedCount);
+        }
+
+        [Test]
+        [TestCase(0, @"Public Sub Derp()
+  On Error GoTo 1
+  Exit Sub
+1
+  Debug.Print ""derp""
+End Sub")]
+        [TestCase(0, @"Public Sub Derp()
+  On Error GoTo 1
+  Exit Sub
+1:
+  Debug.Print ""derp""
+End Sub")]
+        [TestCase(0, @"Public Sub Derp()
+  On Error GoTo 0
+  Exit Sub
+  Debug.Print ""derp""
+End Sub")]
+        [TestCase(1, @"Public Sub Derp()
+  On Error GoTo -1
+  Exit Sub
+  Debug.Print ""derp""
+End Sub")]
+        [TestCase(0, @"Public Sub Derp()
+  On Error GoTo -2
+  Exit Sub
+-2
+  Debug.Print ""derp""
+End Sub")]
+        [TestCase(0, @"Public Sub Derp()
+  On Error GoTo -2
+  Exit Sub
+-2:
+  Debug.Print ""derp""
+End Sub")]
+        public void OnErrorGoToMinusOne_ReturnResults(int expectedCount, string inputCode)
+        {
+            var func = new Func<RubberduckParserState, IInspection>(state =>
+                new OnErrorGoToMinusOneInspection(state));
+            ThunderCatsGo(func, inputCode, expectedCount);
+        }
+
+        private static void ThunderCatsGo(Func<RubberduckParserState, IInspection> inspectionFunction, string inputCode, int expectedCount)
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out var component);
             using (var state = MockParser.CreateAndParse(vbe.Object))

--- a/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
+++ b/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
@@ -55,7 +55,7 @@ End Enum";
         // NOTE: the inspection only covers trivial cases and is not exhaustive
         // For that reason, some of test cases which the evil continuations exists
         // may still pass without any results. To cover them all would likely be too
-        // expensie.
+        // expensive.
         [Test]
         [TestCase(1, @"Private Sub Foo()
 End _


### PR DESCRIPTION
Closes #4778

Screenshot of Thundercode at action:
![image](https://user-images.githubusercontent.com/2367644/53283286-95dc8000-3709-11e9-8625-a8746da6b9d0.png)

At present 3 inspections are provided:

1) Use of non-breaking space
2) Use of keywords in either an enum or a UDT
3) Weird line continuations

Note that I bucked the convention of not adding line breaks to the inspection results, primarily because without it, it does not read as easily and the nod to ThunderFrame gets lost in the text. I hope that is OK. 
