### PR TITLE
Grammar cannot handle an empty moduleConfigProperty

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -59,7 +59,7 @@ moduleConfig :
 
 moduleConfigProperty :
     BEGINPROPERTY whiteSpace unrestrictedIdentifier (LPAREN numberLiteral RPAREN)? (whiteSpace GUIDLITERAL)? endOfStatement
-        (moduleConfigProperty | moduleConfigElement)+
+        (moduleConfigProperty | moduleConfigElement)*
     ENDPROPERTY endOfStatement
 ;
 

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -1096,6 +1096,50 @@ End
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 2);
         }
+		
+        [Category("Parser")]
+        [Test]
+        public void TestNestedVbFormModuleConfigWithAnEmptyNestedProperty()
+        {
+            string code = @"
+VERSION 5.00
+Object = ""{831FDD16-0C5C-11D2-A9FC-0000F8754DA1}#2.1#0""; ""MSCOMCTL.OCX""
+Begin VB.Form Form1 
+   Caption         =   ""Form1""
+   ClientHeight    =   3195
+   ClientLeft      =   60
+   ClientTop       =   345
+   ClientWidth     =   4680
+   LinkTopic       =   ""Form1""
+   ScaleHeight     =   3195
+   ScaleWidth      =   4680
+   StartUpPosition =   3  'Windows Default
+   Begin MSComctlLib.StatusBar StatusBar1 
+      Align           =   2  'Align Bottom
+      Height          =   375
+      Left            =   0
+      TabIndex        =   0
+      Top             =   2820
+      Width           =   4680
+      _ExtentX        =   8255
+      _ExtentY        =   661
+      _Version        =   393216
+      BeginProperty Panels {8E3867A5-8586-11D1-B16A-00C0F0283628} 
+         NumPanels       =   1
+         BeginProperty Panel1 {8E3867AB-8586-11D1-B16A-00C0F0283628} 
+         EndProperty
+      EndProperty
+   End
+End
+Attribute VB_Name = ""Form1""
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = True
+Attribute VB_Exposed = False
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 2);
+        }
 
         [Category("Parser")]
         [Test]


### PR DESCRIPTION
The grammar has the following for module config properties
```
    BEGINPROPERTY whiteSpace unrestrictedIdentifier (LPAREN numberLiteral RPAREN)? (whiteSpace GUIDLITERAL)? endOfStatement
        (moduleConfigProperty | moduleConfigElement)*
    ENDPROPERTY endOfStatement
```
However, I have found a valid VB6 source file that contains the following
```
      BeginProperty Panels {8E3867A5-8586-11D1-B16A-00C0F0283628} 
         NumPanels       =   1
         BeginProperty Panel1 {8E3867AB-8586-11D1-B16A-00C0F0283628} 
         EndProperty
      EndProperty
```
I have modified the grammar to expect zero or more config properties or config elements.