### PR TITLE
Split Documents into subclass of ClassModuleDeclaration

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/HungarianNotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/HungarianNotationInspection.cs
@@ -85,6 +85,7 @@ namespace Rubberduck.Inspections.Concrete
             DeclarationType.Constant,
             DeclarationType.Control,
             DeclarationType.ClassModule,
+            DeclarationType.Document,
             DeclarationType.Member,
             DeclarationType.Module,
             DeclarationType.ProceduralModule,

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MoveFieldCloserToUsageInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MoveFieldCloserToUsageInspection.cs
@@ -20,7 +20,7 @@ namespace Rubberduck.Inspections.Concrete
                 .Where(declaration =>
                 {
                     if (declaration.IsWithEvents
-                        || !new[] {DeclarationType.ClassModule, DeclarationType.ProceduralModule}.Contains(declaration.ParentDeclaration.DeclarationType)
+                        || !new[] {DeclarationType.ClassModule, DeclarationType.Document, DeclarationType.ProceduralModule}.Contains(declaration.ParentDeclaration.DeclarationType)
                         || IsIgnoringInspectionResultFor(declaration, AnnotationName))
                     {
                         return false;

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
@@ -70,7 +70,7 @@ namespace Rubberduck.Inspections.Concrete
                 && (parameter.IsByRef || parameter.IsImplicitByRef)
                 && !IsParameterOfDeclaredLibraryFunction(parameter)
                 && (parameter.AsTypeDeclaration == null 
-                    || (parameter.AsTypeDeclaration.DeclarationType != DeclarationType.ClassModule 
+                    || (!parameter.AsTypeDeclaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
                         && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.UserDefinedType 
                         && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.Enumeration))
                 && !parameter.References.Any(reference => reference.IsAssignment)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureNotUsedInspection.cs
@@ -29,8 +29,10 @@ namespace Rubberduck.Inspections.Concrete
         {
             var declarations = UserDeclarations.ToList();
 
-            var classes = State.DeclarationFinder.UserDeclarations(DeclarationType.ClassModule).ToList(); // declarations.Where(item => item.DeclarationType == DeclarationType.ClassModule).ToList();
-            var modules = State.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).ToList(); // declarations.Where(item => item.DeclarationType == DeclarationType.ProceduralModule).ToList();
+            var classes = State.DeclarationFinder.UserDeclarations(DeclarationType.ClassModule)
+                .Concat(State.DeclarationFinder.UserDeclarations(DeclarationType.Document))
+                .ToList(); 
+            var modules = State.DeclarationFinder.UserDeclarations(DeclarationType.ProceduralModule).ToList();
 
             var handlers = State.DeclarationFinder.UserDeclarations(DeclarationType.Control)
                 .SelectMany(control => declarations.FindEventHandlers(control)).ToList();

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnderscoreInPublicClassModuleMemberInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnderscoreInPublicClassModuleMemberInspection.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Inspections.Concrete
             var eventHandlers = State.DeclarationFinder.FindEventHandlers().ToList();
 
             var names = State.DeclarationFinder.UserDeclarations(Parsing.Symbols.DeclarationType.Member)
-                .Where(w => w.ParentDeclaration.DeclarationType == Parsing.Symbols.DeclarationType.ClassModule)
+                .Where(w => w.ParentDeclaration.DeclarationType.HasFlag(Parsing.Symbols.DeclarationType.ClassModule))
                 .Where(w => !interfaceMembers.Contains(w) && !eventHandlers.Contains(w))
                 .Where(w => w.Accessibility == Parsing.Symbols.Accessibility.Public || w.Accessibility == Parsing.Symbols.Accessibility.Implicit)
                 .Where(w => w.IdentifierName.Contains('_'))

--- a/Rubberduck.CodeAnalysis/QuickFixes/IsMissingOnInappropriateArgumentQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/IsMissingOnInappropriateArgumentQuickFix.cs
@@ -107,6 +107,7 @@ namespace Rubberduck.Inspections.QuickFixes
             switch (parameter.AsTypeDeclaration.DeclarationType)
             {
                 case DeclarationType.ClassModule:
+                case DeclarationType.Document:
                     return $"{parameter.IdentifierName} Is {Tokens.Nothing}";
                 case DeclarationType.Enumeration:
                     var members = _declarationFinderProvider.DeclarationFinder.AllDeclarations.OfType<ValuedDeclaration>()

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/OpenDesignerCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/OpenDesignerCommand.cs
@@ -48,9 +48,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 // ReSharper disable once SwitchStatementMissingSomeCases
                 switch (declaration.DeclarationType)
                 {
-                    case DeclarationType.ClassModule when qualifiedModuleName.ComponentType != ComponentType.Document:
-                        return _projectsProvider.Component(qualifiedModuleName).HasDesigner;
                     case DeclarationType.ClassModule:
+                        return _projectsProvider.Component(qualifiedModuleName).HasDesigner;
+                    case DeclarationType.Document:
                         using (var app = _vbe.HostApplication())
                         {
                             return app?.CanOpenDocumentDesigner(qualifiedModuleName) ?? false;
@@ -71,7 +71,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             if (!base.EvaluateCanExecute(parameter) || 
                 !(parameter is CodeExplorerItemViewModel node) ||
                 node.Declaration == null ||
-                node.Declaration.DeclarationType != DeclarationType.ClassModule)
+                !node.Declaration.DeclarationType.HasFlag(DeclarationType.ClassModule))
             {
                 return;
             }

--- a/Rubberduck.Core/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
+++ b/Rubberduck.Core/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
@@ -32,8 +32,9 @@ namespace Rubberduck.UI.Command.Refactorings
         private static readonly IReadOnlyList<DeclarationType> ModuleTypes = new[] 
         {
             DeclarationType.ClassModule,
+            DeclarationType.Document,
             DeclarationType.UserForm, 
-            DeclarationType.ProceduralModule, 
+            DeclarationType.ProceduralModule
         };
 
         protected override bool EvaluateCanExecute(object parameter)

--- a/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
@@ -201,13 +201,9 @@ namespace Rubberduck.Parsing.Binding
                 The declared type of <l-expression> is a specific class, which has a public default Property 
                 Get, Property Let, function or subroutine, and one of the following is true:
             */
-            bool hasDefaultMember = asTypeDeclaration != null
-                && asTypeDeclaration.DeclarationType == DeclarationType.ClassModule
-                && ((ClassModuleDeclaration)asTypeDeclaration).DefaultMember != null;
-            if (hasDefaultMember)
+            if (asTypeDeclaration is ClassModuleDeclaration classModule
+                && classModule.DefaultMember is Declaration defaultMember)
             {
-                ClassModuleDeclaration classModule = (ClassModuleDeclaration)asTypeDeclaration;
-                Declaration defaultMember = classModule.DefaultMember;
                 bool isPropertyGetLetFunctionProcedure =
                     defaultMember.DeclarationType == DeclarationType.PropertyGet
                     || defaultMember.DeclarationType == DeclarationType.PropertyLet

--- a/Rubberduck.Parsing/Binding/Bindings/MemberAccessDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/MemberAccessDefaultBinding.cs
@@ -144,7 +144,7 @@ namespace Rubberduck.Parsing.Binding
             {
                 return null;
             }
-            if (referencedType.DeclarationType != DeclarationType.UserDefinedType && referencedType.DeclarationType != DeclarationType.ClassModule)
+            if (referencedType.DeclarationType != DeclarationType.UserDefinedType && !referencedType.DeclarationType.HasFlag(DeclarationType.ClassModule))
             {
                 return null;
             }
@@ -378,7 +378,7 @@ namespace Rubberduck.Parsing.Binding
                     -   The member is a value. In this case, the member access expression is classified as a value with 
                         the same declared type as the member. 
              */
-            bool isDefaultInstanceVariableClass = _lExpression.Classification == ExpressionClassification.Type && _lExpression.ReferencedDeclaration.DeclarationType == DeclarationType.ClassModule && ((ClassModuleDeclaration)_lExpression.ReferencedDeclaration).HasDefaultInstanceVariable;
+            bool isDefaultInstanceVariableClass = _lExpression.Classification == ExpressionClassification.Type && _lExpression.ReferencedDeclaration is ClassModuleDeclaration classModule && classModule.HasDefaultInstanceVariable;
             if (_lExpression.Classification != ExpressionClassification.ProceduralModule && !isDefaultInstanceVariableClass)
             {
                 return null;

--- a/Rubberduck.Parsing/Binding/Bindings/MemberAccessTypeBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/MemberAccessTypeBinding.cs
@@ -160,7 +160,7 @@ namespace Rubberduck.Parsing.Binding
              */
             if (lExpressionIsEnclosingProject)
             {
-                if (_module.DeclarationType == DeclarationType.ClassModule && _declarationFinder.IsMatch(_module.IdentifierName, name))
+                if (_module.DeclarationType.HasFlag(DeclarationType.ClassModule) && _declarationFinder.IsMatch(_module.IdentifierName, name))
                 {
                     return new MemberAccessExpression(_module, ExpressionClassification.Type, _expression, _unrestrictedNameContext, lExpression);
                 }

--- a/Rubberduck.Parsing/Binding/Bindings/SimpleNameTypeBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/SimpleNameTypeBinding.cs
@@ -154,7 +154,7 @@ namespace Rubberduck.Parsing.Binding
             {
                 return new SimpleNameExpression(proceduralModuleEnclosingProject, ExpressionClassification.ProceduralModule, _expression);
             }
-            if (_module.DeclarationType == DeclarationType.ClassModule && _declarationFinder.IsMatch(_module.IdentifierName, name))
+            if (_module is ClassModuleDeclaration && _declarationFinder.IsMatch(_module.IdentifierName, name))
             {
                 return new SimpleNameExpression(_module, ExpressionClassification.Type, _expression);
             }

--- a/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ClassModuleDeclaration.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Rubberduck.Parsing.Symbols
 {
-    public sealed class ClassModuleDeclaration : ModuleDeclaration
+    public class ClassModuleDeclaration : ModuleDeclaration
     {
         private readonly List<string> _supertypeNames;
         private readonly HashSet<Declaration> _supertypes;
@@ -28,12 +28,13 @@ namespace Rubberduck.Parsing.Symbols
                   Attributes attributes,
                   bool isWithEvents = false,
                   bool hasDefaultInstanceVariable = false,
-                  bool isControl = false)
+                  bool isControl = false,
+                  bool isDocument = false)
             : base(
                   qualifiedName,
                   projectDeclaration,
                   name,
-                  DeclarationType.ClassModule,
+                  isDocument ? DeclarationType.Document : DeclarationType.ClassModule,
                   isUserDefined,
                   annotations,
                   attributes,

--- a/Rubberduck.Parsing/Symbols/Declaration.cs
+++ b/Rubberduck.Parsing/Symbols/Declaration.cs
@@ -235,7 +235,7 @@ namespace Rubberduck.Parsing.Symbols
             {
                 return null;
             }
-            if (declaration.DeclarationType == DeclarationType.ClassModule || declaration.DeclarationType == DeclarationType.ProceduralModule)
+            if (declaration.DeclarationType.HasFlag(DeclarationType.ClassModule) || declaration.DeclarationType == DeclarationType.ProceduralModule)
             {
                 return declaration;
             }
@@ -546,6 +546,7 @@ namespace Rubberduck.Parsing.Symbols
                     case DeclarationType.Project:
                         return "VBE";
                     case DeclarationType.ClassModule:
+                    case DeclarationType.Document:
                     case DeclarationType.ProceduralModule:
                         return QualifiedModuleName.ToString();
                     case DeclarationType.Procedure:

--- a/Rubberduck.Parsing/Symbols/DocumentModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/DocumentModuleDeclaration.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Rubberduck.Parsing.Annotations;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Parsing.Symbols
+{
+    public class DocumentModuleDeclaration : ClassModuleDeclaration
+    {
+        public DocumentModuleDeclaration(
+            QualifiedMemberName qualifiedName,
+            Declaration projectDeclaration,
+            string name,
+            IEnumerable<IAnnotation> annotations,
+            Attributes attributes)
+            : base(qualifiedName, 
+                projectDeclaration,
+                name,
+                true,
+                annotations,
+                attributes,
+                true,
+                true,
+                false,
+                true)
+        { }
+    }
+}

--- a/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReferenceResolver.cs
@@ -32,7 +32,7 @@ namespace Rubberduck.Parsing.Symbols
             _withBlockExpressions = new Stack<IBoundExpression>();
             _moduleDeclaration = finder.MatchName(_qualifiedModuleName.ComponentName)
                 .SingleOrDefault(item =>
-                    (item.DeclarationType == DeclarationType.ClassModule ||
+                    (item.DeclarationType.HasFlag(DeclarationType.ClassModule) ||
                      item.DeclarationType == DeclarationType.ProceduralModule)
                     && item.QualifiedName.QualifiedModuleName.Equals(_qualifiedModuleName));
             SetCurrentScope();

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -184,6 +184,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         private IDictionary<(VBAParser.ImplementsStmtContext Context, Declaration Implementor), List<ModuleBodyElementDeclaration>> FindAllImplementingMembers()
         {
             var implementsInstructions = UserDeclarations(DeclarationType.ClassModule)
+                .Concat(UserDeclarations(DeclarationType.Document))
                 .SelectMany(cls => cls.References
                     .Where(reference => reference.Context is VBAParser.ImplementsStmtContext 
                         || (reference.Context).IsDescendentOf<VBAParser.ImplementsStmtContext>())
@@ -214,6 +215,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         private Dictionary<ClassModuleDeclaration, List<ClassModuleDeclaration>> FindAllImplementionsByInterface()
         {
             return UserDeclarations(DeclarationType.ClassModule)
+                .Concat(UserDeclarations(DeclarationType.Document))
                 .Cast<ClassModuleDeclaration>()
                 .Where(module => module.IsInterface).ToDictionary(intrface => intrface,
                     intrface => intrface.Subtypes.Cast<ClassModuleDeclaration>()
@@ -237,6 +239,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         private IDictionary<ClassModuleDeclaration, List<Declaration>> FindAllIinterfaceMembersByModule()
         {
             return UserDeclarations(DeclarationType.ClassModule)
+                .Concat(UserDeclarations(DeclarationType.Document))
                 .Cast<ClassModuleDeclaration>()
                 .Where(module => module.IsInterface)
                 .ToDictionary(
@@ -819,7 +822,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         {
             var nameMatches = MatchName(defaultInstanceVariableClassName);
             var moduleMatches = nameMatches.Where(m =>
-                m.DeclarationType == DeclarationType.ClassModule && ((ClassModuleDeclaration)m).HasDefaultInstanceVariable
+                m is ClassModuleDeclaration classModule 
+                && classModule.HasDefaultInstanceVariable
                 && Declaration.GetProjectParent(m).Equals(callingProject)).ToList(); 
             var accessibleModules = moduleMatches.Where(calledModule => AccessibilityCheck.IsModuleAccessible(callingProject, callingModule, calledModule));
             var match = accessibleModules.FirstOrDefault();
@@ -848,8 +852,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         public Declaration FindDefaultInstanceVariableClassReferencedProject(Declaration callingProject, Declaration callingModule, string calleeModuleName)
         {
             var moduleMatches = FindAllInReferencedProjectByPriority(callingProject, calleeModuleName,
-                p => p.DeclarationType == DeclarationType.ClassModule &&
-                     ((ClassModuleDeclaration) p).HasDefaultInstanceVariable);
+                p => p is ClassModuleDeclaration classModule &&
+                     classModule.HasDefaultInstanceVariable);
             var accessibleModules = moduleMatches.Where(calledModule => AccessibilityCheck.IsModuleAccessible(callingProject, callingModule, calledModule));
             var match = accessibleModules.FirstOrDefault();
             return match;
@@ -860,8 +864,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         {
             var moduleMatches = FindAllInReferencedProjectByPriority(callingProject, calleeModuleName,
                 p => referencedProject.Equals(Declaration.GetProjectParent(p))
-                    && p.DeclarationType == DeclarationType.ClassModule 
-                    && ((ClassModuleDeclaration)p).HasDefaultInstanceVariable);
+                    && p is ClassModuleDeclaration classModule
+                    && classModule.HasDefaultInstanceVariable);
             var accessibleModules = moduleMatches.Where(calledModule => AccessibilityCheck.IsModuleAccessible(callingProject, callingModule, calledModule));
             var match = accessibleModules.FirstOrDefault();
             return match;
@@ -1082,7 +1086,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             var isInstanceSensitive = IsInstanceSensitive(memberType);
             var memberMatches = FindAllInReferencedProjectByPriority(callingProject, memberName,
                 p => (!isInstanceSensitive || Declaration.GetModuleParent(p) == null ||
-                      Declaration.GetModuleParent(p).DeclarationType != DeclarationType.ClassModule) &&
+                      !Declaration.GetModuleParent(p).DeclarationType.HasFlag(DeclarationType.ClassModule)) &&
                      p.DeclarationType.HasFlag(memberType));
             var accessibleMembers = memberMatches.Where(m => AccessibilityCheck.IsMemberAccessible(callingProject, callingModule, callingParent, m));
             var match = accessibleMembers.FirstOrDefault();
@@ -1109,7 +1113,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                 memberName, 
                 p => p.DeclarationType.HasFlag(memberType) 
                     && (Declaration.GetModuleParent(p) == null 
-                        || Declaration.GetModuleParent(p).DeclarationType == DeclarationType.ClassModule) 
+                        || Declaration.GetModuleParent(p).DeclarationType.HasFlag(DeclarationType.ClassModule)) 
                     && ((ClassModuleDeclaration)Declaration.GetModuleParent(p)).IsGlobalClassModule);
             var accessibleMembers = memberMatches.Where(m => AccessibilityCheck.IsMemberAccessible(callingProject, callingModule, callingParent, m));
             var match = accessibleMembers.FirstOrDefault();
@@ -1240,7 +1244,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                 return Enumerable.Empty<Declaration>();
             }
 
-            var identifierMatches = MatchName(newName);
+            var identifierMatches = MatchName(newName).ToList();
             if (!identifierMatches.Any())
             {
                 return Enumerable.Empty<Declaration>();
@@ -1252,11 +1256,11 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                     IsEnumOrUDTMemberDeclaration(idm) && idm.ParentDeclaration == renameTarget.ParentDeclaration);
             }
 
-            identifierMatches = identifierMatches.Where(nc => !IsEnumOrUDTMemberDeclaration(nc));
+            identifierMatches = identifierMatches.Where(nc => !IsEnumOrUDTMemberDeclaration(nc)).ToList();
             var referenceConflicts = identifierMatches.Where(idm =>
                 renameTarget.References
                     .Any(renameTargetRef => renameTargetRef.ParentScoping == idm.ParentDeclaration
-                        || renameTarget.ParentDeclaration.DeclarationType != DeclarationType.ClassModule
+                        || !renameTarget.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
                             && idm == renameTargetRef.ParentScoping
                             && !UsesScopeResolution(renameTargetRef.Context.Parent)
                         || idm.References
@@ -1264,7 +1268,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                                 && !UsesScopeResolution(renameTargetRef.Context.Parent)))
                 || idm.DeclarationType.HasFlag(DeclarationType.Variable)
                     && idm.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Module)
-                    && renameTarget.References.Any(renameTargetRef => renameTargetRef.QualifiedModuleName == idm.ParentDeclaration.QualifiedModuleName));
+                    && renameTarget.References.Any(renameTargetRef => renameTargetRef.QualifiedModuleName == idm.ParentDeclaration.QualifiedModuleName))
+                .ToList();
 
             if (referenceConflicts.Any())
             {

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
@@ -176,8 +176,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
             QualifiedModuleName qualifiedModuleName,
             IParseTree tree,
             IDictionary<int, List<IAnnotation>> annotationsOnWhiteSpaceLines,
-            IDictionary<(string scopeIdentifier, DeclarationType scopeType),
-                Attributes> attributes,
+            IDictionary<(string scopeIdentifier, DeclarationType scopeType),Attributes> attributes,
             Declaration projectDeclaration)
         {
             var moduleAttributes = ModuleAttributes(qualifiedModuleName, attributes);
@@ -199,6 +198,13 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                         projectDeclaration,
                         qualifiedModuleName.ComponentName,
                         true,
+                        moduleAnnotations,
+                        moduleAttributes);
+                case ComponentType.Document:
+                    return new DocumentModuleDeclaration(
+                        qualifiedModuleName.QualifyMemberName(qualifiedModuleName.ComponentName),
+                        projectDeclaration,
+                        qualifiedModuleName.ComponentName,
                         moduleAnnotations,
                         moduleAttributes);
                 default:

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
@@ -279,9 +279,10 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                             attributes);
                         break;
                 }
-                if (_parentDeclaration.DeclarationType == DeclarationType.ClassModule && result is ICanBeDefaultMember && ((ICanBeDefaultMember)result).IsDefaultMember)
+                if (_parentDeclaration is ClassModuleDeclaration classParent && 
+                    ((result as ICanBeDefaultMember)?.IsDefaultMember ?? false))
                 {
-                    ((ClassModuleDeclaration)_parentDeclaration).DefaultMember = result;
+                    classParent.DefaultMember = result;
                 }
             }
             return result;

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/CompilationPasses/TypeAnnotationPass.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/CompilationPasses/TypeAnnotationPass.cs
@@ -43,7 +43,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement.CompilationPasses
 
         private void AnnotateType(Declaration declaration)
         {
-            if (declaration.DeclarationType == DeclarationType.ClassModule || 
+            if (declaration.DeclarationType.HasFlag(DeclarationType.ClassModule) || 
                 declaration.DeclarationType == DeclarationType.UserDefinedType || 
                 declaration.DeclarationType == DeclarationType.ComAlias)
             {

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/CompilationPasses/TypeHierarchyPass.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/CompilationPasses/TypeHierarchyPass.cs
@@ -31,8 +31,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement.CompilationPasses
 
         public void Execute(IReadOnlyCollection<QualifiedModuleName> modules)
         {
-            var toRelsolveSupertypesFor = _declarationFinder
-                                            .UserDeclarations(DeclarationType.ClassModule)
+            var toRelsolveSupertypesFor = _declarationFinder.UserDeclarations(DeclarationType.ClassModule)
+                                            .Concat(_declarationFinder.UserDeclarations(DeclarationType.Document))
                                             .Where(decl => modules.Contains(decl.QualifiedName.QualifiedModuleName))
                                             .Concat(_declarationFinder.BuiltInDeclarations(DeclarationType.ClassModule));
             foreach (var declaration in toRelsolveSupertypesFor)
@@ -43,7 +43,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement.CompilationPasses
 
         private void AddImplementedInterface(Declaration potentialClassModule)
         {
-            if (potentialClassModule.DeclarationType != DeclarationType.ClassModule)
+            if (!potentialClassModule.DeclarationType.HasFlag(DeclarationType.ClassModule))
             {
                 return;
             }

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
@@ -148,17 +148,16 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
         private void AddSupertypesForDocumentModules(IReadOnlyCollection<QualifiedModuleName> modules, RubberduckParserState state)
         {
-            var allClassModuleDeclarations = state.DeclarationFinder.UserDeclarations(DeclarationType.ClassModule);
-            var documentModuleDeclarations = allClassModuleDeclarations.Where(declaration =>
-                                                                                declaration.QualifiedName.QualifiedModuleName.ComponentType == ComponentType.Document
-                                                                                && modules.Contains(declaration.QualifiedName.QualifiedModuleName));
+            var documentModuleDeclarations = state.DeclarationFinder.UserDeclarations(DeclarationType.Document)
+                .OfType<DocumentModuleDeclaration>()
+                .Where(declaration => modules.Contains(declaration.QualifiedName.QualifiedModuleName));
 
             foreach (var documentDeclaration in documentModuleDeclarations)
             {
                 var documentSupertype = SupertypeForDocument(documentDeclaration.QualifiedName.QualifiedModuleName, state);
                 if (documentSupertype != null)
                 {
-                    ((ClassModuleDeclaration)documentDeclaration).AddSupertype(documentSupertype);
+                    documentDeclaration.AddSupertype(documentSupertype);
                 }
             }
         }

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -313,10 +313,10 @@ namespace Rubberduck.Parsing.VBA
             foreach (var declaration in AllUserDeclarations)
             {
                 if (declaration.ProjectId == e.ProjectId &&
-                    declaration.DeclarationType == DeclarationType.ClassModule &&
+                    declaration is ClassModuleDeclaration classModule &&
                     declaration.IdentifierName == e.OldName)
                 {
-                    foreach (var superType in ((ClassModuleDeclaration)declaration).Supertypes)
+                    foreach (var superType in classModule.Supertypes)
                     {
                         if (superType.IdentifierName == "Worksheet")
                         {

--- a/Rubberduck.Refactorings/Common/DeclarationExtensions.cs
+++ b/Rubberduck.Refactorings/Common/DeclarationExtensions.cs
@@ -324,7 +324,7 @@ namespace Rubberduck.Common
             .Select(item => new
             {
                 WithEventDeclaration = item, 
-                EventProvider = items.SingleOrDefault(type => type.DeclarationType == DeclarationType.ClassModule && type.QualifiedName.QualifiedModuleName == item.QualifiedName.QualifiedModuleName)
+                EventProvider = items.SingleOrDefault(type => type.DeclarationType.HasFlag(DeclarationType.ClassModule) && type.QualifiedName.QualifiedModuleName == item.QualifiedName.QualifiedModuleName)
             })
             .Select(item => new
             {

--- a/Rubberduck.Refactorings/ImplementInterface/ImplementInterfaceRefactoring.cs
+++ b/Rubberduck.Refactorings/ImplementInterface/ImplementInterfaceRefactoring.cs
@@ -50,7 +50,7 @@ namespace Rubberduck.Refactorings.ImplementInterface
         {
             DeclarationType.ClassModule,
             DeclarationType.UserForm, 
-            DeclarationType.Document, 
+            DeclarationType.Document
         };
 
         public void Refactor(QualifiedSelection selection)

--- a/Rubberduck.Refactorings/IntroduceField/IntroduceFieldRefactoring.cs
+++ b/Rubberduck.Refactorings/IntroduceField/IntroduceFieldRefactoring.cs
@@ -73,7 +73,7 @@ namespace Rubberduck.Refactorings.IntroduceField
 
         private void PromoteVariable(Declaration target)
         {
-            if (new[] { DeclarationType.ClassModule, DeclarationType.ProceduralModule }.Contains(target.ParentDeclaration.DeclarationType))
+            if (new[] { DeclarationType.ClassModule, DeclarationType.Document, DeclarationType.ProceduralModule }.Contains(target.ParentDeclaration.DeclarationType))
             {
                 _messageBox.NotifyWarn(RubberduckUI.PromoteVariable_InvalidSelection, RubberduckUI.IntroduceParameter_Caption);
                 return;

--- a/Rubberduck.Refactorings/IntroduceParameter/IntroduceParameterRefactoring.cs
+++ b/Rubberduck.Refactorings/IntroduceParameter/IntroduceParameterRefactoring.cs
@@ -83,7 +83,7 @@ namespace Rubberduck.Refactorings.IntroduceParameter
                 return;
             }
 
-            if (new[] { DeclarationType.ClassModule, DeclarationType.ProceduralModule }.Contains(target.ParentDeclaration.DeclarationType))
+            if (new[] { DeclarationType.ClassModule, DeclarationType.Document, DeclarationType.ProceduralModule }.Contains(target.ParentDeclaration.DeclarationType))
             {
                 _messageBox.NotifyWarn(RubberduckUI.PromoteVariable_InvalidSelection, RubberduckUI.IntroduceParameter_Caption);
                 return;

--- a/RubberduckTests/CodeExplorer/CodeExplorerComparerTests.cs
+++ b/RubberduckTests/CodeExplorer/CodeExplorerComparerTests.cs
@@ -287,8 +287,6 @@ End Sub
                 var docNode = folder.Children.Single(s => s.Name == "Document1");
 
                 // this tests the logic I wrote to place docs above cls modules even though the parser calls them both cls modules
-                Assert.AreEqual(clsNode.Declaration.DeclarationType, docNode.Declaration.DeclarationType);
-
                 Assert.AreEqual(-1, new CompareByDeclarationType().Compare(docNode, clsNode));
             }
         }


### PR DESCRIPTION
This is basically just a stub ATM, and is intended to house document specific functionality (mainly to allow caching of properties).

Closes #4724