### PR TITLE
Add option to view log in explorer. Ref #4797

### DIFF
--- a/Rubberduck.Core/UI/About/AboutControl.xaml
+++ b/Rubberduck.Core/UI/About/AboutControl.xaml
@@ -77,15 +77,22 @@
         <Border Grid.Row="1" Grid.Column="0" Style="{StaticResource SectionBorder}">
             <StackPanel Grid.Column="0" Grid.Row="1"
                         MinHeight="100" MinWidth="250" 
-                        VerticalAlignment="Center"
-                        MouseLeftButtonDown="CopyVersionInfo_MouseLeftButtonDown" >
+                        VerticalAlignment="Center">
                 <TextBlock x:Name="Version" Text="{Binding Version}" Style="{StaticResource HeadingLabel}" HorizontalAlignment="Center" Margin="5" />
                 <TextBlock x:Name="OperatingSystem" Text="{Binding OperatingSystem}" Style="{StaticResource NormalLabel}" HorizontalAlignment="Center"/>
                 <TextBlock x:Name="HostProduct" Text="{Binding HostProduct}" Style="{StaticResource NormalLabel}" HorizontalAlignment="Center"/>
                 <TextBlock x:Name="HostVersion" Text="{Binding HostVersion}" Style="{StaticResource NormalLabel}" HorizontalAlignment="Center"/>
                 <TextBlock x:Name="HostExecutable" Text="{Binding HostExecutable}" Style="{StaticResource NormalLabel}" HorizontalAlignment="Center"/>
-                <TextBlock Text="{Resx ResxName=Rubberduck.Resources.About.AboutUI, Key=AboutWindow_CopyVersionLabel}" 
-                           Style="{StaticResource SubtleLabel}" HorizontalAlignment="Center" Margin="5,10"/>
+                <TextBlock Style="{StaticResource SubtleLabel}" HorizontalAlignment="Center" Margin="5,10,5,2">
+                    <Hyperlink Click="CopyVersionInfo_Click">
+                        <Run Text="{Resx ResxName=Rubberduck.Resources.About.AboutUI, Key=AboutWindow_CopyVersionLabel}"/>
+                    </Hyperlink>
+                </TextBlock>
+                <TextBlock Style="{StaticResource SubtleLabel}" HorizontalAlignment="Center" Margin="5,2,5,10" >
+                    <Hyperlink Command="{Binding ViewLogCommand}">
+                        <Run Text="{Resx ResxName=Rubberduck.Resources.About.AboutUI, Key=AboutWindow_ViewLogLabel}"/>
+                    </Hyperlink>
+                </TextBlock>
             </StackPanel>
         </Border>
         <Border Grid.Row="2" Grid.Column="0" Style="{StaticResource SectionBorder}">
@@ -99,7 +106,7 @@
                     <Border Style="{StaticResource ReportButtonBorder}">
                         <TextBlock>
                             <Hyperlink Name="GitHubIssueUrl"
-                                       NavigateUri="https://github.com/rubberduck-vba/Rubberduck/issues/new"
+                                       NavigateUri="https://github.com/rubberduck-vba/Rubberduck/issues/new/choose"
                                        TextDecorations="{x:Null}"
                                        Command="{Binding UriCommand}" CommandParameter="{Binding ElementName=GitHubIssueUrl, Path=NavigateUri}">
                                 <Label Height="40" Foreground="White" FontFamily="Segoe UI" FontSize="13" FontWeight="SemiBold"
@@ -151,7 +158,7 @@
             </TextBlock>
         </Border>
         <Border Grid.Row="1" Grid.Column="1" Grid.RowSpan="2" Style="{StaticResource SectionBorder}">
-            <ScrollViewer Margin="5" Height="350" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
+            <ScrollViewer Margin="5" Height="360" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
                 <StackPanel VerticalAlignment="Top">
                     <TextBlock Text="{Resx ResxName=Rubberduck.Resources.About.AboutUI, Key=AboutWindow_AttributionsLabel}"
                                Style="{StaticResource HeadingLabel}" />

--- a/Rubberduck.Core/UI/About/AboutControl.xaml.cs
+++ b/Rubberduck.Core/UI/About/AboutControl.xaml.cs
@@ -23,7 +23,7 @@ namespace Rubberduck.UI.About
             }
         }
 
-        private void CopyVersionInfo_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void CopyVersionInfo_Click(object sender, RoutedEventArgs e)
         {
             CopyVersionInfoToClipboard();
         }

--- a/Rubberduck.Core/UI/About/AboutControlViewModel.cs
+++ b/Rubberduck.Core/UI/About/AboutControlViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using NLog;
+using NLog.Targets;
 using Rubberduck.Resources.About;
 using Rubberduck.UI.Command;
 using Rubberduck.VersionCheck;
@@ -9,8 +10,6 @@ using System.IO;
 
 namespace Rubberduck.UI.About
 {
-    using NLog.Targets;
-
     public class AboutControlViewModel
     {
         private readonly IVersionCheck _version;

--- a/Rubberduck.Core/UI/About/AboutControlViewModel.cs
+++ b/Rubberduck.Core/UI/About/AboutControlViewModel.cs
@@ -17,6 +17,9 @@ namespace Rubberduck.UI.About
         public AboutControlViewModel(IVersionCheck version)
         {
             _version = version;
+
+            UriCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteUri);
+            ViewLogCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteViewLog);
         }
 
         public string Version => string.Format(Resources.RubberduckUI.Rubberduck_AboutBuild, _version.CurrentVersion);
@@ -32,46 +35,28 @@ namespace Rubberduck.UI.About
         public string HostExecutable => string.Format(AboutUI.AboutWindow_HostExecutable,
             Path.GetFileName(Application.ExecutablePath).ToUpper()); // .ToUpper() used to convert ExceL.EXE -> EXCEL.EXE
             
-        private CommandBase _uriCommand;
-        public CommandBase UriCommand
-        {
-            get
-            {
-                if (_uriCommand != null)
-                {
-                    return _uriCommand;
-                }
-                return _uriCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), uri =>
-                {
-                    Process.Start(new ProcessStartInfo(((Uri)uri).AbsoluteUri));
-                });
-            }
-        }
-
-        private CommandBase _viewLogCommand;
-        public CommandBase ViewLogCommand
-        {
-            get
-            {
-                if (_viewLogCommand != null)
-                {
-                    return _viewLogCommand;
-                }
-                return _viewLogCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), _ =>
-                {
-                    var fileTarget = (FileTarget) LogManager.Configuration.FindTargetByName("file");
-                    
-                    var logEventInfo = new LogEventInfo { TimeStamp = DateTime.Now }; 
-                    var fileName = fileTarget.FileName.Render(logEventInfo);
-                    
-                    // The /select argument will only work if the path has backslashes
-                    fileName = fileName.Replace("/", "\\");
-                    Process.Start(new ProcessStartInfo("explorer.exe", $"/select, \"{fileName}\""));
-                });
-            }
-        }
-
         public string AboutCopyright =>
             string.Format(AboutUI.AboutWindow_Copyright, DateTime.Now.Year);
+
+        public CommandBase UriCommand { get; }
+
+        public CommandBase ViewLogCommand { get; }
+
+        private void ExecuteUri(object parameter)
+        {
+            Process.Start(new ProcessStartInfo(((Uri)parameter).AbsoluteUri));
+        }
+
+        private void ExecuteViewLog(object parameter)
+        {
+            var fileTarget = (FileTarget) LogManager.Configuration.FindTargetByName("file");
+                    
+            var logEventInfo = new LogEventInfo { TimeStamp = DateTime.Now }; 
+            var fileName = fileTarget.FileName.Render(logEventInfo);
+                    
+            // The /select argument will only work if the path has backslashes
+            fileName = fileName.Replace("/", "\\");
+            Process.Start(new ProcessStartInfo("explorer.exe", $"/select, \"{fileName}\""));
+        }
     }
 }

--- a/Rubberduck.Core/UI/About/AboutDialog.Designer.cs
+++ b/Rubberduck.Core/UI/About/AboutDialog.Designer.cs
@@ -42,7 +42,7 @@ namespace Rubberduck.UI.About
             this.ElementHost.Location = new System.Drawing.Point(0, 0);
             this.ElementHost.Margin = new System.Windows.Forms.Padding(2);
             this.ElementHost.Name = "ElementHost";
-            this.ElementHost.Size = new System.Drawing.Size(610, 560);
+            this.ElementHost.Size = new System.Drawing.Size(610, 579);
             this.ElementHost.TabIndex = 0;
             this.ElementHost.Child = this.AboutControl;
             // 
@@ -50,7 +50,7 @@ namespace Rubberduck.UI.About
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(610, 560);
+            this.ClientSize = new System.Drawing.Size(610, 579);
             this.Controls.Add(this.ElementHost);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));

--- a/Rubberduck.Resources/About/AboutUI.Designer.cs
+++ b/Rubberduck.Resources/About/AboutUI.Designer.cs
@@ -121,7 +121,7 @@ namespace Rubberduck.Resources.About {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to © Copyright 2014-2018 Rubberduck project contributors.
+        ///   Looks up a localized string similar to © Copyright 2014-{0} Rubberduck project contributors.
         /// </summary>
         public static string AboutWindow_Copyright {
             get {
@@ -139,7 +139,7 @@ namespace Rubberduck.Resources.About {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy version information to clipboard..
+        ///   Looks up a localized string similar to Copy version information to clipboard.
         /// </summary>
         public static string AboutWindow_CopyVersionLabel {
             get {
@@ -245,6 +245,15 @@ namespace Rubberduck.Resources.About {
         public static string AboutWindow_SpecialThanksLabel {
             get {
                 return ResourceManager.GetString("AboutWindow_SpecialThanksLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View log in File Explorer.
+        /// </summary>
+        public static string AboutWindow_ViewLogLabel {
+            get {
+                return ResourceManager.GetString("AboutWindow_ViewLogLabel", resourceCulture);
             }
         }
     }

--- a/Rubberduck.Resources/About/AboutUI.cs.resx
+++ b/Rubberduck.Resources/About/AboutUI.cs.resx
@@ -124,7 +124,7 @@
     <value>O Rubberducku</value>
   </data>
   <data name="AboutWindow_Copyright" xml:space="preserve">
-    <value>© Copyright 2014-2018 Rubberduck project contributors</value>
+    <value>© Copyright 2014-{0} Rubberduck project contributors</value>
   </data>
   <data name="AboutWindow_SpecialThanksLabel" xml:space="preserve">
     <value>Speciální Poděkování</value>
@@ -184,5 +184,8 @@ Všichni ti, co koukají na hvězdy, oblíbenci a následovníci,, pro ten tepl�
   </data>
   <data name="AboutWindow_ReportAnIssue" xml:space="preserve">
     <value>Nahlásit problém</value>
+  </data>
+  <data name="AboutWindow_ViewLogLabel" xml:space="preserve">
+    <value>Zobrazit protokol Průzkumník souborů</value>
   </data>
 </root>

--- a/Rubberduck.Resources/About/AboutUI.cs.resx
+++ b/Rubberduck.Resources/About/AboutUI.cs.resx
@@ -185,7 +185,4 @@ Všichni ti, co koukají na hvězdy, oblíbenci a následovníci,, pro ten tepl�
   <data name="AboutWindow_ReportAnIssue" xml:space="preserve">
     <value>Nahlásit problém</value>
   </data>
-  <data name="AboutWindow_ViewLogLabel" xml:space="preserve">
-    <value>Zobrazit protokol Průzkumník souborů</value>
-  </data>
 </root>

--- a/Rubberduck.Resources/About/AboutUI.cs.resx
+++ b/Rubberduck.Resources/About/AboutUI.cs.resx
@@ -156,7 +156,7 @@ Všichni ti, co koukají na hvězdy, oblíbenci a následovníci,, pro ten tepl�
     <value>Zkopírovat informace o verzi</value>
   </data>
   <data name="AboutWindow_CopyVersionLabel" xml:space="preserve">
-    <value>Klikněte zde pro zkopírování informací do schánky.</value>
+    <value>Klikněte zde pro zkopírování informací do schánky</value>
   </data>
   <data name="AboutWindow_CopyVersionMessage" xml:space="preserve">
     <value>Informace o verzi byly zkopírovány do schránky.</value>

--- a/Rubberduck.Resources/About/AboutUI.de.resx
+++ b/Rubberduck.Resources/About/AboutUI.de.resx
@@ -124,7 +124,7 @@
     <value>Über Rubberduck</value>
   </data>
   <data name="AboutWindow_Copyright" xml:space="preserve">
-    <value>© Copyright 2014-2018 Rubberduck project contributors</value>
+    <value>© Copyright 2014-{0} Rubberduck project contributors</value>
   </data>
   <data name="AboutWindow_SpecialThanksLabel" xml:space="preserve">
     <value>Spezieller Dank</value>
@@ -184,5 +184,8 @@ Allen Sternguckern, Likern &amp; Followern, für das warme Kribbeln
   </data>
   <data name="AboutWindow_ReportAnIssue" xml:space="preserve">
     <value>Einen Fehler melden</value>
+  </data>
+  <data name="AboutWindow_ViewLogLabel" xml:space="preserve">
+    <value>Log-Datei im File Explorer betrachten</value>
   </data>
 </root>

--- a/Rubberduck.Resources/About/AboutUI.de.resx
+++ b/Rubberduck.Resources/About/AboutUI.de.resx
@@ -156,7 +156,7 @@ Allen Sternguckern, Likern &amp; Followern, für das warme Kribbeln
     <value>Erfolgreich Kopiert</value>
   </data>
   <data name="AboutWindow_CopyVersionLabel" xml:space="preserve">
-    <value>Hier klicken, um Versionsinformation in Zwischenablage zu kopieren.</value>
+    <value>Hier klicken, um Versionsinformation in Zwischenablage zu kopieren</value>
   </data>
   <data name="AboutWindow_CopyVersionMessage" xml:space="preserve">
     <value>Versionsinformation in Zwischenablage kopiert.</value>

--- a/Rubberduck.Resources/About/AboutUI.es.resx
+++ b/Rubberduck.Resources/About/AboutUI.es.resx
@@ -124,7 +124,7 @@
     <value>Acerca de Rubberduck</value>
   </data>
   <data name="AboutWindow_Copyright" xml:space="preserve">
-    <value>© Copyright 2014-2018 contribuyentes al proyecto Rubberduck</value>
+    <value>© Copyright 2014-{0} contribuyentes al proyecto Rubberduck</value>
   </data>
   <data name="AboutWindow_SpecialThanksLabel" xml:space="preserve">
     <value>Gracias especiales</value>
@@ -156,7 +156,7 @@ Todos nuestros cazadores de estrellas, seguidores y seguidores, para los cálido
     <value>Copiar información de la versión</value>
   </data>
   <data name="AboutWindow_CopyVersionLabel" xml:space="preserve">
-    <value>Copia la información de la versión al portapapeles.</value>
+    <value>Copia la información de la versión al portapapeles</value>
   </data>
   <data name="AboutWindow_CopyVersionMessage" xml:space="preserve">
     <value>La información de la versión fue copiada al portapapeles.</value>
@@ -184,5 +184,8 @@ Todos nuestros cazadores de estrellas, seguidores y seguidores, para los cálido
   </data>
   <data name="AboutWindow_ReportAnIssue" xml:space="preserve">
     <value>Reportar un problema</value>
+  </data>
+  <data name="AboutWIndow_ViewLogFile" xml:space="preserve">
+    <value>Abrir log en el Explorador de Archivos</value>
   </data>
 </root>

--- a/Rubberduck.Resources/About/AboutUI.fr.resx
+++ b/Rubberduck.Resources/About/AboutUI.fr.resx
@@ -184,7 +184,4 @@ Tous ceux qui nous ont donné une étoile ou un "like"
   <data name="AboutWindow_ReportAnIssue" xml:space="preserve">
     <value>Rapporter un problème</value>
   </data>
-  <data name="AboutWindow_ViewLogLabel" xml:space="preserve">
-    <value>Afficher le journal dans l'explorateur de fichiers</value>
-  </data>
 </root>

--- a/Rubberduck.Resources/About/AboutUI.fr.resx
+++ b/Rubberduck.Resources/About/AboutUI.fr.resx
@@ -155,7 +155,7 @@ Tous ceux qui nous ont donné une étoile ou un "like"
     <value>Les informations ont été copiées dans le presse-papier.</value>
   </data>
   <data name="AboutWindow_CopyVersionLabel" xml:space="preserve">
-    <value>Cliquer ici pour copier les informations dans le presse-papier.</value>
+    <value>Cliquer ici pour copier les informations dans le presse-papier</value>
   </data>
   <data name="AboutWindow_CopyVersionCaption" xml:space="preserve">
     <value>Copie complétée.</value>

--- a/Rubberduck.Resources/About/AboutUI.fr.resx
+++ b/Rubberduck.Resources/About/AboutUI.fr.resx
@@ -132,7 +132,7 @@ Icônes IDE de SharpDevelop
 Support localisation WPF par Grant Frisken</value>
   </data>
   <data name="AboutWindow_Copyright" xml:space="preserve">
-    <value>© Copyright 2014-2018 Rubberduck project contributors</value>
+    <value>© Copyright 2014-{0} Rubberduck project contributors</value>
   </data>
   <data name="AboutWindow_ContributorsHeader" xml:space="preserve">
     <value>Contributeurs et supporters:</value>
@@ -183,5 +183,8 @@ Tous ceux qui nous ont donné une étoile ou un "like"
   </data>
   <data name="AboutWindow_ReportAnIssue" xml:space="preserve">
     <value>Rapporter un problème</value>
+  </data>
+  <data name="AboutWindow_ViewLogLabel" xml:space="preserve">
+    <value>Afficher le journal dans l'explorateur de fichiers</value>
   </data>
 </root>

--- a/Rubberduck.Resources/About/AboutUI.resx
+++ b/Rubberduck.Resources/About/AboutUI.resx
@@ -124,7 +124,7 @@
     <value>About Rubberduck</value>
   </data>
   <data name="AboutWindow_Copyright" xml:space="preserve">
-    <value>© Copyright 2014-2018 Rubberduck project contributors</value>
+    <value>© Copyright 2014-{0} Rubberduck project contributors</value>
   </data>
   <data name="AboutWindow_SpecialThanksLabel" xml:space="preserve">
     <value>Special Thanks</value>
@@ -156,7 +156,7 @@ All our stargazers, likers &amp; followers, for the warm fuzzies
     <value>Copy version info</value>
   </data>
   <data name="AboutWindow_CopyVersionLabel" xml:space="preserve">
-    <value>Copy version information to clipboard.</value>
+    <value>Copy version information to clipboard</value>
   </data>
   <data name="AboutWindow_CopyVersionMessage" xml:space="preserve">
     <value>Version information was copied to clipboard.</value>
@@ -184,5 +184,8 @@ All our stargazers, likers &amp; followers, for the warm fuzzies
   </data>
   <data name="AboutWindow_ReportAnIssue" xml:space="preserve">
     <value>Report an issue</value>
+  </data>
+  <data name="AboutWindow_ViewLogLabel" xml:space="preserve">
+    <value>View log in File Explorer</value>
   </data>
 </root>


### PR DESCRIPTION
This also modifies the copyright year in the bottom label so that it automatically updates (as @retailcoder suggested). Interestingly, the ViewModel was ready for that, but the string resources weren't (they had a hard-coded `2018` instead of `{0}`.

A few extra notes:

1. I also changed the `GitHubIssueUrl` so that now it gives you the option to choose the bug template
2. I thought the trailing dot in the copy version label looked a bit weird with the hyperlink style, so I removed it
3. The code to obtain the path to the log file is taken from [here](https://stackoverflow.com/a/11629408/1712861)
4. I just used Google Translate for the Czech and French translations (which means I am not entirely sure of what I have written there!)
