### PR TITLE
Fix line special form grammar

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -571,10 +571,13 @@ withStmt :
 ;
 
 // Special forms with special syntax, only available in VBA reports or VB6 forms and pictureboxes.
-lineSpecialForm : expression whiteSpace ((STEP whiteSpace?)? tuple whiteSpace?)?
-     MINUS (STEP whiteSpace?)? tuple whiteSpace?
-	 (COMMA whiteSpace? expression)? whiteSpace?
-	 (COMMA whiteSpace? lineSpecialFormOption)?;
+// lineSpecialFormOption is required if expression is missing
+lineSpecialForm : expression whiteSpace ((STEP whiteSpace?)? tuple)?
+    whiteSpace? MINUS whiteSpace?
+	(STEP whiteSpace?)? tuple whiteSpace?
+	(COMMA whiteSpace? expression? whiteSpace?)?
+	(COMMA whiteSpace? lineSpecialFormOption)?
+;
 circleSpecialForm : (expression whiteSpace? DOT whiteSpace?)? CIRCLE whiteSpace (STEP whiteSpace?)? tuple (whiteSpace? COMMA whiteSpace? expression)+;
 scaleSpecialForm : (expression whiteSpace? DOT whiteSpace?)? SCALE whiteSpace tuple whiteSpace? MINUS whiteSpace? tuple;
 pSetSpecialForm : (expression whiteSpace? DOT whiteSpace?)? PSET (whiteSpace STEP)? whiteSpace? tuple whiteSpace? (COMMA whiteSpace? expression)?;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -571,7 +571,10 @@ withStmt :
 ;
 
 // Special forms with special syntax, only available in VBA reports or VB6 forms and pictureboxes.
-lineSpecialForm : expression whiteSpace ((STEP whiteSpace?)? tuple)? MINUS (STEP whiteSpace?)? tuple whiteSpace? (COMMA whiteSpace? expression)? whiteSpace? (COMMA whiteSpace? lineSpecialFormOption)?;
+lineSpecialForm : expression whiteSpace ((STEP whiteSpace?)? tuple whiteSpace?)?
+     MINUS (STEP whiteSpace?)? tuple whiteSpace?
+	 (COMMA whiteSpace? expression)? whiteSpace?
+	 (COMMA whiteSpace? lineSpecialFormOption)?;
 circleSpecialForm : (expression whiteSpace? DOT whiteSpace?)? CIRCLE whiteSpace (STEP whiteSpace?)? tuple (whiteSpace? COMMA whiteSpace? expression)+;
 scaleSpecialForm : (expression whiteSpace? DOT whiteSpace?)? SCALE whiteSpace tuple whiteSpace? MINUS whiteSpace? tuple;
 pSetSpecialForm : (expression whiteSpace? DOT whiteSpace?)? PSET (whiteSpace STEP)? whiteSpace? tuple whiteSpace? (COMMA whiteSpace? expression)?;

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -11,11 +11,12 @@ using System.Diagnostics;
 namespace RubberduckTests.Grammar
 {
     [TestFixture]
+    [Category("Grammar")]
     public class VBAParserTests
     {
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void DoEventsKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -28,9 +29,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void EndKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -43,9 +44,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void CloseKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -58,9 +59,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void DoKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -74,9 +75,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void ElseKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -92,9 +93,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void LoopKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -109,7 +110,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Category("LineLabels")]
         [Test]
         public void NextKeywordDoesNotParseAsLineLabel()
@@ -126,9 +127,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void RandomizeKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -141,9 +142,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void RemKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -157,9 +158,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void ResumeKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -173,9 +174,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void ReturnKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -189,9 +190,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void StopKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -205,9 +206,9 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
-        [Category("LineLabels")]
+        
         [Test]
+        [Category("LineLabels")]
         public void WendKeywordDoesNotParseAsLineLabel()
         {
             var code = @"
@@ -222,7 +223,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_EndSub()
         {
@@ -235,7 +236,7 @@ Sub DoSomething()
             AssertTree(result.Item1, result.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_EndFunction()
         {
@@ -248,7 +249,7 @@ Function DoSomething()
             AssertTree(result.Item1, result.Item2, "//functionStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_EndProperty()
         {
@@ -261,7 +262,7 @@ Property Get DoSomething()
             AssertTree(result.Item1, result.Item2, "//propertyGetStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_IfStmt()
         {
@@ -275,7 +276,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_ElseStmt()
         {
@@ -293,7 +294,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//elseBlock");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_SelectCaseStmt()
         {
@@ -312,7 +313,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//caseClause", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_ForNextLoop()
         {
@@ -328,7 +329,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//forNextStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_ForEachLoop()
         {
@@ -344,7 +345,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//forEachStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_DoLoop()
         {
@@ -360,7 +361,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//doLoopStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_WithBlock()
         {
@@ -376,7 +377,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//withStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParsesWithLineNumbers_WhileLoop()
         {
@@ -392,7 +393,7 @@ End Sub
             AssertTree(result.Item1, result.Item2, "//whileWendStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestParsesEmptyForm()
         {
@@ -417,7 +418,7 @@ Attribute VB_Exposed = False
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeFirstLine()
         {
@@ -428,7 +429,7 @@ VERSION 5.00";
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterModuleHeader()
         {
@@ -449,7 +450,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterModuleConfig()
         {
@@ -471,7 +472,7 @@ Private this As TProgressIndicator
         }
 
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeInsideModuleDeclarations()
         {
@@ -484,7 +485,7 @@ Public WithEvents colCBars2 As Office.CommandBars
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterModuleDeclarations()
         {
@@ -499,7 +500,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeInsideProcedure()
         {
@@ -512,7 +513,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeEndOfFile()
         {
@@ -525,7 +526,7 @@ Attribute VB_Name = ""Form1""
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeNameIsMemberAccessExpr()
         {
@@ -536,7 +537,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestTrivialCase()
         {
@@ -545,7 +546,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//module");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEmptyModule()
         {
@@ -561,7 +562,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//module");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestModuleHeader()
         {
@@ -570,7 +571,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleHeader");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefDirectiveSingleLetter()
         {
@@ -579,7 +580,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//defDirective", matches => matches.Count == 13);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefDirectiveSameDefDirectiveMultipleLetterSpec()
         {
@@ -588,7 +589,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLetter", matches => matches.Count == 3);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefDirectiveLetterRange()
         {
@@ -597,7 +598,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//letterRange", matches => matches.Count == 13);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefDirectiveUniversalLetterRange()
         {
@@ -606,7 +607,7 @@ Attribute view.VB_VarHelpID = -1
             AssertTree(parseResult.Item1, parseResult.Item2, "//universalLetterRange");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestModuleOption()
         {
@@ -620,7 +621,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleOption");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestModuleOption_Indented()
         {
@@ -634,7 +635,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleOption");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestModuleConfig()
         {
@@ -646,7 +647,7 @@ END";
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigElement");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormModuleConfig()
         {
@@ -665,7 +666,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormWithHexLiteralModuleConfig()
         {
@@ -685,7 +686,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormWithAbsoluteResourcePathConfig()
         {
@@ -705,7 +706,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormWithDnsUncResourcePathConfig()
         {
@@ -725,7 +726,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormWithIPUncResourcePathConfig()
         {
@@ -745,7 +746,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormWithDollarPrependedResourceModuleConfig()
         {
@@ -764,7 +765,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormWithAlphaLeadingHexLiteralResourceOffsetModuleConfig()
         {
@@ -783,7 +784,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestVBFormWithNumericLeadingHexLiteralResourceOffsetModuleConfig()
         {
@@ -802,7 +803,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         [TestCase(@"^A")]
         [TestCase(@"^Z")]
@@ -844,7 +845,7 @@ End
         }
 
 
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedVbFormModuleConfig()
         {
@@ -874,7 +875,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedVbFormModuleConfigWithObjectDeclarations()
         {
@@ -906,7 +907,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedVbFormModuleConfigWithMultipleChildren()
         {
@@ -950,7 +951,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfig", matches => matches.Count == 3);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedVbFormModuleConfigWithProperty()
         {
@@ -994,7 +995,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedVbFormModuleConfigWithMultipleProperties()
         {
@@ -1048,7 +1049,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedVbFormModuleConfigWithNestedProperties()
         {
@@ -1097,7 +1098,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 2);
         }
 		
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedVbFormModuleConfigWithAnEmptyNestedProperty()
         {
@@ -1141,7 +1142,7 @@ Attribute VB_Exposed = False
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestIndexedProperty()
         {
@@ -1159,7 +1160,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEmptyComment()
         {
@@ -1168,7 +1169,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEmptyRemComment()
         {
@@ -1177,7 +1178,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//remComment");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOneCharRemComment()
         {
@@ -1186,7 +1187,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//remComment");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCommentThatLooksLikeAnnotation()
         {
@@ -1195,7 +1196,7 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestForeignIdentifier()
         {
@@ -1215,7 +1216,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//identifier", matches => matches.Count == 11);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOneCharComment()
         {
@@ -1224,7 +1225,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//comment");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndEnumMultipleWhiteSpace()
         {
@@ -1236,7 +1237,7 @@ End               Enum";
             AssertTree(parseResult.Item1, parseResult.Item2, "//enumerationStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndTypeMultipleWhiteSpace()
         {
@@ -1248,7 +1249,7 @@ End             Type";
             AssertTree(parseResult.Item1, parseResult.Item2, "//udtDeclaration");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndFunctionLineContinuation()
         {
@@ -1261,7 +1262,7 @@ Function";
             AssertTree(parseResult.Item1, parseResult.Item2, "//functionStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestExitFunctionLineContinuation()
         {
@@ -1274,7 +1275,7 @@ End Function";
             AssertTree(parseResult.Item1, parseResult.Item2, "//functionStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndSubroutineLineContinuation()
         {
@@ -1287,7 +1288,7 @@ Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestExitSubroutineLineContinuation()
         {
@@ -1300,7 +1301,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPropertyGetLineContinuation()
         {
@@ -1312,7 +1313,7 @@ End Property";
             AssertTree(parseResult.Item1, parseResult.Item2, "//propertyGetStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPropertyLetLineContinuation()
         {
@@ -1324,7 +1325,7 @@ End Property";
             AssertTree(parseResult.Item1, parseResult.Item2, "//propertyLetStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPropertySetLineContinuation()
         {
@@ -1336,7 +1337,7 @@ End Property";
             AssertTree(parseResult.Item1, parseResult.Item2, "//propertySetStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndPropertyLineContinuation()
         {
@@ -1349,7 +1350,7 @@ Property";
             AssertTree(parseResult.Item1, parseResult.Item2, "//propertyGetStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestExitPropertyLineContinuation()
         {
@@ -1362,7 +1363,7 @@ End Property";
             AssertTree(parseResult.Item1, parseResult.Item2, "//propertyGetStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndIfLineContinuation()
         {
@@ -1376,7 +1377,7 @@ End Function";
             AssertTree(parseResult.Item1, parseResult.Item2, "//ifStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndSelectLineContinuation()
         {
@@ -1390,7 +1391,7 @@ End Property";
             AssertTree(parseResult.Item1, parseResult.Item2, "//selectCaseStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndWithContinuation()
         {
@@ -1404,7 +1405,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//withStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestExitDoContinuation()
         {
@@ -1419,7 +1420,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//doLoopStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestExitForContinuation()
         {
@@ -1434,7 +1435,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forNextStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineInputLineContinuation()
         {
@@ -1447,7 +1448,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineInputStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestReadWriteKeywordLineContinuation()
         {
@@ -1460,7 +1461,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//openStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLockReadKeywordLineContinuation()
         {
@@ -1473,7 +1474,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//openStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLockWriteKeywordLineContinuation()
         {
@@ -1486,7 +1487,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//openStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLockReadWriteKeywordLineContinuation()
         {
@@ -1500,7 +1501,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//openStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOnErrorLineContinuation()
         {
@@ -1514,7 +1515,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//onErrorStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOnLocalErrorLineContinuation()
         {
@@ -1529,7 +1530,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//onErrorStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOptionBaseLineContinuation()
         {
@@ -1541,7 +1542,7 @@ Base _
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleOption");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOptionExplicitLineContinuation()
         {
@@ -1552,7 +1553,7 @@ Explicit";
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleOption");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOptionCompareLineContinuation()
         {
@@ -1564,7 +1565,7 @@ Text";
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleOption");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOptionPrivateModuleLineContinuation()
         {
@@ -1576,7 +1577,7 @@ Module";
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleOption");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDictionaryAccessExprLineContinuation()
         {
@@ -1590,7 +1591,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestWithDictionaryAccessExprLineContinuation()
         {
@@ -1605,7 +1606,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLetStmtLineContinuation()
         {
@@ -1620,7 +1621,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//letStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestMemberAccessExprLineContinuation()
         {
@@ -1634,7 +1635,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestWithMemberAccessExprLineContinuation()
         {
@@ -1649,7 +1650,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCallStmtLineContinuation()
         {
@@ -1663,7 +1664,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDeclareLineContinuation()
         {
@@ -1675,7 +1676,7 @@ ByVal c As String, ByVal d As String, ByVal e As String, ByVal f As Long) As Lon
             AssertTree(parseResult.Item1, parseResult.Item2, "//declareStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEraseStmt()
         {
@@ -1687,7 +1688,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//eraseStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestFixedLengthString()
         {
@@ -1699,7 +1700,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//fieldLength");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDoLoopStatement()
         {
@@ -1712,7 +1713,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//doLoopStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestForNextStatement()
         {
@@ -1725,7 +1726,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forNextStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCombinedForNextStatement()
         {
@@ -1741,7 +1742,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forNextStmt", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCombinedForNextStatementWhithItermediateCode()
         {
@@ -1757,7 +1758,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forNextStmt", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCombinedForEachStatement()
         {
@@ -1776,7 +1777,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forEachStmt", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCombinedForEachStatementWhithItermediateCode()
         {
@@ -1794,7 +1795,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forEachStmt", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestMixedCombinedForEachAndForNextStatement()
         {
@@ -1819,7 +1820,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forNextStmt", matches => matches.Count == 3);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestMixedRegularAndCombinedForEachAndForNextStatement()
         {
@@ -1845,7 +1846,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//forNextStmt", matches => matches.Count == 4);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineLabelStatement()
         {
@@ -1869,7 +1870,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//statementLabelDefinition", matches => matches.Count == 10);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineLabelStatementWithCodeOnSameLine()
         {
@@ -1887,7 +1888,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//callStmt", matches => matches.Count == 7);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void NameStatement()
         {
@@ -1901,7 +1902,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//nameStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ProcedureNamedName()
         {
@@ -1916,7 +1917,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//identifier", matches => matches.Count == 3);    // name, test, and name
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAnnotations()
         {
@@ -1930,7 +1931,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//annotation", matches => matches.Count == 4);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEmptyAnnotationsWithParentheses()
         {
@@ -1942,7 +1943,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//annotation");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void GivenIfElseBlock_ParsesElseBlockAsElseStatement()
         {
@@ -1959,7 +1960,7 @@ End Sub
             AssertTree(parser.Item1, parser.Item2, "//elseBlock", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestIfStmtSameLineElse()
         {
@@ -1974,7 +1975,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//elseIfBlock");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfEmptyThenEmptyElse()
         {
@@ -1986,7 +1987,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfEmptyThenEndOfStatement()
         {
@@ -1998,7 +1999,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfMultipleThenNoElse()
         {
@@ -2010,7 +2011,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfMultipleThenMultipleElse()
         {
@@ -2022,7 +2023,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfEmptyThen()
         {
@@ -2034,7 +2035,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfSingleThenEmptyElse()
         {
@@ -2046,7 +2047,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfSingleEmptyThenEmptyElse()
         {
@@ -2080,7 +2081,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfSingleEmptyMultiLineThenEmptyElse()
         {
@@ -2093,7 +2094,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfSingleEmptyThenEmptyMultiLineElse()
         {
@@ -2106,7 +2107,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfSingleEmptyThenElse()
         {
@@ -2119,7 +2120,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfNestedEmptyThenEmptyElse()
         {
@@ -2131,7 +2132,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfNestedThenEmptyElse()
         {
@@ -2143,7 +2144,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfNestedEmptyThenElse()
         {
@@ -2155,7 +2156,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfSingleEmptyMultiLineThenEmptyMultiLineElse()
         {
@@ -2169,7 +2170,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfImplicitGoTo()
         {
@@ -2182,7 +2183,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineNumberLabel", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfDoLoop()
         {
@@ -2194,7 +2195,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//doLoopStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfWendLoop()
         {
@@ -2206,7 +2207,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//whileWendStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfRealWorldExample1()
         {
@@ -2218,7 +2219,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfRealWorldExample2()
         {
@@ -2232,7 +2233,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfRealWorldExample3()
         {
@@ -2244,7 +2245,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSingleLineIfRealWorldExample4()
         {
@@ -2256,7 +2257,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestEndStmt()
         {
@@ -2268,7 +2269,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//endStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestRedimStmtArray()
         {
@@ -2280,7 +2281,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//expression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestRedimStmtLowerBoundsArgument()
         {
@@ -2292,7 +2293,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lowerBoundArgumentExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestRedimStmtUpperBoundsArgument()
         {
@@ -2304,7 +2305,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//upperBoundArgumentExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestRedimStmtNormalArgument()
         {
@@ -2316,7 +2317,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestStringFunction()
         {
@@ -2328,7 +2329,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestArrayWithTypeSuffix()
         {
@@ -2346,7 +2347,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 7);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestOpenStmt()
         {
@@ -2358,7 +2359,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//openStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestResetStmt()
         {
@@ -2370,7 +2371,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//resetStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCloseStmt()
         {
@@ -2382,7 +2383,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//closeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSeekStmt()
         {
@@ -2394,7 +2395,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//seekStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSeekFunction()
         {
@@ -2407,7 +2408,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLockStmt()
         {
@@ -2419,7 +2420,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lockStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestUnlockStmt()
         {
@@ -2431,7 +2432,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//unlockStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineInputStmt()
         {
@@ -2443,7 +2444,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineInputStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestWidthStmt()
         {
@@ -2455,7 +2456,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//widthStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPrintStmt()
         {
@@ -2467,7 +2468,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//printStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDebugPrintStmtNoArguments()
         {
@@ -2479,7 +2480,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDebugPrintStmtNormalArgumentSyntax()
         {
@@ -2491,7 +2492,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt/outputList");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDebugPrintStmtOutputItemSemicolon()
         {
@@ -2503,7 +2504,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt/outputList");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDebugPrintStmtOutputItemComma()
         {
@@ -2515,7 +2516,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt/outputList");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDebugPrintRealWorldExample1()
         {
@@ -2532,7 +2533,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt", matches => matches.Count == 4);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDebugPrintRealWorldExample2()
         {
@@ -2547,7 +2548,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDebugPrintRealWorldExample3()
         {
@@ -2561,7 +2562,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestWriteStmt()
         {
@@ -2573,7 +2574,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//writeStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestInputStmt()
         {
@@ -2585,7 +2586,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//inputStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestInputFunction()
         {
@@ -2598,7 +2599,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestInputBFunction()
         {
@@ -2611,7 +2612,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCircleSpecialForm()
         {
@@ -2623,7 +2624,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//circleSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCircleSpecialForm_WithoutStep()
         {
@@ -2635,7 +2636,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//circleSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCircleSpecialForm_WithoutOptionalArguments()
         {
@@ -2647,7 +2648,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//circleSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineAccessReport()
         {
@@ -2659,7 +2660,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineAccessReport_WithoutOptionalArguments()
         {
@@ -2671,7 +2672,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineAccessReport_WithoutStartingTuple()
         {
@@ -2683,7 +2684,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLineAccessReport_WithoutStep()
         {
@@ -2695,7 +2696,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestScaleSpecialForm()
         {
@@ -2707,7 +2708,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//scaleSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPSetVBForm_WithoutStep()
         {
@@ -2719,7 +2720,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//pSetSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPSetVBForm_WithoutOptionalArguments()
         {
@@ -2731,7 +2732,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//pSetSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPSetSpecialForm()
         {
@@ -2743,7 +2744,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//pSetSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPSetSpecialForm_WithoutStep()
         {
@@ -2755,7 +2756,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//pSetSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPSetSpecialForm_WithoutOptionalArguments()
         {
@@ -2767,7 +2768,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//pSetSpecialForm");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPtrSafeAsSub()
         {
@@ -2779,7 +2780,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestFunction_Indented()
         {
@@ -2791,7 +2792,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//functionStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSub_Indented()
         {
@@ -2802,7 +2803,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestSub_InconsistentlyIndented()
         {
@@ -2813,7 +2814,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//subStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestPtrSafeAsVariable()
         {
@@ -2827,7 +2828,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//variableStmt");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestLiteralExpressionResolvesCorrectly()
         {
@@ -2839,7 +2840,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//literalExpression");
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestUdtReservedKeywords()
         {
@@ -2864,7 +2865,7 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//udtMember", matches => matches.Count == 13);
         }
         
-        [Category("Parser")]
+        
         [Test]
         public void TestNestedParensForLiteralExpression()
         {
@@ -2878,7 +2879,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//literalExpression", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestParensForByValSingleArg()
         {
@@ -2891,7 +2892,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentExpression", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestParensForByValFirstArg()
         {
@@ -2904,7 +2905,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentExpression", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefaultMemberAccessCallStmtOnFunctionReturnValue_Single()
         {
@@ -2919,7 +2920,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentList", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefaultMemberAccessCallStmtOnFunctionReturnValue_Multiple()
         {
@@ -2934,7 +2935,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentList", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestFunctionArgumentsOnContinuedLine_Multiple()
         {
@@ -2950,7 +2951,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentExpression", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestFunctionArgumentsOnContinuedLine_Single()
         {
@@ -2966,7 +2967,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentExpression", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefaultMemberAccessCallStmtOnFunctionReturnValue_FunctionArgumentsOnContinuedLine_Single()
         {
@@ -2982,7 +2983,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentList", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestDefaultMemberAccessCallStmtOnFunctionReturnValue_FunctionArgumentsOnContinuedLine_Multiple()
         {
@@ -2998,7 +2999,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentList", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnUnderscoreComment()
         {
@@ -3013,7 +3014,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//ifStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnUnderscoreAfterNonBreakingSpaceInComment()
         {
@@ -3028,7 +3029,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//ifStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnStartOfLineUnderscoreInLineContinuedComment()
         {
@@ -3044,7 +3045,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//ifStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedMemberAccessExpressionInType1()
         {
@@ -3059,7 +3060,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedMemberAccessExpressionInType2()
         {
@@ -3073,7 +3074,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedMemberAccessExpressionOnObject1()
         {
@@ -3088,7 +3089,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedMemberAccessExpressionOnObject2()
         {
@@ -3104,7 +3105,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedMemberAccessExpressionOnObject3()
         {
@@ -3120,7 +3121,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailDoubleBracketForgeignIdentifierWithTypeHint()
         {
@@ -3135,7 +3136,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnBangOperatorFollowedByForeignIdentifier()
         {
@@ -3151,7 +3152,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnBangOperator()
         {
@@ -3167,7 +3168,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         [Ignore("This cannot work with the current setup of identifiers bacause the SLL parser confuses the bang for a type hint.")]
         public void ParserDoesNotFailOnBangOperatorOnForeignIdentifier()
@@ -3182,7 +3183,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnStackedBangOperator()
         {
@@ -3198,7 +3199,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         [Ignore("This cannot work with the current setup of identifiers bacause the SLL parser confuses the bang for a type hint.")]
         public void ParserDoesNotFailOnStackedBangOperator_ForeignIdentifier()
@@ -3215,7 +3216,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//typeHint", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedBangOperator1()
         {
@@ -3232,7 +3233,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedBangOperator2()
         {
@@ -3250,7 +3251,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedBangOperator3()
         {
@@ -3266,7 +3267,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineContinuedTypeDeclaration()
         {
@@ -3279,7 +3280,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnIdentifierEndingInUnderscore()
         {
@@ -3293,7 +3294,7 @@ End Sub
             var parseResult = Parse(code);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineNumberNotOnStartOfLineAfterALineContinuation()
         {
@@ -3309,7 +3310,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//standaloneLineNumberLabel", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineLAbelNotOnStartOfLineAfterALineContinuation()
         {
@@ -3323,7 +3324,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//identifierStatementLabel", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLinecontinuedLabel()
         {
@@ -3337,7 +3338,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//identifierStatementLabel", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineNumberAndLineContinuedLabelNotOnStartOfLineAfterALineContinuation()
         {
@@ -3355,7 +3356,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//identifierStatementLabel", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserDoesNotFailOnLineNumberAndLineContinuedLabelNotOnStartOfLineAfterMultipleLineContinuation()
         {
@@ -3377,7 +3378,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//identifierStatementLabel", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void LeftOutOptionalArgumentsAreCountedAsMissingArguments()
         {
@@ -3396,7 +3397,7 @@ End Function
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentList", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestReDimWithLineContinuation()
         {
@@ -3412,7 +3413,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//argumentExpression", matches => matches.Count == 2);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCaseIsEqExpressionWithLiteral()
         {
@@ -3428,7 +3429,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//rangeClause", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestCaseIsEqExpressionWithEnum()
         {
@@ -3444,7 +3445,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//rangeClause", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestRaiseEventByValParameter()
         {
@@ -3461,7 +3462,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//raiseEventStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestRaiseEvent()
         {
@@ -3477,7 +3478,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//raiseEventStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterSub()
         {
@@ -3492,7 +3493,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterFunction()
         {
@@ -3507,7 +3508,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterPropertyGet()
         {
@@ -3522,7 +3523,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterPropertyLet()
         {
@@ -3537,7 +3538,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void TestAttributeAfterPropertySet()
         {
@@ -3552,7 +3553,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//attributeStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void SubtractionExpressionsAreNoLetterRanges()
         {
@@ -3572,7 +3573,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//universalLetterRange", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void SLLParserDoesNotThrowForArrayDefinitionInModuleWithMultipleSpacesInFromtOfAsType()
         {
@@ -3584,7 +3585,7 @@ Dim Foo1(0 To 3)       As Long
             AssertTree(parseResult.Item1, parseResult.Item2, "//variableSubStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void SLLParserDoesNotThrowForArrayDefinitionInSubWithMultipleSpacesInFromtOfAsType()
         {
@@ -3597,7 +3598,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//variableSubStmt", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void UserDefinedType_TreatsFinalCommentAsComment()
         {
@@ -3614,7 +3615,7 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//commentOrAnnotation", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void MidStatement()
         {
@@ -3629,7 +3630,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void MidDollarStatement()
         {
@@ -3644,6 +3645,8 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
         }
 
+        [Test]
+        
         public void MidBStatement()
         {
             const string code = @"
@@ -3657,7 +3660,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void MidBDollarStatement()
         {
@@ -3672,7 +3675,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void MidFunction()
         {
@@ -3689,7 +3692,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void MidDollarFunction()
         {
@@ -3706,7 +3709,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void MidBFunction()
         {
@@ -3723,7 +3726,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void MidBDollarFunction()
         {
@@ -3740,7 +3743,7 @@ End Sub
             AssertTree(parseResult.Item1, parseResult.Item2, "//midStatement", matches => matches.Count == 0);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserAcceptsScaleMemberInUDT()
         {
@@ -3753,7 +3756,7 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//unrestrictedIdentifier", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserAcceptsCircleMemberInUDT()
         {
@@ -3766,7 +3769,7 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//unrestrictedIdentifier", matches => matches.Count == 1);
         }
 
-        [Category("Parser")]
+        
         [Test]
         public void ParserAcceptsPSetMemberInUDT()
         {
@@ -3779,25 +3782,30 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//unrestrictedIdentifier", matches => matches.Count == 1);
         }
 
+        // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/4875
         [Test]
-        [Category("Parser")]
-        public void LineSpecialForm_WithLineContinuations()
+        [TestCase("form.Line (0, 0)-(12, 12), RGB(255, 255, 0), B")]
+        [TestCase("form.Line (0, 0)-(12, 12), , BF")]
+        [TestCase("form.Line (0, 0)-(12, 12), RGB(255, 255, 0)")]
+        [TestCase("form.Line (0, 0)-(12, 12)")]
+        [TestCase("form.Line -(12,12)")]
+        [TestCase(@"form.Line _
+            (0, 0)-(12, 12), RGB(0, 0, 255)")]
+        [TestCase(@"form.Line (0, 0)- _
+            (12, 12)")]
+        [TestCase(@"form.Line (0, 0) _
+            -(12, 12)")]
+        [TestCase(@"form.Line (0, 0)-(12, 12), _
+            , BF")]
+        public void LineSpecialForm_WithLineContinuations(string validLineSpecialForm)
         {
-            // Taken from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/4875
-            const string code = @"
-Sub Whatever()
-    Section.Parent.Line ((.Left + .Width + SectionProperties.VerticalLineMargin), _
-      PageHeaderHeight + tmpTopMargin + Abs(Section.Parent.Top)) _
-      -Step(0, Section.Parent.Height)
-End Sub
-";
+            string code = $"Sub Whatever()\r\n{validLineSpecialForm}\r\nEnd Sub";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//lineSpecialForm", matches => matches.Count == 1);
         }
-
         
         [Test]
-        [Category("Parser")]
+        
         [TestCase("Private WithEvents foo As EventSource, WithEvents bar As EventSource", 2)]
         [TestCase("Private WithEvents foo As EventSource, bar As EventSource", 2)]
         [TestCase("Private foo As EventSource, WithEvents bar As EventSource", 2)]

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -3779,6 +3779,22 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//unrestrictedIdentifier", matches => matches.Count == 1);
         }
 
+        [Test]
+        [Category("Parser")]
+        public void LineSpecialForm_WithLineContinuations()
+        {
+            // Taken from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/4875
+            const string code = @"
+Sub Whatever()
+    Section.Parent.Line ((.Left + .Width + SectionProperties.VerticalLineMargin), _
+      PageHeaderHeight + tmpTopMargin + Abs(Section.Parent.Top)) _
+      -Step(0, Section.Parent.Height)
+End Sub
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//lineSpecialForm", matches => matches.Count == 1);
+        }
+
         
         [Test]
         [Category("Parser")]

--- a/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
+++ b/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
@@ -20,7 +20,7 @@ End Sub")]
         [TestCase(0, @"Public Sub foo()
 End Sub")]
         [TestCase(0, @"Public Sub foo bar()
-End Sub")]
+End Sub")] // Correctly provokes a parser error
         public void NonBreakingSpaceIdentifier_ReturnsResult(int expectedCount, string inputCode)
         {
             var func = new Func<RubberduckParserState, IInspection>(state =>


### PR DESCRIPTION
Note that this doesn't enforce the same constraints as the VBE when parsing the lineSpecialForm. Most notably, the form `foo.Line -(x, y),` does not provoke a parser error, even though it does not compile.

The grammar should correctly deal with all cases that do compile.