### PR TITLE
Stop CodeMetrics from faceplanting Rubberduck completely

### DIFF
--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -396,8 +396,21 @@ namespace Rubberduck.Parsing.VBA
             var handler = StateChanged;
             if (handler != null && !token.IsCancellationRequested)
             {
-                var args = new ParserStateEventArgs(state, oldStatus, token);
-                handler.Invoke(requestor, args);
+                try
+                {
+                    var args = new ParserStateEventArgs(state, oldStatus, token);
+                    handler.Invoke(requestor, args);
+                }
+                catch (Exception e)
+                {
+                    if (e is OperationCanceledException cancellation)
+                    {
+                        throw cancellation;
+                    }
+                    // Error state, because this implies consumers are not exception-safe!
+                    // this behaviour could leave us in a state where some consumers have correctly updated and some have not
+                    Logger.Error(e, "An exception occurred when notifying consumers of updated parser state.");
+                }
             }
         }
 

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -401,12 +401,12 @@ namespace Rubberduck.Parsing.VBA
                     var args = new ParserStateEventArgs(state, oldStatus, token);
                     handler.Invoke(requestor, args);
                 }
+                catch (OperationCanceledException cancellation)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e is OperationCanceledException cancellation)
-                    {
-                        throw cancellation;
-                    }
                     // Error state, because this implies consumers are not exception-safe!
                     // this behaviour could leave us in a state where some consumers have correctly updated and some have not
                     Logger.Error(e, "An exception occurred when notifying consumers of updated parser state.");


### PR DESCRIPTION
Add exception logging to RPS#OnStateChange and CodeMetricsAnalyst, fixes #4814