### PR TITLE
Clarify how JetBrains supports RD via OSS licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ along with this program.  If not, see http://www.gnu.org/licenses/.
 
 [![JetBrains ReSharper logo](https://cloud.githubusercontent.com/assets/5751684/20271309/616bb740-aa58-11e6-91c9-65287b740985.png)](https://www.jetbrains.com/resharper/)
 
-Since the project's early days, JetBrains' Open-Source team has been supporting Rubberduck - and we deeply thank them for that. ReSharper has been not only a tool we couldn't do without; it's been an inspiration, the ultimate level of polished perfection to strive for in our own IDE add-in project. So just like you're missing out if you write VBA and you're not using Rubberduck, you're missing out if you write C# and aren't using ReSharper.
+Since the project's early days, JetBrains' Open-Source team has been supporting Rubberduck. This support comes in the form of licenses to R# for the core contributors - and we deeply thank them for that. ReSharper has been not only a tool we couldn't do without; it's been an inspiration, the ultimate level of polished perfection to strive for in our own IDE add-in project. So just like you're missing out if you write VBA and you're not using Rubberduck, you're missing out if you write C# and aren't using ReSharper.
 
 <sub>Note: Rubberduck is not a JetBrains product. JetBrains does not contribute and is not affiliated to the Rubberduck project in any way.</sub>


### PR DESCRIPTION
@PeterMTaylor brought up few links on reddit. One of which being https://www.reddit.com/r/vba/comments/avigfe/vba_coding_standards/ehgn38m/?utm_source=share&utm_medium=web2x

> "since the projects early days, JetBrains' open source team has been supporting Rubberduck - and we deeply thank them for that"
> I do see that small disclaimer at the bottom too... I wonder if it just means that the guy knows some people there or something?

Explicitly state that JetBrains contributes via licenses