### PR TITLE
Speed up parsing (slightly)

### DIFF
--- a/Rubberduck.CodeAnalysis/CodeMetrics/CodeMetricsAnalyst.cs
+++ b/Rubberduck.CodeAnalysis/CodeMetrics/CodeMetricsAnalyst.cs
@@ -1,5 +1,4 @@
 ﻿using Antlr4.Runtime.Tree;
-using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor;
 using System.Collections.Generic;
@@ -14,11 +13,11 @@ namespace Rubberduck.CodeAnalysis.CodeMetrics
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        private readonly CodeMetric[] metrics;
+        private readonly CodeMetric[] _metrics;
 
         public CodeMetricsAnalyst(IEnumerable<CodeMetric> supportedMetrics)
         {
-            metrics = supportedMetrics.ToArray();
+            _metrics = supportedMetrics.ToArray();
         }
 
         public IEnumerable<ICodeMetricResult> GetMetrics(RubberduckParserState state)
@@ -45,7 +44,7 @@ namespace Rubberduck.CodeAnalysis.CodeMetrics
 
         private IEnumerable<ICodeMetricResult> TraverseModuleTree(IParseTree parseTree, DeclarationFinder declarationFinder, QualifiedModuleName moduleName)
         {
-            var listeners = metrics.Select(metric => metric.TreeListener).ToList();
+            var listeners = _metrics.Select(metric => metric.TreeListener).ToList();
             foreach (var l in listeners)
             {
                 l.Reset();

--- a/Rubberduck.CodeAnalysis/CodeMetrics/NestingLevelMetric.cs
+++ b/Rubberduck.CodeAnalysis/CodeMetrics/NestingLevelMetric.cs
@@ -1,12 +1,9 @@
 ﻿using Antlr4.Runtime.Misc;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Rubberduck.CodeAnalysis.CodeMetrics
 {

--- a/Rubberduck.Core/CodeAnalysis/CodeMetrics/CodeMetricsViewModel.cs
+++ b/Rubberduck.Core/CodeAnalysis/CodeMetrics/CodeMetricsViewModel.cs
@@ -65,7 +65,8 @@ namespace Rubberduck.CodeAnalysis.CodeMetrics
             var metricResults = _analyst.GetMetrics(_state);
             _resultsByDeclaration = metricResults.GroupBy(r => r.Declaration).ToDictionary(g => g.Key, g => g.ToList());
 
-            _uiDispatcher.Invoke(() =>
+            //We have to wait for the task to guarantee that no new parse starts invalidating all cached components.
+            _uiDispatcher.StartTask(() =>
             {
                 var updates = declarations.ToList();
                 var existing = Projects.OfType<CodeExplorerProjectViewModel>().ToList();
@@ -86,7 +87,7 @@ namespace Rubberduck.CodeAnalysis.CodeMetrics
                     var model = new CodeExplorerProjectViewModel(project, ref updates, _state, _vbe, false);
                     Projects.Add(model);
                 }
-            });
+            }).Wait();
         }
 
         private ICodeExplorerNode _selectedItem;

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -231,7 +231,8 @@ namespace Rubberduck.Navigation.CodeExplorer
             if (e.State == ParserState.Ready)
             {
                 // Finished up resolving references, so we can now update the reference nodes.
-                _uiDispatcher.Invoke(() =>
+                //We have to wait for the task to guarantee that no new parse starts invalidating all cached components.
+                _uiDispatcher.StartTask(() =>
                 {
                     var referenceFolders = Projects.SelectMany(node =>
                         node.Children.OfType<CodeExplorerReferenceFolderViewModel>());
@@ -243,7 +244,7 @@ namespace Rubberduck.Navigation.CodeExplorer
                     Unparsed = !Projects.Any();
                     IsBusy = false;
                     ParserReady = true;
-                });
+                }).Wait();
                 return;
             }
 
@@ -264,7 +265,8 @@ namespace Rubberduck.Navigation.CodeExplorer
         /// </param>
         private void Synchronize(IEnumerable<Declaration> declarations)
         {
-            _uiDispatcher.Invoke(() =>
+            //We have to wait for the task to guarantee that no new parse starts invalidating all cached components.
+            _uiDispatcher.StartTask(() =>
             {
                 var updates = declarations.ToList();
                 var existing = Projects.OfType<CodeExplorerProjectViewModel>().ToList();
@@ -287,7 +289,7 @@ namespace Rubberduck.Navigation.CodeExplorer
                 }
 
                 CanSearch = Projects.Any();
-            });
+            }).Wait();
         }
 
         private void ParserState_ModuleStateChanged(object sender, ParseProgressEventArgs e)

--- a/Rubberduck.Parsing/Common/ParsingStageTimer.cs
+++ b/Rubberduck.Parsing/Common/ParsingStageTimer.cs
@@ -22,7 +22,7 @@ namespace Rubberduck.Parsing.Common
 
         public void Log(string message)
         {
-            Logger.Debug(message, _stopwatch.ElapsedMilliseconds);
+            Logger.Info(message, _stopwatch.ElapsedMilliseconds);
         }
     }
 }

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -436,7 +436,7 @@ namespace Rubberduck.Parsing.VBA
                     ParsingSuspendLock.ExitReadLock();
                 }
             }
-            if (watch != null) Logger.Debug("Parsing run finished after {0}s. (thread {1}).", watch.Elapsed.TotalSeconds, Thread.CurrentThread.ManagedThreadId);
+            if (watch != null) Logger.Info("Parsing run finished after {0}s. (thread {1}).", watch.Elapsed.TotalSeconds, Thread.CurrentThread.ManagedThreadId);
         }
 
         protected void ParseAllInternal(object requestor, CancellationToken token)

--- a/Rubberduck.Parsing/VBA/Parsing/IModuleParser.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/IModuleParser.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.Annotations;
-using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.VBEditor;
 

--- a/Rubberduck.Parsing/VBA/Parsing/ParseRunner.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/ParseRunner.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Rubberduck.Parsing.Common;
 using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.VBA.Parsing
@@ -31,8 +30,6 @@ namespace Rubberduck.Parsing.VBA.Parsing
 
             token.ThrowIfCancellationRequested();
 
-            var parsingStageTimer = ParsingStageTimer.StartNew();
-
             var results = new ConcurrentBag<(QualifiedModuleName module, ModuleParseResults results)>();
 
             var options = new ParallelOptions
@@ -57,9 +54,6 @@ namespace Rubberduck.Parsing.VBA.Parsing
                 StateManager.SetStatusAndFireStateChanged(this, ParserState.Error, token);
                 throw;
             }
-
-            parsingStageTimer.Stop();
-            parsingStageTimer.Log("Parsed user modules in {0}ms.");
 
             return results;
         }

--- a/Rubberduck.Parsing/VBA/Parsing/ParseRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/ParseRunnerBase.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Rubberduck.Parsing.VBA.Parsing.ParsingExceptions;
 using Rubberduck.VBEditor;
@@ -36,23 +38,27 @@ namespace Rubberduck.Parsing.VBA.Parsing
             _parser = parser;
         }
 
+        public void ParseModules(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token)
+        {
+            var parseResults = ModulePareResults(modules, token);
+            SaveModuleParseResultsOnState(parseResults, token);
+        }
 
-        public abstract void ParseModules(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token);
+        protected abstract IReadOnlyCollection<(QualifiedModuleName module, ModuleParseResults results)> ModulePareResults(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token);
 
-
-        protected void ParseModule(QualifiedModuleName module, CancellationToken token)
+        protected ModuleParseResults ModuleParseResults(QualifiedModuleName module, CancellationToken token)
         {
             _state.ClearStateCache(module);
             try
             {
-                var parseResults = _parser.Parse(module, token);
-                SaveModuleParseResultsOnState(module, parseResults, token);
+                return _parser.Parse(module, token);
             }
             catch (SyntaxErrorException syntaxErrorException)
             {
                 //In contrast to the situation in the success scenario, the overall parser state is reevaluated immediately.
-                //This sets the state directly on the state because it is the sole instance where we have to pass the SyntaxErorException.
+                //This sets the state directly on the state because it is the sole instance where we have to pass the SyntaxErrorException.
                 _state.SetModuleState(module, ParserState.Error, token, syntaxErrorException);
+                return default;
             }
             catch (Exception exception)
             {
@@ -61,30 +67,40 @@ namespace Rubberduck.Parsing.VBA.Parsing
             }
         }
 
+        private void SaveModuleParseResultsOnState(IReadOnlyCollection<(QualifiedModuleName module, ModuleParseResults results)> parseResults, CancellationToken token)
+        {
+            foreach (var (module, result) in parseResults)
+            {
+                if (result.CodePaneParseTree == null)
+                {
+                    continue;
+                }
+
+                SaveModuleParseResultsOnState(module, result, token);
+            }
+        }
+
         private void SaveModuleParseResultsOnState(QualifiedModuleName module, ModuleParseResults results, CancellationToken token)
         {
-            lock (_state)
-            {
-                token.ThrowIfCancellationRequested();
+            token.ThrowIfCancellationRequested();
 
-                //This has to come first because it creates the module state if not present.
-                _state.AddModuleStateIfNotPresent(module);
+            //This has to come first because it creates the module state if not present.
+            _state.AddModuleStateIfNotPresent(module);
 
-                _state.SaveContentHash(module);
-                _state.AddParseTree(module, results.CodePaneParseTree);
-                _state.AddParseTree(module, results.AttributesParseTree, CodeKind.AttributesCode);
-                _state.SetModuleComments(module, results.Comments);
-                _state.SetModuleAnnotations(module, results.Annotations);
-                _state.SetModuleAttributes(module, results.Attributes);
-                _state.SetMembersAllowingAttributes(module, results.MembersAllowingAttributes);
-                _state.SetCodePaneTokenStream(module, results.CodePaneTokenStream);
-                _state.SetAttributesTokenStream(module, results.AttributesTokenStream);
+            _state.SaveContentHash(module);
+            _state.AddParseTree(module, results.CodePaneParseTree);
+            _state.AddParseTree(module, results.AttributesParseTree, CodeKind.AttributesCode);
+            _state.SetModuleComments(module, results.Comments);
+            _state.SetModuleAnnotations(module, results.Annotations);
+            _state.SetModuleAttributes(module, results.Attributes);
+            _state.SetMembersAllowingAttributes(module, results.MembersAllowingAttributes);
+            _state.SetCodePaneTokenStream(module, results.CodePaneTokenStream);
+            _state.SetAttributesTokenStream(module, results.AttributesTokenStream);
 
-                // This really needs to go last
-                //It does not reevaluate the overall parer state to avoid concurrent evaluation of all module states and for performance reasons.
-                //The evaluation has to be triggered manually in the calling procedure.
-                StateManager.SetModuleState(module, ParserState.Parsed, token, false); //Note that this is ok because locks allow re-entrancy.
-            }
+            // This really needs to go last
+            //It does not reevaluate the overall parer state to avoid concurrent evaluation of all module states and for performance reasons.
+            //The evaluation has to be triggered manually in the calling procedure.
+            StateManager.SetModuleState(module, ParserState.Parsed, token,false); //Note that this is ok because locks allow re-entrancy.
         }
     }
 }

--- a/Rubberduck.Parsing/VBA/Parsing/ParseRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/ParseRunnerBase.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
+using Rubberduck.Parsing.Common;
 using Rubberduck.Parsing.VBA.Parsing.ParsingExceptions;
 using Rubberduck.VBEditor;
 
@@ -40,8 +39,13 @@ namespace Rubberduck.Parsing.VBA.Parsing
 
         public void ParseModules(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token)
         {
+            var parsingStageTimer = ParsingStageTimer.StartNew();
+
             var parseResults = ModulePareResults(modules, token);
             SaveModuleParseResultsOnState(parseResults, token);
+
+            parsingStageTimer.Stop();
+            parsingStageTimer.Log("Parsed user modules in {0}ms.");
         }
 
         protected abstract IReadOnlyCollection<(QualifiedModuleName module, ModuleParseResults results)> ModulePareResults(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token);

--- a/Rubberduck.Parsing/VBA/Parsing/SynchronousParseRunner.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/SynchronousParseRunner.cs
@@ -18,20 +18,22 @@ namespace Rubberduck.Parsing.VBA.Parsing
         { }
 
 
-        public override void ParseModules(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token)
+        protected override IReadOnlyCollection<(QualifiedModuleName module, ModuleParseResults results)> ModulePareResults(IReadOnlyCollection<QualifiedModuleName> modules, CancellationToken token)
         {
             if (!modules.Any())
             {
-                return;
+                return new List<(QualifiedModuleName module, ModuleParseResults results)>();
             }
 
             token.ThrowIfCancellationRequested();
+
+            var results = new List<(QualifiedModuleName module, ModuleParseResults results)>();
 
             try
             {
                 foreach (var module in modules)
                 {
-                    ParseModule(module, token);
+                    results.Add((module, ModuleParseResults(module, token)));
                 }
             }
             catch (OperationCanceledException)
@@ -43,6 +45,8 @@ namespace Rubberduck.Parsing.VBA.Parsing
                 StateManager.SetStatusAndFireStateChanged(this, ParserState.Error, token);
                 throw;
             }
+
+            return results;
         }
     }
 }

--- a/RubberduckTests/CodeExplorer/CodeExplorerViewModelTests.cs
+++ b/RubberduckTests/CodeExplorer/CodeExplorerViewModelTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using NUnit.Framework;
 using Moq;
@@ -859,6 +860,7 @@ End Sub";
             var dispatcher = new Mock<IUiDispatcher>();
 
             dispatcher.Setup(m => m.Invoke(It.IsAny<Action>())).Callback((Action argument) => argument.Invoke());
+            dispatcher.Setup(m => m.StartTask(It.IsAny<Action>(), It.IsAny<TaskCreationOptions>())).Returns((Action argument, TaskCreationOptions options) => Task.Factory.StartNew(argument.Invoke, options));
 
             var viewModel = new CodeExplorerViewModel(state, null, null, null, dispatcher.Object, vbe.Object, null, new CodeExplorerSyncProvider(vbe.Object, state));
 

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using NUnit.Framework;
 using Moq;
@@ -49,6 +50,7 @@ namespace RubberduckTests.CodeExplorer
                 .Returns(new UnitTestSettings(BindingMode.LateBinding,AssertMode.StrictAssert, true, true, false));
 
             _uiDispatcher.Setup(m => m.Invoke(It.IsAny<Action>())).Callback((Action argument) => argument.Invoke());
+            _uiDispatcher.Setup(m => m.StartTask(It.IsAny<Action>(), It.IsAny<TaskCreationOptions>())).Returns((Action argument, TaskCreationOptions options) => Task.Factory.StartNew(argument.Invoke, options));
 
             SaveDialog = new Mock<ISaveFileDialog>();
             SaveDialog.Setup(o => o.OverwritePrompt);


### PR DESCRIPTION
As mentioned in issue  #4905, we have quite a lot of lock contention in the actual parsing process. This PR removes the contention by first collecting the parse results into a list using local locks. (This approach is faster than using a `ConcurrentBag`.) Then everything gets written to the parser state in one synchronous operation. This saves some, but not much, time in the parcing process. (About 1-2.5s out of 24s for my sample workbook.) Note, that logging on `Trace` level will introduce heavy lock contention on the logger and noticably slow down parsing.

In addition, this PR introduces some safety around the state changed handlers of the CE. Now, these wait for tasks sent to the UI thread. This prevents the parsing process from going on, which is important because this prevents a potential new parse from starting, which in turn would invalidate all cached COM wrappers.

Finally, the logging of the execution times of the parsing stages and the entire parse has been chenged from `Debug` to `Info`, which allows to have a log basically with only this information, warnings and errors.

The other issue from #4905, which concerns the freezing because of the high frequence settings loads, will not be dealt with in this PR but as part of PR #4914 currently in a draft stage.