### PR TITLE
Show components added through the AddComponentService

### DIFF
--- a/Rubberduck.VBEEditor/Utility/AddComponentService.cs
+++ b/Rubberduck.VBEEditor/Utility/AddComponentService.cs
@@ -45,11 +45,34 @@ namespace Rubberduck.VBEditor.Utility
                     using (var loadedComponent = sourceCodeHandler.SubstituteCode(newComponent, code))
                     {
                         AddPrefix(loadedComponent, prefixInModule);
+                        ShowComponent(loadedComponent);
                     }
                 }
                 else
                 {
                     AddPrefix(newComponent, prefixInModule);
+                    ShowComponent(newComponent);
+                }
+            }
+        }
+
+        private static void ShowComponent(IVBComponent component)
+        {
+            if (component == null)
+            {
+                return;
+            }
+
+            using (var codeModule = component.CodeModule)
+            {
+                if (codeModule == null)
+                {
+                    return;
+                }
+
+                using (var codePane = codeModule.CodePane)
+                {
+                    codePane.Show();
                 }
             }
         }


### PR DESCRIPTION
Closes #4919 

This is more in line with the VBE's own behaviour.
As stated in the linkes issue, it worked like that before, but the change in how templates are loaded made them not pop up anymore.