### PR TITLE
Remove dymanic calls from resolver

### DIFF
--- a/Rubberduck.Core/Navigation/RegexSearchReplace/RegexSearchReplace.cs
+++ b/Rubberduck.Core/Navigation/RegexSearchReplace/RegexSearchReplace.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Antlr4.Runtime;
 using Rubberduck.Common;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Symbols;
@@ -137,7 +138,15 @@ namespace Rubberduck.Navigation.RegexSearchReplace
                     var results = GetResultsFromModule(module, searchPattern);
 
                     var qualifiedSelection = pane.GetQualifiedSelection();
-                    dynamic block = state.AllDeclarations.FindTarget(qualifiedSelection.Value, declarationTypes).Context
+
+                    if (!qualifiedSelection.HasValue)
+                    {
+                        return new List<RegexSearchResult>();
+                    }
+
+                    var block = (ParserRuleContext)state.AllDeclarations
+                        .FindTarget(qualifiedSelection.Value, declarationTypes)
+                        .Context
                         .Parent;
                     var selection = new Selection(block.Start.Line, block.Start.Column, block.Stop.Line,
                         block.Stop.Column);

--- a/Rubberduck.Parsing/Binding/BindingService.cs
+++ b/Rubberduck.Parsing/Binding/BindingService.cs
@@ -42,8 +42,7 @@ namespace Rubberduck.Parsing.Binding
         public IBoundExpression ResolveType(Declaration module, Declaration parent, ParserRuleContext expression)
         {
             var context = expression;
-            var opContext = expression as VBAParser.RelationalOpContext;
-            if (opContext != null && opContext.Parent is VBAParser.ComplexTypeContext)
+            if (context is VBAParser.RelationalOpContext opContext && opContext.Parent is VBAParser.ComplexTypeContext)
             {
                 context = opContext.GetChild<VBAParser.LExprContext>(0);
             }

--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -38,17 +38,17 @@ namespace Rubberduck.Parsing.Binding
                 case VBAParser.LExpressionContext lExpressionContext:
                     return Visit(module, parent, lExpressionContext, withBlockVariable, statementContext);
                 case VBAParser.IdentifierValueContext identifierValueContext:
-                    return Visit(module, parent, identifierValueContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, identifierValueContext, statementContext);
                 case VBAParser.CallStmtContext callExpression:
-                    return Visit(module, parent, callExpression, withBlockVariable, statementContext);
+                    return Visit(module, parent, callExpression, withBlockVariable);
                 case VBAParser.BooleanExpressionContext booleanExpressionContext:
-                    return Visit(module, parent, booleanExpressionContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, booleanExpressionContext, withBlockVariable);
                 default:
                     throw new NotSupportedException($"Unexpected context type {expression.GetType()}");
             }
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.CallStmtContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.CallStmtContext expression, IBoundExpression withBlockVariable)
         {
             // Call statements always have an argument list.
             // One of the reasons we're doing this is that an empty argument list could represent a call to a default member,
@@ -64,7 +64,7 @@ namespace Rubberduck.Parsing.Binding
                         expression.lExpression(), lExpressionBinding, new ArgumentList());
             }
 
-            var argList = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable, StatementResolutionContext.Undefined);
+            var argList = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable);
             SetLeftMatch(lExpressionBinding, argList.Arguments.Count);
             return new IndexDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression.lExpression(), lExpressionBinding, argList);
         }
@@ -90,43 +90,43 @@ namespace Rubberduck.Parsing.Binding
                 case VBAParser.LExprContext lExprContext:
                     return Visit(module, parent, lExprContext.lExpression(), withBlockVariable, statementContext);
                 case VBAParser.ParenthesizedExprContext parenthesizedExprContext:
-                    return Visit(module, parent, parenthesizedExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, parenthesizedExprContext, withBlockVariable);
                 case VBAParser.RelationalOpContext relationalOpContext:
-                    return Visit(module, parent, relationalOpContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, relationalOpContext, withBlockVariable);
                 case VBAParser.LiteralExprContext literalExprContext:
-                    return Visit(module, parent, literalExprContext.literalExpression(), withBlockVariable, StatementResolutionContext.Undefined);
+                    return Visit(literalExprContext.literalExpression());
                 case VBAParser.NewExprContext newExprContext:
-                    return Visit(module, parent, newExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, newExprContext, withBlockVariable);
                 case VBAParser.LogicalNotOpContext logicalNotOpContext:
-                    return VisitUnaryOp(module, parent, logicalNotOpContext, logicalNotOpContext.expression(), withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitUnaryOp(module, parent, logicalNotOpContext, logicalNotOpContext.expression(), withBlockVariable);
                 case VBAParser.UnaryMinusOpContext unaryMinusOpContext:
-                    return VisitUnaryOp(module, parent, unaryMinusOpContext, unaryMinusOpContext.expression(), withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitUnaryOp(module, parent, unaryMinusOpContext, unaryMinusOpContext.expression(), withBlockVariable);
                 case VBAParser.LogicalAndOpContext logicalAndOpContext:
-                    return VisitBinaryOp(module, parent, logicalAndOpContext, logicalAndOpContext.expression()[0], logicalAndOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, logicalAndOpContext, logicalAndOpContext.expression()[0], logicalAndOpContext.expression()[1], withBlockVariable);
                 case VBAParser.LogicalOrOpContext logicalOrOpContext:
-                    return VisitBinaryOp(module, parent, logicalOrOpContext, logicalOrOpContext.expression()[0], logicalOrOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, logicalOrOpContext, logicalOrOpContext.expression()[0], logicalOrOpContext.expression()[1], withBlockVariable);
                 case VBAParser.LogicalXorOpContext logicalXorOpContext:
-                    return VisitBinaryOp(module, parent, logicalXorOpContext, logicalXorOpContext.expression()[0], logicalXorOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, logicalXorOpContext, logicalXorOpContext.expression()[0], logicalXorOpContext.expression()[1], withBlockVariable);
                 case VBAParser.LogicalEqvOpContext logicalEqvOpContext:
-                    return VisitBinaryOp(module, parent, logicalEqvOpContext, logicalEqvOpContext.expression()[0], logicalEqvOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, logicalEqvOpContext, logicalEqvOpContext.expression()[0], logicalEqvOpContext.expression()[1], withBlockVariable);
                 case VBAParser.LogicalImpOpContext logicalImpOpContext:
-                    return VisitBinaryOp(module, parent, logicalImpOpContext, logicalImpOpContext.expression()[0], logicalImpOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, logicalImpOpContext, logicalImpOpContext.expression()[0], logicalImpOpContext.expression()[1], withBlockVariable);
                 case VBAParser.AddOpContext addOpContext:
-                    return VisitBinaryOp(module, parent, addOpContext, addOpContext.expression()[0], addOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, addOpContext, addOpContext.expression()[0], addOpContext.expression()[1], withBlockVariable);
                 case VBAParser.ConcatOpContext concatOpContext:
-                    return VisitBinaryOp(module, parent, concatOpContext, concatOpContext.expression()[0], concatOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, concatOpContext, concatOpContext.expression()[0], concatOpContext.expression()[1], withBlockVariable);
                 case VBAParser.MultOpContext multOpContext:
-                    return VisitBinaryOp(module, parent, multOpContext, multOpContext.expression()[0], multOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, multOpContext, multOpContext.expression()[0], multOpContext.expression()[1], withBlockVariable);
                 case VBAParser.ModOpContext modOpContext:
-                    return VisitBinaryOp(module, parent, modOpContext, modOpContext.expression()[0], modOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, modOpContext, modOpContext.expression()[0], modOpContext.expression()[1], withBlockVariable);
                 case VBAParser.PowOpContext powOpContext:
-                    return VisitBinaryOp(module, parent, powOpContext, powOpContext.expression()[0], powOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, powOpContext, powOpContext.expression()[0], powOpContext.expression()[1], withBlockVariable);
                 case VBAParser.IntDivOpContext intDivOpContext:
-                    return VisitBinaryOp(module, parent, intDivOpContext, intDivOpContext.expression()[0], intDivOpContext.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                    return VisitBinaryOp(module, parent, intDivOpContext, intDivOpContext.expression()[0], intDivOpContext.expression()[1], withBlockVariable);
                 case VBAParser.MarkedFileNumberExprContext markedFileNumberExprContext:
-                    return Visit(module, parent, markedFileNumberExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, markedFileNumberExprContext, withBlockVariable);
                 case VBAParser.BuiltInTypeExprContext builtInTypeExprContext:
-                    return Visit(module, parent, builtInTypeExprContext, withBlockVariable, statementContext);
+                    return Visit(builtInTypeExprContext);
                 //We do not handle the VBAParser.TypeofexprContext because that should only ever appear as a child of an IS relational operator expression and is specifically handled there.
                 default:
                     throw new NotSupportedException($"Unexpected expression type {expression.GetType()}");
@@ -138,29 +138,29 @@ namespace Rubberduck.Parsing.Binding
             switch (expression)
             {
                 case VBAParser.SimpleNameExprContext simpleNameExprContext:
-                    return Visit(module, parent, simpleNameExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, simpleNameExprContext, statementContext);
                 case VBAParser.MemberAccessExprContext memberAccessExprContext:
                     return Visit(module, parent, memberAccessExprContext, withBlockVariable, statementContext);
                 case VBAParser.IndexExprContext indexExprContext:
-                    return Visit(module, parent, indexExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, indexExprContext, withBlockVariable);
                 case VBAParser.WithMemberAccessExprContext withMemberAccessExprContext:
                     return Visit(module, parent, withMemberAccessExprContext, withBlockVariable, statementContext);
                 case VBAParser.InstanceExprContext instanceExprContext:
-                    return Visit(module, parent, instanceExprContext, withBlockVariable, statementContext);
+                    return Visit(module, instanceExprContext);
                 case VBAParser.WhitespaceIndexExprContext whitespaceIndexExprContext:
-                    return Visit(module, parent, whitespaceIndexExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, whitespaceIndexExprContext, withBlockVariable);
                 case VBAParser.DictionaryAccessExprContext dictionaryAccessExprContext:
-                    return Visit(module, parent, dictionaryAccessExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, dictionaryAccessExprContext, withBlockVariable);
                 case VBAParser.WithDictionaryAccessExprContext withDictionaryAccessExprContext:
-                    return Visit(module, parent, withDictionaryAccessExprContext, withBlockVariable, statementContext);
+                    return Visit(module, parent, withDictionaryAccessExprContext, withBlockVariable);
                 default:
                     throw new NotSupportedException($"Unexpected lExpression type {expression.GetType()}");
             }
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.NewExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.NewExprContext expression, IBoundExpression withBlockVariable)
         {
-            var typeExpressionBinding = VisitType(module, parent, expression.expression(), withBlockVariable, StatementResolutionContext.Undefined);
+            var typeExpressionBinding = VisitType(module, parent, expression.expression(), withBlockVariable);
             if (typeExpressionBinding == null)
             {
                 return null;
@@ -168,7 +168,7 @@ namespace Rubberduck.Parsing.Binding
             return new NewTypeBinding(_declarationFinder, module, parent, expression, typeExpressionBinding);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.MarkedFileNumberExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.MarkedFileNumberExprContext expression, IBoundExpression withBlockVariable)
         {
             // The MarkedFileNumberExpr doesn't actually exist but for backwards compatibility reasons we support it, ignore the "hash tag" of the file number
             // and resolve it as a normal expression.
@@ -176,23 +176,23 @@ namespace Rubberduck.Parsing.Binding
             return Visit(module, parent, expression.expression(), withBlockVariable, StatementResolutionContext.Undefined);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.BuiltInTypeExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(VBAParser.BuiltInTypeExprContext expression)
         {
             // Not actually an expression, but treated as one to allow for a faster parser.
             return null;
         }
 
-        private IExpressionBinding VisitType(Declaration module, Declaration parent, VBAParser.ExpressionContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding VisitType(Declaration module, Declaration parent, VBAParser.ExpressionContext expression, IBoundExpression withBlockVariable)
         {
             return _typeBindingContext.BuildTree(module, parent, expression, withBlockVariable, StatementResolutionContext.Undefined);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.SimpleNameExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.SimpleNameExprContext expression, StatementResolutionContext statementContext)
         {
             return new SimpleNameDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, Identifier.GetName(expression.identifier()), statementContext);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IdentifierValueContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IdentifierValueContext expression, StatementResolutionContext statementContext)
         {
             return new SimpleNameDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, Identifier.GetName(expression), statementContext);
         }
@@ -204,25 +204,25 @@ namespace Rubberduck.Parsing.Binding
             return new MemberAccessDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, lExpressionBinding, statementContext, expression.unrestrictedIdentifier());
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IndexExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IndexExprContext expression, IBoundExpression withBlockVariable)
         {
             var lExpression = expression.lExpression();
             var lExpressionBinding = Visit(module, parent, lExpression, withBlockVariable, StatementResolutionContext.Undefined);
-            var argumentListBinding = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable, StatementResolutionContext.Undefined);
+            var argumentListBinding = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable);
             SetLeftMatch(lExpressionBinding, argumentListBinding.Arguments.Count);
             return new IndexDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, lExpressionBinding, argumentListBinding);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.WhitespaceIndexExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.WhitespaceIndexExprContext expression, IBoundExpression withBlockVariable)
         {
             var lExpression = expression.lExpression();
             var lExpressionBinding = Visit(module, parent, lExpression, withBlockVariable, StatementResolutionContext.Undefined);
-            var argumentListBinding = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable, StatementResolutionContext.Undefined);
+            var argumentListBinding = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable);
             SetLeftMatch(lExpressionBinding, argumentListBinding.Arguments.Count);
             return new IndexDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, lExpressionBinding, argumentListBinding);
         }
 
-        private ArgumentList VisitArgumentList(Declaration module, Declaration parent, VBAParser.ArgumentListContext argumentList, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private ArgumentList VisitArgumentList(Declaration module, Declaration parent, VBAParser.ArgumentListContext argumentList, IBoundExpression withBlockVariable)
         {
             var convertedList = new ArgumentList();
             if (argumentList == null)
@@ -238,14 +238,12 @@ namespace Rubberduck.Parsing.Binding
                     if (expr.positionalArgument() != null)
                     {
                         convertedList.AddArgument(new ArgumentListArgument(
-                            VisitArgumentBinding(module, parent, expr.positionalArgument().argumentExpression(), withBlockVariable,
-                            StatementResolutionContext.Undefined), ArgumentListArgumentType.Positional));
+                            VisitArgumentBinding(module, parent, expr.positionalArgument().argumentExpression(), withBlockVariable), ArgumentListArgumentType.Positional));
                     }
                     else if (expr.namedArgument() != null)
                     {
                         convertedList.AddArgument(new ArgumentListArgument(
-                            VisitArgumentBinding(module, parent, expr.namedArgument().argumentExpression(), withBlockVariable,
-                            StatementResolutionContext.Undefined), ArgumentListArgumentType.Named,
+                            VisitArgumentBinding(module, parent, expr.namedArgument().argumentExpression(), withBlockVariable), ArgumentListArgumentType.Named,
                             CreateNamedArgumentExpressionCreator(expr.namedArgument().unrestrictedIdentifier().GetText(), expr.namedArgument().unrestrictedIdentifier())));
                     }
                 }
@@ -280,7 +278,7 @@ namespace Rubberduck.Parsing.Binding
             };
         }
 
-        private IExpressionBinding VisitArgumentBinding(Declaration module, Declaration parent, VBAParser.ArgumentExpressionContext argumentExpression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding VisitArgumentBinding(Declaration module, Declaration parent, VBAParser.ArgumentExpressionContext argumentExpression, IBoundExpression withBlockVariable)
         {
             if (argumentExpression.expression() != null)
             {
@@ -299,14 +297,14 @@ namespace Rubberduck.Parsing.Binding
             return _procedurePointerBindingContext.BuildTree(module, parent, expression, withBlockVariable, statementContext);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.DictionaryAccessExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.DictionaryAccessExprContext expression, IBoundExpression withBlockVariable)
         {
             var lExpression = expression.lExpression();
             var lExpressionBinding = Visit(module, parent, lExpression, withBlockVariable, StatementResolutionContext.Undefined);
-            return VisitDictionaryAccessExpression(module, parent, expression, expression.unrestrictedIdentifier(), lExpressionBinding, StatementResolutionContext.Undefined);
+            return VisitDictionaryAccessExpression(module, parent, expression, expression.unrestrictedIdentifier(), lExpressionBinding);
         }
 
-        private IExpressionBinding VisitDictionaryAccessExpression(Declaration module, Declaration parent, ParserRuleContext expression, ParserRuleContext nameContext, IExpressionBinding lExpressionBinding, StatementResolutionContext statementContext)
+        private IExpressionBinding VisitDictionaryAccessExpression(Declaration module, Declaration parent, ParserRuleContext expression, ParserRuleContext nameContext, IExpressionBinding lExpressionBinding)
         {
             /*
                 A dictionary access expression is syntactically translated into an index expression with the same 
@@ -318,7 +316,7 @@ namespace Rubberduck.Parsing.Binding
             return new IndexDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, lExpressionBinding, fakeArgList);
         }
 
-        private IExpressionBinding VisitDictionaryAccessExpression(Declaration module, Declaration parent, ParserRuleContext expression, ParserRuleContext nameContext, IBoundExpression lExpression, StatementResolutionContext statementContext)
+        private IExpressionBinding VisitDictionaryAccessExpression(Declaration module, Declaration parent, ParserRuleContext expression, ParserRuleContext nameContext, IBoundExpression lExpression)
         {
             /*
                 A dictionary access expression is syntactically translated into an index expression with the same 
@@ -335,7 +333,7 @@ namespace Rubberduck.Parsing.Binding
             return new MemberAccessDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, withBlockVariable, expression.unrestrictedIdentifier().GetText(), statementContext, expression.unrestrictedIdentifier());
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.WithDictionaryAccessExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.WithDictionaryAccessExprContext expression, IBoundExpression withBlockVariable)
         {
             /*
                 A <with-member-access-expression> or <with-dictionary-access-expression> is 
@@ -343,25 +341,25 @@ namespace Rubberduck.Parsing.Binding
                 the innermost enclosing With block variable was specified for <l-expression>. If there is no 
                 enclosing With block, the <with-expression> is invalid.
              */
-            return VisitDictionaryAccessExpression(module, parent, expression, expression.unrestrictedIdentifier(), withBlockVariable, StatementResolutionContext.Undefined);
+            return VisitDictionaryAccessExpression(module, parent, expression, expression.unrestrictedIdentifier(), withBlockVariable);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.ParenthesizedExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.ParenthesizedExprContext expression, IBoundExpression withBlockVariable)
         {
             var expressionParens = expression.expression();
             var expressionBinding = Visit(module, parent, expressionParens, withBlockVariable, StatementResolutionContext.Undefined);
             return new ParenthesizedDefaultBinding(expression, expressionBinding);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.RelationalOpContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.RelationalOpContext expression, IBoundExpression withBlockVariable)
         {
             // To make the grammar we treat a type-of-is expression as a construct of the form "TYPEOF expression", where expression
             // is always "expression IS expression".
             if (expression.expression()[0] is VBAParser.TypeofexprContext typeofExpr)
             {
-                return VisitTypeOf(module, parent, expression, typeofExpr, expression.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+                return VisitTypeOf(module, parent, expression, typeofExpr, expression.expression()[1], withBlockVariable);
             }
-            return VisitBinaryOp(module, parent, expression, expression.expression()[0], expression.expression()[1], withBlockVariable, StatementResolutionContext.Undefined);
+            return VisitBinaryOp(module, parent, expression, expression.expression()[0], expression.expression()[1], withBlockVariable);
         }
 
         private IExpressionBinding VisitTypeOf(
@@ -370,43 +368,42 @@ namespace Rubberduck.Parsing.Binding
             VBAParser.RelationalOpContext typeOfIsExpression,
             VBAParser.TypeofexprContext typeOfLeftPartExpression,
             VBAParser.ExpressionContext typeExpression,
-            IBoundExpression withBlockVariable, 
-            StatementResolutionContext statementContext)
+            IBoundExpression withBlockVariable)
         {
             var booleanExpression = typeOfLeftPartExpression.expression();
             var booleanExpressionBinding = Visit(module, parent, booleanExpression, withBlockVariable, StatementResolutionContext.Undefined);
-            var typeExpressionBinding = VisitType(module, parent, typeExpression, withBlockVariable, StatementResolutionContext.Undefined);
+            var typeExpressionBinding = VisitType(module, parent, typeExpression, withBlockVariable);
             return new TypeOfIsDefaultBinding(typeOfIsExpression, booleanExpressionBinding, typeExpressionBinding);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.BooleanExpressionContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.BooleanExpressionContext expression, IBoundExpression withBlockVariable)
         {
             return Visit(module, parent, expression.expression(), withBlockVariable, StatementResolutionContext.Undefined);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IntegerExpressionContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IntegerExpressionContext expression, IBoundExpression withBlockVariable)
         {
             return Visit(module, parent, expression.expression(), withBlockVariable, StatementResolutionContext.Undefined);
         }
 
-        private static IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.InstanceExprContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private static IExpressionBinding Visit(Declaration module, VBAParser.InstanceExprContext expression)
         {
             return new InstanceDefaultBinding(expression, module);
         }
 
-        private static IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.LiteralExpressionContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private static IExpressionBinding Visit(VBAParser.LiteralExpressionContext expression)
         {
             return new LiteralDefaultBinding(expression);
         }
 
-        private IExpressionBinding VisitBinaryOp(Declaration module, Declaration parent, ParserRuleContext context, VBAParser.ExpressionContext left, VBAParser.ExpressionContext right, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding VisitBinaryOp(Declaration module, Declaration parent, ParserRuleContext context, VBAParser.ExpressionContext left, VBAParser.ExpressionContext right, IBoundExpression withBlockVariable)
         {
             var leftBinding = Visit(module, parent, left, withBlockVariable, StatementResolutionContext.Undefined);
             var rightBinding = Visit(module, parent, right, withBlockVariable, StatementResolutionContext.Undefined);
             return new BinaryOpDefaultBinding(context, leftBinding, rightBinding);
         }
 
-        private IExpressionBinding VisitUnaryOp(Declaration module, Declaration parent, ParserRuleContext context, VBAParser.ExpressionContext expr, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        private IExpressionBinding VisitUnaryOp(Declaration module, Declaration parent, ParserRuleContext context, VBAParser.ExpressionContext expr, IBoundExpression withBlockVariable)
         {
             var exprBinding = Visit(module, parent, expr, withBlockVariable, StatementResolutionContext.Undefined);
             return new UnaryOpDefaultBinding(context, exprBinding);

--- a/Rubberduck.Parsing/Binding/Expressions/IndexExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/IndexExpression.cs
@@ -5,9 +5,6 @@ namespace Rubberduck.Parsing.Binding
 {
     public sealed class IndexExpression : BoundExpression
     {
-        private readonly IBoundExpression _lExpression;
-        private readonly ArgumentList _argumentList;
-
         public IndexExpression(
             Declaration referencedDeclaration, 
             ExpressionClassification classification, 
@@ -16,24 +13,11 @@ namespace Rubberduck.Parsing.Binding
             ArgumentList argumentList)
             : base(referencedDeclaration, classification, context)
         {
-            _lExpression = lExpression;
-            _argumentList = argumentList;
+            LExpression = lExpression;
+            ArgumentList = argumentList;
         }
 
-        public IBoundExpression LExpression
-        {
-            get
-            {
-                return _lExpression;
-            }
-        }
-
-        public ArgumentList ArgumentList
-        {
-            get
-            {
-                return _argumentList;
-            }
-        }
+        public IBoundExpression LExpression { get; }
+        public ArgumentList ArgumentList { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/MemberAccessExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/MemberAccessExpression.cs
@@ -5,9 +5,6 @@ namespace Rubberduck.Parsing.Binding
 {
     public sealed class MemberAccessExpression : BoundExpression
     {
-        private readonly IBoundExpression _lExpression;
-        private readonly ParserRuleContext _unrestrictedNameContext;
-
         public MemberAccessExpression(
             Declaration referencedDeclaration, 
             ExpressionClassification classification, 
@@ -16,24 +13,11 @@ namespace Rubberduck.Parsing.Binding
             IBoundExpression lExpression)
             : base(referencedDeclaration, classification, context)
         {
-            _lExpression = lExpression;
-            _unrestrictedNameContext = unrestrictedNameContext;
+            LExpression = lExpression;
+            UnrestrictedNameContext = unrestrictedNameContext;
         }
 
-        public IBoundExpression LExpression
-        {
-            get
-            {
-                return _lExpression;
-            }
-        }
-
-        public ParserRuleContext UnrestrictedNameContext
-        {
-            get
-            {
-                return _unrestrictedNameContext;
-            }
-        }
+        public IBoundExpression LExpression { get; }
+        public ParserRuleContext UnrestrictedNameContext { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/NewExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/NewExpression.cs
@@ -5,8 +5,6 @@ namespace Rubberduck.Parsing.Binding
 {
     public sealed class NewExpression : BoundExpression
     {
-        private readonly IBoundExpression _typeExpression;
-
         public NewExpression(
             Declaration referencedDeclaration,
             ParserRuleContext context,
@@ -14,15 +12,9 @@ namespace Rubberduck.Parsing.Binding
             // Marked as Variable instead of Value to integrate into rest of binding process.
             : base(referencedDeclaration, ExpressionClassification.Variable, context)
         {
-            _typeExpression = typeExpression;
+            TypeExpression = typeExpression;
         }
 
-        public IBoundExpression TypeExpression
-        {
-            get
-            {
-                return _typeExpression;
-            }
-        }
+        public IBoundExpression TypeExpression { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/ParenthesizedExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/ParenthesizedExpression.cs
@@ -5,23 +5,15 @@ namespace Rubberduck.Parsing.Binding
 {
     public sealed class ParenthesizedExpression : BoundExpression
     {
-        private readonly IBoundExpression _expression;
-
         public ParenthesizedExpression(
             Declaration referencedDeclaration,
             ParserRuleContext context,
             IBoundExpression expression)
             : base(referencedDeclaration, ExpressionClassification.Value, context)
         {
-            _expression = expression;
+            Expression = expression;
         }
 
-        public IBoundExpression Expression
-        {
-            get
-            {
-                return _expression;
-            }
-        }
+        public IBoundExpression Expression { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/ResolutionFailedExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/ResolutionFailedExpression.cs
@@ -8,17 +8,9 @@ namespace Rubberduck.Parsing.Binding
 
         public ResolutionFailedExpression()
             : base(null, ExpressionClassification.ResolutionFailed, null)
-        {
-            _successfullyResolvedExpressions = new List<IBoundExpression>();
-        }
+        {}
 
-        public IReadOnlyList<IBoundExpression> SuccessfullyResolvedExpressions
-        {
-            get
-            {
-                return _successfullyResolvedExpressions;
-            }
-        }
+        public IReadOnlyList<IBoundExpression> SuccessfullyResolvedExpressions => _successfullyResolvedExpressions;
 
         public void AddSuccessfullyResolvedExpression(IBoundExpression expression)
         {

--- a/Rubberduck.Parsing/Binding/Expressions/TypeOfIsExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/TypeOfIsExpression.cs
@@ -5,9 +5,6 @@ namespace Rubberduck.Parsing.Binding
 {
     public sealed class TypeOfIsExpression : BoundExpression
     {
-        private readonly IBoundExpression _expression;
-        private readonly IBoundExpression _typeExpression;
-
         public TypeOfIsExpression(
             Declaration referencedDeclaration,
             ParserRuleContext context,
@@ -15,24 +12,11 @@ namespace Rubberduck.Parsing.Binding
             IBoundExpression typeExpression)
             : base(referencedDeclaration, ExpressionClassification.Value, context)
         {
-            _expression = expression;
-            _typeExpression = typeExpression;
+            Expression = expression;
+            TypeExpression = typeExpression;
         }
 
-        public IBoundExpression Expression
-        {
-            get
-            {
-                return _expression;
-            }
-        }
-
-        public IBoundExpression TypeExpression
-        {
-            get
-            {
-                return _typeExpression;
-            }
-        }
+        public IBoundExpression Expression { get; }
+        public IBoundExpression TypeExpression { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/UnaryOpExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/UnaryOpExpression.cs
@@ -5,23 +5,15 @@ namespace Rubberduck.Parsing.Binding
 {
     public sealed class UnaryOpExpression : BoundExpression
     {
-        private readonly IBoundExpression _expr;
-
         public UnaryOpExpression(
             Declaration referencedDeclaration,
             ParserRuleContext context,
             IBoundExpression expr)
             : base(referencedDeclaration, ExpressionClassification.Value, context)
         {
-            _expr = expr;
+            Expr = expr;
         }
 
-        public IBoundExpression Expr
-        {
-            get
-            {
-                return _expr;
-            }
-        }
+        public IBoundExpression Expr { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/IBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/IBindingContext.cs
@@ -1,11 +1,11 @@
-﻿using Antlr4.Runtime;
+﻿using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.Symbols;
 
 namespace Rubberduck.Parsing.Binding
 {
     public interface IBindingContext
     {
-        IBoundExpression Resolve(Declaration module, Declaration parent, ParserRuleContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext);
-        IExpressionBinding BuildTree(Declaration module, Declaration parent, ParserRuleContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext);
+        IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext);
+        IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext);
     }
 }

--- a/Rubberduck.Parsing/Binding/ProcedurePointerBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/ProcedurePointerBindingContext.cs
@@ -1,4 +1,5 @@
-﻿using Antlr4.Runtime;
+﻿using System;
+using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
@@ -14,7 +15,7 @@ namespace Rubberduck.Parsing.Binding
             _declarationFinder = declarationFinder;
         }
 
-        public IBoundExpression Resolve(Declaration module, Declaration parent, ParserRuleContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        public IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
         {
             IExpressionBinding bindingTree = BuildTree(module, parent, expression, withBlockVariable, statementContext);
             if (bindingTree != null)
@@ -24,26 +25,48 @@ namespace Rubberduck.Parsing.Binding
             return null;
         }
 
-        public IExpressionBinding BuildTree(Declaration module, Declaration parent, ParserRuleContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        public IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
         {
-            dynamic dynamicExpression = expression;
-            return Visit(module, parent, dynamicExpression);
-        }
-
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.ExpressionContext expression)
-        {
-            return Visit(module, parent, (dynamic)expression);
+            switch (expression)
+            {
+                case VBAParser.LExpressionContext lExpressionContext:
+                    return Visit(module, parent, lExpressionContext);
+                case VBAParser.ExpressionContext expressionContext:
+                    return Visit(module, parent, expressionContext);
+                case VBAParser.AddressOfExpressionContext addressOfExpressionContext:
+                    return Visit(module, parent, addressOfExpressionContext);
+                default:
+                    throw new NotSupportedException($"Unexpected context type {expression.GetType()}");
+            }
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.AddressOfExpressionContext expression)
         {
-            return Visit(module, parent, (dynamic)expression.expression());
+            return Visit(module, parent, expression.expression());
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.LExprContext expression)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.ExpressionContext expression)
         {
-            dynamic lexpr = expression.lExpression();
-            return Visit(module, parent, lexpr);
+            switch (expression)
+            {
+                case VBAParser.LExprContext lExprContext:
+                    return Visit(module, parent, lExprContext.lExpression());
+                default:
+                    throw new NotSupportedException($"Unexpected expression type {expression.GetType()}");
+            }
+        }
+
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.LExpressionContext expression)
+        {
+            switch (expression)
+            {
+                case VBAParser.SimpleNameExprContext simpleNameExprContext:
+                    return Visit(module, parent, simpleNameExprContext);
+                case VBAParser.MemberAccessExprContext memberAccessExprContext:
+                    return Visit(module, parent, memberAccessExprContext);
+                default:
+                    throw new NotSupportedException($"Unexpected lExpression type {expression.GetType()}");
+            }
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.SimpleNameExprContext expression)
@@ -53,7 +76,7 @@ namespace Rubberduck.Parsing.Binding
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.MemberAccessExprContext expression)
         {
-            dynamic lExpression = expression.lExpression();
+            var lExpression = expression.lExpression();
             var lExpressionBinding = Visit(module, parent, lExpression);
             return new MemberAccessProcedurePointerBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, expression.unrestrictedIdentifier(), lExpressionBinding);
         }

--- a/Rubberduck.Parsing/Binding/TypeBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/TypeBindingContext.cs
@@ -1,4 +1,5 @@
-﻿using Antlr4.Runtime;
+﻿using System;
+using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
@@ -14,7 +15,7 @@ namespace Rubberduck.Parsing.Binding
             _declarationFinder = declarationFinder;
         }
 
-        public IBoundExpression Resolve(Declaration module, Declaration parent, ParserRuleContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        public IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
         {
             IExpressionBinding bindingTree = BuildTree(module, parent, expression, withBlockVariable, statementContext);
             if (bindingTree != null)
@@ -24,31 +25,49 @@ namespace Rubberduck.Parsing.Binding
             return null;
         }
 
-        public IExpressionBinding BuildTree(Declaration module, Declaration parent, ParserRuleContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
+        public IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext)
         {
-            dynamic dynamicExpression = expression;
-            var type = expression.GetType();
-            return Visit(module, parent, dynamicExpression);
+            switch (expression)
+            {
+                case VBAParser.LExprContext lExprContext:
+                    return Visit(module, parent, lExprContext);
+                case VBAParser.CtLExprContext ctLExprContext:
+                    return Visit(module, parent, ctLExprContext);
+                default:
+                    throw new NotSupportedException($"Unexpected context type {expression.GetType()}");
+            }
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.LExprContext expression)
         {
-            dynamic lexpr = expression.lExpression();
-            var type = expression.lExpression().GetType();
+            var lexpr = expression.lExpression();
             return Visit(module, parent, lexpr);
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.CtLExprContext expression)
         {
-            dynamic lexpr = expression.lExpression();
-            var type = expression.lExpression().GetType();
+            var lexpr = expression.lExpression();
             return Visit(module, parent, lexpr);
+        }
+
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.LExpressionContext expression)
+        {
+            switch (expression)
+            {
+                case VBAParser.SimpleNameExprContext simpleNameExprContext:
+                    return Visit(module, parent, simpleNameExprContext);
+                case VBAParser.MemberAccessExprContext memberAccessExprContext:
+                    return Visit(module, parent, memberAccessExprContext);
+                case VBAParser.IndexExprContext indexExprContext:
+                    return Visit(module, parent, indexExprContext);
+                default:
+                    throw new NotSupportedException($"Unexpected lExpression type {expression.GetType()}");
+            }
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IndexExprContext expression)
         {
-            dynamic lexpr = expression.lExpression();
-            var type = expression.lExpression().GetType();
+            var lexpr = expression.lExpression();
             return Visit(module, parent, lexpr);
         }
 

--- a/Rubberduck.Parsing/Binding/TypeBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/TypeBindingContext.cs
@@ -78,7 +78,7 @@ namespace Rubberduck.Parsing.Binding
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.MemberAccessExprContext expression)
         {
-            dynamic lExpression = expression.lExpression();
+            var lExpression = expression.lExpression();
             var lExpressionBinding = Visit(module, parent, lExpression);
             SetPreferProjectOverUdt(lExpressionBinding);
             return new MemberAccessTypeBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, expression.unrestrictedIdentifier(), lExpressionBinding);

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -97,19 +97,9 @@ namespace Rubberduck.Parsing.Symbols
                 return false;
             }
 
-            VBAParser.TypeHintContext hint;
-            switch (Context.Parent)
-            {
-                case VBAParser.TypedIdentifierContext typedIdentifierContext:
-                    hint = typedIdentifierContext.typeHint();
-                    break;
-                case VBAParser.LiteralExpressionContext literalExpressionContext:
-                    hint = literalExpressionContext.typeHint();
-                    break;
-                default:
-                    hint = null;
-                    break;
-            }
+            var hint = Context.Parent is VBAParser.TypedIdentifierContext typedIdentifierContext
+                ? typedIdentifierContext.typeHint()
+                : null;
 
             token = hint?.GetText();
             _hasTypeHint = hint != null;

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -97,7 +97,20 @@ namespace Rubberduck.Parsing.Symbols
                 return false;
             }
 
-            var hint = ((dynamic)Context.Parent).typeHint() as VBAParser.TypeHintContext;
+            VBAParser.TypeHintContext hint;
+            switch (Context.Parent)
+            {
+                case VBAParser.TypedIdentifierContext typedIdentifierContext:
+                    hint = typedIdentifierContext.typeHint();
+                    break;
+                case VBAParser.LiteralExpressionContext literalExpressionContext:
+                    hint = literalExpressionContext.typeHint();
+                    break;
+                default:
+                    hint = null;
+                    break;
+            }
+
             token = hint?.GetText();
             _hasTypeHint = hint != null;
             return _hasTypeHint.Value;

--- a/Rubberduck.Refactorings/Common/DeclarationExtensions.cs
+++ b/Rubberduck.Refactorings/Common/DeclarationExtensions.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using Antlr4.Runtime;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
@@ -423,19 +424,13 @@ namespace Rubberduck.Common
 
                 foreach (var reference in declaration.References)
                 {
-                    var proc = (dynamic)reference.Context.Parent;
+                    var proc = (ParserRuleContext)reference.Context.Parent;
                     var paramList = proc ;
 
-                    // This is to prevent throws when this statement fails:
-                    // (VBAParser.ArgsCallContext)proc.argsCall();
-                    var method = ((Type) proc.GetType()).GetMethod("argsCall");
-                    if (method != null)
+                    if (paramList == null)
                     {
-                        try { paramList = method.Invoke(proc, null); }
-                        catch { continue; }
+                        continue;
                     }
-
-                    if (paramList == null) { continue; }
 
                     activeSelection = new Selection(paramList.Start.Line,
                                                     paramList.Start.Column,


### PR DESCRIPTION
This PR replaces the dynamic call in the binding stage of the references resolver.

This has two main advantages: it is easier to navigate the code when debugging (no need to find some code and run it through the debugger to follow the execution flow) and it is slightly faster. 