### PR TITLE
Fix attributes encoding issue

### DIFF
--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/SerializeProjectsCommandMenuItem.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/SerializeProjectsCommandMenuItem.cs
@@ -77,9 +77,9 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                 _serializationProvider.SerializeProject(library);
             }
 
-#if DEBUG
-            //This block must be inside a DEBUG block because the Serialize method 
-            //called is conditionally compiled and available only for a DEBUG build.
+#if TRACE_COM_SAFE
+            //This block must be inside a conditional compilation block because the Serialize method 
+            //called is conditionally compiled and available only if the compilation constant TRACE_COM_SAFE is set.
             var path = !string.IsNullOrWhiteSpace(_serializationProvider.Target)
                 ? Path.GetDirectoryName(_serializationProvider.Target)
                 : Path.GetTempPath();

--- a/Rubberduck.VBEEditor/ComManagement/ComSafeBase.cs
+++ b/Rubberduck.VBEEditor/ComManagement/ComSafeBase.cs
@@ -32,7 +32,7 @@ namespace Rubberduck.VBEditor.ComManagement
 
         protected virtual void Dispose(bool disposing)
         {
-#if DEBUG
+#if TRACE_COM_SAFE
             if (_disposed)
             {
                 return;
@@ -70,7 +70,7 @@ namespace Rubberduck.VBEditor.ComManagement
 #endif
         }
 
-#if DEBUG
+#if TRACE_COM_SAFE
         private struct TraceData
         {
             internal int HashCode { get; set; }

--- a/Rubberduck.VBEEditor/ComManagement/IComSafe.cs
+++ b/Rubberduck.VBEEditor/ComManagement/IComSafe.cs
@@ -7,9 +7,9 @@ namespace Rubberduck.VBEditor.ComManagement
     {
         void Add(ISafeComWrapper comWrapper);
         bool TryRemove(ISafeComWrapper comWrapper);
-#if DEBUG
+#if TRACE_COM_SAFE
         /// <summary>
-        /// Available in DEBUG build only. Provide a mechanism for serializing both
+        /// Available only if the compilation constant TRACE_COM_SAFE is set. Provide a mechanism for serializing both
         /// a snapshot of the COM safe at the instant and a historical activity log
         /// with a limited stack trace for each entry.
         /// </summary>

--- a/Rubberduck.VBEEditor/ComManagement/StrongComSafe.cs
+++ b/Rubberduck.VBEEditor/ComManagement/StrongComSafe.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+#if TRACE_COM_SAFE
+using System.Linq;
+using System.Collections.Generic;
+#endif
 
 namespace Rubberduck.VBEditor.ComManagement
 {
@@ -19,14 +22,14 @@ namespace Rubberduck.VBEditor.ComManagement
                     comWrapper, 
                     key =>
                     {
-#if DEBUG
+#if TRACE_COM_SAFE
                         TraceAdd(comWrapper);
 #endif
                         return 1;
                     }, 
                     (key, value) =>
                     {
-#if DEBUG
+#if TRACE_COM_SAFE
                         TraceUpdate(comWrapper);
 #endif
                         return value;
@@ -42,7 +45,7 @@ namespace Rubberduck.VBEditor.ComManagement
             }
 
             var result = _comWrapperCache.TryRemove(comWrapper, out _);
-#if DEBUG
+#if TRACE_COM_SAFE
             TraceRemove(comWrapper, result);
 #endif
             return result;
@@ -67,7 +70,7 @@ namespace Rubberduck.VBEditor.ComManagement
             _comWrapperCache.Clear();
         }
 
-#if DEBUG
+#if TRACE_COM_SAFE
         protected override IDictionary<int, ISafeComWrapper> GetWrappers()
         {
             return _comWrapperCache.Keys.ToDictionary(GetComWrapperObjectHashCode);

--- a/Rubberduck.VBEEditor/ComManagement/WeakComSafe.cs
+++ b/Rubberduck.VBEEditor/ComManagement/WeakComSafe.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
-#if DEBUG
+#if TRACE_COM_SAFE
 using System.Linq;
+using System.Collections.Generic;
 #endif
 
 namespace Rubberduck.VBEditor.ComManagement
@@ -22,14 +22,14 @@ namespace Rubberduck.VBEditor.ComManagement
                     GetComWrapperObjectHashCode(comWrapper), 
                     key =>
                     {
-#if DEBUG
+#if TRACE_COM_SAFE
                         TraceAdd(comWrapper);
 #endif
                         return (DateTime.UtcNow, new WeakReference<ISafeComWrapper>(comWrapper));
                     },
                     (key, value) =>
                     {
-#if DEBUG
+#if TRACE_COM_SAFE
                         TraceUpdate(comWrapper);
 #endif
                         return (value.insertTime, new WeakReference<ISafeComWrapper>(comWrapper));
@@ -46,7 +46,7 @@ namespace Rubberduck.VBEditor.ComManagement
             }
 
             var result = _comWrapperCache.TryRemove(GetComWrapperObjectHashCode(comWrapper), out _);
-#if DEBUG
+#if TRACE_COM_SAFE
             TraceRemove(comWrapper, result);
 #endif
             return result;
@@ -74,7 +74,7 @@ namespace Rubberduck.VBEditor.ComManagement
             _comWrapperCache.Clear();
         }
 
-#if DEBUG
+#if TRACE_COM_SAFE
         protected override IDictionary<int, ISafeComWrapper> GetWrappers()
         {
             var dictionary = new Dictionary<int, ISafeComWrapper>();

--- a/Rubberduck.VBEEditor/SourceCodeHandling/SourceFileHandlerComponentSourceCodeHandlerAdapter.cs
+++ b/Rubberduck.VBEEditor/SourceCodeHandling/SourceFileHandlerComponentSourceCodeHandlerAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
@@ -31,7 +32,7 @@ namespace Rubberduck.VBEditor.SourceCodeHandling
             {
                 return module;
             }
-            File.WriteAllText(fileName, newCode);
+            File.WriteAllText(fileName, newCode, Encoding.Default);
             return _tempSourceFileHandler.ImportAndCleanUp(module, fileName);
         }
     }


### PR DESCRIPTION
This PR does two things:

First, it fixes the oversight that the export encoding was not specified when substituting code via a file.
ref #4906 

Second, it restricts tracing of the `ComSafe` to when the compilation constant `TRACE_COM_SAFE` is specified instead of tracing it on all debug builds. This makes testing performance easier while still keeping the possibility to trace if needed for some investigation.