### PR TITLE
Hotfix to TodoExplorer 

### DIFF
--- a/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -49,6 +49,12 @@ namespace Rubberduck.UI.ToDoItems
             _uiDispatcher = uiDispatcher;
             _state.StateChanged += HandleStateChanged;
 
+            RefreshCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(),
+                _ =>
+                {
+                    _state.OnParseRequested(this);
+                },
+                _ => _state.IsDirty());
             NavigateCommand = new NavigateCommand(selectionService);
             RemoveCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteRemoveCommand, CanExecuteRemoveCommand);
             CollapseAllCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteCollapseAll);
@@ -131,7 +137,7 @@ namespace Rubberduck.UI.ToDoItems
 
         public INavigateCommand NavigateCommand { get; }
 
-        public ReparseCommand RefreshCommand { get; set; }
+        public CommandBase RefreshCommand { get; set; }
 
         public CommandBase RemoveCommand { get; }
 


### PR DESCRIPTION
From an email reporting, it was observed that decompile do not work on Access. Investigating, it's not really the decompile but in fact the reparse command being executed during the startup which also compiles the codebase, giving an appearance of not working. This is further confirmed by the fact that if a project has broken code, dialog will be shown asking to parse code anyway at the startup. We do not want to parse code during startup as this is usually too premature. This seemed to be caused by the change of `RefreshCommand` which is invoked during the load. The hot fix converts the RefreshCommand into a CommandBase, so it is property-injected rather than newed up directly.