### PR TITLE
Correct exporting settings file

### DIFF
--- a/Rubberduck.SettingsProvider/Persistence/XmlPersistenceService.cs
+++ b/Rubberduck.SettingsProvider/Persistence/XmlPersistenceService.cs
@@ -61,9 +61,9 @@ namespace Rubberduck.SettingsProvider
                 }
             }
 
-            EnsurePathExists();
+            EnsurePathExists(filePath);
 
-            using (var xml = XmlWriter.Create(FilePath, OutputXmlSettings))
+            using (var xml = XmlWriter.Create(filePath, OutputXmlSettings))
             {
                 doc.WriteTo(xml);
                 Cached = toSerialize;


### PR DESCRIPTION
Closes #4966. Previously was exporting to %appdata%\Rubberduck\ and overwriting
rubberduck.config. Now exports to chosen directory and uses chosen filename.