### PR TITLE
TypeLibsAPI integration: document module interfaces

### DIFF
--- a/Rubberduck.API/VBA/Parser.cs
+++ b/Rubberduck.API/VBA/Parser.cs
@@ -148,19 +148,7 @@ namespace Rubberduck.API.VBA
                 _state, 
                 parserStateManager, 
                 comSynchronizer);
-            var referenceResolveRunner = new ReferenceResolveRunner(
-                _state,
-                parserStateManager,
-                moduleToModuleReferenceManager,
-                referenceRemover);
-            var parsingStageService = new ParsingStageService(
-                comSynchronizer,
-                builtInDeclarationLoader,
-                parseRunner,
-                declarationResolveRunner,
-                referenceResolveRunner,
-                userComProjectSynchronizer
-                );
+
             var parsingCacheService = new ParsingCacheService(
                 _state,
                 moduleToModuleReferenceManager,
@@ -169,6 +157,22 @@ namespace Rubberduck.API.VBA
                 compilationsArgumentsCache,
                 userProjectsRepository,
                 projectsToBeLoadedFromComSelector
+            );
+
+            var referenceResolveRunner = new ReferenceResolveRunner(
+                _state,
+                parserStateManager,
+                moduleToModuleReferenceManager,
+                referenceRemover,
+                parsingCacheService);
+
+            var parsingStageService = new ParsingStageService(
+                comSynchronizer,
+                builtInDeclarationLoader,
+                parseRunner,
+                declarationResolveRunner,
+                referenceResolveRunner,
+                userComProjectSynchronizer
                 );
 
             _parser = new SynchronousParseCoordinator(

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/Excel/SheetAccessedUsingStringInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/Excel/SheetAccessedUsingStringInspection.cs
@@ -55,7 +55,7 @@ namespace Rubberduck.Inspections.Concrete
 
         private static readonly string[] InterestingClasses =
         {
-            "_Global", "_Application", "Global", "Application", "Workbook"
+            "Workbook" // "_Global", "_Application", "Global", "Application", "Workbook"
         };
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/OptionExplicitInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/OptionExplicitInspection.cs
@@ -60,14 +60,22 @@ namespace Rubberduck.Inspections.Concrete
 
         public class MissingOptionExplicitListener : VBAParserBaseListener, IInspectionListener
         {
-            private readonly List<QualifiedContext<ParserRuleContext>> _contexts = new List<QualifiedContext<ParserRuleContext>>();
-            public IReadOnlyList<QualifiedContext<ParserRuleContext>> Contexts => _contexts;
+            private readonly IDictionary<string, QualifiedContext<ParserRuleContext>> _contexts = new Dictionary<string,QualifiedContext<ParserRuleContext>>();
+            public IReadOnlyList<QualifiedContext<ParserRuleContext>> Contexts => _contexts.Values.ToList();
 
             public QualifiedModuleName CurrentModuleName { get; set; }
 
             public void ClearContexts()
             {
                 _contexts.Clear();
+            }
+
+            public override void ExitModuleBody(VBAParser.ModuleBodyContext context)
+            {
+                if (context.ChildCount == 0 && _contexts.ContainsKey(CurrentModuleName.Name))
+                {
+                    _contexts.Remove(CurrentModuleName.Name);
+                }
             }
 
             public override void ExitModuleDeclarations([NotNull] VBAParser.ModuleDeclarationsContext context)
@@ -83,7 +91,7 @@ namespace Rubberduck.Inspections.Concrete
 
                 if (!hasOptionExplicit)
                 {
-                    _contexts.Add(new QualifiedContext<ParserRuleContext>(CurrentModuleName, (ParserRuleContext)context.Parent));
+                    _contexts.Add(CurrentModuleName.Name, new QualifiedContext<ParserRuleContext>(CurrentModuleName, (ParserRuleContext)context.Parent));
                 }
             }
         }

--- a/Rubberduck.Parsing/ComReflection/ComProject.cs
+++ b/Rubberduck.Parsing/ComReflection/ComProject.cs
@@ -157,7 +157,9 @@ namespace Rubberduck.Parsing.ComReflection
                                 //TKIND_UNION is not a supported member type in VBA.
                                 break;
                             case TYPEKIND_VBE.TKIND_VBACLASS:
-                                //TODO: Implement this.
+                                //TODO: remove this when VBProject modules are exposed as TKIND_DISPATCH
+                                var vbInterface = type ?? new ComInterface(this, typeLibrary, info, typeAttributes, index);
+                                _interfaces.Add(vbInterface as ComInterface);
                                 break;
                             default:
                                 throw new NotImplementedException($"Didn't expect a TYPEATTR with multiple typekind flags set in {Path}.");

--- a/Rubberduck.Parsing/ComReflection/ComProject.cs
+++ b/Rubberduck.Parsing/ComReflection/ComProject.cs
@@ -101,17 +101,19 @@ namespace Rubberduck.Parsing.ComReflection
                     {
                         var typeAttributes = Marshal.PtrToStructure<TYPEATTR>(typeAttributesPointer);
                         KnownTypes.TryGetValue(typeAttributes.guid, out var type);
-                        
+
                         switch (typeAttributes.typekind.ToTypeKindVbe())
                         {
                             case TYPEKIND_VBE.TKIND_ENUM:
-                                var enumeration = type ?? new ComEnumeration(this, typeLibrary, info, typeAttributes, index);
+                                var enumeration =
+                                    type ?? new ComEnumeration(this, typeLibrary, info, typeAttributes, index);
                                 Debug.Assert(enumeration is ComEnumeration);
                                 _enumerations.Add(enumeration as ComEnumeration);
                                 if (type == null && !enumeration.Guid.Equals(Guid.Empty))
                                 {
                                     KnownTypes.TryAdd(typeAttributes.guid, enumeration);
                                 }
+
                                 break;
                             case TYPEKIND_VBE.TKIND_COCLASS:
                                 var coclass = type ?? new ComCoClass(this, typeLibrary, info, typeAttributes, index);
@@ -121,6 +123,7 @@ namespace Rubberduck.Parsing.ComReflection
                                 {
                                     KnownTypes.TryAdd(typeAttributes.guid, coclass);
                                 }
+
                                 break;
                             case TYPEKIND_VBE.TKIND_DISPATCH:
                             case TYPEKIND_VBE.TKIND_INTERFACE:
@@ -131,6 +134,7 @@ namespace Rubberduck.Parsing.ComReflection
                                 {
                                     KnownTypes.TryAdd(typeAttributes.guid, intface);
                                 }
+
                                 break;
                             case TYPEKIND_VBE.TKIND_RECORD:
                                 var structure = new ComStruct(this, typeLibrary, info, typeAttributes, index);
@@ -144,6 +148,7 @@ namespace Rubberduck.Parsing.ComReflection
                                 {
                                     KnownTypes.TryAdd(typeAttributes.guid, module);
                                 }
+
                                 break;
                             case TYPEKIND_VBE.TKIND_ALIAS:
                                 var alias = new ComAlias(this, typeLibrary, info, index, typeAttributes);
@@ -152,21 +157,26 @@ namespace Rubberduck.Parsing.ComReflection
                                 {
                                     KnownAliases.TryAdd(alias.Guid, alias);
                                 }
+
                                 break;
                             case TYPEKIND_VBE.TKIND_UNION:
                                 //TKIND_UNION is not a supported member type in VBA.
                                 break;
                             case TYPEKIND_VBE.TKIND_VBACLASS:
-                                //TODO: remove this when VBProject modules are exposed as TKIND_DISPATCH
                                 var vbInterface = type ?? new ComInterface(this, typeLibrary, info, typeAttributes, index);
                                 _interfaces.Add(vbInterface as ComInterface);
+
                                 break;
                             default:
-                                throw new NotImplementedException($"Didn't expect a TYPEATTR with multiple typekind flags set in {Path}.");
+                                throw new NotImplementedException(
+                                    $"Didn't expect a TYPEATTR with multiple typekind flags set in {Path}.");
                         }
                     }
                 }
-                catch (COMException) { }
+                catch (COMException e)
+                {
+                    Debug.WriteLine(e.ToString());
+                }
             }
             ApplySpecificLibraryTweaks();
         }

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
@@ -32,22 +32,9 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
             IParserStateManager parserStateManager,
             IProjectReferencesProvider projectReferencesProvider)
         {
-            if (state == null)
-            {
-                throw new ArgumentNullException(nameof(state));
-            }
-            if (parserStateManager == null)
-            {
-                throw new ArgumentNullException(nameof(parserStateManager));
-            }
-            if (projectReferencesProvider == null)
-            {
-                throw new ArgumentNullException(nameof(projectReferencesProvider));
-            }
-
-            _state = state;
-            _parserStateManager = parserStateManager;
-            _projectReferencesProvider = projectReferencesProvider;
+            _state = state ?? throw new ArgumentNullException(nameof(state));
+            _parserStateManager = parserStateManager ?? throw new ArgumentNullException(nameof(parserStateManager));
+            _projectReferencesProvider = projectReferencesProvider ?? throw new ArgumentNullException(nameof(projectReferencesProvider));
         }
 
 

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/UserComProjectSynchronizer.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/UserComProjectSynchronizer.cs
@@ -47,11 +47,28 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
             var projectsToBeUndloaded =
                 _currentlyLoadedProjectIds.Where(projectId => !projectIdsToBeLoaded.Contains(projectId));
 
-            LoadProjects(newProjectIdsToBeLoaded);
-            UnloadProjects(projectsToBeUndloaded);
+            var hasNewProjectIds = newProjectIdsToBeLoaded.Any();
+            var hasUnloadedProjects = projectsToBeUndloaded.Any();
+            var hasWorkToDo = hasNewProjectIds || hasUnloadedProjects;
+            if (hasNewProjectIds)
+            {
+                LoadProjects(newProjectIdsToBeLoaded);
+            }
+
+            if (hasUnloadedProjects)
+            {
+                UnloadProjects(projectsToBeUndloaded);
+            }
 
             parsingStateTimer.Stop();
-            parsingStateTimer.Log("Loaded declarations from ComProjects for user projects in {0}ms.");
+            if (hasWorkToDo)
+            {
+                parsingStateTimer.Log("Loaded declarations from ComProjects for user projects in {0}ms.");
+            }
+            else
+            {
+                parsingStateTimer.Log("SyncUserComProjects: no work to do.");
+            }
         }
 
         private void LoadProjects(IEnumerable<string> projectIds)

--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -43,32 +43,11 @@ namespace Rubberduck.Parsing.VBA
             IParserStateManager parserStateManager,
             IRewritingManager rewritingManager = null)
         {
-            if (state == null)
-            {
-                throw new ArgumentNullException(nameof(state));
-            }
-            if (parsingStageService == null)
-            {
-                throw new ArgumentNullException(nameof(parsingStageService));
-            }
-            if (parsingStageService == null)
-            {
-                throw new ArgumentNullException(nameof(parsingStageService));
-            }
-            if (parsingCacheService == null)
-            {
-                throw new ArgumentNullException(nameof(parsingCacheService));
-            }
-            if (parserStateManager == null)
-            {
-                throw new ArgumentNullException(nameof(parserStateManager));
-            }
-
-            State = state;
-            _parsingStageService = parsingStageService;
-            _projectManager = projectManager;
-            _parsingCacheService = parsingCacheService;
-            _parserStateManager = parserStateManager;
+            State = state ?? throw new ArgumentNullException(nameof(state));
+            _parsingStageService = parsingStageService ?? throw new ArgumentNullException(nameof(parsingStageService));
+            _projectManager = projectManager ?? throw new ArgumentNullException(nameof(projectManager));
+            _parsingCacheService = parsingCacheService ?? throw new ArgumentNullException(nameof(parsingCacheService));
+            _parserStateManager = parserStateManager ?? throw new ArgumentNullException(nameof(parserStateManager));
             _rewritingManager = rewritingManager;
 
             state.ParseRequest += ReparseRequested;
@@ -240,12 +219,12 @@ namespace Rubberduck.Parsing.VBA
             token.ThrowIfCancellationRequested();
 
             //TODO: Remove the conditional compilation after loading from typelibs actually works.
-#if LOAD_USER_COM_PROJECTS
+//#if LOAD_USER_COM_PROJECTS
             RefreshUserComProjects(toParse, newProjectIds);
             token.ThrowIfCancellationRequested();
 
             SyncDeclarationsFromUserComProjects(toParse, token, toReresolveReferences);
-#endif
+//#endif
 
             SyncComReferences(toParse, token, toReresolveReferences);
             token.ThrowIfCancellationRequested();

--- a/Rubberduck.Parsing/VBA/ParsingStageService.cs
+++ b/Rubberduck.Parsing/VBA/ParsingStageService.cs
@@ -26,37 +26,12 @@ namespace Rubberduck.Parsing.VBA
             IReferenceResolveRunner referenceResolver,
             IUserComProjectSynchronizer userComProjectSynchronizer)
         {
-            if(comSynchronizer == null)
-            {
-                throw new ArgumentNullException(nameof(comSynchronizer));
-            }
-            if (builtInDeclarationLoader == null)
-            {
-                throw new ArgumentNullException(nameof(builtInDeclarationLoader));
-            }
-            if (parseRunner == null)
-            {
-                throw new ArgumentNullException(nameof(parseRunner));
-            }
-            if (declarationResolver == null)
-            {
-                throw new ArgumentNullException(nameof(declarationResolver));
-            }
-            if (referenceResolver == null)
-            {
-                throw new ArgumentNullException(nameof(referenceResolver));
-            }
-            if (userComProjectSynchronizer == null)
-            {
-                throw new ArgumentNullException(nameof(userComProjectSynchronizer));
-            }
-
-            _comSynchronizer = comSynchronizer;
-            _builtInDeclarationLoader = builtInDeclarationLoader;
-            _parseRunner = parseRunner;
-            _declarationResolver = declarationResolver;
-            _referenceResolver = referenceResolver;
-            _userComProjectSynchronizer = userComProjectSynchronizer;
+            _comSynchronizer = comSynchronizer ?? throw new ArgumentNullException(nameof(comSynchronizer));
+            _builtInDeclarationLoader = builtInDeclarationLoader ?? throw new ArgumentNullException(nameof(builtInDeclarationLoader));
+            _parseRunner = parseRunner ?? throw new ArgumentNullException(nameof(parseRunner));
+            _declarationResolver = declarationResolver ?? throw new ArgumentNullException(nameof(declarationResolver));
+            _referenceResolver = referenceResolver ?? throw new ArgumentNullException(nameof(referenceResolver));
+            _userComProjectSynchronizer = userComProjectSynchronizer ?? throw new ArgumentNullException(nameof(userComProjectSynchronizer));
         }
 
         public bool LastLoadOfBuiltInDeclarationsLoadedDeclarations => _builtInDeclarationLoader.LastLoadOfBuiltInDeclarationsLoadedDeclarations;

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunner.cs
@@ -17,11 +17,13 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             RubberduckParserState state, 
             IParserStateManager parserStateManager, 
             IModuleToModuleReferenceManager moduletToModuleReferenceManager,
-            IReferenceRemover referenceRemover) 
+            IReferenceRemover referenceRemover,
+            IParsingCacheService parsingCacheService) 
         :base(state, 
             parserStateManager, 
             moduletToModuleReferenceManager,
-            referenceRemover)
+            referenceRemover,
+            parsingCacheService)
         { }
 
 

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
@@ -26,6 +26,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
         protected readonly RubberduckParserState _state;
         protected readonly IParserStateManager _parserStateManager;
+        protected readonly IParsingCacheService _parsingCacheService;
+
         private readonly IModuleToModuleReferenceManager _moduleToModuleReferenceManager;
         private readonly IReferenceRemover _referenceRemover;
 
@@ -33,29 +35,14 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             RubberduckParserState state,
             IParserStateManager parserStateManager,
             IModuleToModuleReferenceManager moduletToModuleReferenceManager,
-            IReferenceRemover referenceRemover)
+            IReferenceRemover referenceRemover,
+            IParsingCacheService parsingCacheService)
         {
-            if (state == null)
-            {
-                throw new ArgumentNullException(nameof(state));
-            }
-            if (parserStateManager == null)
-            {
-                throw new ArgumentNullException(nameof(parserStateManager));
-            }
-            if (moduletToModuleReferenceManager == null)
-            {
-                throw new ArgumentNullException(nameof(moduletToModuleReferenceManager));
-            }
-            if (referenceRemover == null)
-            {
-                throw new ArgumentNullException(nameof(referenceRemover));
-            }
-
-            _state = state;
-            _parserStateManager = parserStateManager;
-            _moduleToModuleReferenceManager = moduletToModuleReferenceManager;
-            _referenceRemover = referenceRemover;
+            _state = state ?? throw new ArgumentNullException(nameof(state));
+            _parserStateManager = parserStateManager ?? throw new ArgumentNullException(nameof(parserStateManager));
+            _moduleToModuleReferenceManager = moduletToModuleReferenceManager ?? throw new ArgumentNullException(nameof(moduletToModuleReferenceManager));
+            _referenceRemover = referenceRemover ?? throw new ArgumentNullException(nameof(referenceRemover));
+            _parsingCacheService = parsingCacheService;
         }
 
 
@@ -131,7 +118,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 {
                     // This pass has to come first because the type binding resolution depends on it.
                     new ProjectReferencePass(_state.DeclarationFinder),
-                    new TypeHierarchyPass(_state.DeclarationFinder, new VBAExpressionParser()),
+                    new TypeHierarchyPass(_state.DeclarationFinder, new VBAExpressionParser(), _parsingCacheService),
                     new TypeAnnotationPass(_state.DeclarationFinder, new VBAExpressionParser())
                 };
             try

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/SynchronousReferenceResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/SynchronousReferenceResolveRunner.cs
@@ -13,11 +13,12 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             RubberduckParserState state,
             IParserStateManager parserStateManager,
             IModuleToModuleReferenceManager moduletToModuleReferenceManager,
-            IReferenceRemover referenceRemover)
+            IReferenceRemover referenceRemover,
+            IParsingCacheService parsingCacheService)
         : base(state,
             parserStateManager,
             moduletToModuleReferenceManager,
-            referenceRemover)
+            referenceRemover, parsingCacheService)
         { }
 
 

--- a/RubberduckTests/Inspections/OptionExplicitInspectionTests.cs
+++ b/RubberduckTests/Inspections/OptionExplicitInspectionTests.cs
@@ -10,11 +10,33 @@ namespace RubberduckTests.Inspections
     [TestFixture]
     public class OptionExplicitInspectionTests
     {
+        private const string OptionExplicitNotSpecified = @"
+Sub DoSomething()
+End Sub";
+
+        [Test]
+        [Category("Inspections")]
+        public void EmptyModule_NoResult()
+        {
+            const string inputCode = @"";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new OptionExplicitInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
+        }
+
         [Test]
         [Category("Inspections")]
         public void NotAlreadySpecified_ReturnsResult()
         {
-            const string inputCode = @"";
+            const string inputCode = OptionExplicitNotSpecified;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
             using (var state = MockParser.CreateAndParse(vbe.Object))
@@ -50,7 +72,7 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void NotAlreadySpecified_ReturnsMultipleResults()
         {
-            const string inputCode = @"";
+            const string inputCode = OptionExplicitNotSpecified;
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
@@ -74,7 +96,7 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void PartiallySpecified_ReturnsResults()
         {
-            const string inputCode1 = @"";
+            const string inputCode1 = OptionExplicitNotSpecified;
             const string inputCode2 = @"Option Explicit";
 
             var builder = new MockVbeBuilder();

--- a/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
+++ b/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
@@ -14,7 +14,7 @@ namespace RubberduckTests.Inspections
     public class SheetAccessedUsingStringInspectionTests
     {
         [Test]
-        //[Ignore("See #4411")]
+        //[Ignore("ThisWorkbook.Worksheets fails to resolve")]
         [Category("Inspections")]
         public void SheetAccessedUsingString_ThisWorkbookQualifier_HasResult()
         {

--- a/RubberduckTests/Mocks/MockParser.cs
+++ b/RubberduckTests/Mocks/MockParser.cs
@@ -21,10 +21,12 @@ using Rubberduck.Parsing.VBA.Parsing;
 using Rubberduck.Parsing.VBA.Parsing.ParsingExceptions;
 using Rubberduck.Parsing.VBA.ReferenceManagement;
 using Rubberduck.VBEditor.ComManagement;
+using Rubberduck.VBEditor.ComManagement.TypeLibs;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.SourceCodeHandling;
 using Rubberduck.VBEditor.Utility;
+using Rubberduck.VBEditor.ComManagement.TypeLibsAPI;
 
 namespace RubberduckTests.Mocks
 {
@@ -115,19 +117,7 @@ namespace RubberduckTests.Mocks
                 state, 
                 parserStateManager, 
                 comSynchronizer);
-            var referenceResolveRunner = new SynchronousReferenceResolveRunner(
-                state,
-                parserStateManager,
-                moduleToModuleReferenceManager,
-                referenceRemover);
-            var parsingStageService = new ParsingStageService(
-                comSynchronizer,
-                builtInDeclarationLoader,
-                parseRunner,
-                declarationResolveRunner,
-                referenceResolveRunner,
-                userComProjectSynchronizer
-                );
+
             var parsingCacheService = new ParsingCacheService(
                 state,
                 moduleToModuleReferenceManager,
@@ -135,8 +125,21 @@ namespace RubberduckTests.Mocks
                 supertypeClearer,
                 compilationsArgumentsCache,
                 userComProjectsRepository,
-                projectsToBeLoadedFromComSelector
-                );
+                projectsToBeLoadedFromComSelector);
+            var referenceResolveRunner = new SynchronousReferenceResolveRunner(
+                state,
+                parserStateManager,
+                moduleToModuleReferenceManager,
+                referenceRemover, 
+                parsingCacheService);
+            var parsingStageService = new ParsingStageService(
+                comSynchronizer,
+                builtInDeclarationLoader,
+                parseRunner,
+                declarationResolveRunner,
+                referenceResolveRunner,
+                userComProjectSynchronizer);
+
             var tokenStreamCache = new StateTokenStreamCache(state);
             var moduleRewriterFactory = new ModuleRewriterFactory(
                 codePaneSourceCodeHandler,


### PR DESCRIPTION
This PR will introduce modifications to the parser, using the data collected from the user project typelib to resolve the interfaces implemented by document modules.

The original intent was to address a handful of "easy" inspection issues (started with that anyway)... once completed, this PR will fix #4998 ...and potentially a bunch of other issues (needs verification).