### PR TITLE
Synchronize reference explorer with selected item

### DIFF
--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml
@@ -181,7 +181,8 @@
                                       SelectionMode="Single"
                                       ItemsSource="{Binding AvailableReferences}" 
                                       HorizontalContentAlignment="Stretch"
-                                      ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                      GotFocus="ListView_SynchronizeCurrentSelection_OnGotFocus">
                                 <ListView.ItemContainerStyle>
                                     <Style TargetType="ListViewItem">
                                         <Setter Property="Height" Value="20" />
@@ -239,7 +240,8 @@
                                       SelectionMode="Single"
                                       ItemsSource="{Binding ProjectReferences, NotifyOnTargetUpdated=True}" 
                                       ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                                      HorizontalContentAlignment="Stretch">
+                                      HorizontalContentAlignment="Stretch"
+                                      GotFocus="ListView_SynchronizeCurrentSelection_OnGotFocus">
                                 <ListView.ItemContainerStyle>
                                     <Style TargetType="ListViewItem">
                                         <Setter Property="Height" Value="20" />
@@ -388,18 +390,22 @@
                                     <ColumnDefinition Width="50" />
                                     <ColumnDefinition Width="100" />
                                 </Grid.ColumnDefinitions>
-                                <TextBox Grid.Row="0" Grid.Column="0" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.Description, Mode=OneWay}" />
+                                <TextBox x:Name="Description"
+                                         Grid.Row="0" Grid.Column="0" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.Description, Mode=OneWay}" />
                                 <Label Grid.Row="0" Grid.Column="1"  
                                        Foreground="{x:Static SystemColors.GrayTextBrush}" 
                                        VerticalAlignment="Center" 
                                        Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=References_Version}" />
-                                <TextBox Grid.Row="0" Grid.Column="2" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.Version, Mode=OneWay}" />
+                                <TextBox x:Name="Version"
+                                         Grid.Row="0" Grid.Column="2" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.Version, Mode=OneWay}" />
                                 <Label Grid.Row="0" Grid.Column="3"  
                                        Foreground="{x:Static SystemColors.GrayTextBrush}" 
                                        VerticalAlignment="Center" 
                                        Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=References_Locale}" />
-                                <TextBox Grid.Row="0" Grid.Column="4" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.LocaleName, Mode=OneWay}" />
-                                <TextBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.FullPath, Mode=OneWay}"  />
+                                <TextBox x:Name="LocaleName"
+                                         Grid.Row="0" Grid.Column="4" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.LocaleName, Mode=OneWay}" />
+                                <TextBox x:Name="FullPath"
+                                         Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" Style="{StaticResource SelectableText}" Text="{Binding CurrentSelection.FullPath, Mode=OneWay}"  />
                             </Grid>
                         </Border>
                     </Border>

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows.Controls;
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Rubberduck.AddRemoveReferences;
 
 namespace Rubberduck.UI.AddRemoveReferences
 {
@@ -13,5 +16,22 @@ namespace Rubberduck.UI.AddRemoveReferences
         }
 
         private AddRemoveReferencesViewModel ViewModel => DataContext as AddRemoveReferencesViewModel;
+
+        private void ListView_SynchronizeCurrentSelection_OnGotFocus(object sender, RoutedEventArgs e)
+        {
+            UpdateCurrentSelection((Selector)sender);
+
+            var cs = ViewModel.CurrentSelection;
+            Description.Text = cs.Description;
+            Version.Text = cs.Version;
+            LocaleName.Text = cs.LocaleName;
+            FullPath.Text = cs.FullPath;
+        }
+
+        private void UpdateCurrentSelection(Selector sender)
+        {
+            var selectedReferenceModel = (ReferenceModel)sender.SelectedItem;
+            ViewModel.CurrentSelection = selectedReferenceModel;
+        }
     }
 }

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Rubberduck.AddRemoveReferences;
 
@@ -8,7 +7,7 @@ namespace Rubberduck.UI.AddRemoveReferences
     /// <summary>
     /// Interaction logic for AddRemoveReferencesWindow.xaml
     /// </summary>
-    public partial class AddRemoveReferencesWindow : UserControl
+    public partial class AddRemoveReferencesWindow
     {
         public AddRemoveReferencesWindow()
         {


### PR DESCRIPTION
Close #4798.

Previously when activating between `LibrarySelect` and `ProjectSelect` the footer wouldn't update if a new selection wasn't chosen. Now the footer displays the correct information whenever focus changes.