### PR TITLE
Enable Del key for CodeExplorer module removal

### DIFF
--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -412,7 +412,8 @@
                   ItemContainerStyle="{StaticResource TreeViewContainerStyle}"
                   FontSize="{Binding FontSize, Mode=OneWay}"
                   BorderThickness="0,1"
-                  VirtualizingPanel.IsVirtualizing="False">
+                  VirtualizingPanel.IsVirtualizing="False"
+                  KeyDown="ProjectTree_KeyDown">
             <TreeView.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_Open}"

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml.cs
@@ -30,5 +30,14 @@ namespace Rubberduck.UI.CodeExplorer
             ((TreeViewItem)sender).IsSelected = true;
             e.Handled = true;
         }
+
+        private void ProjectTree_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Delete)
+            {
+                ViewModel.RemoveCommand.Execute(ViewModel.SelectedItem);
+                e.Handled = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Close #4879. [Should we inform the user they can't delete a document object](https://chat.stackexchange.com/transcript/message/50906814#50906814) answered with [No](https://chat.stackexchange.com/transcript/message/50906786#50906786).