### PR TITLE
Resolve recursive and parameterless default member accesses

### DIFF
--- a/Rubberduck.Parsing/Binding/Bindings/DictionaryAccessDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/DictionaryAccessDefaultBinding.cs
@@ -75,7 +75,7 @@ namespace Rubberduck.Parsing.Binding
                     is classified as an unbound member with a declared type of Variant, referencing <l-expression> with no member name.
                 */
                 ResolveArgumentList(lDeclaration, argumentList);
-                return new DictionaryAccessExpression(null, ExpressionClassification.Unbound, expression, lExpression, argumentList);
+                return new DictionaryAccessExpression(null, ExpressionClassification.Unbound, expression, lExpression, argumentList, 1);
             }
 
             if (lDeclaration == null)
@@ -102,7 +102,7 @@ namespace Rubberduck.Parsing.Binding
             return failedExpr;
         }
 
-        private static IBoundExpression ResolveViaDefaultMember(IBoundExpression lExpression, string asTypeName, Declaration asTypeDeclaration, ArgumentList argumentList, ParserRuleContext expression, int recursionDepth = 0)
+        private static IBoundExpression ResolveViaDefaultMember(IBoundExpression lExpression, string asTypeName, Declaration asTypeDeclaration, ArgumentList argumentList, ParserRuleContext expression, int recursionDepth = 1)
         {
             if (Tokens.Variant.Equals(asTypeName, StringComparison.InvariantCultureIgnoreCase) 
                     || Tokens.Object.Equals(asTypeName, StringComparison.InvariantCultureIgnoreCase))
@@ -113,7 +113,7 @@ namespace Rubberduck.Parsing.Binding
                     a declared type of Variant, referencing <l-expression> with no member name. 
                 */
                 ResolveArgumentList(null, argumentList);
-                return new DictionaryAccessExpression(null, ExpressionClassification.Unbound, expression, lExpression, argumentList);
+                return new DictionaryAccessExpression(null, ExpressionClassification.Unbound, expression, lExpression, argumentList, recursionDepth);
             }
 
             /*
@@ -141,11 +141,11 @@ namespace Rubberduck.Parsing.Binding
                     declared type.  
                 */
                 ResolveArgumentList(defaultMember, argumentList);
-                return new DictionaryAccessExpression(defaultMember, defaultMemberClassification, expression, lExpression, argumentList);
+                return new DictionaryAccessExpression(defaultMember, defaultMemberClassification, expression, lExpression, argumentList, recursionDepth);
             }
 
             if (parameters.Count(param => !param.IsOptional) == 0 
-                && DEFAULT_MEMBER_RECURSION_LIMIT > recursionDepth)
+                && DEFAULT_MEMBER_RECURSION_LIMIT >= recursionDepth)
             {
                 /*
                     This default member cannot accept any parameters. In this case, the static analysis restarts 
@@ -153,6 +153,7 @@ namespace Rubberduck.Parsing.Binding
                     same <argument-list>.
                 */
 
+                //In contrast to the IndexDefaultBinding we pass the original expression context since the default member accesses will be attached to the exclamation mark.
                 return ResolveRecursiveDefaultMember(defaultMember, defaultMemberClassification, argumentList, expression, recursionDepth);
             }
 

--- a/Rubberduck.Parsing/Binding/Expressions/DictionaryAccessExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/DictionaryAccessExpression.cs
@@ -12,29 +12,22 @@ namespace Rubberduck.Parsing.Binding
             ParserRuleContext context,
             IBoundExpression lExpression,
             ArgumentList argumentList,
-            int defaultMemberResursionDepth)
+            ParserRuleContext defaultMemberContext,
+            int defaultMemberRecursionDepth = 1,
+            RecursiveDefaultMemberAccessExpression containedDefaultMemberRecursionExpression = null)
             : base(referencedDeclaration, classification, context)
         {
             LExpression = lExpression;
             ArgumentList = argumentList;
-            DefaultMemberRecursionDepth = defaultMemberResursionDepth;
+            DefaultMemberRecursionDepth = defaultMemberRecursionDepth;
+            ContainedDefaultMemberRecursionExpression = containedDefaultMemberRecursionExpression;
+            DefaultMemberContext = defaultMemberContext;
         }
 
         public IBoundExpression LExpression { get; }
         public ArgumentList ArgumentList { get; }
         public int DefaultMemberRecursionDepth { get; }
-
-        public ParserRuleContext DefaultMemberContext
-        {
-            get
-            {
-                if (Context is VBAParser.DictionaryAccessExprContext dictionaryAccess)
-                {
-                    return dictionaryAccess.dictionaryAccess();
-                }
-
-                return ((VBAParser.WithDictionaryAccessExprContext) Context).dictionaryAccess();
-            }
-        }
+        public ParserRuleContext DefaultMemberContext { get; }
+        public RecursiveDefaultMemberAccessExpression ContainedDefaultMemberRecursionExpression { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/DictionaryAccessExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/DictionaryAccessExpression.cs
@@ -11,15 +11,18 @@ namespace Rubberduck.Parsing.Binding
             ExpressionClassification classification,
             ParserRuleContext context,
             IBoundExpression lExpression,
-            ArgumentList argumentList)
+            ArgumentList argumentList,
+            int defaultMemberResursionDepth)
             : base(referencedDeclaration, classification, context)
         {
             LExpression = lExpression;
             ArgumentList = argumentList;
+            DefaultMemberRecursionDepth = defaultMemberResursionDepth;
         }
 
         public IBoundExpression LExpression { get; }
         public ArgumentList ArgumentList { get; }
+        public int DefaultMemberRecursionDepth { get; }
 
         public ParserRuleContext DefaultMemberContext
         {

--- a/Rubberduck.Parsing/Binding/Expressions/IndexExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/IndexExpression.cs
@@ -12,18 +12,21 @@ namespace Rubberduck.Parsing.Binding
             IBoundExpression lExpression,
             ArgumentList argumentList,
             bool isArrayAccess = false,
-            bool isDefaultMemberAccess = false)
+            bool isDefaultMemberAccess = false,
+            int defaultMemberRecursionDepth = 0)
             : base(referencedDeclaration, classification, context)
         {
             LExpression = lExpression;
             ArgumentList = argumentList;
             IsArrayAccess = isArrayAccess;
             IsDefaultMemberAccess = isDefaultMemberAccess;
+            DefaultMemberRecursionDepth = defaultMemberRecursionDepth;
         }
 
         public IBoundExpression LExpression { get; }
         public ArgumentList ArgumentList { get; }
         public bool IsArrayAccess { get; }
         public bool IsDefaultMemberAccess { get; }
+        public int DefaultMemberRecursionDepth { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/RecursiveDefaultMemberAccessExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/RecursiveDefaultMemberAccessExpression.cs
@@ -3,33 +3,21 @@ using Rubberduck.Parsing.Symbols;
 
 namespace Rubberduck.Parsing.Binding
 {
-    public sealed class IndexExpression : BoundExpression
+    public class RecursiveDefaultMemberAccessExpression : BoundExpression
     {
-        public IndexExpression(Declaration referencedDeclaration,
+        public RecursiveDefaultMemberAccessExpression(
+            Declaration referencedDeclaration,
             ExpressionClassification classification,
             ParserRuleContext context,
-            IBoundExpression lExpression,
-            ArgumentList argumentList,
-            bool isArrayAccess = false,
-            bool isDefaultMemberAccess = false,
             int defaultMemberRecursionDepth = 0,
             RecursiveDefaultMemberAccessExpression containedDefaultMemberRecursionExpression = null)
             : base(referencedDeclaration, classification, context)
         {
-            LExpression = lExpression;
-            ArgumentList = argumentList;
-            IsArrayAccess = isArrayAccess;
-            IsDefaultMemberAccess = isDefaultMemberAccess;
             DefaultMemberRecursionDepth = defaultMemberRecursionDepth;
             ContainedDefaultMemberRecursionExpression = containedDefaultMemberRecursionExpression;
         }
-
-        public IBoundExpression LExpression { get; }
-        public ArgumentList ArgumentList { get; }
-        public bool IsArrayAccess { get; }
-        public bool IsDefaultMemberAccess { get; }
+        
         public int DefaultMemberRecursionDepth { get; }
-
         public RecursiveDefaultMemberAccessExpression ContainedDefaultMemberRecursionExpression { get; }
     }
 }

--- a/Rubberduck.Parsing/Symbols/Declaration.cs
+++ b/Rubberduck.Parsing/Symbols/Declaration.cs
@@ -363,7 +363,9 @@ namespace Rubberduck.Parsing.Symbols
             bool isAssignmentTarget = false,
             bool hasExplicitLetStatement = false,
             bool isSetAssigned = false,
-            bool isDefaultMemberAccess = false,
+            bool isIndexedDefaultMemberAccess = false,
+            bool isNonIndexedDefaultMemberAccess = false,
+            int defaultMemberRecursionDepth = 0,
             bool isArrayAccess = false
             )
         {
@@ -392,7 +394,9 @@ namespace Rubberduck.Parsing.Symbols
                 hasExplicitLetStatement,
                 annotations,
                 isSetAssigned,
-                isDefaultMemberAccess,
+                isIndexedDefaultMemberAccess,
+                isNonIndexedDefaultMemberAccess,
+                defaultMemberRecursionDepth,
                 isArrayAccess);
             _references.AddOrUpdate(newReference, 1, (key, value) => 1);
         }

--- a/Rubberduck.Parsing/Symbols/IDeclarationFinderFactory.cs
+++ b/Rubberduck.Parsing/Symbols/IDeclarationFinderFactory.cs
@@ -1,14 +1,19 @@
-﻿using System;
-using Rubberduck.Parsing.Annotations;
+﻿using Rubberduck.Parsing.Annotations;
 using System.Collections.Generic;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.Symbols
 {
     public interface IDeclarationFinderFactory
     {
-        DeclarationFinder Create(IReadOnlyList<Declaration> declarations, IEnumerable<IAnnotation> annotations, IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations, IHostApplication hostApp);
+        DeclarationFinder Create(
+            IReadOnlyList<Declaration> declarations, 
+            IEnumerable<IAnnotation> annotations, 
+            IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations, 
+            IReadOnlyDictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>> unboundDefaultMemberAccesses, 
+            IHostApplication hostApp);
         void Release(DeclarationFinder declarationFinder);
     }
 }

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -24,7 +24,9 @@ namespace Rubberduck.Parsing.Symbols
             bool hasExplicitLetStatement = false, 
             IEnumerable<IAnnotation> annotations = null,
             bool isSetAssigned = false,
-            bool isDefaultMemberAccess = false,
+            bool isIndexedDefaultMemberAccess = false,
+            bool isNonIndexedDefaultMemberAccess = false,
+            int defaultMemberRecursionDepth = 0,
             bool isArrayAccess = false)
         {
             ParentScoping = parentScopingDeclaration;
@@ -37,7 +39,9 @@ namespace Rubberduck.Parsing.Symbols
             HasExplicitLetStatement = hasExplicitLetStatement;
             IsAssignment = isAssignmentTarget;
             IsSetAssignment = isSetAssigned;
-            IsDefaultMemberAccess = isDefaultMemberAccess;
+            IsIndexedDefaultMemberAccess = isIndexedDefaultMemberAccess;
+            IsNonIndexedDefaultMemberAccess = isNonIndexedDefaultMemberAccess;
+            DefaultMemberRecursionDepth = defaultMemberRecursionDepth;
             IsArrayAccess = isArrayAccess;
             Annotations = annotations ?? new List<IAnnotation>();
         }
@@ -64,7 +68,10 @@ namespace Rubberduck.Parsing.Symbols
 
         public bool IsSetAssignment { get; }
 
-        public bool IsDefaultMemberAccess { get; }
+        public bool IsIndexedDefaultMemberAccess { get; }
+        public bool IsNonIndexedDefaultMemberAccess { get; }
+        public bool IsDefaultMemberAccess => IsIndexedDefaultMemberAccess || IsNonIndexedDefaultMemberAccess;
+        public int DefaultMemberRecursionDepth { get; }
 
         public bool IsArrayAccess { get; }
 

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -125,7 +125,8 @@ namespace Rubberduck.Parsing.Symbols
             return other != null
                 && other.QualifiedModuleName.Equals(QualifiedModuleName)
                 && other.Selection.Equals(Selection)
-                && other.Declaration.Equals(Declaration);
+                && (other.Declaration != null && other.Declaration.Equals(Declaration)
+                    || other.Declaration == null && Declaration == null);
         }
 
         public override bool Equals(object obj)
@@ -135,7 +136,9 @@ namespace Rubberduck.Parsing.Symbols
 
         public override int GetHashCode()
         {
-            return HashCode.Compute(QualifiedModuleName, Selection, Declaration);
+            return Declaration != null
+                ? HashCode.Compute(QualifiedModuleName, Selection, Declaration)
+                : HashCode.Compute(QualifiedModuleName, Selection);
         }
     }
 }

--- a/Rubberduck.Parsing/TypeResolvers/SetTypeResolver.cs
+++ b/Rubberduck.Parsing/TypeResolvers/SetTypeResolver.cs
@@ -201,10 +201,11 @@ namespace Rubberduck.Parsing.TypeResolvers
         private Declaration ResolveIndexExpressionAsDefaultMemberAccess(VBAParser.LExpressionContext lExpressionOfIndexExpression, QualifiedModuleName containingModule, DeclarationFinder finder)
         {
             // A default member access references the entire lExpression.
+            // If there are multiple, the references are ordered by recursion depth.
             var qualifiedSelection = new QualifiedSelection(containingModule, lExpressionOfIndexExpression.GetSelection());
             return finder
                 .IdentifierReferences(qualifiedSelection)
-                .FirstOrDefault(reference => reference.IsDefaultMemberAccess)
+                .LastOrDefault(reference => reference.IsDefaultMemberAccess)
                 ?.Declaration;
         }
         
@@ -215,7 +216,7 @@ namespace Rubberduck.Parsing.TypeResolvers
             var qualifiedSelection = new QualifiedSelection(containingModule, actualIndexExpr.GetSelection());
             return finder
                 .IdentifierReferences(qualifiedSelection)
-                .FirstOrDefault(reference => reference.IsArrayAccess)
+                .LastOrDefault(reference => reference.IsArrayAccess)
                 ?.Declaration;
         }
 
@@ -223,7 +224,7 @@ namespace Rubberduck.Parsing.TypeResolvers
         {
             var declaration = finder.IdentifierReferences(identifier, containingModule)
                 .Select(reference => reference.Declaration)
-                .FirstOrDefault();
+                .LastOrDefault();
             return (declaration, MightHaveSetType(declaration));
         }
 
@@ -231,7 +232,7 @@ namespace Rubberduck.Parsing.TypeResolvers
         {
             var declaration = finder.IdentifierReferences(identifier, containingModule)
                 .Select(reference => reference.Declaration)
-                .FirstOrDefault();
+                .LastOrDefault();
             return (declaration, MightHaveSetType(declaration));
         }
 
@@ -240,7 +241,7 @@ namespace Rubberduck.Parsing.TypeResolvers
             var qualifiedSelection = new QualifiedSelection(containingModule, dictionaryAccess.GetSelection());
             var declaration = finder.IdentifierReferences(qualifiedSelection)
                 .Select(reference => reference.Declaration)
-                .FirstOrDefault();
+                .LastOrDefault();
             return (declaration, MightHaveSetType(declaration));
         }
 

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.VBA.DeclarationCaching
@@ -11,8 +12,13 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
     {
         private const int _maxDegreeOfConstructionParallelism = -1;
 
-        public ConcurrentlyConstructedDeclarationFinder(IReadOnlyList<Declaration> declarations, IEnumerable<IAnnotation> annotations, IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations, IHostApplication hostApp = null) 
-            :base(declarations, annotations, unresolvedMemberDeclarations, hostApp)
+        public ConcurrentlyConstructedDeclarationFinder(
+            IReadOnlyList<Declaration> declarations, 
+            IEnumerable<IAnnotation> annotations, 
+            IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations,
+            IReadOnlyDictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>> unboundDefaultMemberAccesses, 
+            IHostApplication hostApp = null) 
+            :base(declarations, annotations, unresolvedMemberDeclarations, unboundDefaultMemberAccesses, hostApp)
         {}
 
         protected override void ExecuteCollectionConstructionActions(List<Action> collectionConstructionActions)

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinderFactory.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinderFactory.cs
@@ -1,15 +1,21 @@
 ﻿using System.Collections.Generic;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.VBA.DeclarationCaching
 {
     public class ConcurrentlyConstructedDeclarationFinderFactory : IDeclarationFinderFactory
     {
-        public DeclarationFinder Create(IReadOnlyList<Declaration> declarations, IEnumerable<IAnnotation> annotations, IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations, IHostApplication hostApp)
+        public DeclarationFinder Create(
+            IReadOnlyList<Declaration> declarations, 
+            IEnumerable<IAnnotation> annotations, 
+            IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations,
+            IReadOnlyDictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>> unboundDefaultMemberAccesses,
+            IHostApplication hostApp)
         {
-            return new ConcurrentlyConstructedDeclarationFinder(declarations, annotations, unresolvedMemberDeclarations, hostApp);
+            return new ConcurrentlyConstructedDeclarationFinder(declarations, annotations, unresolvedMemberDeclarations, unboundDefaultMemberAccesses, hostApp);
         }
 
         public void Release(DeclarationFinder declarationFinder)

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -1435,7 +1435,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         public IEnumerable<IdentifierReference> IdentifierReferences(QualifiedSelection selection)
         {
             return _referencesBySelection.TryGetValue(selection, out var value)
-                ? value
+                ? value.OrderBy(reference => reference.DefaultMemberRecursionDepth)
                 : Enumerable.Empty<IdentifierReference>();
         }
 
@@ -1446,17 +1446,20 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         {
             return IdentifierReferences(qualifiedSelection.QualifiedName)
                 .Where(reference => qualifiedSelection.Selection.Contains(reference.Selection))
-                .OrderBy(reference => reference.Selection);
+                .OrderBy(reference => reference.Selection)
+                .ThenBy(reference => reference.DefaultMemberRecursionDepth);
         }
 
         /// <summary>
-        /// Gets all identifier references containing a qualified selection, ordered by selection (start position, then length)
+        /// Gets all identifier references containing a qualified selection, ordered by selection (start position, then length).
+        /// Default member accesses with identical selections are ordered by call order.
         /// </summary>
         public IEnumerable<IdentifierReference> ContainingIdentifierReferences(QualifiedSelection qualifiedSelection)
         {
             return IdentifierReferences(qualifiedSelection.QualifiedName)
                 .Where(reference => reference.Selection.Contains(qualifiedSelection.Selection))
-                .OrderBy(reference => reference.Selection);
+                .OrderBy(reference => reference.Selection)
+                .ThenBy(reference => reference.DefaultMemberRecursionDepth);
         }
 
         /// <summary>

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Antlr4.Runtime;
 using NLog;
 using Rubberduck.Parsing.Annotations;
@@ -25,6 +24,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         private readonly IHostApplication _hostApp;
         private IDictionary<string, List<Declaration>> _declarationsByName;
         private IDictionary<QualifiedModuleName, List<Declaration>> _declarations;
+        private readonly ConcurrentDictionary<QualifiedModuleName, ConcurrentBag<IdentifierReference>> _newUnboundDefaultMemberAccesses;
         private readonly ConcurrentDictionary<QualifiedMemberName, ConcurrentBag<Declaration>> _newUndeclared;
         private readonly ConcurrentBag<UnboundMemberDeclaration> _newUnresolved;
         private List<UnboundMemberDeclaration> _unresolved;
@@ -39,13 +39,15 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         private IReadOnlyDictionary<string, IReadOnlyList<IdentifierReference>> _referencesByProjectId;
         private IDictionary<QualifiedMemberName, List<IdentifierReference>> _referencesByMember;
 
+        private readonly IReadOnlyDictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>> _unboundDefaultMemberAccesses;
+
         private Lazy<IDictionary<DeclarationType, List<Declaration>>> _builtInDeclarationsByType;
         private Lazy<IDictionary<Declaration, List<Declaration>>> _handlersByWithEventsField;
 
         private Lazy<IDictionary<(VBAParser.ImplementsStmtContext Context, Declaration Implementor), List<ModuleBodyElementDeclaration>>> _implementingMembers;
         private Lazy<IDictionary<VBAParser.ImplementsStmtContext, List<ModuleBodyElementDeclaration>>> _membersByImplementsContext;
         private Lazy<IDictionary<ClassModuleDeclaration, List<Declaration>>> _interfaceMembers;
-        private Lazy<IDictionary<ClassModuleDeclaration, List<ClassModuleDeclaration>>> _interfaceImplementions;
+        private Lazy<IDictionary<ClassModuleDeclaration, List<ClassModuleDeclaration>>> _interfaceImplementations;
         private Lazy<IDictionary<IInterfaceExposable, List<ModuleBodyElementDeclaration>>> _implementationsByMember;
 
         private Lazy<List<Declaration>> _nonBaseAsType;
@@ -63,13 +65,19 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                 : declaration.QualifiedSelection;
         }
 
-        public DeclarationFinder(IReadOnlyList<Declaration> declarations, IEnumerable<IAnnotation> annotations, 
-            IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations, IHostApplication hostApp = null)
+        public DeclarationFinder(
+            IReadOnlyList<Declaration> declarations, 
+            IEnumerable<IAnnotation> annotations, 
+            IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations,
+            IReadOnlyDictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>> unboundDefaultMemberAccesses, 
+            IHostApplication hostApp = null)
         {
             _hostApp = hostApp;
+            _unboundDefaultMemberAccesses = unboundDefaultMemberAccesses;
 
             _newUndeclared = new ConcurrentDictionary<QualifiedMemberName, ConcurrentBag<Declaration>>(new Dictionary<QualifiedMemberName, ConcurrentBag<Declaration>>());
             _newUnresolved = new ConcurrentBag<UnboundMemberDeclaration>(new List<UnboundMemberDeclaration>());
+            _newUnboundDefaultMemberAccesses = new ConcurrentDictionary<QualifiedModuleName, ConcurrentBag<IdentifierReference>>();
 
             var collectionConstructionActions = CollectionConstructionActions(declarations, annotations, unresolvedMemberDeclarations);
             ExecuteCollectionConstructionActions(collectionConstructionActions);
@@ -177,7 +185,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             _implementingMembers = new Lazy<IDictionary<(VBAParser.ImplementsStmtContext Context, Declaration Implementor), List<ModuleBodyElementDeclaration>>>(FindAllImplementingMembers, true);
             _interfaceMembers = new Lazy<IDictionary<ClassModuleDeclaration, List<Declaration>>>(FindAllIinterfaceMembersByModule, true);
             _membersByImplementsContext = new Lazy<IDictionary<VBAParser.ImplementsStmtContext, List<ModuleBodyElementDeclaration>>>(FindAllImplementingMembersByImplementsContext, true);
-            _interfaceImplementions = new Lazy<IDictionary<ClassModuleDeclaration, List<ClassModuleDeclaration>>>(FindAllImplementionsByInterface, true);
+            _interfaceImplementations = new Lazy<IDictionary<ClassModuleDeclaration, List<ClassModuleDeclaration>>>(FindAllImplementionsByInterface, true);
             _implementationsByMember = new Lazy<IDictionary<IInterfaceExposable, List<ModuleBodyElementDeclaration>>>(FindAllImplementingMembersByMember, true);
         }
 
@@ -343,6 +351,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         //This does not need a lock because enumerators over a ConcurrentBag uses a snapshot.    
         public IEnumerable<UnboundMemberDeclaration> FreshUnresolvedMemberDeclarations => _newUnresolved.ToList();
 
+        public IEnumerable<IdentifierReference> FreshUnboundDefaultMemberAccesses => _newUnboundDefaultMemberAccesses.AllValues();
+
         public IEnumerable<UnboundMemberDeclaration> UnresolvedMemberDeclarations => _unresolved;
 
         public IEnumerable<Declaration> Members(Declaration module)
@@ -458,7 +468,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         /// <returns>All classes implementing the interface.</returns>
         public IEnumerable<Declaration> FindAllImplementationsOfInterface(ClassModuleDeclaration interfaceDeclaration)
         {
-            var lookup = _interfaceImplementions.Value;
+            var lookup = _interfaceImplementations.Value;
             return lookup.TryGetValue(interfaceDeclaration, out var implementations)
                 ? implementations
                 : Enumerable.Empty<Declaration>();
@@ -1016,6 +1026,12 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             _newUnresolved.Add(declaration);
         }
 
+        public void AddUnboundDefaultMemberAccess(IdentifierReference defaultMemberAccess)
+        {
+            var accesses = _newUnboundDefaultMemberAccesses.GetOrAdd(defaultMemberAccess.QualifiedModuleName, new ConcurrentBag<IdentifierReference>());
+            accesses.Add(defaultMemberAccess);
+        }
+
         public Declaration OnBracketedExpression(string expression, ParserRuleContext context)
         {
             var hostApp = FindProject(_hostApp == null ? "VBA" : _hostApp.ApplicationName);
@@ -1459,6 +1475,25 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         public IEnumerable<IdentifierReference> AllIdentifierReferences()
         {
             return _referencesByModule.Values.SelectMany(list => list);
+        }
+
+        /// <summary>
+        /// Gets the unbound default member calls in a module.
+        /// </summary>
+        public IReadOnlyCollection<IdentifierReference> UnboundDefaultMemberAccesses(QualifiedModuleName module)
+        {
+            return _unboundDefaultMemberAccesses.TryGetValue(module, out var defaultMemberAccesses)
+                ? defaultMemberAccesses
+                : new HashSet<IdentifierReference>();
+        }
+
+        /// <summary>
+        /// Gets all unbound default member calls.
+        /// </summary>
+        public IEnumerable<IdentifierReference> AllUnboundDefaultMemberAccesses()
+        {
+            return _unboundDefaultMemberAccesses.Values
+                .SelectMany(defaultMemberAccess => defaultMemberAccess);
         }
     }
 }

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinderFactory.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinderFactory.cs
@@ -1,15 +1,20 @@
 ﻿using System.Collections.Generic;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.VBA.DeclarationCaching
 {
     public class DeclarationFinderFactory : IDeclarationFinderFactory 
     {
-        public DeclarationFinder Create(IReadOnlyList<Declaration> declarations, IEnumerable<IAnnotation> annotations, IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations, IHostApplication hostApp)
+        public DeclarationFinder Create(IReadOnlyList<Declaration> declarations, 
+            IEnumerable<IAnnotation> annotations, 
+            IReadOnlyList<UnboundMemberDeclaration> unresolvedMemberDeclarations, 
+            IReadOnlyDictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>> unboundDefaultMemberAccesses,
+            IHostApplication hostApp)
         {
-            return new DeclarationFinder(declarations, annotations, unresolvedMemberDeclarations, hostApp);
+            return new DeclarationFinder(declarations, annotations, unresolvedMemberDeclarations, unboundDefaultMemberAccesses, hostApp);
         }
 
         public void Release(DeclarationFinder declarationFinder)

--- a/Rubberduck.Parsing/VBA/ModuleState.cs
+++ b/Rubberduck.Parsing/VBA/ModuleState.cs
@@ -25,10 +25,12 @@ namespace Rubberduck.Parsing.VBA
         public SyntaxErrorException ModuleException { get; private set; }
         public IDictionary<(string scopeIdentifier, DeclarationType scopeType), Attributes> ModuleAttributes { get; private set; }
         public IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext> MembersAllowingAttributes { get; private set; }
+        public IReadOnlyCollection<IdentifierReference> UnboundDefaultMemberAccesses => _unboundDefaultMemberAccesses;
 
         public bool IsNew { get; private set; }
         public bool IsMarkedAsModified { get; private set; }
 
+        private readonly HashSet<IdentifierReference> _unboundDefaultMemberAccesses = new HashSet<IdentifierReference>();
 
         public ModuleState(ConcurrentDictionary<Declaration, byte> declarations)
         {
@@ -148,6 +150,18 @@ namespace Rubberduck.Parsing.VBA
         public ModuleState SetAttributesTokenStream(ITokenStream attributesTokenStream)
         {
             AttributesTokenStream = attributesTokenStream;
+            return this;
+        }
+
+        public ModuleState AddUnboundDefaultMemberAccess(IdentifierReference defaultMemberAccess)
+        {
+            if (defaultMemberAccess.IsDefaultMemberAccess
+                && defaultMemberAccess.Declaration == null
+                && !_unboundDefaultMemberAccesses.Contains(defaultMemberAccess))
+            {
+                _unboundDefaultMemberAccesses.Add(defaultMemberAccess);
+            }
+
             return this;
         }
 

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -181,6 +181,10 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 {
                     AddDefaultMemberReference(expression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment);
                 }
+                else
+                {
+                    AddUnboundDefaultMemberReference(expression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment);
+                }
             }
             else if (expression.Classification != ExpressionClassification.Unbound
                 && expression.IsArrayAccess
@@ -262,6 +266,34 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 hasExplicitLetStatement,
                 isSetAssignment,
                 isDefaultMemberAccess: true);
+        }
+
+        private void AddUnboundDefaultMemberReference(
+            IndexExpression expression,
+            QualifiedModuleName module,
+            Declaration scope,
+            Declaration parent,
+            bool isAssignmentTarget,
+            bool isSetAssignment,
+            bool hasExplicitLetStatement)
+        {
+            var callSiteContext = expression.LExpression.Context;
+            var identifier = expression.LExpression.Context.GetText();
+            var callee = expression.ReferencedDeclaration;
+            var reference = new IdentifierReference(
+                module,
+                scope,
+                parent,
+                identifier,
+                callSiteContext.GetSelection(),
+                callSiteContext,
+                callee,
+                isAssignmentTarget,
+                hasExplicitLetStatement,
+                FindIdentifierAnnotations(module, callSiteContext.GetSelection().StartLine),
+                isSetAssignment,
+                isDefaultMemberAccess: true);
+            _declarationFinder.AddUnboundDefaultMemberAccess(reference);
         }
 
         private void Visit(

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -265,7 +265,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 isAssignmentTarget,
                 hasExplicitLetStatement,
                 isSetAssignment,
-                isDefaultMemberAccess: true);
+                isIndexedDefaultMemberAccess: true,
+                defaultMemberRecursionDepth: expression.DefaultMemberRecursionDepth);
         }
 
         private void AddUnboundDefaultMemberReference(
@@ -292,7 +293,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 hasExplicitLetStatement,
                 FindIdentifierAnnotations(module, callSiteContext.GetSelection().StartLine),
                 isSetAssignment,
-                isDefaultMemberAccess: true);
+                isIndexedDefaultMemberAccess: true,
+                defaultMemberRecursionDepth: expression.DefaultMemberRecursionDepth);
             _declarationFinder.AddUnboundDefaultMemberAccess(reference);
         }
 
@@ -325,7 +327,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                     isAssignmentTarget,
                     hasExplicitLetStatement,
                     isSetAssignment,
-                    isDefaultMemberAccess: true);
+                    isIndexedDefaultMemberAccess: true,
+                    defaultMemberRecursionDepth: expression.DefaultMemberRecursionDepth);
             }
             // Argument List not affected by being unbound.
             foreach (var argument in expression.ArgumentList.Arguments)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
@@ -114,6 +114,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
             AddNewUndeclaredVariablesToDeclarations();
             AddNewUnresolvedMemberDeclarations();
+            AddNewUnboundDefaultMemberAccesses();
 
             _toResolve.Clear();
         }
@@ -291,10 +292,21 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
         private void AddNewUnresolvedMemberDeclarations()
         {
-            var unresolved = _state.DeclarationFinder.FreshUnresolvedMemberDeclarations;
+            var unresolved = _state.DeclarationFinder.FreshUnresolvedMemberDeclarations
+                .GroupBy(declaration => declaration.QualifiedModuleName);
             foreach (var declaration in unresolved)
             {
-                _state.AddUnresolvedMemberDeclaration(declaration);
+                _state.AddUnresolvedMemberDeclarations(declaration.Key, declaration);
+            }
+        }
+
+        private void AddNewUnboundDefaultMemberAccesses()
+        {
+            var unboundDefaultMembers = _state.DeclarationFinder.FreshUnboundDefaultMemberAccesses
+                .GroupBy(access => access.QualifiedModuleName); ;
+            foreach (var access in unboundDefaultMembers)
+            {
+                _state.AddUnboundDefaultMemberAccesses(access.Key, access);
             }
         }
     }

--- a/RubberduckTests/Inspections/InspectionResultTests.cs
+++ b/RubberduckTests/Inspections/InspectionResultTests.cs
@@ -141,7 +141,7 @@ namespace RubberduckTests.Inspections
 
             var declarationFinderProviderMock = new Mock<IDeclarationFinderProvider>();
             var declaratioFinder = new DeclarationFinder(new List<Declaration>(), new List<IAnnotation>(),
-                new List<UnboundMemberDeclaration>());
+                new List<UnboundMemberDeclaration>(), new Dictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>>());
             declarationFinderProviderMock.SetupGet(m => m.DeclarationFinder).Returns(declaratioFinder);
             var inspectionResult = new IdentifierReferenceInspectionResult(inspectionMock.Object, string.Empty, declarationFinderProviderMock.Object, identifierReference);
 
@@ -170,7 +170,7 @@ namespace RubberduckTests.Inspections
 
             var declarationFinderProviderMock = new Mock<IDeclarationFinderProvider>();
             var declaratioFinder = new DeclarationFinder(new List<Declaration>(), new List<IAnnotation>(),
-                new List<UnboundMemberDeclaration>());
+                new List<UnboundMemberDeclaration>(), new Dictionary<QualifiedModuleName, IReadOnlyCollection<IdentifierReference>>());
             declarationFinderProviderMock.SetupGet(m => m.DeclarationFinder).Returns(declaratioFinder);
             var inspectionResult = new IdentifierReferenceInspectionResult(inspectionMock.Object, string.Empty, declarationFinderProviderMock.Object, identifierReference);
 


### PR DESCRIPTION
This PR aims to enhance the resolver to actually resolve default member accesses due to Let coersion and to generate identifier references for intermediate default member accesses in recursive default member resolutions.

Moreover, this PR includes a few fixes to the resolver.

So far, the identifier references for the intermediate default member accesses are generated. So, if somebody was interested to see how that is incorporated, I would appreciate any feedback.