### PR TITLE
Add description filter for Code Inspections

### DIFF
--- a/Rubberduck.Core/Common/ExportFormatter.cs
+++ b/Rubberduck.Core/Common/ExportFormatter.cs
@@ -121,7 +121,7 @@ namespace Rubberduck.Common
                 "</body>\r\n" +
                 "</html>";
 
-            var html = ExportFormatter.HtmlTable(data, title, columnInfos);
+            var html = HtmlTable(data, title, columnInfos);
 
             var CFHeaderLength = string.Format(CFHeaderTemplate, OffsetFormat, OffsetFormat, OffsetFormat, OffsetFormat).Length;
             var startFragment = CFHeaderLength + HtmlHeader.Length;

--- a/Rubberduck.Core/Common/ExportFormatter.cs
+++ b/Rubberduck.Core/Common/ExportFormatter.cs
@@ -75,7 +75,7 @@ namespace Rubberduck.Common
 
         private static string CsvEncode(object value)
         {
-            var s = "";
+            var s = string.Empty;
             if (value is string)
             {
                 s = value.ToString();

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Windows.Forms;
 using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.Resources.CodeExplorer;

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
@@ -9,8 +9,8 @@ namespace Rubberduck.UI.CodeExplorer
     public sealed partial class CodeExplorerWindow : UserControl, IDockableUserControl
     {
         private const string ClassId = "C5318B59-172F-417C-88E3-B377CDA2D809";
-        string IDockableUserControl.ClassId { get { return ClassId; } }
-        string IDockableUserControl.Caption { get { return CodeExplorerUI.CodeExplorerDockablePresenter_Caption; } }
+        string IDockableUserControl.ClassId => ClassId;
+        string IDockableUserControl.Caption => CodeExplorerUI.CodeExplorerDockablePresenter_Caption;
 
         private CodeExplorerWindow()
         {

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
@@ -20,14 +20,9 @@ namespace Rubberduck.UI.CodeExplorer
 
         public CodeExplorerWindow(CodeExplorerViewModel viewModel) : this()
         {
-            _viewModel = viewModel;
-            codeExplorerControl1.DataContext = _viewModel;
+            ViewModel = viewModel;
+            codeExplorerControl1.DataContext = ViewModel;
         }
-
-        private readonly CodeExplorerViewModel _viewModel;
-        public CodeExplorerViewModel ViewModel
-        {
-            get { return _viewModel; }
-        }
+        public CodeExplorerViewModel ViewModel { get; }
     }
 }

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerWindow.cs
@@ -20,7 +20,7 @@ namespace Rubberduck.UI.CodeExplorer
         public CodeExplorerWindow(CodeExplorerViewModel viewModel) : this()
         {
             ViewModel = viewModel;
-            codeExplorerControl1.DataContext = ViewModel;
+            codeExplorerControl1.DataContext = viewModel;
         }
         public CodeExplorerViewModel ViewModel { get; }
     }

--- a/Rubberduck.Core/UI/Controls/SearchBox.xaml
+++ b/Rubberduck.Core/UI/Controls/SearchBox.xaml
@@ -48,7 +48,7 @@
         <Button Name="SearchButton"  Grid.Column="1" Command="{Binding ClearSearchCommand}" 
                 BorderBrush="{x:Static SystemColors.ControlLightBrush}"
                 Background="Transparent"
-                Width="20" Height="20" Padding="0" Margin="0,1"
+                Width="20" Height="20" Padding="0"
                 xmlns:sys="clr-namespace:System;assembly=mscorlib">
             <Button.Resources>
                 <converters:SearchImageSourceConverter x:Key="SearchToIcon" />

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -139,6 +139,8 @@
                 <controls:SearchBox Width="100"
                                     Text="{Binding InspectionDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
+                <Label Content="{Resx ResxName=Rubberduck.Resources.Inspections.InspectionsUI ,Key=CodeInspection_SeverityFilter}" />
+
                 <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByError}"
                               IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Error}}">

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -136,6 +136,9 @@
 
                 <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_Filter}" VerticalContentAlignment="Center" />
 
+                <controls:SearchBox Width="100"
+                                    Text="{Binding InspectionDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
                 <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByError}"
                               IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Error}}">

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -13,6 +13,8 @@ using System.Windows.Data;
 using System.Windows.Input;
 using NLog;
 using Rubberduck.Common;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
 using Rubberduck.Interaction.Navigation;
 using Rubberduck.Parsing.Inspections;
 using Rubberduck.Parsing.Inspections.Abstract;
@@ -257,6 +259,34 @@ namespace Rubberduck.UI.Inspections
                 // updating Filter forces a Refresh
                 Results.Filter = i => InspectionFilter((IInspectionResult)i);
             }
+        }
+
+        private string _inspectionDescriptionFilter = string.Empty;
+        public string InspectionDescriptionFilter
+        {
+            get => _inspectionDescriptionFilter;
+            set
+            {
+                if (_inspectionDescriptionFilter != value)
+                {
+                    _inspectionDescriptionFilter = value;
+                    OnPropertyChanged();
+                    Results.Filter = FilterResults;
+                    OnPropertyChanged(nameof(Results));
+                }
+            }
+        }
+
+        private bool FilterResults(object inspectionResult)
+        {
+            if (InspectionDescriptionFilter == string.Empty)
+            {
+                return true;
+            }
+
+            var inspectionResultBase = inspectionResult as InspectionResultBase;
+            
+            return inspectionResultBase.Description.ToUpper().Contains(InspectionDescriptionFilter.ToUpper()); ;
         }
 
         private bool InspectionFilter(IInspectionResult result)

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -649,20 +649,20 @@ namespace Rubberduck.UI.Inspections
         private void ExecuteCopyResultsCommand(object parameter)
         {
             const string xmlSpreadsheetDataFormat = "XML Spreadsheet";
-            if (_results == null)
+            if (Results == null)
             {
                 return;
             }
 
-            var resultArray = _results.OfType<IExportable>().Select(result => result.ToArray()).ToArray();
+            var resultArray = Results.OfType<IExportable>().Select(result => result.ToArray()).ToArray();
 
-            var resource = _results.Count == 1
+            var resource = resultArray.Count() == 1
                 ? Resources.RubberduckUI.CodeInspections_NumberOfIssuesFound_Singular
                 : Resources.RubberduckUI.CodeInspections_NumberOfIssuesFound_Plural;
 
-            var title = string.Format(resource, DateTime.Now.ToString(CultureInfo.InvariantCulture), _results.Count);
+            var title = string.Format(resource, DateTime.Now.ToString(CultureInfo.InvariantCulture), resultArray.Count());
 
-            var textResults = title + Environment.NewLine + string.Join("", _results.OfType<IExportable>().Select(result => result.ToClipboardString() + Environment.NewLine).ToArray());
+            var textResults = title + Environment.NewLine + string.Join("", Results.OfType<IExportable>().Select(result => result.ToClipboardString() + Environment.NewLine).ToArray());
             var csvResults = ExportFormatter.Csv(resultArray, title, ColumnInformation);
             var htmlResults = ExportFormatter.HtmlClipboardFragment(resultArray, title, ColumnInformation);
             var rtfResults = ExportFormatter.RTF(resultArray, title);

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -662,7 +662,7 @@ namespace Rubberduck.UI.Inspections
 
             var title = string.Format(resource, DateTime.Now.ToString(CultureInfo.InvariantCulture), resultArray.Count());
 
-            var textResults = title + Environment.NewLine + string.Join("", Results.OfType<IExportable>().Select(result => result.ToClipboardString() + Environment.NewLine).ToArray());
+            var textResults = title + Environment.NewLine + string.Join(string.Empty, Results.OfType<IExportable>().Select(result => result.ToClipboardString() + Environment.NewLine).ToArray());
             var csvResults = ExportFormatter.Csv(resultArray, title, ColumnInformation);
             var htmlResults = ExportFormatter.HtmlClipboardFragment(resultArray, title, ColumnInformation);
             var rtfResults = ExportFormatter.RTF(resultArray, title);

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -279,11 +279,6 @@ namespace Rubberduck.UI.Inspections
 
         private bool FilterResults(object inspectionResult)
         {
-            if (InspectionDescriptionFilter == string.Empty)
-            {
-                return true;
-            }
-
             var inspectionResultBase = inspectionResult as InspectionResultBase;
             
             return inspectionResultBase.Description.ToUpper().Contains(InspectionDescriptionFilter.ToUpper()); ;

--- a/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
+++ b/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
@@ -279,22 +279,20 @@
                     <DockPanel FlowDirection="LeftToRight">
                         <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                             <Label Style="{StaticResource HeaderText}"
-                                Content="{Resx Key=CodeInspectionSettings_InspectionSeveritySettingsLabel, ResxName=Rubberduck.Resources.RubberduckUI}" Margin="5,5,0,5" Width="123" />
+                                Content="{Resx Key=CodeInspectionSettings_InspectionSeveritySettingsLabel, ResxName=Rubberduck.Resources.RubberduckUI}" Margin="5,5,0,5" Width="127" />
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                                 <StackPanel.Resources>
-                                    <Style TargetType="FrameworkElement">
+                                    <Style BasedOn="{StaticResource HeaderText}" TargetType="Label">
                                         <Setter Property="Margin" Value="0,5" />
                                     </Style>
                                 </StackPanel.Resources>
                                 <Label Content="-" />
                                 <Image Source="{StaticResource FilterImage}" Width="19" />
-                                <Label Style="{StaticResource HeaderText}"
-                                       Content="{Resx Key=InspectionSettings_FilterByDescription, ResxName=Rubberduck.Resources.RubberduckUI}" />
+                                <Label Content="{Resx Key=InspectionSettings_FilterByDescription, ResxName=Rubberduck.Resources.RubberduckUI}" />
                                 <controls:SearchBox Width="100"
                                                     Text="{Binding InspectionSettingsDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="26" />
                                 <Border Width="10" />
-                                <Label Style="{StaticResource HeaderText}"
-                                       Content="{Resx Key=InspectionSettings_FilterBySeverity, ResxName=Rubberduck.Resources.RubberduckUI}" />
+                                <Label Content="{Resx Key=InspectionSettings_FilterBySeverity, ResxName=Rubberduck.Resources.RubberduckUI}" />
                                 <ComboBox Width="100"
                                           ItemsSource="{Binding SeverityFilters, UpdateSourceTrigger=PropertyChanged}"
                                           SelectedItem="{Binding SelectedSeverityFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
+++ b/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
@@ -285,18 +285,23 @@
                             <Label Style="{StaticResource HeaderText}"
                                 Content="{Resx Key=CodeInspectionSettings_InspectionSeveritySettingsLabel, ResxName=Rubberduck.Resources.RubberduckUI}" Margin="5,5,0,5" Width="123" />
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-                                <Label Content="-" Margin="0,5"/>
-                                <Image Source="{StaticResource FilterImage}" Margin="0,5" Width="19" RenderTransformOrigin="0.564,1.859" />
+                                <StackPanel.Resources>
+                                    <Style TargetType="FrameworkElement">
+                                        <Setter Property="Margin" Value="0,5" />
+                                    </Style>
+                                </StackPanel.Resources>
+                                <Label Content="-" />
+                                <Image Source="{StaticResource FilterImage}" Width="19" />
                                 <Label Style="{StaticResource HeaderText}"
-                                       Content="{Resx Key=InspectionSettings_FilterByDescription, ResxName=Rubberduck.Resources.RubberduckUI}" Margin="0,5" />
+                                       Content="{Resx Key=InspectionSettings_FilterByDescription, ResxName=Rubberduck.Resources.RubberduckUI}" />
                                 <controls:SearchBox Width="100"
-                                                    Text="{Binding InspectionSettingsDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,5" Height="26" />
+                                                    Text="{Binding InspectionSettingsDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="26" />
                                 <Border Width="10" />
                                 <Label Style="{StaticResource HeaderText}"
-                                       Content="{Resx Key=InspectionSettings_FilterBySeverity, ResxName=Rubberduck.Resources.RubberduckUI}" Margin="0,5" />
+                                       Content="{Resx Key=InspectionSettings_FilterBySeverity, ResxName=Rubberduck.Resources.RubberduckUI}" />
                                 <ComboBox Width="100"
                                           ItemsSource="{Binding SeverityFilters, UpdateSourceTrigger=PropertyChanged}"
-                                          SelectedItem="{Binding SelectedSeverityFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,5" />
+                                          SelectedItem="{Binding SelectedSeverityFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             </StackPanel>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" HorizontalAlignment="Left"

--- a/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
+++ b/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
@@ -256,10 +256,6 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
-        <Style x:Key="HeaderBackground" TargetType="Label">
-            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-            <Setter Property="Background" Value="DarkGray"/>
-        </Style>
         <Style x:Key="HeaderText" TargetType="Label">
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontWeight" Value="SemiBold"/>

--- a/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
+++ b/Rubberduck.Core/UI/Settings/InspectionSettings.xaml
@@ -289,8 +289,8 @@
                                 <Image Source="{StaticResource FilterImage}" Margin="0,5" Width="19" RenderTransformOrigin="0.564,1.859" />
                                 <Label Style="{StaticResource HeaderText}"
                                        Content="{Resx Key=InspectionSettings_FilterByDescription, ResxName=Rubberduck.Resources.RubberduckUI}" Margin="0,5" />
-                                <TextBox MinWidth="125"
-                                         Text="{Binding InspectionSettingsDescriptionFilter, UpdateSourceTrigger=PropertyChanged}" Margin="0,5" Height="26" />
+                                <controls:SearchBox Width="100"
+                                                    Text="{Binding InspectionSettingsDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,5" Height="26" />
                                 <Border Width="10" />
                                 <Label Style="{StaticResource HeaderText}"
                                        Content="{Resx Key=InspectionSettings_FilterBySeverity, ResxName=Rubberduck.Resources.RubberduckUI}" Margin="0,5" />

--- a/Rubberduck.Core/UI/Settings/InspectionSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/InspectionSettingsViewModel.cs
@@ -69,7 +69,9 @@ namespace Rubberduck.UI.Settings
                 if (_inspectionSettingsDescriptionFilter != value)
                 {
                     _inspectionSettingsDescriptionFilter = value;
+                    OnPropertyChanged();
                     InspectionSettings.Filter = FilterResults;
+                    OnPropertyChanged(nameof(InspectionSettings));
                 }
             }
         }
@@ -88,13 +90,13 @@ namespace Rubberduck.UI.Settings
                     _selectedSeverityFilter = value.Replace(" ", string.Empty);
                     OnPropertyChanged();
                     InspectionSettings.Filter = FilterResults;
+                    OnPropertyChanged(nameof(InspectionSettings));
                 }
             }
         }        
 
         private bool FilterResults(object setting)
         {
-            OnPropertyChanged(nameof(InspectionSettings));
             var cis = setting as CodeInspectionSetting;
 
             return cis.Description.ToUpper().Contains(_inspectionSettingsDescriptionFilter.ToUpper())

--- a/Rubberduck.Core/UI/Settings/InspectionSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/InspectionSettingsViewModel.cs
@@ -69,7 +69,7 @@ namespace Rubberduck.UI.Settings
                 if (_inspectionSettingsDescriptionFilter != value)
                 {
                     _inspectionSettingsDescriptionFilter = value;
-                    InspectionSettings.Filter = item => FilterResults(item);
+                    InspectionSettings.Filter = FilterResults;
                 }
             }
         }
@@ -87,7 +87,7 @@ namespace Rubberduck.UI.Settings
                 {
                     _selectedSeverityFilter = value.Replace(" ", string.Empty);
                     OnPropertyChanged();
-                    InspectionSettings.Filter = item => FilterResults(item);
+                    InspectionSettings.Filter = FilterResults;
                 }
             }
         }        

--- a/Rubberduck.Core/UI/Settings/InspectionSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/InspectionSettingsViewModel.cs
@@ -106,10 +106,7 @@ namespace Rubberduck.UI.Settings
         private ListCollectionView _inspectionSettings;
         public ListCollectionView InspectionSettings
         {
-            get
-            {
-                return _inspectionSettings;
-            }
+            get => _inspectionSettings;
 
             set
             {

--- a/Rubberduck.Resources/Inspections/InspectionsUI.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionsUI.Designer.cs
@@ -70,6 +70,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Severity.
+        /// </summary>
+        public static string CodeInspection_SeverityFilter {
+            get {
+                return ResourceManager.GetString("CodeInspection_SeverityFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Code Quality Issues.
         /// </summary>
         public static string CodeInspectionSettings_CodeQualityIssues {

--- a/Rubberduck.Resources/Inspections/InspectionsUI.resx
+++ b/Rubberduck.Resources/Inspections/InspectionsUI.resx
@@ -226,4 +226,7 @@
   <data name="ExportColumnHeader_Type" xml:space="preserve">
     <value>Type</value>
   </data>
+  <data name="CodeInspection_SeverityFilter" xml:space="preserve">
+    <value>Severity</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.Designer.cs
+++ b/Rubberduck.Resources/RubberduckUI.Designer.cs
@@ -1693,7 +1693,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter.
+        ///   Looks up a localized string similar to Issue Description.
         /// </summary>
         public static string GroupingGrid_Filter {
             get {

--- a/Rubberduck.Resources/RubberduckUI.resx
+++ b/Rubberduck.Resources/RubberduckUI.resx
@@ -1517,7 +1517,7 @@ NOTE: Restart is required for the setting to take effect.</value>
     <comment>{0}: Variable Name; {1}: name of conflicting declaration</comment>
   </data>
   <data name="GroupingGrid_Filter" xml:space="preserve">
-    <value>Filter</value>
+    <value>Issue Description</value>
   </data>
   <data name="GroupingStyle_ByName" xml:space="preserve">
     <value>By inspection</value>


### PR DESCRIPTION
Close #5080

I have a BrainTickle over the use of [InspectionsUI.ResourceManager.GetString("CodeInspectionSeverity_All", CultureInfo.CurrentUICulture);](https://github.com/IvenBach/Rubberduck/blob/Issue5080_Text_filter_for_Code_Inspections/Rubberduck.Core/UI/Settings/InspectionSettingsViewModel.cs#L81). Is it done this way because of localization? In previous PR I recall using `InspectionsUI.CodeInspectionSeverity_All` and assumed it was good.

![CodeInspections description filter](https://user-images.githubusercontent.com/26076874/63721361-f0b07a80-c805-11e9-9cce-05686b7d4eff.png)