### PR TITLE
ignore the xmldoc export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ CodeGraphData/
 
 #Gradle 
 /.gradle/
+/Rubberduck.CodeAnalysis/Rubberduck.CodeAnalysis.xml


### PR DESCRIPTION
Rubberduck.CodeAnalysis.xml is a build artifact, shouldn't be under SC.