### PR TITLE
Hot Fix for Resolver

### DIFF
--- a/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
@@ -102,16 +102,16 @@ namespace Rubberduck.Parsing.Binding
 
                             break;
                     }
-                }
 
-                if (IsVariablePropertyFunctionWithoutParameters(lExpression))
-                {
-                    var parameterlessLExpressionAccess = ResolveLExpressionIsVariablePropertyFunctionNoParameters(lExpression, argumentList, expression, defaultMemberResolutionRecursionDepth, containedExpression);
-                    if (parameterlessLExpressionAccess != null)
+                    if (IsVariablePropertyFunctionWithoutParameters(lExpression))
                     {
-                        return parameterlessLExpressionAccess;
+                        var parameterlessLExpressionAccess = ResolveLExpressionIsVariablePropertyFunctionNoParameters(lExpression, argumentList, expression, defaultMemberResolutionRecursionDepth, containedExpression);
+                        if (parameterlessLExpressionAccess != null)
+                        {
+                            return parameterlessLExpressionAccess;
+                        }
                     }
-                }
+                }    
             }
 
             if (lExpression.Classification == ExpressionClassification.Property

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -4161,7 +4161,6 @@ End Function
             {
                 var module = state.DeclarationFinder.AllModules.First(qmn => qmn.ComponentName == "Module1");
                 var qualifiedSelection = new QualifiedSelection(module, selection);
-var references = state.DeclarationFinder.IdentifierReferences(qualifiedSelection).ToList();
                 var reference = state.DeclarationFinder.IdentifierReferences(qualifiedSelection).Last();
                 var referencedDeclaration = reference.Declaration;
 
@@ -4171,6 +4170,52 @@ var references = state.DeclarationFinder.IdentifierReferences(qualifiedSelection
                 Assert.AreEqual(expectedReferencedDeclarationName, actualReferencedDeclarationName);
                 Assert.IsTrue(reference.IsIndexedDefaultMemberAccess);
                 Assert.AreEqual(1, reference.DefaultMemberRecursionDepth);
+            }
+        }
+
+        [Category("Grammar")]
+        [Category("Resolver")]
+        [Test]
+        public void IndexExpressionWithoutArgumentsOnFunctionReturningClassWithParameterlessDefaultMemberReferencesFunction()
+        {
+            var classCode = @"
+Public Function Foo() As String
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Sub Bar()
+    Dim baz As Class1
+    Set baz = Foo()
+End Sub
+
+Private Function Foo() As Class1 
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", classCode, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var selection = new Selection(4, 15, 4, 18);
+
+            using (var state = Resolve(vbe.Object))
+            {
+                var module = state.DeclarationFinder.AllModules.First(qmn => qmn.ComponentName == "Module1");
+                var qualifiedSelection = new QualifiedSelection(module, selection);
+                var reference = state.DeclarationFinder.IdentifierReferences(qualifiedSelection).Last();
+                var referencedDeclaration = reference.Declaration;
+
+                var expectedReferencedDeclarationName = "Module1.Foo";
+                var actualReferencedDeclarationName = $"{referencedDeclaration.ComponentName}.{referencedDeclaration.IdentifierName}";
+
+                var expectedAsTypeName = "Class1";
+                var actualAsTypeName = referencedDeclaration.AsTypeName;
+
+                Assert.AreEqual(expectedReferencedDeclarationName, actualReferencedDeclarationName);
+                Assert.AreEqual(expectedAsTypeName, actualAsTypeName);
+                Assert.AreEqual(0, reference.DefaultMemberRecursionDepth);
             }
         }
 


### PR DESCRIPTION
Closes #5112

Fix that the default member case in IndexDefaultBinding is only taken if there are arguments. (The bug to use it even without was introduces in one of my two previous PRs.)

