### PR TITLE
Stop reporting missing 'Option Explicit' in otherwise empty modules

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/OptionExplicitInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/OptionExplicitInspection.cs
@@ -60,14 +60,22 @@ namespace Rubberduck.Inspections.Concrete
 
         public class MissingOptionExplicitListener : VBAParserBaseListener, IInspectionListener
         {
-            private readonly List<QualifiedContext<ParserRuleContext>> _contexts = new List<QualifiedContext<ParserRuleContext>>();
-            public IReadOnlyList<QualifiedContext<ParserRuleContext>> Contexts => _contexts;
+            private readonly IDictionary<string, QualifiedContext<ParserRuleContext>> _contexts = new Dictionary<string,QualifiedContext<ParserRuleContext>>();
+            public IReadOnlyList<QualifiedContext<ParserRuleContext>> Contexts => _contexts.Values.ToList();
 
             public QualifiedModuleName CurrentModuleName { get; set; }
 
             public void ClearContexts()
             {
                 _contexts.Clear();
+            }
+
+            public override void ExitModuleBody(VBAParser.ModuleBodyContext context)
+            {
+                if (context.ChildCount == 0 && _contexts.ContainsKey(CurrentModuleName.Name))
+                {
+                    _contexts.Remove(CurrentModuleName.Name);
+                }
             }
 
             public override void ExitModuleDeclarations([NotNull] VBAParser.ModuleDeclarationsContext context)
@@ -83,7 +91,7 @@ namespace Rubberduck.Inspections.Concrete
 
                 if (!hasOptionExplicit)
                 {
-                    _contexts.Add(new QualifiedContext<ParserRuleContext>(CurrentModuleName, (ParserRuleContext)context.Parent));
+                    _contexts.Add(CurrentModuleName.Name, new QualifiedContext<ParserRuleContext>(CurrentModuleName, (ParserRuleContext)context.Parent));
                 }
             }
         }

--- a/Rubberduck.CodeAnalysis/QuickFixes/OptionExplicitQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/OptionExplicitQuickFix.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.Inspections.QuickFixes
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
             var rewriter = rewriteSession.CheckOutModuleRewriter(result.QualifiedSelection.QualifiedName);
-            rewriter.InsertBefore(0, Tokens.Option + ' ' + Tokens.Explicit + Environment.NewLine + Environment.NewLine);
+            rewriter.InsertBefore(0, Tokens.Option + ' ' + Tokens.Explicit + Environment.NewLine);
         }
 
         public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.OptionExplicitQuickFix;

--- a/Rubberduck.Core/AutoComplete/SelfClosingPairs/SelfClosingPairHandler.cs
+++ b/Rubberduck.Core/AutoComplete/SelfClosingPairs/SelfClosingPairHandler.cs
@@ -91,7 +91,7 @@ namespace Rubberduck.AutoComplete.SelfClosingPairs
             // 1-based selection span in the code pane starts at column 1 but really encompasses the entire line.
             var snippetPosition = new Selection(result.SnippetPosition.StartLine, 1, result.SnippetPosition.EndLine, 1);
             result = new CodeString(result.Code, result.CaretPosition, snippetPosition);
-
+            _scpService.ShowIntellisense();
             e.Handled = true;
             return true;
         }
@@ -143,7 +143,6 @@ namespace Rubberduck.AutoComplete.SelfClosingPairs
                 {
                     e.Handled = true;
                     result = reprettified;
-                    _scpService.ShowIntellisense();
                     return true;
                 }
 

--- a/RubberduckTests/Inspections/OptionExplicitInspectionTests.cs
+++ b/RubberduckTests/Inspections/OptionExplicitInspectionTests.cs
@@ -10,11 +10,33 @@ namespace RubberduckTests.Inspections
     [TestFixture]
     public class OptionExplicitInspectionTests
     {
+        private const string OptionExplicitNotSpecified = @"
+Sub DoSomething()
+End Sub";
+
+        [Test]
+        [Category("Inspections")]
+        public void EmptyModule_NoResult()
+        {
+            const string inputCode = @"";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+
+                var inspection = new OptionExplicitInspection(state);
+                var inspector = InspectionsHelper.GetInspector(inspection);
+                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+
+                Assert.AreEqual(0, inspectionResults.Count());
+            }
+        }
+
         [Test]
         [Category("Inspections")]
         public void NotAlreadySpecified_ReturnsResult()
         {
-            const string inputCode = @"";
+            const string inputCode = OptionExplicitNotSpecified;
 
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
             using (var state = MockParser.CreateAndParse(vbe.Object))
@@ -50,7 +72,7 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void NotAlreadySpecified_ReturnsMultipleResults()
         {
-            const string inputCode = @"";
+            const string inputCode = OptionExplicitNotSpecified;
 
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
@@ -74,7 +96,7 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void PartiallySpecified_ReturnsResults()
         {
-            const string inputCode1 = @"";
+            const string inputCode1 = OptionExplicitNotSpecified;
             const string inputCode2 = @"Option Explicit";
 
             var builder = new MockVbeBuilder();

--- a/RubberduckTests/QuickFixes/OptionExplicitQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/OptionExplicitQuickFixTests.cs
@@ -17,6 +17,8 @@ namespace RubberduckTests.QuickFixes
             const string expectedCode =
 @"Option Explicit
 
+Public Sub Test() ' inspection won't yield any results if module is empty (#2621)
+End Sub
 ";
 
             var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new OptionExplicitInspection(state));

--- a/RubberduckTests/QuickFixes/OptionExplicitQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/OptionExplicitQuickFixTests.cs
@@ -13,9 +13,11 @@ namespace RubberduckTests.QuickFixes
         [Category("QuickFixes")]
         public void NotAlreadySpecified_QuickFixWorks()
         {
-            const string inputCode = "";
-            const string expectedCode =
-@"Option Explicit
+            const string inputCode = @"
+Public Sub Test() ' inspection won't yield any results if module is empty (#2621)
+End Sub
+";
+            const string expectedCode = @"Option Explicit
 
 Public Sub Test() ' inspection won't yield any results if module is empty (#2621)
 End Sub


### PR DESCRIPTION
fixes #2621