### PR TITLE
Fixes all-at-once GroupingGrid collapse/expand

### DIFF
--- a/Rubberduck.Core/UI/Controls/GroupingGrid.xaml
+++ b/Rubberduck.Core/UI/Controls/GroupingGrid.xaml
@@ -63,7 +63,7 @@
                 <Setter.Value>
                     <ControlTemplate>
                         <Expander Background="WhiteSmoke" Foreground="Black" FontWeight="SemiBold" 
-                                  IsExpanded="{Binding InitialExpandedState, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:GroupingGrid}}}">
+                                  IsExpanded="{Binding InitialExpandedState, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:GroupingGrid}}}">
                             <Expander.Header>
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Margin="4" 


### PR DESCRIPTION
The problem was the binding mode on `InitialExpandedState`, that needed to be `OneWay`.