### PR TITLE
Clean up the ToDoExplorerViewModel class and add arrange to the tests.

### DIFF
--- a/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -42,8 +42,8 @@ namespace Rubberduck.UI.ToDoItems
             RubberduckParserState state,
             IConfigurationService<Configuration> configService, 
             ISettingsFormFactory settingsFormFactory, 
-            ISelectionService selectionService, 
-            IUiDispatcher uiDispatcher)
+            IUiDispatcher uiDispatcher,
+            INavigateCommand navigateCommand)
         {
             _state = state;
             _configService = configService;
@@ -51,6 +51,7 @@ namespace Rubberduck.UI.ToDoItems
             _uiDispatcher = uiDispatcher;
             _state.StateChanged += HandleStateChanged;
 
+            NavigateCommand = navigateCommand;
             RefreshCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(),
                 _ =>
                 {
@@ -191,9 +192,9 @@ namespace Rubberduck.UI.ToDoItems
             });
         }
 
-        public INavigateCommand NavigateCommand { get; set; }
+        public INavigateCommand NavigateCommand { get; }
 
-        public CommandBase RefreshCommand { get; set; }
+        public CommandBase RefreshCommand { get; }
 
         public CommandBase RemoveCommand { get; }
 

--- a/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
+++ b/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
@@ -39,7 +39,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = ArranageViewModel(state, cs);
+                var vm = ArrangeViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -74,7 +74,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = ArranageViewModel(state, cs);
+                var vm = ArrangeViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -109,7 +109,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TO-DO", "N@TE", "BUG " });
-                var vm = ArranageViewModel(state, cs);
+                var vm = ArrangeViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -143,7 +143,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = ArranageViewModel(state, cs);
+                var vm = ArrangeViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -179,7 +179,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = ArranageViewModel(state, cs);
+                var vm = ArrangeViewModel(state, cs);
                 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -221,7 +221,7 @@ namespace RubberduckTests.TodoExplorer
             return dispatcher.Object;
         }
 
-        private ToDoExplorerViewModel ArranageViewModel(RubberduckParserState state, IConfigurationService<Configuration> configService)
+        private ToDoExplorerViewModel ArrangeViewModel(RubberduckParserState state, IConfigurationService<Configuration> configService)
         {
             return new ToDoExplorerViewModel(state, configService, null, GetMockedUiDispatcher(), null);
         }

--- a/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
+++ b/RubberduckTests/TodoExplorer/TodoExplorerTests.cs
@@ -29,8 +29,6 @@ namespace RubberduckTests.TodoExplorer
 ' Bug this is a bug comment
 ";
 
-            var selectionService = new Mock<ISelectionService>().Object;
-
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, inputCode)
@@ -41,7 +39,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, null, selectionService, GetMockedUiDispatcher());
+                var vm = ArranageViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -66,8 +64,6 @@ namespace RubberduckTests.TodoExplorer
 ' bUg this is a bug comment
 ";
 
-            var selectionService = new Mock<ISelectionService>().Object;
-
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, inputCode)
@@ -78,7 +74,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, null, selectionService, GetMockedUiDispatcher());
+                var vm = ArranageViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -103,8 +99,6 @@ namespace RubberduckTests.TodoExplorer
 ' bug: this should not be seen due to the colon
 ";
 
-            var selectionService = new Mock<ISelectionService>().Object;
-
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, inputCode)
@@ -115,7 +109,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TO-DO", "N@TE", "BUG " });
-                var vm = new ToDoExplorerViewModel(state, cs, null, selectionService, GetMockedUiDispatcher());
+                var vm = ArranageViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -139,8 +133,6 @@ namespace RubberduckTests.TodoExplorer
 ' Denoted 
 ";
 
-            var selectionService = new Mock<ISelectionService>().Object;
-
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, inputCode)
@@ -151,7 +143,7 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, null, selectionService, GetMockedUiDispatcher());
+                var vm = ArranageViewModel(state, cs);
 
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
@@ -175,8 +167,6 @@ namespace RubberduckTests.TodoExplorer
             const string expected =
                 @"Dim d As Variant  ";
 
-            var selectionService = new Mock<ISelectionService>().Object;
-
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, inputCode)
@@ -189,11 +179,8 @@ namespace RubberduckTests.TodoExplorer
             using (var state = parser.State)
             {
                 var cs = GetConfigService(new[] { "TODO", "NOTE", "BUG" });
-                var vm = new ToDoExplorerViewModel(state, cs, null, selectionService, GetMockedUiDispatcher())
-                {
-                    RefreshCommand = new ReparseCommand(vbe.Object, new Mock<IConfigurationService<GeneralSettings>>().Object, state, null, null, null, vbeEvents.Object)
-                };
-
+                var vm = ArranageViewModel(state, cs);
+                
                 parser.Parse(new CancellationTokenSource());
                 if (state.Status >= ParserState.Error)
                 {
@@ -232,6 +219,11 @@ namespace RubberduckTests.TodoExplorer
             var dispatcher = new Mock<IUiDispatcher>();
             dispatcher.Setup(m => m.Invoke(It.IsAny<Action>())).Callback((Action argument) => argument.Invoke());
             return dispatcher.Object;
+        }
+
+        private ToDoExplorerViewModel ArranageViewModel(RubberduckParserState state, IConfigurationService<Configuration> configService)
+        {
+            return new ToDoExplorerViewModel(state, configService, null, GetMockedUiDispatcher(), null);
         }
     }
 }


### PR DESCRIPTION
Closes #5119 

This fixes the bad changes introduced in the #4833 where the navigate command wasn't correctly injected. Reviewing the view model, there were few eyebrow-raisers within the class, so I took the opportunity to make it less eyebrow-raising and a bit more mainstream. 