### PR TITLE
Fixes around recursive function calls

### DIFF
--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -67,13 +67,13 @@ namespace Rubberduck.Parsing.Binding
                 SetLeftMatch(lExpressionBinding, argList.Arguments.Count);
                 if (argList.HasArguments)
                 {
-                    return new IndexDefaultBinding(expression.lExpression(), lExpressionBinding, argList);
+                    return new IndexDefaultBinding(expression.lExpression(), lExpressionBinding, argList, parent);
                 }
 
-                return new ProcedureCoercionDefaultBinding(expression.lExpression(), lExpressionBinding, false);
+                return new ProcedureCoercionDefaultBinding(expression.lExpression(), lExpressionBinding, false, parent);
             }
 
-            return new ProcedureCoercionDefaultBinding(expression.lExpression(), lExpressionBinding, true);
+            return new ProcedureCoercionDefaultBinding(expression.lExpression(), lExpressionBinding, true, parent);
         }
 
         private static void SetLeftMatch(IExpressionBinding binding, int argumentCount)
@@ -217,7 +217,7 @@ namespace Rubberduck.Parsing.Binding
             var lExpressionBinding = Visit(module, parent, lExpression, withBlockVariable, StatementResolutionContext.Undefined);
             var argumentListBinding = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable);
             SetLeftMatch(lExpressionBinding, argumentListBinding.Arguments.Count);
-            return new IndexDefaultBinding(expression, lExpressionBinding, argumentListBinding);
+            return new IndexDefaultBinding(expression, lExpressionBinding, argumentListBinding, parent);
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.WhitespaceIndexExprContext expression, IBoundExpression withBlockVariable)
@@ -226,7 +226,7 @@ namespace Rubberduck.Parsing.Binding
             var lExpressionBinding = Visit(module, parent, lExpression, withBlockVariable, StatementResolutionContext.Undefined);
             var argumentListBinding = VisitArgumentList(module, parent, expression.argumentList(), withBlockVariable);
             SetLeftMatch(lExpressionBinding, argumentListBinding.Arguments.Count);
-            return new IndexDefaultBinding(expression, lExpressionBinding, argumentListBinding);
+            return new IndexDefaultBinding(expression, lExpressionBinding, argumentListBinding, parent);
         }
 
         private ArgumentList VisitArgumentList(Declaration module, Declaration parent, VBAParser.ArgumentListContext argumentList, IBoundExpression withBlockVariable)

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -124,7 +124,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The expression &apos;{0}&apos; requires a default member access, but the type &apos;{0}&apos; does not have a suitable default member..
+        ///   Looks up a localized string similar to The expression &apos;{0}&apos; requires a default member access, but the type &apos;{1}&apos; does not have a suitable default member..
         /// </summary>
         public static string DefaultMemberRequiredInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -455,7 +455,7 @@ In memoriam, 1972-2018</value>
     <comment>{0} expression; {1} type</comment>
   </data>
   <data name="DefaultMemberRequiredInspection" xml:space="preserve">
-    <value>The expression '{0}' requires a default member access, but the type '{0}' does not have a suitable default member.</value>
+    <value>The expression '{0}' requires a default member access, but the type '{1}' does not have a suitable default member.</value>
     <comment>{0} expression; {1} type</comment>
   </data>
 </root>

--- a/RubberduckTests/Inspections/ProcedureRequiredInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureRequiredInspectionTests.cs
@@ -476,6 +476,35 @@ End Sub
             Assert.IsFalse(inspectionResults.Any());
         }
 
+        [Category("Grammar")]
+        [Category("Resolver")]
+        [Test]
+        [TestCase("", "Call Foo")]
+        [TestCase("", "Call Foo()")]
+        [TestCase("", "Foo")]
+        [TestCase("ByVal arg As Variant", "Call Foo(arg)")]
+        [TestCase("ByVal arg As Variant", "Foo arg")]
+        public void RecursiveProcedureCall_NoResult(string argumentList, string statement)
+        {
+            var classCode = @"
+Public Function Foo(index As Variant) As Class1
+End Function
+";
+
+            var moduleCode = $@"
+Private Function Foo({argumentList}) As Class1
+    {statement}
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", classCode, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+           Assert.IsFalse(inspectionResults.Any());
+        }
+
 
         protected override IInspection InspectionUnderTest(RubberduckParserState state)
         {


### PR DESCRIPTION
Closes  #5147

This PR fixes that both the `IndexDefaultBinding` and the `ProcdureCoercionBinding` did not consider recursive function calls. For these, the expression referring to the function is classified as a variable becasue that is appropriate for the variable holding the return value. So, this situation needs to be special cased.  