### PR TITLE
Use of bang notation inspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/IdentifierReferenceInspectionBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/IdentifierReferenceInspectionBase.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Inspections.Extensions;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Inspections.Abstract
+{
+    public abstract class IdentifierReferenceInspectionBase : InspectionBase
+    {
+        protected readonly IDeclarationFinderProvider DeclarationFinderProvider;
+
+        public IdentifierReferenceInspectionBase(RubberduckParserState state)
+            : base(state)
+        {
+            DeclarationFinderProvider = state;
+        }
+
+        protected abstract bool IsResultReference(IdentifierReference reference);
+        protected abstract string ResultDescription(IdentifierReference reference);
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            var results = new List<IInspectionResult>();
+            foreach (var moduleDeclaration in State.DeclarationFinder.UserDeclarations(DeclarationType.Module))
+            {
+                if (moduleDeclaration == null || moduleDeclaration.IsIgnoringInspectionResultFor(AnnotationName))
+                {
+                    continue;
+                }
+
+                var module = moduleDeclaration.QualifiedModuleName;
+                results.AddRange(DoGetInspectionResults(module));
+            }
+
+            return results;
+        }
+
+        private IEnumerable<IInspectionResult> DoGetInspectionResults(QualifiedModuleName module)
+        {
+            var objectionableReferences = ReferencesInModule(module)
+                .Where(IsResultReference);
+
+            return objectionableReferences
+                .Select(reference => InspectionResult(reference, DeclarationFinderProvider))
+                .ToList();
+        }
+
+        protected virtual IEnumerable<IdentifierReference> ReferencesInModule(QualifiedModuleName module)
+        {
+            return DeclarationFinderProvider.DeclarationFinder.IdentifierReferences(module);
+        }
+
+        protected virtual IInspectionResult InspectionResult(IdentifierReference reference, IDeclarationFinderProvider declarationFinderProvider)
+        {
+            return new IdentifierReferenceInspectionResult(
+                this,
+                ResultDescription(reference),
+                declarationFinderProvider,
+                reference);
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfBangNotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfBangNotationInspection.cs
@@ -1,0 +1,115 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Inspections.Inspections.Extensions;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Inspections.Concrete
+{
+    /// <summary>
+    /// Identifies the use of bang notation, formally known as dictionary access expression.
+    /// </summary>
+    /// <why>
+    /// A dictionary access expression looks like a strongly typed call, but it actually is a stringly typed access to the parameterized default member of the object. 
+    /// </why>
+    /// <example hasResult="true">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal wkb As Excel.Workbook)
+    ///     wkb.Worksheets!MySheet.Range("A1").Value = 42
+    /// End Sub
+    /// ]]>
+    /// </example>
+    /// <example hasResult="true">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal wkb As Excel.Workbook)
+    ///     With wkb.Worksheets
+    ///         !MySheet.Range("A1").Value = 42
+    ///     End With
+    /// End Sub
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal wkb As Excel.Workbook)
+    ///     wkb.Worksheets("MySheet").Range("A1").Value = 42
+    /// End Sub
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal wkb As Excel.Workbook)
+    ///     wkb.Worksheets.Item("MySheet").Range("A1").Value = 42
+    /// End Sub
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal wkb As Excel.Workbook)
+    ///     With wkb.Worksheets
+    ///         .Item("MySheet").Range("A1").Value = 42
+    ///     End With
+    /// End Sub
+    /// ]]>
+    /// </example>
+    public sealed class UseOfBangNotationInspection : InspectionBase
+    {
+        public UseOfBangNotationInspection(RubberduckParserState state)
+            : base(state) { }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            var results = new List<IInspectionResult>();
+            foreach (var moduleDeclaration in State.DeclarationFinder.UserDeclarations(DeclarationType.Module))
+            {
+                if (moduleDeclaration == null || moduleDeclaration.IsIgnoringInspectionResultFor(AnnotationName))
+                {
+                    continue;
+                }
+
+                var module = moduleDeclaration.QualifiedModuleName;
+                results.AddRange(DoGetInspectionResults(module));
+            }
+
+            return results;
+        }
+
+        private IEnumerable<IInspectionResult> DoGetInspectionResults(QualifiedModuleName module)
+        {
+            var usesOfBang = State.DeclarationFinder
+                .IdentifierReferences(module)
+                .Where(IsRelevantReference);
+
+            return usesOfBang
+                .Select(useOfBang => InspectionResult(useOfBang, State))
+                .ToList();
+        }
+
+        private bool IsRelevantReference(IdentifierReference reference)
+        {
+            return reference.IsIndexedDefaultMemberAccess
+                   && reference.DefaultMemberRecursionDepth == 1
+                   && reference.Context is VBAParser.DictionaryAccessContext
+                   && !reference.IsIgnoringInspectionResultFor(AnnotationName);
+        }
+
+        private IInspectionResult InspectionResult(IdentifierReference dictionaryAccess, IDeclarationFinderProvider declarationFinderProvider)
+        {
+            return new IdentifierReferenceInspectionResult(this,
+                ResultDescription(dictionaryAccess),
+                declarationFinderProvider,
+                dictionaryAccess);
+        }
+
+        private string ResultDescription(IdentifierReference dictionaryAccess)
+        {
+            var expression = dictionaryAccess.IdentifierName;
+            return string.Format(InspectionResults.UseOfBangNotationInspection, expression);
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfRecursiveBangNotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfRecursiveBangNotationInspection.cs
@@ -1,0 +1,86 @@
+﻿using Rubberduck.Inspections.Abstract;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Inspections.Inspections.Extensions;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections;
+
+namespace Rubberduck.Inspections.Concrete
+{
+    /// <summary>
+    /// Identifies the use of bang notation, formally known as dictionary access expression, for which a recursive default member resolution is necessary.
+    /// </summary>
+    /// <why>
+    /// A dictionary access expression looks like a strongly typed call, but it actually is a stringly typed access to the parameterized default member of the object.
+    /// This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first.  
+    /// </why>
+    /// <example hasResult="true">
+    /// <![CDATA[
+    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    ///     MyName = rst!Name.Value
+    /// End Function
+    /// ]]>
+    /// </example>
+    /// <example hasResult="true">
+    /// <![CDATA[
+    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    ///     With rst
+    ///         !Name.Value
+    ///     End With
+    /// End Function
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    ///     MyName = rst.Fields.Item("Name").Value
+    /// End Function
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    ///     MyName = rst("Name").Value
+    /// End Function
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    ///     MyName = rst.Fields!Name.Value
+    /// End Function
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    ///     With rst
+    ///         MyName = .Fields.Item("Name").Value
+    ///     End With
+    /// End Function
+    /// ]]>
+    /// </example>
+    public sealed class UseOfRecursiveBangNotationInspection : IdentifierReferenceInspectionBase
+    {
+        public UseOfRecursiveBangNotationInspection(RubberduckParserState state)
+            : base(state)
+        {
+            Severity = CodeInspectionSeverity.Suggestion;
+        }
+
+        protected override bool IsResultReference(IdentifierReference reference)
+        {
+            return reference.IsIndexedDefaultMemberAccess
+                   && reference.DefaultMemberRecursionDepth > 1
+                   && reference.Context is VBAParser.DictionaryAccessContext
+                   && !reference.IsIgnoringInspectionResultFor(AnnotationName);
+        }
+
+        protected override string ResultDescription(IdentifierReference reference)
+        {
+            var expression = reference.IdentifierName;
+            return string.Format(InspectionResults.UseOfRecursiveBangNotationInspection, expression);
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfRecursiveBangNotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfRecursiveBangNotationInspection.cs
@@ -48,7 +48,7 @@ namespace Rubberduck.Inspections.Concrete
     /// <example hasResult="false">
     /// <![CDATA[
     /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
-    ///     MyName = rst.Fields!Name.Value
+    ///     MyName = rst.Fields!Name.Value 'see "UseOfBangNotation" inspection
     /// End Function
     /// ]]>
     /// </example>

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfUnboundBangNotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UseOfUnboundBangNotationInspection.cs
@@ -1,30 +1,32 @@
-﻿using Rubberduck.Inspections.Abstract;
+﻿using System.Collections.Generic;
+using Rubberduck.Inspections.Abstract;
 using Rubberduck.Resources.Inspections;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Inspections.Inspections.Extensions;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Inspections;
+using Rubberduck.VBEditor;
 
 namespace Rubberduck.Inspections.Concrete
 {
     /// <summary>
-    /// Identifies the use of bang notation, formally known as dictionary access expression, for which a recursive default member resolution is necessary.
+    /// Identifies the use of bang notation, formally known as dictionary access expression, for which the default member is not known at compile time.
     /// </summary>
     /// <why>
     /// A dictionary access expression looks like a strongly typed call, but it actually is a stringly typed access to the parameterized default member of the object.
-    /// This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first.  
+    /// This is especially misleading the default member cannot be determined at compile time.  
     /// </why>
     /// <example hasResult="true">
     /// <![CDATA[
-    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    /// Public Function MyName(ByVal rst As Object) As Variant
     ///     MyName = rst!Name.Value
     /// End Function
     /// ]]>
     /// </example>
     /// <example hasResult="true">
     /// <![CDATA[
-    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    /// Public Function MyName(ByVal rst As Variant) As Variant
     ///     With rst
     ///         MyName = !Name.Value
     ///     End With
@@ -34,45 +36,42 @@ namespace Rubberduck.Inspections.Concrete
     /// <example hasResult="false">
     /// <![CDATA[
     /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
-    ///     MyName = rst.Fields.Item("Name").Value
+    ///     MyName = rst!Name.Value
     /// End Function
     /// ]]>
     /// </example>
     /// <example hasResult="false">
     /// <![CDATA[
-    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    /// Public Function MyName(ByVal rst As Object) As Variant
     ///     MyName = rst("Name").Value
     /// End Function
     /// ]]>
     /// </example>
     /// <example hasResult="false">
     /// <![CDATA[
-    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
-    ///     MyName = rst.Fields!Name.Value
-    /// End Function
-    /// ]]>
-    /// </example>
-    /// <example hasResult="false">
-    /// <![CDATA[
-    /// Public Function MyName(ByVal rst As ADODB.Recordset) As Variant
+    /// Public Function MyName(ByVal rst As Variant) As Variant
     ///     With rst
     ///         MyName = .Fields.Item("Name").Value
     ///     End With
     /// End Function
     /// ]]>
     /// </example>
-    public sealed class UseOfRecursiveBangNotationInspection : IdentifierReferenceInspectionBase
+    public sealed class UseOfUnboundBangNotationInspection : IdentifierReferenceInspectionBase
     {
-        public UseOfRecursiveBangNotationInspection(RubberduckParserState state)
+        public UseOfUnboundBangNotationInspection(RubberduckParserState state)
             : base(state)
         {
-            Severity = CodeInspectionSeverity.Suggestion;
+            Severity = CodeInspectionSeverity.Warning;
+        }
+
+        protected override IEnumerable<IdentifierReference> ReferencesInModule(QualifiedModuleName module)
+        {
+            return DeclarationFinderProvider.DeclarationFinder.UnboundDefaultMemberAccesses(module);
         }
 
         protected override bool IsResultReference(IdentifierReference reference)
         {
             return reference.IsIndexedDefaultMemberAccess
-                   && reference.DefaultMemberRecursionDepth > 1
                    && reference.Context is VBAParser.DictionaryAccessContext
                    && !reference.IsIgnoringInspectionResultFor(AnnotationName);
         }

--- a/Rubberduck.CodeAnalysis/QuickFixes/ExpandBangNotationQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/ExpandBangNotationQuickFix.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using Antlr4.Runtime;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.CodeAnalysis.QuickFixes
+{
+    public class ExpandBangNotationQuickFix : QuickFixBase
+    {
+        private readonly IDeclarationFinderProvider _declarationFinderProvider; 
+
+        public ExpandBangNotationQuickFix(IDeclarationFinderProvider declarationFinderProvider)
+        : base(typeof(UseOfBangNotationInspection), typeof(UseOfRecursiveBangNotationInspection))
+        {
+            _declarationFinderProvider = declarationFinderProvider;
+        }
+
+        public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
+        {
+            var rewriter = rewriteSession.CheckOutModuleRewriter(result.QualifiedSelection.QualifiedName);
+
+            var dictionaryAccessContext = (VBAParser.DictionaryAccessContext)result.Context;
+            AdjustArgument(dictionaryAccessContext, rewriter);
+
+            var finder = _declarationFinderProvider.DeclarationFinder;
+            var selection = result.QualifiedSelection;
+            InsertDefaultMember(dictionaryAccessContext, selection, finder, rewriter);
+        }
+
+        private void AdjustArgument(VBAParser.DictionaryAccessContext dictionaryAccessContext, IModuleRewriter rewriter)
+        {
+            var argumentContext = ArgumentContext(dictionaryAccessContext);
+            rewriter.InsertBefore(argumentContext.Start.TokenIndex, "(\"");
+            rewriter.InsertAfter(argumentContext.Stop.TokenIndex, "\")");
+        }
+
+        private ParserRuleContext ArgumentContext(VBAParser.DictionaryAccessContext dictionaryAccessContext)
+        {
+            if (dictionaryAccessContext.parent is VBAParser.DictionaryAccessExprContext dictionaryAccess)
+            {
+                return dictionaryAccess.unrestrictedIdentifier();
+            }
+
+            return ((VBAParser.WithDictionaryAccessExprContext) dictionaryAccessContext.parent).unrestrictedIdentifier();
+        }
+
+        private void InsertDefaultMember(VBAParser.DictionaryAccessContext dictionaryAccessContext, QualifiedSelection selection, DeclarationFinder finder, IModuleRewriter rewriter)
+        {
+            var defaultMemberAccessCode = DefaultMemberAccessCode(selection, finder);
+            rewriter.Replace(dictionaryAccessContext, defaultMemberAccessCode);
+        }
+
+        private string DefaultMemberAccessCode(QualifiedSelection selection, DeclarationFinder finder)
+        {
+            var defaultMemberAccesses = finder.IdentifierReferences(selection);
+            var defaultMemberNames = defaultMemberAccesses.Select(reference => reference.Declaration.IdentifierName);
+            return $".{string.Join("().", defaultMemberNames)}";
+        }
+
+        public override string Description(IInspectionResult result)
+        {
+            return Resources.Inspections.QuickFixes.ExpandBangNotationQuickFix;
+        }
+
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+    }
+}

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -118,6 +118,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             var callSiteContext = expression.Context;
             var identifier = expression.Context.GetText();
             var callee = expression.ReferencedDeclaration;
+            var selection = callSiteContext.GetSelection();
             expression.ReferencedDeclaration.AddReference(
                 module,
                 scope,
@@ -125,8 +126,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 callSiteContext,
                 identifier,
                 callee,
-                callSiteContext.GetSelection(),
-                FindIdentifierAnnotations(module, callSiteContext.GetSelection().StartLine),
+                selection,
+                FindIdentifierAnnotations(module, selection.StartLine),
                 isAssignmentTarget,
                 hasExplicitLetStatement,
                 isSetAssignment);
@@ -157,6 +158,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             var callSiteContext = expression.UnrestrictedNameContext;
             var identifier = expression.UnrestrictedNameContext.GetText();
             var callee = expression.ReferencedDeclaration;
+            var selection = callSiteContext.GetSelection();
             expression.ReferencedDeclaration.AddReference(
                 module,
                 scope,
@@ -164,8 +166,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 callSiteContext,
                 identifier,
                 callee,
-                callSiteContext.GetSelection(),
-                FindIdentifierAnnotations(module, callSiteContext.GetSelection().StartLine),
+                selection,
+                FindIdentifierAnnotations(module, selection.StartLine),
                 isAssignmentTarget,
                 hasExplicitLetStatement,
                 isSetAssignment);
@@ -712,8 +714,9 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             bool isSetAssignment)
         {
             var callSiteContext = expression.DefaultMemberContext;
-            var identifier = expression.ReferencedDeclaration.IdentifierName;
+            var identifier = expression.Context.GetText();
             var callee = expression.ReferencedDeclaration;
+            var selection = callSiteContext.GetSelection();
             expression.ReferencedDeclaration.AddReference(
                 module,
                 scope,
@@ -721,8 +724,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 callSiteContext,
                 identifier,
                 callee,
-                callSiteContext.GetSelection(),
-                FindIdentifierAnnotations(module, callSiteContext.GetSelection().StartLine),
+                selection,
+                FindIdentifierAnnotations(module, selection.StartLine),
                 isAssignmentTarget,
                 hasExplicitLetStatement,
                 isSetAssignment,
@@ -847,6 +850,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
         {
             var callSiteContext = expression.Context;
             var identifier = expression.Context.GetText();
+            var selection = callSiteContext.GetSelection();
             var callee = expression.ReferencedDeclaration;
             expression.ReferencedDeclaration.AddReference(
                 module,
@@ -855,8 +859,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 callSiteContext,
                 identifier,
                 callee,
-                callSiteContext.GetSelection(),
-                FindIdentifierAnnotations(module, callSiteContext.GetSelection().StartLine),
+                selection,
+                FindIdentifierAnnotations(module, selection.StartLine),
                 isAssignmentTarget,
                 hasExplicitLetStatement,
                 isSetAssignment);

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -872,6 +872,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on..
+        /// </summary>
+        public static string UseOfBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The VBA compiler does not raise an error if an object is used in a place that requires a value type and the object&apos;s declared type does not have a suitable default member. Under almost all circumstances, this leads to a run-time error 91 &apos;Object or With block variable not set&apos; or 438 &apos;Object doesn&apos;t support this property or method&apos; depending on whether the object has the value &apos;Nothing&apos; or not, which is harder to detect and indicates a bug..
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -890,6 +890,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading the default member cannot be determined at compile time..
+        /// </summary>
+        public static string UseOfUnboundBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfUnboundBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The VBA compiler does not raise an error if an object is used in a place that requires a value type and the object&apos;s declared type does not have a suitable default member. Under almost all circumstances, this leads to a run-time error 91 &apos;Object or With block variable not set&apos; or 438 &apos;Object doesn&apos;t support this property or method&apos; depending on whether the object has the value &apos;Nothing&apos; or not, which is harder to detect and indicates a bug..
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -872,7 +872,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on..
+        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly-typed access to the parameterized default member of the object it is used on..
         /// </summary>
         public static string UseOfBangNotationInspection {
             get {
@@ -881,7 +881,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first. .
+        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly-typed access to the parameterized default member of the object it is used on. This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first..
         /// </summary>
         public static string UseOfRecursiveBangNotationInspection {
             get {
@@ -890,7 +890,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading the default member cannot be determined at compile time..
+        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly-typed access to the parameterized default member of the object it is used on. This is especially misleading the default member cannot be determined at compile time..
         /// </summary>
         public static string UseOfUnboundBangNotationInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -881,6 +881,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first. .
+        /// </summary>
+        public static string UseOfRecursiveBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfRecursiveBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The VBA compiler does not raise an error if an object is used in a place that requires a value type and the object&apos;s declared type does not have a suitable default member. Under almost all circumstances, this leads to a run-time error 91 &apos;Object or With block variable not set&apos; or 438 &apos;Object doesn&apos;t support this property or method&apos; depending on whether the object has the value &apos;Nothing&apos; or not, which is harder to detect and indicates a bug..
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
@@ -403,4 +403,7 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   <data name="DefaultMemberRequiredInspection" xml:space="preserve">
     <value>Der VBA-Compiler gibt keinen Fehler aus, wenn ein Standardmemberzugriff nötig ist, aber der der deklarierte Type des Objekts keinen passenden Standardmember hat. In fast allen Fällen führt dies zu einem Laufzeitfehler91 'Objektvariable oder With-Blockvariable nicht festgelegt' oder 438 'Objekt unterstützt diese Eigenschaft oder Methode nicht' abhängig davon, ob die Variable den Wert 'Nothing' hat oder nicht, der schwerer zu entdecken ist und auf einen Programmierfehler hinweist.</value>
   </data>
+  <data name="UseOfBangNotationInspection" xml:space="preserve">
+    <value>Die Ausrufezeichennotation erweckt den Eindruck, dass es sich um einen Zugriff handelt, der Typchecks unterliegt. Allerdings handelt es sich lediglich um einen Zugriff auf den Standardmember des Objekts, auf das sie angewendent wird, bei dem das Argument als Zeichenkette übergeben wird.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
@@ -409,4 +409,7 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
     <value>Die Ausrufezeichennotation erweckt den Eindruck, dass es sich um einen Zugriff handelt, der Typchecks unterliegt. Allerdings handelt es sich lediglich um einen Zugriff auf den Standardmember des Objekts, auf das sie angewendet wird, bei dem das Argument als Zeichenkette übergeben wird. Dies ist besonders verwirrend, wenn der Standardmember des Objekts selber keine Zeichenkette akzeptiert und deshalb ein rekursiver Zugriff auf den parameterlosen Standardmember erfolgen muss.</value>
   </data>
+  <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
+    <value>Die Ausrufezeichennotation erweckt den Eindruck, dass es sich um einen Zugriff handelt, der Typchecks unterliegt. Allerdings handelt es sich lediglich um einen Zugriff auf den Standardmember des Objekts, auf das sie angewendet wird, bei dem das Argument als Zeichenkette übergeben wird. Dies ist besonders verwirrend, wenn der Standardmember nicht zum Zeitpunkt des Kompilierens ermittelt werden kann.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
@@ -404,6 +404,9 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
     <value>Der VBA-Compiler gibt keinen Fehler aus, wenn ein Standardmemberzugriff nötig ist, aber der der deklarierte Type des Objekts keinen passenden Standardmember hat. In fast allen Fällen führt dies zu einem Laufzeitfehler91 'Objektvariable oder With-Blockvariable nicht festgelegt' oder 438 'Objekt unterstützt diese Eigenschaft oder Methode nicht' abhängig davon, ob die Variable den Wert 'Nothing' hat oder nicht, der schwerer zu entdecken ist und auf einen Programmierfehler hinweist.</value>
   </data>
   <data name="UseOfBangNotationInspection" xml:space="preserve">
-    <value>Die Ausrufezeichennotation erweckt den Eindruck, dass es sich um einen Zugriff handelt, der Typchecks unterliegt. Allerdings handelt es sich lediglich um einen Zugriff auf den Standardmember des Objekts, auf das sie angewendent wird, bei dem das Argument als Zeichenkette übergeben wird.</value>
+    <value>Die Ausrufezeichennotation erweckt den Eindruck, dass es sich um einen Zugriff handelt, der Typchecks unterliegt. Allerdings handelt es sich lediglich um einen Zugriff auf den Standardmember des Objekts, auf das sie angewendet wird, bei dem das Argument als Zeichenkette übergeben wird.</value>
+  </data>
+  <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
+    <value>Die Ausrufezeichennotation erweckt den Eindruck, dass es sich um einen Zugriff handelt, der Typchecks unterliegt. Allerdings handelt es sich lediglich um einen Zugriff auf den Standardmember des Objekts, auf das sie angewendet wird, bei dem das Argument als Zeichenkette übergeben wird. Dies ist besonders verwirrend, wenn der Standardmember des Objekts selber keine Zeichenkette akzeptiert und deshalb ein rekursiver Zugriff auf den parameterlosen Standardmember erfolgen muss.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -406,4 +406,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="UseOfBangNotationInspection" xml:space="preserve">
     <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on.</value>
   </data>
+  <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
+    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first. </value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -404,12 +404,12 @@ If the parameter can be null, ignore this inspection result; passing a null valu
     <value>The VBA compiler does not raise an error if an indexed default member call is required but the object's declared type does not have a suitable default member. Under almost all circumstances, this leads to a run-time error 91 'Object or With block variable not set' or 438 'Object doesn't support this property or method' depending on whether the object has the value 'Nothing' or not, which is harder to detect and indicates a bug.</value>
   </data>
   <data name="UseOfBangNotationInspection" xml:space="preserve">
-    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on.</value>
+    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly-typed access to the parameterized default member of the object it is used on.</value>
   </data>
   <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
-    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first. </value>
+    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly-typed access to the parameterized default member of the object it is used on. This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first.</value>
   </data>
   <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
-    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading the default member cannot be determined at compile time.</value>
+    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly-typed access to the parameterized default member of the object it is used on. This is especially misleading the default member cannot be determined at compile time.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -403,4 +403,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="DefaultMemberRequiredInspection" xml:space="preserve">
     <value>The VBA compiler does not raise an error if an indexed default member call is required but the object's declared type does not have a suitable default member. Under almost all circumstances, this leads to a run-time error 91 'Object or With block variable not set' or 438 'Object doesn't support this property or method' depending on whether the object has the value 'Nothing' or not, which is harder to detect and indicates a bug.</value>
   </data>
+  <data name="UseOfBangNotationInspection" xml:space="preserve">
+    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -409,4 +409,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
     <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading if the parameterized default member is not on the object itself and can only be reached by calling the parameterless default member first. </value>
   </data>
+  <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
+    <value>Bang notation, formally known as dictionary access expression, looks like it is strongly typed. However, it is actually a stringly  typed access to the paramterized default member of the object it is used on. This is especially misleading the default member cannot be determined at compile time.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -880,6 +880,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use of recursive bang notation.
+        /// </summary>
+        public static string UseOfRecursiveBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfRecursiveBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Object used where a value is required.
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -871,6 +871,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use of bang notation.
+        /// </summary>
+        public static string UseOfBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Object used where a value is required.
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -889,6 +889,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use of unbound bang notation.
+        /// </summary>
+        public static string UseOfUnboundBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfUnboundBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Object used where a value is required.
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -387,4 +387,7 @@
   <data name="DefaultMemberRequiredInspection" xml:space="preserve">
     <value>Standardmemberzugriff ohne Standardmember</value>
   </data>
+  <data name="UseOfBangNotationInspection" xml:space="preserve">
+    <value>Verwendung der Ausrufezeichennotation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -393,4 +393,7 @@
   <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
     <value>Verwendung rekursiver Ausrufezeichennotation</value>
   </data>
+  <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
+    <value>Verwendung nicht gebundener Ausrufezeichennotation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -390,4 +390,7 @@
   <data name="UseOfBangNotationInspection" xml:space="preserve">
     <value>Verwendung der Ausrufezeichennotation</value>
   </data>
+  <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
+    <value>Verwendung rekursiver Ausrufezeichennotation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -413,4 +413,7 @@
   <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
     <value>Use of recursive bang notation</value>
   </data>
+  <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
+    <value>Use of unbound bang notation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -410,4 +410,7 @@
   <data name="UseOfBangNotationInspection" xml:space="preserve">
     <value>Use of bang notation</value>
   </data>
+  <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
+    <value>Use of recursive bang notation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -407,4 +407,7 @@
   <data name="DefaultMemberRequiredInspection" xml:space="preserve">
     <value>Indexed default member access without default member</value>
   </data>
+  <data name="UseOfBangNotationInspection" xml:space="preserve">
+    <value>Use of bang notation</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -946,6 +946,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The expression &apos;{0}&apos; contains a use of bang notation..
+        /// </summary>
+        public static string UseOfBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In a context that requires a value type, the expression &apos;{0}&apos; of object type &apos;{1}&apos; is used that does not have a suitable default member..
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -946,7 +946,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The expression &apos;{0}&apos; contains a use of bang notation..
+        ///   Looks up a localized string similar to The expression &apos;{0}&apos; uses bang notation..
         /// </summary>
         public static string UseOfBangNotationInspection {
             get {
@@ -955,7 +955,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The expression &apos;{0}&apos; contains a use of recursive bang notation..
+        ///   Looks up a localized string similar to The expression &apos;{0}&apos; uses a recursive bang operator..
         /// </summary>
         public static string UseOfRecursiveBangNotationInspection {
             get {
@@ -964,7 +964,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The expression &apos;{0}&apos; contains a use of unbound bang notation..
+        ///   Looks up a localized string similar to The expression &apos;{0}&apos; uses an unbound bang operator..
         /// </summary>
         public static string UseOfUnboundBangNotationInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -955,6 +955,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The expression &apos;{0}&apos; contains a use of recursive bang notation..
+        /// </summary>
+        public static string UseOfRecursiveBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfRecursiveBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In a context that requires a value type, the expression &apos;{0}&apos; of object type &apos;{1}&apos; is used that does not have a suitable default member..
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -964,6 +964,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The expression &apos;{0}&apos; contains a use of unbound bang notation..
+        /// </summary>
+        public static string UseOfUnboundBangNotationInspection {
+            get {
+                return ResourceManager.GetString("UseOfUnboundBangNotationInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In a context that requires a value type, the expression &apos;{0}&apos; of object type &apos;{1}&apos; is used that does not have a suitable default member..
         /// </summary>
         public static string ValueRequiredInspection {

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -428,4 +428,7 @@ In Memoriam, 1972-2018</value>
   <data name="DefaultMemberRequiredInspection" xml:space="preserve">
     <value>Der Ausdruck '{0}' erfordert einen Standardmemberzugriff, aber der Typ '{1}' hat keinen passenden Standardmember.</value>
   </data>
+  <data name="UseOfBangNotationInspection" xml:space="preserve">
+    <value>Der Ausdruck '{0}' verwendet Ausrufezeichennotation.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -434,4 +434,7 @@ In Memoriam, 1972-2018</value>
   <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
     <value>Der Ausdruck '{0}' verwendet rekursive Ausrufezeichennotation.</value>
   </data>
+  <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
+    <value>Der Ausdruck '{0}' verwendet nicht gebundene Ausrufezeichennotation.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -431,4 +431,7 @@ In Memoriam, 1972-2018</value>
   <data name="UseOfBangNotationInspection" xml:space="preserve">
     <value>Der Ausdruck '{0}' verwendet Ausrufezeichennotation.</value>
   </data>
+  <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
+    <value>Der Ausdruck '{0}' verwendet rekursive Ausrufezeichennotation.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -466,4 +466,8 @@ In memoriam, 1972-2018</value>
     <value>The expression '{0}' contains a use of recursive bang notation.</value>
     <comment>{0} expression</comment>
   </data>
+  <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
+    <value>The expression '{0}' contains a use of unbound bang notation.</value>
+    <comment>{0} expression</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -458,4 +458,8 @@ In memoriam, 1972-2018</value>
     <value>The expression '{0}' requires a default member access, but the type '{1}' does not have a suitable default member.</value>
     <comment>{0} expression; {1} type</comment>
   </data>
+  <data name="UseOfBangNotationInspection" xml:space="preserve">
+    <value>The expression '{0}' contains a use of bang notation.</value>
+    <comment>{0} expression</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -462,4 +462,8 @@ In memoriam, 1972-2018</value>
     <value>The expression '{0}' contains a use of bang notation.</value>
     <comment>{0} expression</comment>
   </data>
+  <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
+    <value>The expression '{0}' contains a use of recursive bang notation.</value>
+    <comment>{0} expression</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -459,15 +459,15 @@ In memoriam, 1972-2018</value>
     <comment>{0} expression; {1} type</comment>
   </data>
   <data name="UseOfBangNotationInspection" xml:space="preserve">
-    <value>The expression '{0}' contains a use of bang notation.</value>
+    <value>The expression '{0}' uses bang notation.</value>
     <comment>{0} expression</comment>
   </data>
   <data name="UseOfRecursiveBangNotationInspection" xml:space="preserve">
-    <value>The expression '{0}' contains a use of recursive bang notation.</value>
+    <value>The expression '{0}' uses a recursive bang operator.</value>
     <comment>{0} expression</comment>
   </data>
   <data name="UseOfUnboundBangNotationInspection" xml:space="preserve">
-    <value>The expression '{0}' contains a use of unbound bang notation.</value>
+    <value>The expression '{0}' uses an unbound bang operator.</value>
     <comment>{0} expression</comment>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -196,6 +196,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace bang notation with explicit access.
+        /// </summary>
+        public static string ExpandBangNotationQuickFix {
+            get {
+                return ResourceManager.GetString("ExpandBangNotationQuickFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ignore once.
         /// </summary>
         public static string IgnoreOnce {

--- a/Rubberduck.Resources/Inspections/QuickFixes.de.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.de.resx
@@ -291,4 +291,7 @@
   <data name="ReplaceWhileWendWithDoWhileLoopQuickFix" xml:space="preserve">
     <value>'While...Wend' durch'Do While...Loop' ersetzen</value>
   </data>
+  <data name="ExpandBangNotationQuickFix" xml:space="preserve">
+    <value>Ersetze die Ausrufezeichennotation durch einen expliziten Aufruf</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.resx
@@ -291,4 +291,7 @@
   <data name="ReplaceWhileWendWithDoWhileLoopQuickFix" xml:space="preserve">
     <value>Replace 'While...Wend' with 'Do While...Loop'</value>
   </data>
+  <data name="ExpandBangNotationQuickFix" xml:space="preserve">
+    <value>Replace bang notation with explicit access</value>
+  </data>
 </root>

--- a/RubberduckTests/Inspections/DefaultMemberRequiredInspectionTests.cs
+++ b/RubberduckTests/Inspections/DefaultMemberRequiredInspectionTests.cs
@@ -13,9 +13,7 @@ namespace RubberduckTests.Inspections
     [TestFixture]
     public class DefaultMemberRequiredInspectionTests : InspectionTestsBase
     {
-
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void ChainedDictionaryAccessFailedAtEnd_OneResult()
         {
@@ -53,8 +51,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void ChainedDictionaryAccessExpressionFailedAtStart_OneResult()
         {
@@ -92,8 +89,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedDictionaryAccessExpressionWithIndexedDefaultMemberAccess_OneResult()
         {
@@ -131,8 +127,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnVariable_WithoutArguments_OneResult()
         {
@@ -161,8 +156,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnVariable_WithArguments_OneResult()
         {
@@ -191,8 +185,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnArrayAccess_WithoutArguments_OneResult()
         {
@@ -221,8 +214,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnArrayAccess_WithArguments_OneResult()
         {
@@ -251,8 +243,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnOtherIndexExpression_WithoutArguments_OneResult()
         {
@@ -281,8 +272,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnOtherIndexExpression_WithArguments_OneResult()
         {
@@ -311,8 +301,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnParameterlessFunction_WithArguments_OneResult()
         {
@@ -341,8 +330,7 @@ End Function
             Assert.AreEqual(expectedSelection, actualSelection);
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void FailedIndexExpressionOnFunctionWithParameters_NoResult()
         {
@@ -367,8 +355,7 @@ End Function
             Assert.IsFalse(inspectionResults.Any());
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         [TestCase("String", "bar = \"Hello \" & Foo(Nothing)")]
         [TestCase("Class1", "Set Foo = Foo(Nothing)")]

--- a/RubberduckTests/Inspections/ProcedureRequiredInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureRequiredInspectionTests.cs
@@ -12,8 +12,7 @@ namespace RubberduckTests.Inspections
     public class ProcedureRequiredInspectionTests : InspectionTestsBase
     {
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         //This will be handled by another inspection, since it is a failed indexed default member resolution.
         public void FailedParameterizedProcedureCoercionReferenceOnEntireContext()
         {
@@ -51,8 +50,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void FailedNonParameterizedProcedureCoercionReferenceOnEntireContext()
         {
             var class1Code = @"
@@ -89,8 +87,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         //This will be handled by another inspection, since it is a failed indexed default member resolution.
         public void FailedParameterizedProcedureCoercionReferenceOnEntireContext_ExplicitCall()
         {
@@ -128,8 +125,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void FailedNonParameterizedProcedureCoercionReferenceOnEntireContext_ExplicitCall()
         {
             var class1Code = @"
@@ -166,8 +162,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void FailedNonParameterizedProcedureCoercionOnArrayAccessReferenceOnEntireContext()
         {
             var class1Code = @"
@@ -204,8 +199,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void FailedNonParameterizedProcedureCoercionOnArrayAccessReferenceOnEntireContext_ExplicitCall()
         {
             var class1Code = @"
@@ -240,9 +234,9 @@ End Sub
             var inspectionResults = InspectionResults(vbe.Object);
             Assert.AreEqual(1, inspectionResults.Count());
         }
+
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void SuccessfulParameterizedProcedureCoercionReferenceOnEntireContext()
         {
             var class1Code = @"
@@ -280,8 +274,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void SuccessfulNonParameterizedProcedureCoercionReferenceOnEntireContext()
         {
             var class1Code = @"
@@ -319,8 +312,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void SuccessfulParameterizedProcedureCoercionReferenceOnEntireContext_ExplicitCall()
         {
             var class1Code = @"
@@ -358,8 +350,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void SuccessfulNonParameterizedProcedureCoercionReferenceOnEntireContext_ExplicitCall()
         {
             var class1Code = @"
@@ -397,8 +388,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void SuccessfulNonParameterizedProcedureCoercionOnArrayAccessReferenceOnEntireContext()
         {
             var class1Code = @"
@@ -437,8 +427,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         public void SuccessfulNonParameterizedProcedureCoercionOnArrayAccessReferenceOnEntireContext_ExplicitCall()
         {
             var class1Code = @"
@@ -476,8 +465,7 @@ End Sub
             Assert.IsFalse(inspectionResults.Any());
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         [TestCase("", "Call Foo")]
         [TestCase("", "Call Foo()")]

--- a/RubberduckTests/Inspections/UseOfBangNotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/UseOfBangNotationInspectionTests.cs
@@ -1,0 +1,328 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class UseOfBangNotationInspectionTests : InspectionTestsBase
+    {
+        [Test]
+        [Category("Inspections")]
+        public void DictionaryAccessExpression_OneResult()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+        [Test]
+        [Category("Inspections")]
+        public void WithDictionaryAccessExpression_OneResult()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    With New Class1
+        Set Foo = !newClassObject
+    End With
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ChainedDictionaryAccessExpression_OneResultEach()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject!whatever
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(2, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void IndexedDefaultMemberAccessExpression_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls(""newClassObject"")
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExplicitCall_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls.Foo(""newClassObject"")
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //Covered by UseOfUnboundBangInspection.
+        public void UnboundDictionaryAccessExpression_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+    Set Foo = New Class2
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+    Set Baz = New Class2
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As Object
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void DictionaryAccessOnDefaultMemberArrayAccess_OneResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2()
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls(0)!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //Covered by UseOfRecursiveBangInspection.
+        public void RecursiveDictionaryAccessOnDefaultMemberArrayAccess_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class3()
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var class3Code = @"
+Public Function Baz() As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls(0)!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Class3", class3Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //Covered by UseOfUnboundBangInspection.
+        public void RecursiveUnboundDictionaryAccessExpression_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Object
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new UseOfBangNotationInspection(state);
+        }
+    }
+}

--- a/RubberduckTests/Inspections/UseOfRecursiveBangNotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/UseOfRecursiveBangNotationInspectionTests.cs
@@ -1,0 +1,326 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class UseOfRecursiveBangNotationInspectionTests : InspectionTestsBase
+    {
+        [Test]
+        [Category("Inspections")]
+        public void RecursiveDictionaryAccessExpression_OneResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+        [Test]
+        [Category("Inspections")]
+        public void RecursiveWithDictionaryAccessExpression_OneResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    With New Class1
+        Set Foo = !newClassObject
+    End With
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ChainedRecursiveDictionaryAccessExpression_OneResultEach()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class3
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var class3Code = @"
+Public Function Baz() As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject!whatever
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Class3", class3Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(2, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void RecursiveIndexedDefaultMemberAccessExpression_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls(""newClassObject"")
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExplicitCall_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls.Foo(""newClassObject"")
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //Covered by UseOfUnboundBangInspection.
+        public void UnboundDictionaryAccessExpression_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2
+Attribute Foo.VB_UserMemId = 0
+    Set Foo = New Class2
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+    Set Baz = New Class2
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As Object
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void RecursiveDictionaryAccessOnDefaultMemberArrayAccess_OneResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class3()
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var class3Code = @"
+Public Function Baz() As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls(0)!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Class3", class3Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void NonRecursiveDictionaryAccessOnDefaultMemberArrayAccess_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2()
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls(0)!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void NonRecursiveDictionaryAccessExpression_NoResult()
+        {
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class2
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new UseOfRecursiveBangNotationInspection(state);
+        }
+    }
+}

--- a/RubberduckTests/Inspections/UseOfUnboundBangNotationInspectionTests.cs
+++ b/RubberduckTests/Inspections/UseOfUnboundBangNotationInspectionTests.cs
@@ -1,0 +1,192 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class UseOfUnboundBangNotationInspectionTests : InspectionTestsBase
+    {
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Class1", 0)]
+        [TestCase("Object", 1)]
+        [TestCase("Variant", 1)]
+        public void DictionaryAccessExpression(string typeName, int expectedNumberOfResults)
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = $@"
+Private Function Foo() As Class2 
+    Dim cls As {typeName}
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(expectedNumberOfResults, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Class1", 0)]
+        [TestCase("Object", 1)]
+        [TestCase("Variant", 1)]
+        public void WithDictionaryAccessExpression(string typeName, int expectedNumberOfResults)
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = $@"
+Private Function Foo() As Class2 
+    Dim bar As {typeName}
+    With bar
+        Set Foo = !newClassObject
+    End With
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(expectedNumberOfResults, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ChainedUnboundDictionaryAccessExpression_OneResultEach()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Object
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Object
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As Object
+    Set Foo = cls!newClassObject!whatever
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(2, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void IndexedDefaultMemberAccessExpression_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As Object
+    Set Foo = cls(""newClassObject"")
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void RecursiveUnboundDictionaryAccessExpression_OneResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Object
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new UseOfUnboundBangNotationInspection(state);
+        }
+    }
+}

--- a/RubberduckTests/Inspections/ValueRequiredInspectionTests.cs
+++ b/RubberduckTests/Inspections/ValueRequiredInspectionTests.cs
@@ -13,8 +13,7 @@ namespace RubberduckTests.Inspections
     public class ValueRequiredInspectionTests : InspectionTestsBase
     {
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [TestCase("    Bar cls.Baz")]
         [TestCase("    Baz (cls.Baz)")]
         [TestCase("    Debug.Print cls.Baz")]
@@ -151,8 +150,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [TestCase("    Foo = cls.Baz")]
         [TestCase("    Let Foo = cls.Baz")]
         [TestCase("    Foo = cls.Baz + 42")]
@@ -239,8 +237,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [TestCase("    Foo = cls.Baz")]
         [TestCase("    Let Foo = cls.Baz")]
         [TestCase("    fooBaz(42) = cls.Baz")]
@@ -297,8 +294,7 @@ End Sub
         }
 
         [Test]
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [TestCase("    cls.Baz = 42")]
         [TestCase("    Let cls.Baz = 42")]
         [TestCase("    cls.Bar(42) = 42")]
@@ -342,8 +338,7 @@ End Sub
             Assert.IsFalse(inspectionResults.Any());
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void ParamArray_NoResult()
         {
@@ -371,8 +366,7 @@ End Function
             Assert.IsFalse(inspectionResults.Any());
         }
 
-        [Category("Grammar")]
-        [Category("Resolver")]
+        [Category("Inspections")]
         [Test]
         public void ParamArrayInLibrary_NoResult()
         {

--- a/RubberduckTests/QuickFixes/ExpandBangNotationQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ExpandBangNotationQuickFixTests.cs
@@ -1,0 +1,176 @@
+﻿using NUnit.Framework;
+using Rubberduck.CodeAnalysis.QuickFixes;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.QuickFixes
+{
+    public class ExpandBangNotationQuickFixTests : QuickFixTestBase
+    {
+        [Test]
+        [Category("QuickFixes")]
+        public void DictionaryAccessExpression_QuickFixWorks()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var expectedModuleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls.Foo(""newClassObject"")
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfBangNotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedModuleCode, actualModuleCode);
+        }
+        [Test]
+        [Category("QuickFixes")]
+        public void RecursiveDictionaryAccessExpression_QuickFixWorks()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls!newClassObject
+End Function
+";
+
+            var expectedModuleCode = @"
+Private Function Foo() As Class2 
+    Dim cls As New Class1
+    Set Foo = cls.Foo().Baz(""newClassObject"")
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfRecursiveBangNotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedModuleCode, actualModuleCode);
+        }
+        [Test]
+        [Category("QuickFixes")]
+        public void WithDictionaryAccessExpression_QuickFixWorks()
+        {
+            var class1Code = @"
+Public Function Foo(bar As String) As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    With New Class1
+        Set Foo = !newClassObject
+    End With
+End Function
+";
+
+            var expectedModuleCode = @"
+Private Function Foo() As Class2 
+    With New Class1
+        Set Foo = .Foo(""newClassObject"")
+    End With
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfBangNotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedModuleCode, actualModuleCode);
+        }
+        [Test]
+        [Category("QuickFixes")]
+        public void RecursiveWithDictionaryAccessExpression_QuickFixWorks()
+        {
+            var class1Code = @"
+Public Function Foo() As Class2
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Function Baz(bar As String) As Class2
+Attribute Baz.VB_UserMemId = 0
+End Function
+";
+
+            var moduleCode = @"
+Private Function Foo() As Class2 
+    With New Class1
+        Set Foo = !newClassObject
+    End With
+End Function
+";
+
+            var expectedModuleCode = @"
+Private Function Foo() As Class2 
+    With New Class1
+        Set Foo = .Foo().Baz(""newClassObject"")
+    End With
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfRecursiveBangNotationInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedModuleCode, actualModuleCode);
+        }
+
+        protected override IQuickFix QuickFix(RubberduckParserState state)
+        {
+            return new ExpandBangNotationQuickFix(state);
+        }
+    }
+}


### PR DESCRIPTION
Closes #4406 
Deals with the non-control part of issue #5093 

This PR introduces the `UseOfBangNotationInspection`, which finds all uses of the bang operator. It also provides a quick fix that turns the bang notation into an explicit default member access, passing the argument as a string.