### PR TITLE
Suspicious Let assignment inspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/SuspiciousLetAssignmentInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/SuspiciousLetAssignmentInspection.cs
@@ -1,0 +1,180 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Inspections.Abstract;
+using Rubberduck.Inspections.Inspections.Extensions;
+using Rubberduck.Inspections.Results;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Inspections;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.Resources.Inspections;
+using Rubberduck.VBEditor;
+
+namespace Rubberduck.Inspections.Concrete
+{
+    /// <summary>
+    /// Identifies assignments without Set for which both sides are objects.
+    /// </summary>
+    /// <why>
+    /// Whenever both sides of an assignment without Set are objects, there is an assignment from the default member of the RHS to the one on the LHS.
+    /// Although this might be intentional, in many situations it will just mask an erroneously forgotten Set. 
+    /// </why>
+    /// <example hasResult="true">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal rng As Excel.Range, ByVal arg As ADODB Field)
+    ///     rng = arg
+    /// End Sub
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal rng As Excel.Range, ByVal arg As ADODB Field)
+    ///     rng.Value = arg.Value
+    /// End Sub
+    /// ]]>
+    /// </example>
+    /// <example hasResult="false">
+    /// <![CDATA[
+    /// Public Sub DoSomething(ByVal rng As Excel.Range, ByVal arg As ADODB Field)
+    ///     Let rng = arg
+    /// End Sub
+    /// ]]>
+    /// </example>
+    public sealed class SuspiciousLetAssignmentInspection : InspectionBase
+    {
+        private readonly IDeclarationFinderProvider _declarationFinderProvider;
+
+        public SuspiciousLetAssignmentInspection(RubberduckParserState state)
+            : base(state)
+        {
+            _declarationFinderProvider = state;
+            Severity = CodeInspectionSeverity.Warning;
+        }
+
+        protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
+        {
+            var results = new List<IInspectionResult>();
+            foreach (var moduleDeclaration in State.DeclarationFinder.UserDeclarations(DeclarationType.Module))
+            {
+                if (moduleDeclaration == null || moduleDeclaration.IsIgnoringInspectionResultFor(AnnotationName))
+                {
+                    continue;
+                }
+
+                var module = moduleDeclaration.QualifiedModuleName;
+                results.AddRange(DoGetInspectionResults(module));
+            }
+
+            return results;
+        }
+
+        private IEnumerable<IInspectionResult> DoGetInspectionResults(QualifiedModuleName module)
+        {
+            var finder = _declarationFinderProvider.DeclarationFinder;
+            return BoundLhsInspectionResults(module, finder)
+                .Concat(UnboundLhsInspectionResults(module, finder));
+        }
+
+        private IEnumerable<IInspectionResult> BoundLhsInspectionResults(QualifiedModuleName module, DeclarationFinder finder)
+        {
+            var implicitDefaultMemberAssignments = finder
+                .IdentifierReferences(module)
+                .Where(IsImplicitDefaultMemberAssignment)
+                .ToList();
+
+            var results = new List<IInspectionResult>();
+            foreach (var assignment in implicitDefaultMemberAssignments)
+            {
+                var (rhsDefaultMemberAccess, isUnbound) = RhsImplicitDefaultMemberAccess(assignment, finder);
+
+                if (rhsDefaultMemberAccess != null)
+                {
+                    var result = InspectionResult(assignment, rhsDefaultMemberAccess, isUnbound, _declarationFinderProvider);
+                    results.Add(result);
+                }
+            }
+
+            return results;
+        }
+
+        private bool IsImplicitDefaultMemberAssignment(IdentifierReference reference)
+        {
+            return reference.IsNonIndexedDefaultMemberAccess
+                   && reference.IsAssignment
+                   && !reference.IsSetAssignment
+                   && !reference.HasExplicitLetStatement
+                   && !reference.IsIgnoringInspectionResultFor(AnnotationName);
+        }
+
+        private (IdentifierReference identifierReference, bool isUnbound) RhsImplicitDefaultMemberAccess(IdentifierReference assignment, DeclarationFinder finder)
+        {
+            if (!(assignment.Context.Parent is VBAParser.LetStmtContext letStatement))
+            {
+                return (null, false);
+            }
+
+            var rhsSelection = new QualifiedSelection(assignment.QualifiedModuleName, letStatement.expression().GetSelection());
+
+            var boundRhsDefaultMemberAccess = finder.IdentifierReferences(rhsSelection)
+                .FirstOrDefault(reference => reference.IsNonIndexedDefaultMemberAccess
+                                             && !reference.IsInnerRecursiveDefaultMemberAccess);
+            if (boundRhsDefaultMemberAccess != null)
+            {
+                return (boundRhsDefaultMemberAccess, false);
+            }
+
+            var unboundRhsDefaultMemberAccess = finder.UnboundDefaultMemberAccesses(rhsSelection.QualifiedName)
+                .FirstOrDefault(reference => reference.IsNonIndexedDefaultMemberAccess
+                                             && !reference.IsInnerRecursiveDefaultMemberAccess
+                                             && reference.Selection.Equals(rhsSelection.Selection));
+            return (unboundRhsDefaultMemberAccess, true);
+        }
+
+        private IInspectionResult InspectionResult(IdentifierReference lhsReference, IdentifierReference rhsReference, bool isUnbound, IDeclarationFinderProvider declarationFinderProvider)
+        {
+            var result = new IdentifierReferenceInspectionResult(
+                this,
+                ResultDescription(lhsReference, rhsReference),
+                declarationFinderProvider,
+                lhsReference);
+            result.Properties.RhSReference = rhsReference;
+            if (isUnbound)
+            {
+                result.Properties.DisableFixes = "ExpandDefaultMemberQuickFix";
+            }
+
+            return result;
+        }
+
+        private string ResultDescription(IdentifierReference lhsReference, IdentifierReference rhsReference)
+        {
+            var lhsExpression = lhsReference.IdentifierName;
+            var rhsExpression = rhsReference.IdentifierName;
+            return string.Format(InspectionResults.SuspiciousLetAssignmentInspection, lhsExpression, rhsExpression);
+        }
+
+        private IEnumerable<IInspectionResult> UnboundLhsInspectionResults(QualifiedModuleName module, DeclarationFinder finder)
+        {
+            var implicitDefaultMemberAssignments = finder
+                .UnboundDefaultMemberAccesses(module)
+                .Where(IsImplicitDefaultMemberAssignment);
+
+            var results = new List<IInspectionResult>();
+            foreach (var assignment in implicitDefaultMemberAssignments)
+            {
+                var (rhsDefaultMemberAccess, isUnbound) = RhsImplicitDefaultMemberAccess(assignment, finder);
+
+                if (rhsDefaultMemberAccess != null)
+                {
+                    var result = InspectionResult(assignment, rhsDefaultMemberAccess, true, _declarationFinderProvider);
+                    results.Add(result);
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/QuickFixes/ExpandDefaultMemberQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/ExpandDefaultMemberQuickFix.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Abstract;
 using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.VBEditor;
@@ -20,7 +21,8 @@ namespace Rubberduck.CodeAnalysis.QuickFixes
             typeof(IndexedDefaultMemberAccessInspection), 
             typeof(IndexedRecursiveDefaultMemberAccessInspection), 
             typeof(ImplicitDefaultMemberAccessInspection), 
-            typeof(ImplicitRecursiveDefaultMemberAccessInspection))
+            typeof(ImplicitRecursiveDefaultMemberAccessInspection),
+            typeof(SuspiciousLetAssignmentInspection))
         {
             _declarationFinderProvider = declarationFinderProvider;
         }
@@ -33,6 +35,14 @@ namespace Rubberduck.CodeAnalysis.QuickFixes
             var lExpressionContext = result.Context;
             var selection = result.QualifiedSelection;
             InsertDefaultMember(lExpressionContext, selection, finder, rewriter);
+
+            if (result.Inspection is SuspiciousLetAssignmentInspection)
+            {
+                IdentifierReference rhsReference = result.Properties.RhSReference;
+                var rhsLExpressionContext = rhsReference.Context;
+                var rhsSelection = rhsReference.QualifiedSelection;
+                InsertDefaultMember(rhsLExpressionContext, rhsSelection, finder, rewriter);
+            }
         }
 
         private void InsertDefaultMember(ParserRuleContext lExpressionContext, QualifiedSelection selection, DeclarationFinder finder, IModuleRewriter rewriter)

--- a/Rubberduck.CodeAnalysis/QuickFixes/UseSetKeywordForObjectAssignmentQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/UseSetKeywordForObjectAssignmentQuickFix.cs
@@ -10,7 +10,7 @@ namespace Rubberduck.Inspections.QuickFixes
     public sealed class UseSetKeywordForObjectAssignmentQuickFix : QuickFixBase
     {
         public UseSetKeywordForObjectAssignmentQuickFix()
-            : base(typeof(ObjectVariableNotSetInspection))
+            : base(typeof(ObjectVariableNotSetInspection), typeof(SuspiciousLetAssignmentInspection))
         {}
 
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)

--- a/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
@@ -298,14 +298,21 @@ namespace Rubberduck.Parsing.Binding
                 named arguments. In this case, the index expression is classified as an unbound member with 
                 a declared type of Variant, referencing <l-expression> with no member name. 
              */
-            if (
-                (Tokens.Variant.Equals(asTypeName, StringComparison.InvariantCultureIgnoreCase)
-                    || Tokens.Object.Equals(asTypeName, StringComparison.InvariantCultureIgnoreCase))
+            if (Tokens.Variant.Equals(asTypeName, StringComparison.InvariantCultureIgnoreCase)
+                && !argumentList.HasNamedArguments)
+            {
+                ResolveArgumentList(null, argumentList);
+                //We do not treat unbound accesses on variables of type Variant as default member accesses because they could be array accesses as well. 
+                return new IndexExpression(null, ExpressionClassification.Unbound, expression, _lExpression, argumentList, isDefaultMemberAccess: false, defaultMemberRecursionDepth: defaultMemberResolutionRecursionDepth, containedDefaultMemberRecursionExpression: containedExpression);
+            }
+
+            if (Tokens.Object.Equals(asTypeName, StringComparison.InvariantCultureIgnoreCase)
                 && !argumentList.HasNamedArguments)
             {
                 ResolveArgumentList(null, argumentList);
                 return new IndexExpression(null, ExpressionClassification.Unbound, expression, _lExpression, argumentList, isDefaultMemberAccess: true, defaultMemberRecursionDepth: defaultMemberResolutionRecursionDepth, containedDefaultMemberRecursionExpression: containedExpression);
             }
+
             /*
                 The declared type of <l-expression> is a specific class, which has a public default Property 
                 Get, Property Let, function or subroutine, and one of the following is true:

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -33,9 +33,8 @@ namespace Rubberduck.Parsing.Symbols
         {
             ParentScoping = parentScopingDeclaration;
             ParentNonScoping = parentNonScopingDeclaration;
-            QualifiedModuleName = qualifiedName;
+            QualifiedSelection = new QualifiedSelection(qualifiedName, selection);
             IdentifierName = identifierName;
-            Selection = selection;
             Context = context;
             Declaration = declaration;
             HasExplicitLetStatement = hasExplicitLetStatement;
@@ -50,11 +49,11 @@ namespace Rubberduck.Parsing.Symbols
             IsInnerRecursiveDefaultMemberAccess = isInnerRecursiveDefaultMemberAccess;
         }
 
-        public QualifiedModuleName QualifiedModuleName { get; }
+        public QualifiedSelection QualifiedSelection { get; }
+        public QualifiedModuleName QualifiedModuleName => QualifiedSelection.QualifiedName;
+        public Selection Selection => QualifiedSelection.Selection;
 
         public string IdentifierName { get; }
-
-        public Selection Selection { get; }
 
         /// <summary>
         /// Gets the scoping <see cref="Declaration"/> that contains this identifier reference,

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -250,6 +250,11 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 Visit(expression.LExpression, module, scope, parent, hasExplicitLetStatement: hasExplicitLetStatement);
                 AddArrayAccessReference(expression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment);
             }
+            else if (expression.Classification == ExpressionClassification.Unbound
+                     && expression.ReferencedDeclaration == null)
+            {
+                Visit(expression.LExpression, module, scope, parent);
+            }
             else
             {
                 // Index expressions are a bit special in that they can refer to parameterized properties and functions.

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -862,6 +862,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Whenever both sides of an assignment without Set are objects, there is an assignment from the default member of the RHS to the one on the LHS. Although this might be intentional, in many situations it will just mask an erroneously forgotten Set..
+        /// </summary>
+        public static string SuspiciousLetAssignmentInspection {
+            get {
+                return ResourceManager.GetString("SuspiciousLetAssignmentInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This is likely a bug. A variable is being referred to, but is never assigned..
         /// </summary>
         public static string UnassignedVariableUsageInspection {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.de.resx
@@ -427,4 +427,7 @@ Falls der Parameter 'null' sein kann, bitte dieses Auftreten ignorieren. 'null' 
   <data name="ImplicitUnboundDefaultMemberAccessInspection" xml:space="preserve">
     <value>Zugriffe auf Standardmember verstecken, welcher Member aufgerufen wird. Dies ist besonders verwirrend, wenn in dem Ausdruck selber keine Indikation vorhanden ist, dass ein solcher Zugriff erfolgt, und zudem der Standardmember erst zur Laufzeit ermittelt werden kann. Dies kann dazu führen, dass Fehler durch vergessene Memberaufrufe nicht erkannt werden. Sollte weiterhin zur Laufzeit kein Standardmember auf dem Objekt existsieren, so kommt es zu einem Fehler 438 'Objekt unterstützt diese Eigenschaft oder Methode nicht'.</value>
   </data>
+  <data name="SuspiciousLetAssignmentInspection" xml:space="preserve">
+    <value>Wenn beide Seiten einer Zuweisung ohne Set Objekte sind, kommt es zu einer Zuweisung vom Standardmember der rechten Seite zu dem der linken. Auch wenn dies manchmal beabsichtigt sein kann, kann es in vielen Fällen dazu führen, dass nicht bemerkt wird, dass Set fehlerhafter Weise vergessen wurde.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -430,4 +430,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="ImplicitUnboundDefaultMemberAccessInspection" xml:space="preserve">
     <value>Default member accesses hide away the actually called member. This is especially misleading if there is no indication in the expression that such a call is made and if the default member cannot be determined from the declared type of the object. As a consequence, errors in which a member was forgotten to be called can go unnoticed and should there not be a suitable default member at runtime, an error 438 'Object doesn't support this property or method' will be raised.</value>
   </data>
+  <data name="SuspiciousLetAssignmentInspection" xml:space="preserve">
+    <value>Whenever both sides of an assignment without Set are objects, there is an assignment from the default member of the RHS to the one on the LHS. Although this might be intentional, in many situations it will just mask an erroneously forgotten Set.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -862,6 +862,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Suspicious Let assignment.
+        /// </summary>
+        public static string SuspiciousLetAssignmentInspection {
+            get {
+                return ResourceManager.GetString("SuspiciousLetAssignmentInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Variable is used but not assigned.
         /// </summary>
         public static string UnassignedVariableUsageInspection {

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -414,4 +414,7 @@
   <data name="ImplicitUnboundDefaultMemberAccessInspection" xml:space="preserve">
     <value>Impliziter nicht gebundener Zugriff auf einen Standardmember</value>
   </data>
+  <data name="SuspiciousLetAssignmentInspection" xml:space="preserve">
+    <value>Verdächtige Let-Zuweisung</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -434,4 +434,7 @@
   <data name="ImplicitUnboundDefaultMemberAccessInspection" xml:space="preserve">
     <value>Implicit unbound default member access</value>
   </data>
+  <data name="SuspiciousLetAssignmentInspection" xml:space="preserve">
+    <value>Suspicious Let assignment</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -889,6 +889,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is an assignment from the default member of the result of expression &apos;{1}&apos; to that of the expression &apos;{0}&apos;..
+        /// </summary>
+        public static string SuspiciousLetAssignmentInspection {
+            get {
+                return ResourceManager.GetString("SuspiciousLetAssignmentInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}
         ///Andrew &quot;ThunderFrame&quot; Jackson would be proud! 
         ///You&apos;re seeing this inspection result because there&apos;s no way that&apos;s real code and you&apos;re just pushing the limits of Rubberduck&apos;s parsing and resolving capabilities, right? ...RIGHT? 

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -437,4 +437,7 @@ In Memoriam, 1972-2018</value>
   <data name="ImplicitUnboundDefaultMemberAccessInspection" xml:space="preserve">
     <value>Für den Ausdruck '{0}' kommt es zu einem impliziten nicht gebundenen Standardmemberzugriff.</value>
   </data>
+  <data name="SuspiciousLetAssignmentInspection" xml:space="preserve">
+    <value>Es wird vom Standardmember des Resultats des Ausdrucks '{1}' dem des Resultats des Ausdrucks '{0}' zugewiesen.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -494,4 +494,8 @@ In memoriam, 1972-2018</value>
     <value>On the expression '{0}', there is an implicit unbound default member access.</value>
     <comment>{0} expression</comment>
   </data>
+  <data name="SuspiciousLetAssignmentInspection" xml:space="preserve">
+    <value>There is an assignment from the default member of the result of expression '{1}' to that of the expression '{0}'.</value>
+    <comment>{0} lhsExpression; {1} rhsExpression</comment>
+  </data>
 </root>

--- a/RubberduckTests/Inspections/IndexedUnboundDefaultMemberAccessInspectionTests.cs
+++ b/RubberduckTests/Inspections/IndexedUnboundDefaultMemberAccessInspectionTests.cs
@@ -184,6 +184,26 @@ End Function
             Assert.AreEqual(1, inspectionResults.Count());
         }
 
+        [Test]
+        [Category("Inspections")]
+        public void JaggedArray_NoResult()
+        {
+            var moduleCode = @"
+Private Function Foo() As Variant 
+    Dim outerArray() As Variant
+    Dim firstInnerArray() As Variant
+    Dim secondInnerArray() As Variant
+    outerArray = Array(firstInnerArray, secondInnerArray)
+    Foo = outerArray(0)(0)
+End Function
+";
+
+            var inspectionResults = InspectionResultsForStandardModule(moduleCode);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+
         protected override IInspection InspectionUnderTest(RubberduckParserState state)
         {
             return new IndexedUnboundDefaultMemberAccessInspection(state);

--- a/RubberduckTests/Inspections/SuspiciousLetAssignmentInspectionTests.cs
+++ b/RubberduckTests/Inspections/SuspiciousLetAssignmentInspectionTests.cs
@@ -1,0 +1,178 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class SuspiciousLetAssignmentInspectionTests : InspectionTestsBase
+    {
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Class1", "Class2")]
+        [TestCase("Object", "Class2")]
+        [TestCase("Class1", "Object")]
+        [TestCase("Object", "Object")]
+        public void BothSidesOfAssignmentHaveDefaultMemberAccess_NoExplicitLet_OneResult(string assignedTypeName, string assignedToTypeName)
+        {
+            var class1Code = @"
+Public Function Foo() As Long
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Property Let Baz(RHS As Long)
+Attribute Baz.VB_UserMemId = 0
+End Property
+";
+
+            var moduleCode = $@"
+Private Sub Bar() 
+    Dim cls1 As {assignedTypeName}
+    Dim cls2 As {assignedToTypeName} 
+    Set cls1 = New Class1
+    Set cls2 = New Class2
+    cls2 = cls1
+End Sub
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+            var inspectionResult = inspectionResults.Single();
+
+            Assert.IsNotNull(inspectionResult.Properties.RhSReference);
+
+            if (assignedTypeName.Equals("Object") || assignedToTypeName.Equals("Object"))
+            {
+                var deactivatedFixes = inspectionResult.Properties.DisableFixes;
+                Assert.AreEqual("ExpandDefaultMemberQuickFix", deactivatedFixes);
+            }
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Class1", "Class2")]
+        [TestCase("Object", "Class2")]
+        [TestCase("Class1", "Object")]
+        [TestCase("Object", "Object")]
+        public void BothSidesOfAssignmentHaveDefaultMemberAccess_ExplicitLet_NoResult(string assignedTypeName, string assignedToTypeName)
+        {
+            var class1Code = @"
+Public Function Foo() As Long
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Property Let Baz(RHS As Long)
+Attribute Baz.VB_UserMemId = 0
+End Property
+";
+
+            var moduleCode = $@"
+Private Sub Bar() 
+    Dim cls1 As {assignedTypeName}
+    Dim cls2 As {assignedToTypeName} 
+    Set cls1 = New Class1
+    Set cls2 = New Class2
+    Let cls2 = cls1
+End Sub
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //This is covered by ObjectVariableNotSetInspection
+        public void LeftSideFailedDefaultMemberResolution_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Long
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Property Let Baz(RHS As Long)
+End Property
+";
+
+            var moduleCode = @"
+Private Sub Bar() 
+    Dim cls1 As Class1
+    Dim cls2 As Class2
+    Set cls1 = New Class1
+    Set cls2 = New Class2
+    Let cls2 = cls1
+End Sub
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //This is covered by ObjectVariableNotSetInspection
+        public void RightSideFailedDefaultMemberResolution_NoResult()
+        {
+            var class1Code = @"
+Public Function Foo() As Long
+End Function
+";
+
+            var class2Code = @"
+Public Property Let Baz(RHS As Long)
+Attribute Baz.VB_UserMemId = 0
+End Property
+";
+
+            var moduleCode = @"
+Private Sub Bar() 
+    Dim cls1 As Class1
+    Dim cls2 As Class2
+    Set cls1 = New Class1
+    Set cls2 = New Class2
+    Let cls2 = cls1
+End Sub
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new SuspiciousLetAssignmentInspection(state);
+        }
+    }
+}

--- a/RubberduckTests/QuickFixes/ExpandBangNotationQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ExpandBangNotationQuickFixTests.cs
@@ -3,7 +3,6 @@ using Rubberduck.CodeAnalysis.QuickFixes;
 using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
-using Rubberduck.Parsing.VBA.Parsing;
 using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;
 
@@ -46,7 +45,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfBangNotationInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfBangNotationInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -85,7 +84,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfRecursiveBangNotationInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfRecursiveBangNotationInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -126,7 +125,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfBangNotationInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfBangNotationInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -167,7 +166,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfRecursiveBangNotationInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new UseOfRecursiveBangNotationInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 

--- a/RubberduckTests/QuickFixes/ExpandDefaultMemberQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ExpandDefaultMemberQuickFixTests.cs
@@ -88,7 +88,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new ObjectWhereProcedureIsRequiredInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new ObjectWhereProcedureIsRequiredInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -128,7 +128,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new ObjectWhereProcedureIsRequiredInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new ObjectWhereProcedureIsRequiredInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -168,7 +168,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new ObjectWhereProcedureIsRequiredInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToFirstInspectionResult(vbe.Object, "Module1", state => new ObjectWhereProcedureIsRequiredInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -207,7 +207,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -246,7 +246,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedRecursiveDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedRecursiveDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -285,7 +285,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -324,7 +324,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedRecursiveDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedRecursiveDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -370,7 +370,7 @@ End Function
                 ("Class3", class3Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -416,7 +416,7 @@ End Function
                 ("Class3", class3Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedRecursiveDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new IndexedRecursiveDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -452,7 +452,7 @@ End Function
                 ("Class1", class1Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -495,7 +495,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitRecursiveDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitRecursiveDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -538,7 +538,7 @@ End Function
                 ("Class2", class2Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitDefaultMemberAccessInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 
@@ -595,7 +595,52 @@ End Function
                 ("Class4", class4Code, ComponentType.ClassModule),
                 ("Module1", moduleCode, ComponentType.StandardModule));
 
-            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitRecursiveDefaultMemberAccessInspection(state), CodeKind.AttributesCode);
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new ImplicitRecursiveDefaultMemberAccessInspection(state));
+            Assert.AreEqual(expectedModuleCode, actualModuleCode);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void BothSidesOfAssignmentHaveDefaultMemberAccess_NoExplicitLet_QuickFixWorks()
+        {
+            var class1Code = @"
+Public Function Foo() As Long
+Attribute Foo.VB_UserMemId = 0
+End Function
+";
+
+            var class2Code = @"
+Public Property Let Baz(RHS As Long)
+Attribute Baz.VB_UserMemId = 0
+End Property
+";
+
+            var moduleCode = $@"
+Private Sub Bar() 
+    Dim cls1 As Class1
+    Dim cls2 As Class2
+    Set cls1 = New Class1
+    Set cls2 = New Class2
+    cls2 = cls1
+End Sub
+";
+
+            var expectedModuleCode = $@"
+Private Sub Bar() 
+    Dim cls1 As Class1
+    Dim cls2 As Class2
+    Set cls1 = New Class1
+    Set cls2 = New Class2
+    cls2.Baz = cls1.Foo
+End Sub
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", class1Code, ComponentType.ClassModule),
+                ("Class2", class2Code, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var actualModuleCode = ApplyQuickFixToAllInspectionResults(vbe.Object, "Module1", state => new SuspiciousLetAssignmentInspection(state));
             Assert.AreEqual(expectedModuleCode, actualModuleCode);
         }
 


### PR DESCRIPTION
Closes #5099 
Closes #5201

This PR introduces the `SuspiciousLetAssignmentInspection`. It finds all Let assignments in which both sides are objects and either have suitable default members or are of type `Object` and there is no explicit `Let` keyword. (The cases in which there is no suitable default member on any side is already covered by the `ObjectVariableNotSetInspection`.) The case with explicit `Let` does not yield a result because one has to assume that the default member is intentional in that case.

There are two fixes for the  `SuspiciousLetAssignmentInspection`, the enhanced `ExpandDefaultMemberInspectionQuickFix`, which expands the default members of both sides and is deactivated for results involving unboud default members, and the `UseSetKeywordForObjectAssignmentQuickFix`, which adds a `Set` keyword turning the Let assignment into a Set assignment.

NOTE:
Since the `ExpandDefaultMemberInspectionQuickFix` is further expanded in this PR, it is based on PR #5166. Please do not merge this PR before that PR is merged. I will rebase this one once the other one is merged.