### PR TITLE
Fixes "parameter can be byval" false negative with enums

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
@@ -97,7 +97,7 @@ namespace Rubberduck.Inspections.Concrete
                 && (parameter.AsTypeDeclaration == null 
                     || (!parameter.AsTypeDeclaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
                         && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.UserDefinedType 
-                        && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.Enumeration))
+                        /*&& parameter.AsTypeDeclaration.DeclarationType != DeclarationType.Enumeration*/))
                 && !parameter.References.Any(reference => reference.IsAssignment)
                 && !IsPotentiallyUsedAsByRefParameter(parameter);
             return canPossiblyBeChangedToBePassedByVal;

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
@@ -96,8 +96,7 @@ namespace Rubberduck.Inspections.Concrete
                 && !IsParameterOfDeclaredLibraryFunction(parameter)
                 && (parameter.AsTypeDeclaration == null 
                     || (!parameter.AsTypeDeclaration.DeclarationType.HasFlag(DeclarationType.ClassModule)
-                        && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.UserDefinedType 
-                        /*&& parameter.AsTypeDeclaration.DeclarationType != DeclarationType.Enumeration*/))
+                        && parameter.AsTypeDeclaration.DeclarationType != DeclarationType.UserDefinedType))
                 && !parameter.References.Any(reference => reference.IsAssignment)
                 && !IsPotentiallyUsedAsByRefParameter(parameter);
             return canPossiblyBeChangedToBePassedByVal;

--- a/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterCanBeByValInspectionTests.cs
@@ -1577,6 +1577,30 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
+        public void ParameterCanBeByVal_EnumMemberParameterCanBeByVal()
+        {
+            //Input
+            const string inputCode = @"Option Explicit
+Public Enum TestEnum
+    Foo
+    Bar
+End Enum
+
+Private Sub DoSomething(e As TestEnum)
+    Debug.Print e
+End Sub";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ParameterCanBeByValInspection(state);
+                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+
+                Assert.AreEqual("e", inspectionResults.Single().Target.IdentifierName);
+            }
+        }
+        [Test]
+        [Category("Inspections")]
         public void InspectionName()
         {
             const string inspectionName = "ParameterCanBeByValInspection";


### PR DESCRIPTION
`DeclarationType.Enumeration` was explicitly excluded, along with `DeclarationType.UserDefinedType`. Now I can see why a UDT would need to be excluded, but not an enum. Removing the exclusion fixes the issue.