### PR TITLE
Hacktoberfest parser fixes

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MissingAttributeInspection.cs
@@ -48,7 +48,9 @@ namespace Rubberduck.Inspections.Concrete
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
             var declarationsWithAttributeAnnotations = State.DeclarationFinder.AllUserDeclarations
-                .Where(declaration => declaration.Annotations.Any(pta => pta.Annotation is IAttributeAnnotation));
+                .Where(declaration => declaration.Annotations.Any(pta => pta.Annotation is IAttributeAnnotation)
+                    && (declaration.DeclarationType.HasFlag(DeclarationType.Module) 
+                        || declaration.AttributesPassContext != null));
             var results = new List<DeclarationInspectionResult>();
             foreach (var declaration in declarationsWithAttributeAnnotations.Where(decl => decl.QualifiedModuleName.ComponentType != ComponentType.Document
                                                                                                    && !decl.IsIgnoringInspectionResultFor(AnnotationName)))

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ShadowedDeclarationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ShadowedDeclarationInspection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Rubberduck.Inspections.Abstract;
@@ -196,6 +197,12 @@ namespace Rubberduck.Inspections.Concrete
 
             // Events don't have a body, so their parameters can't be accessed
             if (userDeclaration.DeclarationType == DeclarationType.Parameter && userDeclaration.ParentDeclaration.DeclarationType == DeclarationType.Event)
+            {
+                return false;
+            }
+
+            // We insert Debug.Assert as a member access on an artificial Debug standard module. Thus, Assert will also be seen as shadowing Debug.Assert, which is not true. 
+            if (originalDeclaration.IdentifierName.Equals("Assert", StringComparison.InvariantCultureIgnoreCase) && originalDeclaration.QualifiedModuleName.ComponentName.Equals("Debug", StringComparison.InvariantCultureIgnoreCase))
             {
                 return false;
             }

--- a/Rubberduck.Parsing/Binding/Bindings/MemberAccessDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/MemberAccessDefaultBinding.cs
@@ -46,6 +46,29 @@ namespace Rubberduck.Parsing.Binding
             Declaration project,
             Declaration module,
             Declaration parent,
+            VBAParser.ObjectPrintExprContext expression,
+            IExpressionBinding lExpressionBinding,
+            StatementResolutionContext statementContext,
+            ParserRuleContext unrestrictedNameContext)
+            : this(
+                declarationFinder,
+                project,
+                module,
+                parent,
+                expression,
+                null,
+                Tokens.Print,
+                statementContext,
+                unrestrictedNameContext)
+        {
+            _lExpressionBinding = lExpressionBinding;
+        }
+
+        public MemberAccessDefaultBinding(
+            DeclarationFinder declarationFinder,
+            Declaration project,
+            Declaration module,
+            Declaration parent,
             ParserRuleContext expression,
             IBoundExpression lExpression,
             string name,

--- a/Rubberduck.Parsing/Binding/Bindings/ObjectPrintDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/ObjectPrintDefaultBinding.cs
@@ -5,24 +5,24 @@ namespace Rubberduck.Parsing.Binding
     public sealed class ObjectPrintDefaultBinding : IExpressionBinding
     {
         private readonly ParserRuleContext _context;
-        private readonly IExpressionBinding _memberAccessBinding;
+        private readonly IExpressionBinding _printMethodBinding;
         private readonly IExpressionBinding _outputListBinding;
 
         public ObjectPrintDefaultBinding(
             ParserRuleContext context,
-            IExpressionBinding memberAccessBinding,
+            IExpressionBinding printMethodBinding,
             IExpressionBinding outputListBinding)
         {
             _context = context;
-            _memberAccessBinding = memberAccessBinding;
+            _printMethodBinding = printMethodBinding;
             _outputListBinding = outputListBinding;
         }
 
         public IBoundExpression Resolve()
         {
-            var memberAccessExpression = _memberAccessBinding.Resolve();
+            var printMethodExpression = _printMethodBinding.Resolve();
             var outputListExpression = _outputListBinding.Resolve();
-            return new ObjectPrintExpression(_context, memberAccessExpression, outputListExpression);
+            return new ObjectPrintExpression(_context, printMethodExpression, outputListExpression);
         }
     }
 }

--- a/Rubberduck.Parsing/Binding/Bindings/ObjectPrintDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/ObjectPrintDefaultBinding.cs
@@ -1,0 +1,28 @@
+﻿using Antlr4.Runtime;
+
+namespace Rubberduck.Parsing.Binding
+{
+    public sealed class ObjectPrintDefaultBinding : IExpressionBinding
+    {
+        private readonly ParserRuleContext _context;
+        private readonly IExpressionBinding _memberAccessBinding;
+        private readonly IExpressionBinding _outputListBinding;
+
+        public ObjectPrintDefaultBinding(
+            ParserRuleContext context,
+            IExpressionBinding memberAccessBinding,
+            IExpressionBinding outputListBinding)
+        {
+            _context = context;
+            _memberAccessBinding = memberAccessBinding;
+            _outputListBinding = outputListBinding;
+        }
+
+        public IBoundExpression Resolve()
+        {
+            var memberAccessExpression = _memberAccessBinding.Resolve();
+            var outputListExpression = _outputListBinding.Resolve();
+            return new ObjectPrintExpression(_context, memberAccessExpression, outputListExpression);
+        }
+    }
+}

--- a/Rubberduck.Parsing/Binding/Bindings/ObjectPrintDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/ObjectPrintDefaultBinding.cs
@@ -21,7 +21,7 @@ namespace Rubberduck.Parsing.Binding
         public IBoundExpression Resolve()
         {
             var printMethodExpression = _printMethodBinding.Resolve();
-            var outputListExpression = _outputListBinding.Resolve();
+            var outputListExpression = _outputListBinding?.Resolve();
             return new ObjectPrintExpression(_context, printMethodExpression, outputListExpression);
         }
     }

--- a/Rubberduck.Parsing/Binding/Bindings/OutputListDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/OutputListDefaultBinding.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime;
+
+namespace Rubberduck.Parsing.Binding
+{
+    public sealed class OutputListDefaultBinding : IExpressionBinding
+    {
+        private readonly ParserRuleContext _context;
+        private readonly List<IExpressionBinding> _itemBindings;
+
+        public OutputListDefaultBinding(
+            ParserRuleContext context,
+            List<IExpressionBinding> itemBindings)
+        {
+            _context = context;
+            _itemBindings = itemBindings;
+        }
+
+        public IBoundExpression Resolve()
+        {
+            var itemExpressions = new List<IBoundExpression>();
+            foreach (var itemBinding in _itemBindings)
+            {
+                itemExpressions.Add(itemBinding.Resolve());
+            };
+            return new OutputListExpression(_context, itemExpressions);
+        }
+    }
+}

--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -73,8 +73,8 @@ namespace Rubberduck.Parsing.Binding
                     return Visit(module, parent, integerExpressionContext, withBlockVariable);
                 case VBAParser.OutputListContext outputListContext:
                     return Visit(module, parent, outputListContext, withBlockVariable);
-                case VBAParser.PrintStmtContext printStmtContext:
-                    return Visit(module, parent, printStmtContext, withBlockVariable);
+                case VBAParser.UnqualifiedObjectPrintStmtContext unqualifiedObjectPrintStmtContext:
+                    return Visit(module, parent, unqualifiedObjectPrintStmtContext, withBlockVariable);
                 default:
                     throw new NotSupportedException($"Unexpected context type {expression.GetType()}");
             }
@@ -266,7 +266,7 @@ namespace Rubberduck.Parsing.Binding
             return new ObjectPrintDefaultBinding(expression, memberAccessBinding, outputListBinding);
         }
 
-        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.PrintStmtContext expression, IBoundExpression withBlockVariable)
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.UnqualifiedObjectPrintStmtContext expression, IBoundExpression withBlockVariable)
         {
             var printMethodContext = expression.printMethod();
             var simpleNameBinding = new SimpleNameDefaultBinding(

--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -2,6 +2,7 @@
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using System;
+using System.Collections.Generic;
 using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 
@@ -29,7 +30,26 @@ namespace Rubberduck.Parsing.Binding
             return bindingTree?.Resolve();
         }
 
-        public IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public IExpressionBinding BuildTree(
+            Declaration module, 
+            Declaration parent, 
+            IParseTree expression, 
+            IBoundExpression withBlockVariable, 
+            StatementResolutionContext statementContext,
+            bool requiresLetCoercion = false, 
+            bool isLetAssignment = false)
+        {
+            return Visit(
+                module,
+                parent,
+                expression,
+                withBlockVariable,
+                statementContext,
+                requiresLetCoercion,
+                isLetAssignment);
+        }
+
+        public IExpressionBinding Visit(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
         {
             if (requiresLetCoercion && expression is ParserRuleContext context)
             {
@@ -51,6 +71,8 @@ namespace Rubberduck.Parsing.Binding
                     return Visit(module, parent, booleanExpressionContext, withBlockVariable);
                 case VBAParser.IntegerExpressionContext integerExpressionContext:
                     return Visit(module, parent, integerExpressionContext, withBlockVariable);
+                case VBAParser.OutputListContext outputListContext:
+                    return Visit(module, parent, outputListContext, withBlockVariable);
                 default:
                     throw new NotSupportedException($"Unexpected context type {expression.GetType()}");
             }
@@ -160,6 +182,8 @@ namespace Rubberduck.Parsing.Binding
                     return Visit(module, parent, dictionaryAccessExprContext, withBlockVariable);
                 case VBAParser.WithDictionaryAccessExprContext withDictionaryAccessExprContext:
                     return Visit(module, parent, withDictionaryAccessExprContext, withBlockVariable);
+                case VBAParser.ObjectPrintExprContext objectPrintExprContext:
+                    return Visit(module, parent, objectPrintExprContext, withBlockVariable);
                 default:
                     throw new NotSupportedException($"Unexpected lExpression type {expression.GetType()}");
             }
@@ -208,7 +232,36 @@ namespace Rubberduck.Parsing.Binding
         {
             var lExpression = expression.lExpression();
             var lExpressionBinding = Visit(module, parent, lExpression, withBlockVariable, StatementResolutionContext.Undefined);
-            return new MemberAccessDefaultBinding(_declarationFinder, Declaration.GetProjectParent(parent), module, parent, expression, lExpressionBinding, statementContext, expression.unrestrictedIdentifier());
+            return new MemberAccessDefaultBinding(
+                _declarationFinder, 
+                Declaration.GetProjectParent(parent), 
+                module, 
+                parent, 
+                expression, 
+                lExpressionBinding,
+                statementContext, 
+                expression.unrestrictedIdentifier());
+        }
+
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.ObjectPrintExprContext expression, IBoundExpression withBlockVariable)
+        {
+            var lExpression = expression.lExpression();
+            var lExpressionBinding = Visit(module, parent, lExpression, withBlockVariable, StatementResolutionContext.Undefined);
+            var memberAccessBinding = new MemberAccessDefaultBinding(
+                _declarationFinder,
+                Declaration.GetProjectParent(parent),
+                module,
+                parent,
+                expression,
+                lExpressionBinding,
+                StatementResolutionContext.Undefined,
+                expression.printMethod());
+            var outputListBinding = Visit(
+                module,
+                parent,
+                expression.outputList(),
+                withBlockVariable);
+            return new ObjectPrintDefaultBinding(expression, memberAccessBinding, outputListBinding);
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IndexExprContext expression, IBoundExpression withBlockVariable)
@@ -414,6 +467,49 @@ namespace Rubberduck.Parsing.Binding
         {
             var innerExpression =  Visit(module, parent, expression.expression(), withBlockVariable, StatementResolutionContext.Undefined);
             return new LetCoercionDefaultBinding(expression, innerExpression);
+        }
+
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.OutputListContext outputListContext, IBoundExpression withBlockVariable)
+        {
+            var itemBindings = new List<IExpressionBinding>();
+            foreach (var outputItem in outputListContext.outputItem())
+            {
+                if (outputItem.outputClause() != null)
+                {
+                    if (outputItem.outputClause().spcClause() != null)
+                    {
+                        itemBindings.Add(Visit(
+                            module, 
+                            parent, 
+                            outputItem.outputClause().spcClause().spcNumber().expression(), 
+                            withBlockVariable, 
+                            StatementResolutionContext.Undefined, 
+                            requiresLetCoercion: true));
+                    }
+                    if (outputItem.outputClause().tabClause() != null && outputItem.outputClause().tabClause().tabNumberClause() != null)
+                    {
+                        itemBindings.Add(Visit(
+                            module, 
+                            parent, 
+                            outputItem.outputClause().tabClause().tabNumberClause().tabNumber().expression(), 
+                            withBlockVariable, 
+                            StatementResolutionContext.Undefined, 
+                            requiresLetCoercion: true));
+                    }
+                    if (outputItem.outputClause().outputExpression() != null)
+                    {
+                        itemBindings.Add(Visit(
+                            module,
+                            parent,
+                            outputItem.outputClause().outputExpression().expression(),
+                            withBlockVariable,
+                            StatementResolutionContext.Undefined,
+                            requiresLetCoercion: true));
+                    }
+                }
+            }
+
+            return new OutputListDefaultBinding(outputListContext, itemBindings);
         }
 
         private static IExpressionBinding Visit(Declaration module, VBAParser.InstanceExprContext expression)

--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -73,6 +73,8 @@ namespace Rubberduck.Parsing.Binding
                     return Visit(module, parent, integerExpressionContext, withBlockVariable);
                 case VBAParser.OutputListContext outputListContext:
                     return Visit(module, parent, outputListContext, withBlockVariable);
+                case VBAParser.PrintStmtContext printStmtContext:
+                    return Visit(module, parent, printStmtContext, withBlockVariable);
                 default:
                     throw new NotSupportedException($"Unexpected context type {expression.GetType()}");
             }
@@ -262,6 +264,25 @@ namespace Rubberduck.Parsing.Binding
                 expression.outputList(),
                 withBlockVariable);
             return new ObjectPrintDefaultBinding(expression, memberAccessBinding, outputListBinding);
+        }
+
+        private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.PrintStmtContext expression, IBoundExpression withBlockVariable)
+        {
+            var printMethodContext = expression.printMethod();
+            var simpleNameBinding = new SimpleNameDefaultBinding(
+                _declarationFinder,
+                Declaration.GetProjectParent(parent),
+                module,
+                parent,
+                printMethodContext,
+                printMethodContext.GetText(),
+                StatementResolutionContext.Undefined);
+            var outputListBinding = Visit(
+                module,
+                parent,
+                expression.outputList(),
+                withBlockVariable);
+            return new ObjectPrintDefaultBinding(expression, simpleNameBinding, outputListBinding);
         }
 
         private IExpressionBinding Visit(Declaration module, Declaration parent, VBAParser.IndexExprContext expression, IBoundExpression withBlockVariable)

--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -258,11 +258,14 @@ namespace Rubberduck.Parsing.Binding
                 lExpressionBinding,
                 StatementResolutionContext.Undefined,
                 expression.printMethod());
-            var outputListBinding = Visit(
-                module,
-                parent,
-                expression.outputList(),
-                withBlockVariable);
+            var outputListContext = expression.outputList();
+            var outputListBinding = outputListContext != null
+                ? Visit(
+                    module,
+                    parent,
+                    outputListContext,
+                    withBlockVariable)
+                : null;
             return new ObjectPrintDefaultBinding(expression, memberAccessBinding, outputListBinding);
         }
 
@@ -277,11 +280,14 @@ namespace Rubberduck.Parsing.Binding
                 printMethodContext,
                 printMethodContext.GetText(),
                 StatementResolutionContext.Undefined);
-            var outputListBinding = Visit(
-                module,
-                parent,
-                expression.outputList(),
-                withBlockVariable);
+            var outputListContext = expression.outputList();
+            var outputListBinding = outputListContext != null 
+                ? Visit(
+                    module,
+                    parent,
+                    outputListContext,
+                    withBlockVariable)
+                : null;
             return new ObjectPrintDefaultBinding(expression, simpleNameBinding, outputListBinding);
         }
 

--- a/Rubberduck.Parsing/Binding/Expressions/ObjectPrintExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/ObjectPrintExpression.cs
@@ -6,15 +6,15 @@ namespace Rubberduck.Parsing.Binding
     {
         public ObjectPrintExpression(
             ParserRuleContext context,
-            IBoundExpression memberAccessExpression,
+            IBoundExpression printMethodExpression,
             IBoundExpression outputListBoundExpression)
             : base(null, ExpressionClassification.Subroutine, context)
         {
-            MemberAccessExpressions = memberAccessExpression;
+            PrintMethodExpressions = printMethodExpression;
             OutputListExpression = outputListBoundExpression;
         }
 
-        public IBoundExpression MemberAccessExpressions { get; }
+        public IBoundExpression PrintMethodExpressions { get; }
         public IBoundExpression OutputListExpression { get; }
     }
 }

--- a/Rubberduck.Parsing/Binding/Expressions/ObjectPrintExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/ObjectPrintExpression.cs
@@ -1,0 +1,20 @@
+﻿using Antlr4.Runtime;
+
+namespace Rubberduck.Parsing.Binding
+{
+    public sealed class ObjectPrintExpression : BoundExpression
+    {
+        public ObjectPrintExpression(
+            ParserRuleContext context,
+            IBoundExpression memberAccessExpression,
+            IBoundExpression outputListBoundExpression)
+            : base(null, ExpressionClassification.Subroutine, context)
+        {
+            MemberAccessExpressions = memberAccessExpression;
+            OutputListExpression = outputListBoundExpression;
+        }
+
+        public IBoundExpression MemberAccessExpressions { get; }
+        public IBoundExpression OutputListExpression { get; }
+    }
+}

--- a/Rubberduck.Parsing/Binding/Expressions/OutputListExpression.cs
+++ b/Rubberduck.Parsing/Binding/Expressions/OutputListExpression.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime;
+
+namespace Rubberduck.Parsing.Binding
+{
+    public sealed class OutputListExpression : BoundExpression
+    {
+        public OutputListExpression(
+            ParserRuleContext context,
+            IReadOnlyCollection<IBoundExpression> itemExpressions)
+            : base(null, ExpressionClassification.Value, context)
+        {
+            ItemExpressions = itemExpressions;
+        }
+
+        public IReadOnlyCollection<IBoundExpression> ItemExpressions { get; }
+    }
+}

--- a/Rubberduck.Parsing/Grammar/PartialExtensions/VBAParserPartialExtensions.cs
+++ b/Rubberduck.Parsing/Grammar/PartialExtensions/VBAParserPartialExtensions.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
-using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
-using Rubberduck.Parsing.VBA;
 
 // ReSharper disable once CheckNamespace; namespace MUST be the same as Antlr-generated VBAParser types.
 namespace Rubberduck.Parsing.Grammar
@@ -110,6 +107,44 @@ namespace Rubberduck.Parsing.Grammar
             public void AddAttributes(Attributes attributes)
             {
                 foreach(var attribute in attributes)
+                {
+                    Attributes.Add(new AttributeNode(attribute.Name, attribute.Values));
+                }
+            }
+            #endregion
+        }
+
+        public partial class DeclareStmtContext : IIdentifierContext, IAnnotatedContext
+        {
+            #region IIdentifierContext
+
+            public Interval IdentifierTokens
+            {
+                get
+                {
+                    Interval tokenInterval;
+                    Identifier.GetName(this, out tokenInterval);
+                    return tokenInterval;
+                }
+            }
+
+            #endregion
+
+            #region IAnnotatedContext
+            public Attributes Attributes { get; } = new Attributes();
+            public int AttributeTokenIndex => Stop.TokenIndex + 1;
+
+            private readonly List<AnnotationContext> _annotations = new List<AnnotationContext>();
+            public IEnumerable<AnnotationContext> Annotations => _annotations;
+
+            public void Annotate(AnnotationContext annotation)
+            {
+                _annotations.Add(annotation);
+            }
+
+            public void AddAttributes(Attributes attributes)
+            {
+                foreach (var attribute in attributes)
                 {
                     Attributes.Add(new AttributeNode(attribute.Name, attribute.Values));
                 }

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -309,7 +309,7 @@ variable : expression;
 constStmt : (visibility whiteSpace)? CONST whiteSpace constSubStmt (whiteSpace? COMMA whiteSpace? constSubStmt)*;
 constSubStmt : identifier (whiteSpace asTypeClause)? whiteSpace? EQ whiteSpace? expression;
 
-declareStmt : (visibility whiteSpace)? DECLARE whiteSpace (PTRSAFE whiteSpace)? (FUNCTION | SUB) whiteSpace identifier whiteSpace (CDECL whiteSpace)? LIB whiteSpace STRINGLITERAL (whiteSpace ALIAS whiteSpace STRINGLITERAL)? (whiteSpace? argList)? (whiteSpace asTypeClause)?;
+declareStmt : (visibility whiteSpace)? DECLARE whiteSpace (PTRSAFE whiteSpace)? (FUNCTION | SUB) whiteSpace identifier whiteSpace (CDECL whiteSpace)? LIB whiteSpace STRINGLITERAL (whiteSpace ALIAS whiteSpace STRINGLITERAL)? (whiteSpace? argList)? (whiteSpace asTypeClause)? (endOfLine attributeStmt)*;
 
 argList : LPAREN (whiteSpace? arg (whiteSpace? COMMA whiteSpace? arg)*)? whiteSpace? RPAREN;
 

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -186,7 +186,6 @@ fileStmt :
     | unlockStmt
     | lineInputStmt
     | widthStmt
-    | debugPrintStmt
     | printStmt
     | writeStmt
     | inputStmt
@@ -258,13 +257,6 @@ lineWidth : expression;
 
 
 // 5.4.5.8   Print Statement
-// Debug.Print is special because it seems to take an output list as argument.
-// To shield the rest of the parsing/binding from this peculiarity, we treat it as a statement
-// and let the resolver handle it.
-debugPrintStmt : debugPrint (whiteSpace outputList)?;
-// We split it up into separate rules so that we have context classes generated that can be used in declarations/references.
-debugPrint : debugModule whiteSpace? DOT whiteSpace? printMethod;
-debugModule : DEBUG;
 printMethod : PRINT;
 printStmt : PRINT whiteSpace markedFileNumber whiteSpace? COMMA (whiteSpace? outputList)?;
 

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -172,6 +172,7 @@ mainBlockStmt :
     | circleSpecialForm
     | scaleSpecialForm
     | pSetSpecialForm
+    | unqualifiedObjectPrintStmt
     | callStmt
     | nameStmt
 ;
@@ -257,10 +258,10 @@ lineWidth : expression;
 
 
 // 5.4.5.8   Print Statement
-//We make the part regarding the file handle optional to support VB6's print statement in forms.
-//It is an invocation of the Print member of the enclosing form, which also takes an output list as argument.
+//The unqualifiedObjectPrintStmt is an invocation of the Print member of the enclosing form or report, which also takes an output list as argument.
 printMethod : PRINT;
-printStmt : printMethod (whiteSpace markedFileNumber whiteSpace? COMMA)? (whiteSpace? outputList)?;
+printStmt : printMethod whiteSpace markedFileNumber whiteSpace? COMMA (whiteSpace? outputList)?;
+unqualifiedObjectPrintStmt : printMethod (whiteSpace outputList)?;
 
 // 5.4.5.8.1 Output Lists
 outputList : outputItem (whiteSpace? outputItem)*;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -258,9 +258,9 @@ lineWidth : expression;
 // and let the resolver handle it.
 debugPrintStmt : debugPrint (whiteSpace outputList)?;
 // We split it up into separate rules so that we have context classes generated that can be used in declarations/references.
-debugPrint : debugModule whiteSpace? DOT whiteSpace? debugPrintSub;
+debugPrint : debugModule whiteSpace? DOT whiteSpace? printMethod;
 debugModule : DEBUG;
-debugPrintSub : PRINT;
+printMethod : PRINT;
 printStmt : PRINT whiteSpace markedFileNumber whiteSpace? COMMA (whiteSpace? outputList)?;
 
 // 5.4.5.8.1 Output Lists
@@ -667,7 +667,7 @@ expression :
     | expression whiteSpace? EQV whiteSpace? expression                                             # logicalEqvOp
     | expression whiteSpace? IMP whiteSpace? expression                                             # logicalImpOp
     | literalExpression                                                                             # literalExpr
-    | builtInType                                                                                   # builtInTypeExpr
+    | {!IsTokenType(TokenTypeAtRelativePosition(2),LPAREN)}? builtInType                            # builtInTypeExpr
     | lExpression                                                                                   # lExpr
 ;
 
@@ -686,6 +686,7 @@ variantLiteralIdentifier : EMPTY | NULL;
 
 lExpression :
     lExpression LPAREN whiteSpace? argumentList? whiteSpace? RPAREN                                                 # indexExpr
+    | lExpression mandatoryLineContinuation? DOT mandatoryLineContinuation? printMethod (whiteSpace outputList)?    # objectPrintExpr
     | lExpression mandatoryLineContinuation? DOT mandatoryLineContinuation? unrestrictedIdentifier                  # memberAccessExpr
     | lExpression mandatoryLineContinuation? dictionaryAccess mandatoryLineContinuation? unrestrictedIdentifier     # dictionaryAccessExpr
     | ME                                                                                                            # instanceExpr

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -257,8 +257,10 @@ lineWidth : expression;
 
 
 // 5.4.5.8   Print Statement
+//We make the part regarding the file handle optional to support VB6's print statement in forms.
+//It is an invocation of the Print member of the enclosing form, which also takes an output list as argument.
 printMethod : PRINT;
-printStmt : PRINT whiteSpace markedFileNumber whiteSpace? COMMA (whiteSpace? outputList)?;
+printStmt : printMethod (whiteSpace markedFileNumber whiteSpace? COMMA)? (whiteSpace? outputList)?;
 
 // 5.4.5.8.1 Output Lists
 outputList : outputItem (whiteSpace? outputItem)*;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -64,7 +64,12 @@ moduleConfigProperty :
 ;
 
 moduleConfigElement :
-    (unrestrictedIdentifier | lExpression) whiteSpace? EQ whiteSpace? (shortcut | resource | expression) endOfStatement
+    (unrestrictedIdentifier | lExpression) whiteSpace? EQ whiteSpace? (shortcut | resource | expression | germanStyleFloatingPointNumber) endOfStatement
+;
+
+germanStyleFloatingPointNumber : 
+    INTEGERLITERAL COMMA INTEGERLITERAL
+    | COMMA INTEGERLITERAL
 ;
 
 shortcut :

--- a/Rubberduck.Parsing/Symbols/DeclarationLoaders/DebugDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationLoaders/DebugDeclarations.cs
@@ -9,7 +9,6 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
 {
     public class DebugDeclarations : ICustomDeclarationLoader
     {
-        public static Declaration DebugPrint;
         private readonly IDeclarationFinderProvider _finderProvider;
 
         public DebugDeclarations(IDeclarationFinderProvider finderProvider)
@@ -57,12 +56,6 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
             var debugObject = DebugObjectDeclaration(debugModule);
             var debugAssert = DebugAssertDeclaration(debugClass);
             var debugPrint = DebugPrintDeclaration(debugClass);
-
-            // Debug.Print has the same special syntax as the print and write statement.
-            // Because of that it is treated specially in the grammar and normally wouldn't be resolved.
-            // Since we still want it to be resolved we make it easier for the resolver to access the debug print
-            // declaration by exposing it in this way.
-            DebugPrint = debugPrint;
 
             return new List<Declaration> { 
                 debugModule,

--- a/Rubberduck.Parsing/Symbols/DeclarationLoaders/DebugDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationLoaders/DebugDeclarations.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Rubberduck.Parsing.Annotations;
+using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.VBEditor;
@@ -52,15 +53,11 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
         private List<Declaration> LoadDebugDeclarations(Declaration parentProject)
         {
             var debugModule = DebugModuleDeclaration(parentProject);
-            var debugClass = DebugClassDeclaration(parentProject); 
-            var debugObject = DebugObjectDeclaration(debugModule);
-            var debugAssert = DebugAssertDeclaration(debugClass);
-            var debugPrint = DebugPrintDeclaration(debugClass);
+            var debugAssert = DebugAssertDeclaration(debugModule);
+            var debugPrint = DebugPrintDeclaration(debugModule);
 
             return new List<Declaration> { 
                 debugModule,
-                debugClass,
-                debugObject,
                 debugAssert,
                 debugPrint
             };
@@ -70,7 +67,7 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
         private static ProceduralModuleDeclaration DebugModuleDeclaration(Declaration parentProject)
         {
             return new ProceduralModuleDeclaration(
-                new QualifiedMemberName(DebugModuleName(parentProject), "DebugModule"),
+                new QualifiedMemberName(DebugModuleName(parentProject), Tokens.Debug),
                 parentProject,
                 "DebugModule",
                 false,
@@ -83,55 +80,15 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
                 return new QualifiedModuleName(
                     parentProject.QualifiedName.QualifiedModuleName.ProjectName,
                     parentProject.QualifiedName.QualifiedModuleName.ProjectPath,
-                    "DebugModule");
+                    Tokens.Debug);
             }
 
-
-        private static ClassModuleDeclaration DebugClassDeclaration(Declaration parentProject)
-        {
-            return new ClassModuleDeclaration(
-                new QualifiedMemberName(DebugClassName(parentProject), "DebugClass"), 
-                parentProject, 
-                "DebugClass", 
-                false, 
-                new List<IParseTreeAnnotation>(), 
-                new Attributes(), 
-                true);
-        }
-
-        private static QualifiedModuleName DebugClassName(Declaration parentProject)
-        {
-            return new QualifiedModuleName(
-                parentProject.QualifiedName.QualifiedModuleName.ProjectName,
-                parentProject.QualifiedName.QualifiedModuleName.ProjectPath,
-                "DebugClass");
-        }
-
-        private static Declaration DebugObjectDeclaration(ProceduralModuleDeclaration debugModule)
-        {
-            return new Declaration(
-                new QualifiedMemberName(debugModule.QualifiedName.QualifiedModuleName, "Debug"), 
-                debugModule, 
-                "Global", 
-                "DebugClass", 
-                null, 
-                true, 
-                false, 
-                Accessibility.Global, 
-                DeclarationType.Variable, 
-                false, 
-                null,
-                false,
-                new List<IParseTreeAnnotation>(),
-                new Attributes());
-        }
-
-        private static SubroutineDeclaration DebugAssertDeclaration(ClassModuleDeclaration debugClass)
+        private static SubroutineDeclaration DebugAssertDeclaration(ProceduralModuleDeclaration debugModule)
         {
             return new SubroutineDeclaration(
-                new QualifiedMemberName(debugClass.QualifiedName.QualifiedModuleName, "Assert"), 
-                debugClass, 
-                debugClass, 
+                new QualifiedMemberName(debugModule.QualifiedName.QualifiedModuleName, "Assert"),
+                debugModule,
+                debugModule, 
                 null, 
                 Accessibility.Global, 
                 null,
@@ -142,12 +99,12 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
                 new Attributes());
         }
 
-        private static SubroutineDeclaration DebugPrintDeclaration(ClassModuleDeclaration debugClass)
+        private static SubroutineDeclaration DebugPrintDeclaration(ProceduralModuleDeclaration debugModule)
         {
             return new SubroutineDeclaration(
-                new QualifiedMemberName(debugClass.QualifiedName.QualifiedModuleName, "Print"), 
-                debugClass, 
-                debugClass, 
+                new QualifiedMemberName(debugModule.QualifiedName.QualifiedModuleName, "Print"),
+                debugModule,
+                debugModule, 
                 null, 
                 Accessibility.Global, 
                 null, 

--- a/Rubberduck.Parsing/Symbols/ExternalProcedureDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ExternalProcedureDeclaration.cs
@@ -20,9 +20,11 @@ namespace Rubberduck.Parsing.Symbols
             VBAParser.AsTypeClauseContext asTypeContext,
             Accessibility accessibility,
             ParserRuleContext context,
+            ParserRuleContext attributesPassContext,
             Selection selection,
             bool isUserDefined,
-            IEnumerable<IParseTreeAnnotation> annotations)
+            IEnumerable<IParseTreeAnnotation> annotations,
+            Attributes attributes)
             : base(
                   name,
                   parent,
@@ -34,13 +36,13 @@ namespace Rubberduck.Parsing.Symbols
                   accessibility,
                   declarationType,
                   context,
-                  null,
+                  attributesPassContext,
                   selection,
                   false,
                   asTypeContext,
                   isUserDefined,
                   annotations,
-                  null)
+                  attributes)
         {
             _parameters = new List<ParameterDeclaration>();
         }

--- a/Rubberduck.Parsing/Symbols/FunctionDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/FunctionDeclaration.cs
@@ -1,7 +1,6 @@
 ﻿using Antlr4.Runtime;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.ComReflection;
-using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor;
 using System.Collections.Generic;
 using System.Linq;

--- a/Rubberduck.Parsing/Symbols/Identifier.cs
+++ b/Rubberduck.Parsing/Symbols/Identifier.cs
@@ -23,6 +23,12 @@ namespace Rubberduck.Parsing.Symbols
             return GetName(nameContext, out tokenInterval);
         }
 
+        public static string GetName(VBAParser.DeclareStmtContext context, out Interval tokenInterval)
+        {
+            var nameContext = context.identifier();
+            return GetName(nameContext, out tokenInterval);
+        }
+
         public static string GetName(VBAParser.EventStmtContext context, out Interval tokenInterval)
         {
             var nameContext = context.identifier();

--- a/Rubberduck.Parsing/Symbols/ProceduralModuleDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ProceduralModuleDeclaration.cs
@@ -1,6 +1,5 @@
 ﻿using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.ComReflection;
-using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor;
 using System.Collections.Generic;
 

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -1159,7 +1159,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                      (Declaration.GetModuleParent(p) == null ||
                       Declaration.GetModuleParent(p).DeclarationType == moduleType));
             var accessibleMembers = memberMatches.Where(m => AccessibilityCheck.IsMemberAccessible(callingProject, callingModule, callingParent, m));
-            var match = accessibleMembers.FirstOrDefault();
+            var match = accessibleMembers.FirstOrDefault(member => !(member.IdentifierName.Equals("Assert") 
+                                                                     && member.QualifiedModuleName.ComponentName.Equals("Debug")));
             return match;
         }
 

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -1159,8 +1159,9 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                      (Declaration.GetModuleParent(p) == null ||
                       Declaration.GetModuleParent(p).DeclarationType == moduleType));
             var accessibleMembers = memberMatches.Where(m => AccessibilityCheck.IsMemberAccessible(callingProject, callingModule, callingParent, m));
-            var match = accessibleMembers.FirstOrDefault(member => !(member.IdentifierName.Equals("Assert") 
-                                                                     && member.QualifiedModuleName.ComponentName.Equals("Debug")));
+            var match = accessibleMembers.FirstOrDefault(member => !(member.QualifiedModuleName.ComponentName.Equals("Debug") 
+                                                                     && (member.IdentifierName.Equals("Assert") 
+                                                                         || member.IdentifierName.Equals("Print"))));
             return match;
         }
 

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
@@ -11,7 +11,6 @@ using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA.ComReferenceLoading;
-using Rubberduck.Parsing.VBA.Extensions;
 using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers;

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
@@ -176,10 +176,12 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                             asTypeName, 
                             asTypeContext, 
                             accessibility, 
-                            context, 
+                            context,
+                            attributesPassContext,
                             selection, 
                             true,
-                            FindMemberAnnotations(selection.StartLine));
+                            FindMemberAnnotations(selection.StartLine),
+                            attributes);
                         break;
                     case DeclarationType.PropertyGet:
                         result = new PropertyGetDeclaration(

--- a/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
@@ -42,6 +42,23 @@ namespace Rubberduck.Parsing.VBA.Parsing
             }
         }
 
+        public override void EnterDeclareStmt(VBAParser.DeclareStmtContext context)
+        {
+            var name = Identifier.GetName(context.identifier());
+            var declarationType = context.FUNCTION() != null
+                ? DeclarationType.LibraryFunction
+                : DeclarationType.LibraryProcedure;
+            var attributeScope = (name, declarationType);
+            PushNewScope(attributeScope);
+            _membersAllowingAttributes[attributeScope] = context;
+        }
+
+        public override void ExitDeclareStmt(VBAParser.DeclareStmtContext context)
+        {
+            SaveCurrentScopeAttributes(context);
+            PopScope();
+        }
+
         public override void EnterSubStmt(VBAParser.SubStmtContext context)
         {
             var attributeScope = (Identifier.GetName(context.subroutineName()), DeclarationType.Procedure);

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -185,7 +185,12 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             Declaration scope,
             Declaration parent)
         {
-            Visit(expression.OutputListExpression, module, scope, parent);
+            var outputListExpression = expression.OutputListExpression;
+            if (outputListExpression != null)
+            {
+                Visit(expression.OutputListExpression, module, scope, parent);
+            }
+
             Visit(expression.PrintMethodExpressions, module, scope, parent);
         }
 

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -186,7 +186,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             Declaration parent)
         {
             Visit(expression.OutputListExpression, module, scope, parent);
-            Visit(expression.MemberAccessExpressions, module, scope, parent);
+            Visit(expression.PrintMethodExpressions, module, scope, parent);
         }
 
         private void Visit(

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -88,6 +88,12 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                     break;
                 case MissingArgumentExpression missingArgumentExpression:
                     break;
+                case OutputListExpression outputListExpression:
+                    Visit(outputListExpression, module, scope, parent);
+                    break;
+                case ObjectPrintExpression objectPrintExpression:
+                    Visit(objectPrintExpression, module, scope, parent);
+                    break;
                 default:
                     throw new NotSupportedException($"Unexpected bound expression type {boundExpression.GetType()}");
             }
@@ -171,6 +177,28 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 isAssignmentTarget,
                 hasExplicitLetStatement,
                 isSetAssignment);
+        }
+
+        private void Visit(
+            ObjectPrintExpression expression,
+            QualifiedModuleName module,
+            Declaration scope,
+            Declaration parent)
+        {
+            Visit(expression.OutputListExpression, module, scope, parent);
+            Visit(expression.MemberAccessExpressions, module, scope, parent);
+        }
+
+        private void Visit(
+            OutputListExpression expression,
+            QualifiedModuleName module,
+            Declaration scope,
+            Declaration parent)
+        {
+            foreach (var itemExpression in expression.ItemExpressions)
+            {
+                Visit(itemExpression, module, scope, parent);
+            }
         }
 
         private void Visit(

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/FailedResolutionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/FailedResolutionVisitor.cs
@@ -70,6 +70,12 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 case ProcedureCoercionExpression procedureCoercionExpression:
                     Visit(procedureCoercionExpression, parent, withExpression);
                     break;
+                case OutputListExpression outputListExpression:
+                    Visit(outputListExpression, parent, withExpression);
+                    break;
+                case ObjectPrintExpression objectPrintExpression:
+                    Visit(objectPrintExpression, parent, withExpression);
+                    break;
                 case MissingArgumentExpression missingArgumentExpression:
                     break;
                 default:
@@ -105,6 +111,20 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
         private void Visit(MemberAccessExpression expression, Declaration parent, IBoundExpression withExpression)
         {
             Visit(expression.LExpression, parent, withExpression);
+        }
+
+        private void Visit(ObjectPrintExpression expression, Declaration parent, IBoundExpression withExpression)
+        {
+            Visit(expression.OutputListExpression, parent, withExpression);
+            Visit(expression.MemberAccessExpressions, parent, withExpression);
+        }
+
+        private void Visit(OutputListExpression expression, Declaration parent, IBoundExpression withExpression)
+        {
+            foreach (var itemExpression in expression.ItemExpressions)
+            {
+                Visit(itemExpression, parent, withExpression);
+            }
         }
 
         private void Visit(IndexExpression expression, Declaration parent, IBoundExpression withExpression)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/FailedResolutionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/FailedResolutionVisitor.cs
@@ -116,7 +116,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
         private void Visit(ObjectPrintExpression expression, Declaration parent, IBoundExpression withExpression)
         {
             Visit(expression.OutputListExpression, parent, withExpression);
-            Visit(expression.MemberAccessExpressions, parent, withExpression);
+            Visit(expression.PrintMethodExpressions, parent, withExpression);
         }
 
         private void Visit(OutputListExpression expression, Declaration parent, IBoundExpression withExpression)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/FailedResolutionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/FailedResolutionVisitor.cs
@@ -115,7 +115,12 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
         private void Visit(ObjectPrintExpression expression, Declaration parent, IBoundExpression withExpression)
         {
-            Visit(expression.OutputListExpression, parent, withExpression);
+            var outputListExpression = expression.OutputListExpression;
+            if (outputListExpression != null)
+            {
+                Visit(expression.OutputListExpression, parent, withExpression);
+            }
+
             Visit(expression.PrintMethodExpressions, parent, withExpression);
         }
 

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceListener.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceListener.cs
@@ -331,10 +331,5 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
         {
             _resolver.Resolve(context);
         }
-
-        public override void EnterDebugPrintStmt([NotNull] VBAParser.DebugPrintStmtContext context)
-        {
-            _resolver.Resolve(context);
-        }
     }
 }

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceListener.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceListener.cs
@@ -237,6 +237,11 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             _resolver.Resolve(context);
         }
 
+        public override void EnterUnqualifiedObjectPrintStmt([NotNull] VBAParser.UnqualifiedObjectPrintStmtContext context)
+        {
+            _resolver.Resolve(context);
+        }
+
         public override void EnterWriteStmt([NotNull] VBAParser.WriteStmtContext context)
         {
             _resolver.Resolve(context);

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -501,6 +501,19 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
         public void Resolve(VBAParser.PrintStmtContext context)
         {
+            if (context.markedFileNumber() != null)
+            {
+                ResolvePrintStatement(context);
+            }
+            else
+            {
+                //Since there is no file handle, this must be an unqualified print member call in a VB6 form.  
+                ResolveDefault(context);
+            }
+        }
+
+        public void ResolvePrintStatement(VBAParser.PrintStmtContext context)
+        {
             ResolveDefault(context.markedFileNumber().expression(), true);
             ResolveOutputList(context.outputList());
         }

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -501,21 +501,13 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
         public void Resolve(VBAParser.PrintStmtContext context)
         {
-            if (context.markedFileNumber() != null)
-            {
-                ResolvePrintStatement(context);
-            }
-            else
-            {
-                //Since there is no file handle, this must be an unqualified print member call in a VB6 form.  
-                ResolveDefault(context);
-            }
-        }
-
-        public void ResolvePrintStatement(VBAParser.PrintStmtContext context)
-        {
             ResolveDefault(context.markedFileNumber().expression(), true);
             ResolveOutputList(context.outputList());
+        }
+
+        public void Resolve(VBAParser.UnqualifiedObjectPrintStmtContext context)
+        {
+            ResolveDefault(context);
         }
 
         public void Resolve(VBAParser.WriteStmtContext context)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -502,7 +502,11 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
         public void Resolve(VBAParser.PrintStmtContext context)
         {
             ResolveDefault(context.markedFileNumber().expression(), true);
-            ResolveOutputList(context.outputList());
+            var outputList = context.outputList();
+            if (outputList != null)
+            {
+                ResolveOutputList(outputList);
+            }
         }
 
         public void Resolve(VBAParser.UnqualifiedObjectPrintStmtContext context)
@@ -513,7 +517,11 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
         public void Resolve(VBAParser.WriteStmtContext context)
         {
             ResolveDefault(context.markedFileNumber().expression(), true);
-            ResolveOutputList(context.outputList());
+            var outputList = context.outputList();
+            if (outputList != null)
+            {
+                ResolveOutputList(outputList);
+            }
         }
 
         private void ResolveOutputList(VBAParser.OutputListContext outputList)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -513,28 +513,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
 
         private void ResolveOutputList(VBAParser.OutputListContext outputList)
         {
-            if (outputList == null)
-            {
-                return;
-            }
-            foreach (var outputItem in outputList.outputItem())
-            {
-                if (outputItem.outputClause() != null)
-                {
-                    if (outputItem.outputClause().spcClause() != null)
-                    {
-                        ResolveDefault(outputItem.outputClause().spcClause().spcNumber().expression(), true);
-                    }
-                    if (outputItem.outputClause().tabClause() != null && outputItem.outputClause().tabClause().tabNumberClause() != null)
-                    {
-                        ResolveDefault(outputItem.outputClause().tabClause().tabNumberClause().tabNumber().expression(), true);
-                    }
-                    if (outputItem.outputClause().outputExpression() != null)
-                    {
-                        ResolveDefault(outputItem.outputClause().outputExpression().expression(), true);
-                    }
-                }
-            }
+            ResolveDefault(outputList);
         }
 
         public void Resolve(VBAParser.InputStmtContext context)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -797,47 +797,5 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 }
             }
         }
-
-        public void Resolve(VBAParser.DebugPrintStmtContext context)
-        {
-            if (DebugDeclarations.DebugPrint != null)
-            {
-                // Because Debug.Print has a special argument (an output list) instead
-                // of normal arguments we can't treat it as a function call.
-                var debugPrint = DebugDeclarations.DebugPrint;
-                var debugModule = debugPrint.ParentDeclaration;
-                debugModule.AddReference(
-                    _qualifiedModuleName,
-                    _currentScope,
-                    _currentParent,
-                    context.debugPrint().debugModule(),
-                    context.debugPrint().debugModule().GetText(),
-                    debugModule,
-                    context.debugPrint().debugModule().GetSelection(),
-                    FindIdentifierAnnotations(_qualifiedModuleName,
-                        context.debugPrint().debugModule().GetSelection().StartLine));
-                debugPrint.AddReference(
-                    _qualifiedModuleName,
-                    _currentScope,
-                    _currentParent,
-                    context.debugPrint().printMethod(),
-                    context.debugPrint().printMethod().GetText(),
-                    debugPrint,
-                    context.debugPrint().printMethod().GetSelection(),
-                    FindIdentifierAnnotations(_qualifiedModuleName,
-                        context.debugPrint().printMethod().GetSelection().StartLine));
-            }
-            else
-            {
-                Logger.Warn("Debug.Print (custom declaration) has not been loaded, skipping resolving Debug.Print call.");
-            }
-
-            //The output list should be resolved no matter whether we have a declaration for Debug.Print or not.
-            var outputList = context.outputList();
-            if (outputList != null)
-            {
-                ResolveOutputList(outputList);
-            }
-        }
     }
 }

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -841,12 +841,12 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                     _qualifiedModuleName,
                     _currentScope,
                     _currentParent,
-                    context.debugPrint().debugPrintSub(),
-                    context.debugPrint().debugPrintSub().GetText(),
+                    context.debugPrint().printMethod(),
+                    context.debugPrint().printMethod().GetText(),
                     debugPrint,
-                    context.debugPrint().debugPrintSub().GetSelection(),
+                    context.debugPrint().printMethod().GetSelection(),
                     FindIdentifierAnnotations(_qualifiedModuleName,
-                        context.debugPrint().debugPrintSub().GetSelection().StartLine));
+                        context.debugPrint().printMethod().GetSelection().StartLine));
             }
             else
             {

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -2213,6 +2213,27 @@ End Sub
         [Category("Grammar")]
         [Category("Resolver")]
         [Test]
+        public void ObjectPrintExpr_IsReferenceToLocalVariable()
+        {
+            var code = @"
+Sub Test()
+    Dim obj As Object
+    Dim referenced As String
+    obj.Print referenced;referenced, referenced , referenced ;
+End Sub";
+            using (var state = Resolve(code))
+            {
+
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+                Assert.AreEqual(4, declaration.References.Count());
+            }
+        }
+
+        [Category("Grammar")]
+        [Category("Resolver")]
+        [Test]
         public void WriteStmt_IsReferenceToLocalVariable()
         {
             var code = @"

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -6812,13 +6812,13 @@ End Function
 
             using (var state = Resolve(vbe.Object))
             {
-                var debugAssertDeclaration = state.DeclarationFinder
+                var debugPrintDeclaration = state.DeclarationFinder
                     .BuiltInDeclarations(DeclarationType.Procedure)
                     .Single(declaration => declaration.IdentifierName.Equals("Print")
                                            && declaration.QualifiedModuleName.ComponentName.Equals("Debug"));
-                var debugAssertReferences = debugAssertDeclaration.References;
+                var debugPrintReferences = debugPrintDeclaration.References;
 
-                Assert.IsFalse(debugAssertReferences.Any());
+                Assert.IsFalse(debugPrintReferences.Any());
             }
         }
 
@@ -6849,13 +6849,13 @@ End Function
 
             using (var state = Resolve(vbe.Object))
             {
-                var debugAssertDeclaration = state.DeclarationFinder
+                var debugPrintDeclaration = state.DeclarationFinder
                     .BuiltInDeclarations(DeclarationType.Procedure)
                     .Single(declaration => declaration.IdentifierName.Equals("Print")
                                            && declaration.QualifiedModuleName.ComponentName.Equals("Debug"));
-                var debugAssertReferences = debugAssertDeclaration.References;
+                var debugPrintReferences = debugPrintDeclaration.References;
 
-                Assert.AreEqual(2, debugAssertReferences.Count());
+                Assert.AreEqual(2, debugPrintReferences.Count());
             }
         }
     }

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -2234,6 +2234,27 @@ End Sub";
         [Category("Grammar")]
         [Category("Resolver")]
         [Test]
+        public void ObjectPrintExprsSeparatedByStatementSeparator_IsReferenceToLocalVariable()
+        {
+            var code = @"
+Sub Test()
+    Dim obj As Object
+    Dim referenced As String
+    obj.Print referenced;referenced, referenced , referenced ; : obj.Print referenced; referenced , referenced ;
+End Sub";
+            using (var state = Resolve(code))
+            {
+
+                var declaration = state.AllUserDeclarations.Single(item =>
+                    item.DeclarationType == DeclarationType.Variable && item.IdentifierName == "referenced");
+
+                Assert.AreEqual(7, declaration.References.Count());
+            }
+        }
+
+        [Category("Grammar")]
+        [Category("Resolver")]
+        [Test]
         public void WriteStmt_IsReferenceToLocalVariable()
         {
             var code = @"

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -2275,7 +2275,7 @@ End Sub
                 var printReference = printDeclaration.References.Single();
 
                 var module = state.DeclarationFinder.AllModules.Single(qmn => qmn.ComponentType == ComponentType.ClassModule);
-                var expectedPrintSelection = new QualifiedSelection(module, new Selection(5, 5,5, 10));
+                var expectedPrintSelection = new QualifiedSelection(module, new Selection(4, 5,4, 10));
                 var actualPrintSelection = new QualifiedSelection(printReference.QualifiedModuleName, printReference.Selection);
 
                 Assert.AreEqual(4, referencedDeclaration.References.Count());

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -2238,7 +2238,6 @@ End Sub";
         {
             var code = @"
 Sub Test()
-    Dim obj As Object
     Dim referenced As String
     obj.Print referenced;referenced, referenced , referenced ; : obj.Print referenced; referenced , referenced ;
 End Sub";

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -1041,6 +1041,50 @@ End
 
 
         [Test]
+        public void MixedStyleFloatingPointsInFormsPart()
+        {
+            string code = @"
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin MSDataGridLib.DataGrid DataGrid1
+      Bindings = ""frmMain.frx"":0000
+      Height = 2055
+      Left = 2520
+      TabIndex = 0
+      Top = 120
+      Width = 5655
+      _ExtentX = 9975
+      _ExtentY = 3625
+      _Version = 393216
+      HeadLines = 1
+      RowHeight = 15
+      AllowAddNew = -1  'True
+      BeginProperty HeadFont {0BE35203-8F91-11CE-9DE3-00AA004BB851}
+            Name = ""MS Sans Serif""
+         Size = 8,25
+         Charset = 0
+         Weight = 400.4
+         Underline = 0   'False
+         Italic = 0   'False
+         Strikethrough = 0   'False
+      EndProperty
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//germanStyleFloatingPointNumber", matches => matches.Count == 1);
+        }
+
+
+        [Test]
         public void TestNestedVbFormModuleConfigWithMultipleProperties()
         {
             string code = @"

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -2578,7 +2578,7 @@ Sub Test()
     Debug.Print
 End Sub";
             var parseResult = Parse(code);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt");
+            AssertTree(parseResult.Item1, parseResult.Item2, "//printMethod");
         }
 
         
@@ -2590,7 +2590,7 @@ Sub Test()
     Debug.Print ""Anything""
 End Sub";
             var parseResult = Parse(code);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt/outputList");
+            AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression/outputList");
         }
 
         
@@ -2602,7 +2602,7 @@ Sub Test()
     Debug.Print 1;
 End Sub";
             var parseResult = Parse(code);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt/outputList");
+            AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression/outputList");
         }
 
         
@@ -2614,7 +2614,7 @@ Sub Test()
     Debug.Print 1,
 End Sub";
             var parseResult = Parse(code);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt/outputList");
+            AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression/outputList");
         }
 
         
@@ -2631,7 +2631,7 @@ Sub Test()
     Next
 End Sub";
             var parseResult = Parse(code);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt", matches => matches.Count == 4);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//printMethod", matches => matches.Count == 4);
         }
 
         
@@ -2646,7 +2646,7 @@ Sub Test()
     End If
 End Sub";
             var parseResult = Parse(code, PredictionMode.Sll);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt", matches => matches.Count == 2);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//printMethod", matches => matches.Count == 2);
         }
 
         
@@ -2660,7 +2660,7 @@ Sub Test()
     Next i
 End Sub";
             var parseResult = Parse(code);
-            AssertTree(parseResult.Item1, parseResult.Item2, "//debugPrintStmt", matches => matches.Count == 1);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//printMethod", matches => matches.Count == 1);
         }
 
         

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -2329,7 +2329,7 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression");
         }
 
-        
+
         [Test]
         public void TestArrayWithTypeSuffix()
         {
@@ -2468,7 +2468,20 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//printStmt");
         }
 
-        
+
+        [Test]
+        public void TestObjectPrintStmt()
+        {
+            string code = @"
+Sub Test()
+    Dim obj As Object
+    obj.Print ""Hello "";""World"", ""!"" ;
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//outputList");
+        }
+
+
         [Test]
         public void TestDebugPrintStmtNoArguments()
         {

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -995,7 +995,51 @@ End
             AssertTree(parseResult.Item1, parseResult.Item2, "//moduleConfigProperty", matches => matches.Count == 1);
         }
 
-        
+
+        [Test]
+        public void GermanStyleFloatingPointsInFormsPart()
+        {
+            string code = @"
+Begin VB.Form Form1
+   Caption = ""Main""
+   ClientHeight = 2970
+   ClientLeft = 60
+   ClientTop = 450
+   ClientWidth = 8250
+   LinkTopic = ""Form1""
+   ScaleHeight = 2970
+   ScaleWidth = 8250
+   StartUpPosition = 2  'CenterScreen
+   Begin MSDataGridLib.DataGrid DataGrid1
+      Bindings = ""frmMain.frx"":0000
+      Height = 2055
+      Left = 2520
+      TabIndex = 0
+      Top = 120
+      Width = 5655
+      _ExtentX = 9975
+      _ExtentY = 3625
+      _Version = 393216
+      HeadLines = 1
+      RowHeight = 15
+      AllowAddNew = -1  'True
+      BeginProperty HeadFont {0BE35203-8F91-11CE-9DE3-00AA004BB851}
+            Name = ""MS Sans Serif""
+         Size = 8,25
+         Charset = 0
+         Weight = 400
+         Underline = 0   'False
+         Italic = 0   'False
+         Strikethrough = 0   'False
+      EndProperty
+   End
+End
+";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//germanStyleFloatingPointNumber", matches => matches.Count == 1);
+        }
+
+
         [Test]
         public void TestNestedVbFormModuleConfigWithMultipleProperties()
         {
@@ -3782,7 +3826,7 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//unrestrictedIdentifier", matches => matches.Count == 1);
         }
 
-        
+
         [Test]
         public void ParserAcceptsPSetMemberInUDT()
         {

--- a/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
+++ b/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
@@ -1,15 +1,16 @@
-using System;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
 using Rubberduck.Inspections.Concrete;
+using Rubberduck.Parsing.Inspections.Abstract;
+using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
     [TestFixture]
-    public class IllegalAnnotationsInspectionTests
+    public class IllegalAnnotationsInspectionTests : InspectionTestsBase
     {
         [Test]
         [Category("Inspections")]
@@ -20,16 +21,8 @@ namespace RubberduckTests.Inspections
     Const const1 As Integer = 9
 End Sub";
 
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -53,16 +46,11 @@ Option Explicit
 Public Sub ModuleInitializeAlsoLegal()
 End Sub";
 
-            var vbe = MockVbeBuilder.BuildFromStdModules(("Module1", inputCode1), ("Module2", inputCode2));
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
+            var inspectionResults = InspectionResultsForModules(
+                ("Module1", inputCode1, ComponentType.StandardModule), 
+                ("Module2", inputCode2, ComponentType.StandardModule));
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -74,16 +62,8 @@ Option Explicit
 '@PredeclaredId
 ";
 
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -102,16 +82,12 @@ End Sub
 Option Explicit
 '@Folder(""Legal"")
 ";
-            var vbe = MockVbeBuilder.BuildFromStdModules(("Module1", inputCode1), ("Module2", inputCode2));
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
+            var inspectionResults = InspectionResultsForModules(
+                ("Module1", inputCode1, ComponentType.StandardModule),
+                ("Module2", inputCode2, ComponentType.StandardModule));
 
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -154,16 +130,8 @@ Public Sub TestCleanup()
 End Sub
 ";
 
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -183,16 +151,9 @@ Private Fakes As Object
 Public Sub Test1()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -210,16 +171,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -237,16 +191,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -264,16 +211,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -293,16 +233,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(0, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -323,16 +256,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(0, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -352,16 +278,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -382,16 +301,9 @@ Public Sub Test2()
 End Sub
 '@Description ""Test""
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -412,16 +324,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -440,16 +345,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -468,16 +366,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -496,16 +387,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(0, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -522,16 +406,9 @@ Public foo As Long
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -549,16 +426,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(2, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(2, inspectionResults.Count());
         }
 
         [Test]
@@ -576,16 +446,9 @@ Public foo As Long
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -604,16 +467,9 @@ End Sub
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(0, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -630,16 +486,9 @@ Public foo As Long
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -658,16 +507,9 @@ Public Sub Test2()
     a = foo
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -686,16 +528,9 @@ Public Sub Test2()
     a = foo
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -717,15 +552,9 @@ Public Sub Test2()
     a = foo
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -743,15 +572,9 @@ Public Sub Test2()
     a = foo
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -769,15 +592,9 @@ Public Sub Test2()
     a = foo '@Ignore
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -797,16 +614,9 @@ label:
     a =15
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -826,16 +636,9 @@ label:
     a =15
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -855,16 +658,9 @@ label:
     a =15
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -884,15 +680,9 @@ label:
     a =15
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -909,15 +699,9 @@ Public foo As Long
 Public Sub Test2()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         //Issue #4558.
@@ -935,15 +719,12 @@ Implements IWorkbookData
 Implements IWorkbookData
 
 ";
-            var vbe = MockVbeBuilder.BuildFromModules(new[]{("testClass", inputCode, ComponentType.ClassModule), ("IWorkbookData", interfaceCode, ComponentType.ClassModule) });
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.IsFalse(inspectionResults.Any());
-            }
+            var inspectionResults = InspectionResultsForModules(
+                ("testClass", inputCode, ComponentType.ClassModule), 
+                ("IWorkbookData", interfaceCode, ComponentType.ClassModule));
+
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]
@@ -954,15 +735,9 @@ Implements IWorkbookData
 '@ModuleAttribute VB_Description, ""Desc""
 
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.Document, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForModules(("TestDocument", inputCode, ComponentType.Document));
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -974,15 +749,26 @@ Implements IWorkbookData
 Public Sub Foo()
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromSingleModule(inputCode, ComponentType.Document, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
 
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+            var inspectionResults = InspectionResultsForModules(("TestDocument", inputCode, ComponentType.Document));
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void AttributeAnnotationOnDeclarationNotAllowingAttributes_OneResult()
+        {
+            const string inputCode =
+                @"
+Private Sub Foo()
+'local variables do not allow attributes
+    '@VariableDescription(""Desc"")
+    Dim bar As Variant
+End Sub
+";
+
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
         }
 
         [Test]
@@ -1006,16 +792,13 @@ Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
 
-            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
-            using (var state = MockParser.CreateAndParse(vbe.Object))
-            {
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
 
-                var inspection = new IllegalAnnotationInspection(state);
-                var inspector = InspectionsHelper.GetInspector(inspection);
-                var inspectionResults = inspector.FindIssuesAsync(state, CancellationToken.None).Result;
-
-                Assert.IsFalse(inspectionResults.Any());
-            }
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new IllegalAnnotationInspection(state);
         }
     }
 }

--- a/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.Parsing;
 using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;
 
@@ -385,6 +386,33 @@ Private Sub Foo()
     '@VariableDescription(""Desc"")
     Dim bar As Variant
 End Sub
+";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MissingMemberAttributeOnDeclareStatement_OneResult()
+        {
+            const string inputCode =
+                @"'@Description(""Desc"")
+Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void MemberAttributeAnnotationOnDeclareStatement_WithAttribute_NoResult()
+        {
+            const string inputCode =
+                @"'@Description(""Desc"")
+Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+Attribute CopyMemory.VB_Description = ""Desc""
 ";
 
             var inspectionResults = InspectionResults(inputCode);

--- a/RubberduckTests/Inspections/ShadowedDeclarationInspectionTests.cs
+++ b/RubberduckTests/Inspections/ShadowedDeclarationInspectionTests.cs
@@ -5111,6 +5111,157 @@ Public {sameName} As String";
 
         [Test]
         [Category("Inspections")]
+        [TestCase("", "As Object", "")]    //Variable
+        [TestCase("Function", "As Object", "End Function")]
+        [TestCase("Sub", "", "End Sub")]
+        [TestCase("Property Get", "As Object", "End Property")]
+        [TestCase("Property Let", "", "End Property")]
+        [TestCase("Property Set", "", "End Property")]
+        public void ShadowedDeclaration_DoesNotReturnResult_AssertBecauseOfDebugAssert(string memberType, string asTypeClause, string endTag)
+        {
+            var code =
+                $@"Public {memberType} Assert() {asTypeClause} 
+{endTag}";
+
+            var vbe = new MockVbeBuilder()
+                .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
+                .AddComponent("TestClass", ComponentType.ClassModule, code)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddProjectToVbeBuilder()
+                .Build();
+
+            IEnumerable<IInspectionResult> inspectionResults;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ShadowedDeclarationInspection(state);
+                inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+            }
+
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ShadowedDeclaration_DoesNotReturnResult_LocalAssertVariableAssertBecauseOfDebugAssert()
+        {
+            var code =
+                @"Public Sub Foo()
+    Dim Assert As Long
+End Sub";
+
+            var vbe = new MockVbeBuilder()
+                .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
+                .AddComponent("TestClass", ComponentType.ClassModule, code)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddProjectToVbeBuilder()
+                .Build();
+
+            IEnumerable<IInspectionResult> inspectionResults;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ShadowedDeclarationInspection(state);
+                inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+            }
+
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ShadowedDeclaration_DoesNotReturnResult_AssertParameterAssertBecauseOfDebugAssert()
+        {
+            var code =
+                @"Public Sub Foo(Assert As Boolean)
+End Sub";
+
+            var vbe = new MockVbeBuilder()
+                .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
+                .AddComponent("TestClass", ComponentType.ClassModule, code)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddProjectToVbeBuilder()
+                .Build();
+
+            IEnumerable<IInspectionResult> inspectionResults;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ShadowedDeclarationInspection(state);
+                inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+            }
+
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("", "As Object", "")]    //Variable
+        [TestCase("Function", "As Object", "End Function")]
+        [TestCase("Sub", "", "End Sub")]
+        [TestCase("Property Get", "As Object", "End Property")]
+        [TestCase("Property Let", "", "End Property")]
+        [TestCase("Property Set", "", "End Property")]
+        public void ShadowedDeclaration_ReturnResult_LocalAssertVariableAssertBecauseOfNonDebugAssert(string memberType, string asTypeClause, string endTag)
+        {
+            var code =
+                $@"Public {memberType} Assert() {asTypeClause} 
+{endTag}
+
+Public Sub Foo()
+    Dim Assert As Long
+End Sub";
+
+            var vbe = new MockVbeBuilder()
+                .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
+                .AddComponent("TestClass", ComponentType.ClassModule, code)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddProjectToVbeBuilder()
+                .Build();
+
+            IEnumerable<IInspectionResult> inspectionResults;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ShadowedDeclarationInspection(state);
+                inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+            }
+
+            Assert.AreEqual(1,inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("", "As Object", "")]    //Variable
+        [TestCase("Function", "As Object", "End Function")]
+        [TestCase("Sub", "", "End Sub")]
+        [TestCase("Property Get", "As Object", "End Property")]
+        [TestCase("Property Let", "", "End Property")]
+        [TestCase("Property Set", "", "End Property")]
+        public void ShadowedDeclaration_ReturnResult_AssertParameterAssertBecauseOfNonDebugAssert(string memberType, string asTypeClause, string endTag)
+        {
+            var code =
+                $@"Public {memberType} Assert() {asTypeClause} 
+{endTag}
+
+Public Sub Foo(Assert As Boolean)
+End Sub";
+
+            var vbe = new MockVbeBuilder()
+                .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
+                .AddComponent("TestClass", ComponentType.ClassModule, code)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddProjectToVbeBuilder()
+                .Build();
+
+            IEnumerable<IInspectionResult> inspectionResults;
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                var inspection = new ShadowedDeclarationInspection(state);
+                inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
+            }
+
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ShadowedDeclaration_Ignored_DoesNotReturnResult()
         {
             string ignoredDeclarationCode =

--- a/RubberduckTests/Inspections/UndeclaredVariableInspectionTests.cs
+++ b/RubberduckTests/Inspections/UndeclaredVariableInspectionTests.cs
@@ -23,6 +23,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("MyClass", ComponentType.ClassModule, inputCode)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
@@ -49,6 +50,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("MyClass", ComponentType.ClassModule, inputCode)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
@@ -76,6 +78,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("MyClass", ComponentType.ClassModule, inputCode)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
@@ -132,6 +135,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("MyClass", ComponentType.ClassModule, inputCode)
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
                 .Build();
             var vbe = builder.AddProject(project).Build();
 

--- a/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
@@ -58,7 +58,7 @@ End Sub";
         {
             const string inputCode =
                 @"'@Description(""Desc"")
-#If Win64 Then
+#If False Then
     Private Sub Bar(ByVal arg As Long)
 #Else
     Private Sub Foo(ByVal arg As Long)
@@ -67,7 +67,7 @@ End Sub";
 
             const string expectedCode =
                     @"'@Description(""Desc"")
-#If Win64 Then
+#If False Then
     Private Sub Bar(ByVal arg As Long)
 #Else
     Private Sub Foo(ByVal arg As Long)
@@ -104,16 +104,16 @@ Attribute CopyMemory.VB_Description = ""Desc""
         {
             const string inputCode =
                 @"'@Description(""Desc"")
-#If Win64 Then
-    Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+#If False Then
+    Private Declare PtrSafe Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
 #Else
     Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory""(ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
 #End If";
 
             const string expectedCode =
                 @"'@Description(""Desc"")
-#If Win64 Then
-    Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+#If False Then
+    Private Declare PtrSafe Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
 #Else
     Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory""(ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
 Attribute CopyMemory.VB_Description = ""Desc""

--- a/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
@@ -54,6 +54,77 @@ End Sub";
 
         [Test]
         [Category("QuickFixes")]
+        public void MissingMemberAttributeOnConditionalCompilation_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@Description(""Desc"")
+#If Win64 Then
+    Private Sub Bar(ByVal arg As Long)
+#Else
+    Private Sub Foo(ByVal arg As Long)
+#End If
+End Sub";
+
+            const string expectedCode =
+                    @"'@Description(""Desc"")
+#If Win64 Then
+    Private Sub Bar(ByVal arg As Long)
+#Else
+    Private Sub Foo(ByVal arg As Long)
+Attribute Foo.VB_Description = ""Desc""
+#End If
+End Sub";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MissingMemberAttributeOnDeclareStatement_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@Description(""Desc"")
+Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+";
+
+            const string expectedCode =
+                @"'@Description(""Desc"")
+Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+Attribute CopyMemory.VB_Description = ""Desc""
+";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MissingMemberAttributeOnConditionalCompilation_DeclareStatement_QuickFixWorks()
+        {
+            const string inputCode =
+                @"'@Description(""Desc"")
+#If Win64 Then
+    Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+#Else
+    Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory""(ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+#End If";
+
+            const string expectedCode =
+                @"'@Description(""Desc"")
+#If Win64 Then
+    Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory"" (ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+#Else
+    Private Declare Sub CopyMemory Lib ""kernel32.dll"" Alias ""RtlMoveMemory""(ByRef Destination As Any, ByRef Source As Any, ByVal length As Long)
+Attribute CopyMemory.VB_Description = ""Desc""
+#End If";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
         public void MissingModuleAttributeWithMultipleValues_QuickFixWorks()
         {
             const string inputCode =

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -630,13 +630,14 @@ End Sub
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("foo", ProjectProtection.Unprotected)
                 .AddComponent("foo", ComponentType.StandardModule, code, new Selection(6, 6))
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
                 .AddProjectToVbeBuilder()
                 .Build();
 
             var parser = MockParser.Create(vbe.Object);
             parser.Parse(new CancellationTokenSource());
 
-            var expected = parser.State.DeclarationFinder.DeclarationsWithType(DeclarationType.Variable).Single();
+            var expected = parser.State.DeclarationFinder.DeclarationsWithType(DeclarationType.Variable).Single(declaration => declaration.IdentifierName.Equals("foo"));
             var actual = parser.State.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
 
             Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);
@@ -659,13 +660,14 @@ End Sub
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestModule", ComponentType.StandardModule, code, new Selection(6, 6))
+                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
                 .AddProjectToVbeBuilder()
                 .Build();
 
             var parser = MockParser.Create(vbe.Object);
             parser.Parse(new CancellationTokenSource());
 
-            var expected = parser.State.DeclarationFinder.DeclarationsWithType(DeclarationType.Variable).Single();
+            var expected = parser.State.DeclarationFinder.DeclarationsWithType(DeclarationType.Variable).Single(declaration => declaration.IdentifierName.Equals("foo"));
             var actual = parser.State.DeclarationFinder.FindSelectedDeclaration(vbe.Object.ActiveCodePane);
 
             Assert.AreEqual(expected, actual, "Expected {0}, resolved to {1}", expected.DeclarationType, actual.DeclarationType);

--- a/RubberduckTests/Symbols/ExternalProcedureDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ExternalProcedureDeclarationTests.cs
@@ -20,7 +20,7 @@ namespace RubberduckTests.Symbols
             private static ExternalProcedureDeclaration GetTestExternalProcedure(string name)
             {
                 var qualifiedProcedureName = new QualifiedMemberName(StubQualifiedModuleName(), name);
-                return new ExternalProcedureDeclaration(qualifiedProcedureName, null, null, DeclarationType.Procedure, "test", null, Accessibility.Public, null, Selection.Home, true, null);
+                return new ExternalProcedureDeclaration(qualifiedProcedureName, null, null, DeclarationType.Procedure, "test", null, Accessibility.Public, null, null, Selection.Home, true, null, null);
             }
 
                 private static QualifiedModuleName StubQualifiedModuleName()


### PR DESCRIPTION
Closes #5028 
Closes #4983 
Closes #4888 
Closes #2679

This PR contains some grammar and parser fixes for the issues above, i.e. allows the parser to deal with VB6's object print statement, allows simple German style floating point literals in form properties and enables attibutes and attribute annotations on declare statements.

Moreover, it makes attribute annotations illegal on non-module declarations for which we do not collect an attribute context.