### PR TITLE
ImplementedInterfaceMemberInspection evals Annotated-only and implemented interfaces

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplementedInterfaceMemberInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplementedInterfaceMemberInspection.cs
@@ -8,6 +8,7 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.Inspections.Inspections.Extensions;
 using Rubberduck.Common;
 using System;
+using Rubberduck.Parsing.Annotations;
 
 namespace Rubberduck.Inspections.Concrete
 {
@@ -45,7 +46,7 @@ namespace Rubberduck.Inspections.Concrete
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {
             var annotatedAsInterface = State.DeclarationFinder.Classes
-                .Where(cls => cls.Annotations.Any(an => an.Annotation.Name.Equals("Interface"))).Cast<ClassModuleDeclaration>();
+                .Where(cls => cls.Annotations.Any(an => an.Annotation is InterfaceAnnotation)).Cast<ClassModuleDeclaration>();
 
             var implementedAndOrAnnotatedInterfaceModules = State.DeclarationFinder.FindAllUserInterfaces()
                 .Union(annotatedAsInterface);


### PR DESCRIPTION
Resolves #5143.  `ImplementedInterfaceMemberInspection` now inspects class modules with the `@Interface` annotation even if the interface has yet to be implemented by another class.  Incorporates `InspectionTestsBase` into the test class. 