### PR TITLE
Extract Interface from Code Explorer 

### DIFF
--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -393,6 +393,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         public AddRemoveReferencesCommand AddRemoveReferencesCommand { get; set; }
         public ICommand ClearSearchCommand { get; }
         public CommandBase SyncCodePaneCommand { get; }
+        public CodeExplorerExtractInterfaceCommand CodeExplorerExtractInterfaceCommand { get; set; }
 
         public ICodeExplorerNode FindVisibleNodeForDeclaration(Declaration declaration)
         {

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -43,6 +43,7 @@
             <BitmapImage x:Key="AddRemoveReferencesImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/node-select-all.png" />
             <BitmapImage x:Key="SyncImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Custom/PNG/SyncArrows.png" />
             <BitmapImage x:Key="FontSizeImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/edit-size.png" />
+            <BitmapImage x:Key="ExtractInterfaceImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Custom/PNG/ExtractInterface.png" />
 
             <converters:BooleanToNullableDoubleConverter x:Key="BoolToDouble" />
             <converters:BoolToHiddenVisibilityConverter x:Key="BoolToHiddenVisibility" />
@@ -438,6 +439,13 @@
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Rename}"
                       Command="{Binding RenameCommand}"
                       CommandParameter="{Binding SelectedItem, Mode=OneWay}" />
+                    <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_ExtractInterfaceText}"
+                          Command="{Binding CodeExplorerExtractInterfaceCommand}"
+                          CommandParameter="{Binding SelectedItem, Mode=OneWay}">
+                        <MenuItem.Icon>
+                            <Image Source="{StaticResource ExtractInterfaceImage}" />
+                        </MenuItem.Icon>
+                    </MenuItem>
                     <Separator />
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=References_Caption}"
                           Command="{Binding AddRemoveReferencesCommand}"

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerExtractInterfaceCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerExtractInterfaceCommand.cs
@@ -38,8 +38,6 @@ namespace Rubberduck.UI.CodeExplorer.Commands
         {
             return _state.Status == ParserState.Ready &&
                    parameter is CodeExplorerComponentViewModel node &&
-                   //node.Declaration.DeclarationType.HasFlag(DeclarationType.ClassModule) &&
-                   //node.Children.Any(child => child.Declaration.DeclarationType.HasFlag(DeclarationType.Member));
                    ExtractInterfaceRefactoring.CanExecute((RubberduckParserState)_state, node.QualifiedSelection.Value.QualifiedName);
         }
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerExtractInterfaceCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerExtractInterfaceCommand.cs
@@ -1,0 +1,58 @@
+﻿using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings.ExtractInterface;
+using Rubberduck.UI.Command.Refactorings.Notifiers;
+using Rubberduck.VBEditor.Events;
+using System;
+using System.Collections.Generic;
+
+namespace Rubberduck.UI.CodeExplorer.Commands
+{
+    public class CodeExplorerExtractInterfaceCommand : CodeExplorerCommandBase
+    {
+        private static readonly Type[] ApplicableNodes =
+        {
+            typeof(CodeExplorerComponentViewModel)
+        };
+
+        private readonly IParserStatusProvider _state;
+        private readonly ExtractInterfaceRefactoring _refactoring;
+        private readonly ExtractInterfaceFailedNotifier _failureNotifier;
+
+        public CodeExplorerExtractInterfaceCommand(
+            ExtractInterfaceRefactoring refactoring,
+            IParserStatusProvider state,
+            ExtractInterfaceFailedNotifier failureNotifier,
+            IVbeEvents vbeEvents) 
+            : base(vbeEvents)
+        {
+            _state = state;
+            _refactoring = refactoring;
+            _failureNotifier = failureNotifier;
+            AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
+        }
+
+        public sealed override IEnumerable<Type> ApplicableNodeTypes => ApplicableNodes;
+
+        private bool SpecialEvaluateCanExecute(object parameter)
+        {
+            return _state.Status == ParserState.Ready &&
+                   parameter is CodeExplorerComponentViewModel node &&
+                   //node.Declaration.DeclarationType.HasFlag(DeclarationType.ClassModule) &&
+                   //node.Children.Any(child => child.Declaration.DeclarationType.HasFlag(DeclarationType.Member));
+                   ExtractInterfaceRefactoring.CanExecute((RubberduckParserState)_state, node.QualifiedSelection.Value.QualifiedName);
+        }
+
+        protected override void OnExecute(object parameter)
+        {
+            if (_state.Status != ParserState.Ready ||
+                !(parameter is CodeExplorerItemViewModel node) ||
+                node.Declaration == null)
+            {
+                return;
+            }
+
+            _refactoring.Refactor(node.Declaration);
+        }
+    }
+}

--- a/Rubberduck.Core/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
+++ b/Rubberduck.Core/UI/Command/Refactorings/RefactorExtractInterfaceCommand.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.UI.Command.Refactorings
     public class RefactorExtractInterfaceCommand : RefactorCodePaneCommandBase
     {
         private readonly RubberduckParserState _state;
-        
+
         public RefactorExtractInterfaceCommand(ExtractInterfaceRefactoring refactoring, ExtractInterfaceFailedNotifier extractInterfaceFailedNotifier, RubberduckParserState state, ISelectionService selectionService)
             :base(refactoring, extractInterfaceFailedNotifier, selectionService, state)
         {
@@ -32,41 +32,14 @@ namespace Rubberduck.UI.Command.Refactorings
             {
                 return false;
             }
-
-            var interfaceClass = _state.AllUserDeclarations.SingleOrDefault(item =>
-                item.QualifiedName.QualifiedModuleName.Equals(activeSelection.Value.QualifiedName)
-                && ModuleTypes.Contains(item.DeclarationType));
-
-            if (interfaceClass == null)
-            {
-                return false;
-            }
-
-            // interface class must have members to be implementable
-            var hasMembers = _state.AllUserDeclarations.Any(item =>
-                item.DeclarationType.HasFlag(DeclarationType.Member)
-                && item.ParentDeclaration != null
-                && item.ParentDeclaration.Equals(interfaceClass));
-
-            if (!hasMembers)
-            {
-                return false;
-            }
-
-            var parseTree = _state.GetParseTree(interfaceClass.QualifiedName.QualifiedModuleName);
-            var context = ((ParserRuleContext)parseTree).GetDescendents<VBAParser.ImplementsStmtContext>();
-
-            // true if active code pane is for a class/document/form module
-            return !context.Any()
-                   && !_state.IsNewOrModified(interfaceClass.QualifiedModuleName)
-                   && !_state.IsNewOrModified(activeSelection.Value.QualifiedName);
+            return ExtractInterfaceRefactoring.CanExecute(_state, activeSelection.Value.QualifiedName);
         }
 
-        private static readonly IReadOnlyList<DeclarationType> ModuleTypes = new[] 
+        private static readonly IReadOnlyList<DeclarationType> ModuleTypes = new[]
         {
             DeclarationType.ClassModule,
-            DeclarationType.UserForm, 
-            DeclarationType.Document, 
+            DeclarationType.UserForm,
+            DeclarationType.Document,
         };
     }
 }

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
@@ -327,6 +327,15 @@ namespace Rubberduck.Resources.CodeExplorer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Extract Interface.
+        /// </summary>
+        public static string CodeExplorer_ExtractInterfaceText {
+            get {
+                return ResourceManager.GetString("CodeExplorer_ExtractInterfaceText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Find All Implementations....
         /// </summary>
         public static string CodeExplorer_FindAllImplementationsText {

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
@@ -440,4 +440,7 @@ Continue?</value>
     
 {0}</value>
   </data>
+  <data name="CodeExplorer_ExtractInterfaceText" xml:space="preserve">
+    <value>Extract Interface</value>
+  </data>
 </root>


### PR DESCRIPTION
Partially applies to #2702

Added Extract Interface refactoring to Code Explorer context menu.
I didn't really know how to write proper tests for it.

Moved `CanExecute `logic to `ExtractInterfaceRefactoring`, since it was needed in two separate command implementations.

I have noticed that ExtractInterface is already available in Project Explorer context menu.