### PR TITLE
suppress warning 1591 about missing xmldoc comment

### DIFF
--- a/Rubberduck.CodeAnalysis/Rubberduck.CodeAnalysis.csproj
+++ b/Rubberduck.CodeAnalysis/Rubberduck.CodeAnalysis.csproj
@@ -11,6 +11,10 @@
   <PropertyGroup>
     <DocumentationFile>Rubberduck.CodeAnalysis.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsAsErrors>NU1605</WarningsAsErrors>
+    <NoWarn>1701;1702;;4011;1001;7035;1053;1591</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
 
   <ItemGroup>

--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -23,6 +23,10 @@
     <DocumentationFile>bin\Debug\Rubberduck.XML</DocumentationFile>
     <DebugType>full</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsAsErrors>NU1605; CS1591</WarningsAsErrors>
+    <NoWarn>1701;1702;;1591;4011;1001;1591</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Infralution.Localization.Wpf">
       <HintPath>..\libs\Infralution.Localization.Wpf.dll</HintPath>

--- a/Rubberduck.Deployment/Rubberduck.Deployment.csproj
+++ b/Rubberduck.Deployment/Rubberduck.Deployment.csproj
@@ -10,6 +10,9 @@
     <!-- Installer references depend on the unified output path -->
     <UnifyOutputPath>true</UnifyOutputPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;;4011;1001;7035;1053;;4011;1001;7035;1053;1591</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
 
   <ItemGroup>
@@ -54,15 +57,7 @@
     <CreateProperty Value="$(ProjectDir)$(OutputPath)$(TargetFileName)">
       <Output TaskParameter="Value" PropertyName="TargetAssembly" />
     </CreateProperty>
-    <RubberduckPostBuildTask 
-       Config="$(ConfigurationName)" 
-       NetToolsDir="$(SdkPath)bin\NETFX 4.6.1 Tools\" 
-       WixToolsDir="$(ProjectDir)WixToolset\" 
-       SourceDir="$(TargetDir)" 
-       TargetDir="$(TargetDir)" 
-       ProjectDir="$(ProjectDir)" 
-       IncludeDir="$(ProjectDir)InnoSetup\Includes\" 
-       FilesToExtract="Rubberduck.dll" />
+    <RubberduckPostBuildTask Config="$(ConfigurationName)" NetToolsDir="$(SdkPath)bin\NETFX 4.6.1 Tools\" WixToolsDir="$(ProjectDir)WixToolset\" SourceDir="$(TargetDir)" TargetDir="$(TargetDir)" ProjectDir="$(ProjectDir)" IncludeDir="$(ProjectDir)InnoSetup\Includes\" FilesToExtract="Rubberduck.dll" />
     <Message Text="Ran Rubberduck postbuild task" Importance="normal" />
   </Target>
 </Project>

--- a/Rubberduck.Interaction/Rubberduck.Interaction.csproj
+++ b/Rubberduck.Interaction/Rubberduck.Interaction.csproj
@@ -6,6 +6,9 @@
     <Title>Rubberduck.Interaction</Title>
     <ProjectGuid>{AC54B7FB-170D-4DA6-A30B-8CAD182F0E6B}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;;4011;1001;7035;1053;1591</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
   
   <ItemGroup>

--- a/Rubberduck.JunkDrawer/Rubberduck.JunkDrawer.csproj
+++ b/Rubberduck.JunkDrawer/Rubberduck.JunkDrawer.csproj
@@ -8,5 +8,8 @@
     <RootNamespace>Rubberduck.JunkDrawer</RootNamespace>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;;4011;1001;7035;1053;1591</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
 </Project>

--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>1</WarningLevel>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <Antlr4UseCSharpGenerator>True</Antlr4UseCSharpGenerator>

--- a/Rubberduck.Refactorings/Rubberduck.Refactorings.csproj
+++ b/Rubberduck.Refactorings/Rubberduck.Refactorings.csproj
@@ -6,6 +6,9 @@
     <AssemblyName>Rubberduck.Refactorings</AssemblyName>
     <Copyright>Copyright © 2018-2019</Copyright>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
   
   <ItemGroup>

--- a/Rubberduck.RegexAssistant/Rubberduck.RegexAssistant.csproj
+++ b/Rubberduck.RegexAssistant/Rubberduck.RegexAssistant.csproj
@@ -6,6 +6,9 @@
     <Copyright>Copyright © 2016-2019</Copyright>
     <ProjectGuid>{40CC03E3-756C-4674-AF07-384115DEAEE2}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
 
   <ItemGroup>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -6,6 +6,9 @@
     <Copyright>Copyright © 2018-2019</Copyright>
     <ProjectGuid>{1B84B387-F7C4-4876-9BDF-C644C365359A}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
   <ItemGroup>
     <Resource Include="**\*.png" Exclude="$(IntermediateOutputPath)\**" />

--- a/Rubberduck.SettingsProvider/Rubberduck.SettingsProvider.csproj
+++ b/Rubberduck.SettingsProvider/Rubberduck.SettingsProvider.csproj
@@ -6,6 +6,9 @@
     <Copyright>Copyright © 2016-2019</Copyright>
     <ProjectGuid>{E85E1253-86D6-45EE-968B-F37348D44132}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
 
   <ItemGroup>

--- a/Rubberduck.SmartIndenter/Rubberduck.SmartIndenter.csproj
+++ b/Rubberduck.SmartIndenter/Rubberduck.SmartIndenter.csproj
@@ -6,6 +6,9 @@
     <Copyright>Copyright © 2015-2019</Copyright>
     <ProjectGuid>{B9C0BF22-4D8A-4BF4-89F9-E789C0063DEB}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
   
   <ItemGroup>

--- a/Rubberduck.UnitTesting/Rubberduck.UnitTesting.csproj
+++ b/Rubberduck.UnitTesting/Rubberduck.UnitTesting.csproj
@@ -6,6 +6,9 @@
     <Copyright>Copyright © 2018-2019</Copyright>
     <ProjectGuid>{68F55404-32CA-4414-96B8-E284F3B1F846}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
 
   <ItemGroup>

--- a/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
+++ b/Rubberduck.VBEEditor/Rubberduck.VBEditor.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants></DefineConstants>
+    <NoWarn>1701;1702;;4011;1001;7035;1053;1591</NoWarn>
   </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
   <ItemGroup>

--- a/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
+++ b/Rubberduck.VBEditor.VB6/Rubberduck.VBEditor.VB6.csproj
@@ -6,6 +6,9 @@
     <Copyright>Copyright © 2018-2019</Copyright>
     <ProjectGuid>{5D683117-21F1-4A01-A0C7-6AE6F30A16A7}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;;4011;1001;7035;1053;1591</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
   
   <ItemGroup>

--- a/Rubberduck.VBEditor.VBA/Rubberduck.VBEditor.VBA.csproj
+++ b/Rubberduck.VBEditor.VBA/Rubberduck.VBEditor.VBA.csproj
@@ -6,6 +6,9 @@
     <Copyright>Copyright © 2018-2019</Copyright>
     <ProjectGuid>{D488071E-EDCB-4601-B734-1A3109ED903C}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;;4011;1001;7035;1053;1591</NoWarn>
+  </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
 
   <ItemGroup>

--- a/RubberduckTests/RubberduckTests.csproj
+++ b/RubberduckTests/RubberduckTests.csproj
@@ -22,6 +22,7 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <NoWarn>1701;1702;;4011;1001;7035;1053;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />


### PR DESCRIPTION
This brings the number of build warnings down from over 1600 to under 300.