### PR TITLE
Plug the WPF leak... maybe.

### DIFF
--- a/Rubberduck.Core/UI/Converters/ImageSourceConverter.cs
+++ b/Rubberduck.Core/UI/Converters/ImageSourceConverter.cs
@@ -12,17 +12,19 @@ namespace Rubberduck.UI.Converters
     {
         protected static ImageSource ToImageSource(Image source)
         {
-            var ms = new MemoryStream();
+            using (var ms = new MemoryStream())
+            {
+                ((Bitmap) source).Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                var image = new BitmapImage();
+                image.BeginInit();
+                image.CacheOption = BitmapCacheOption.OnLoad;
+                ms.Seek(0, SeekOrigin.Begin);
+                image.StreamSource = ms;
+                image.EndInit();
+                image.Freeze();
 
-            ((Bitmap)source).Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-            var image = new BitmapImage();
-            image.BeginInit();
-            ms.Seek(0, SeekOrigin.Begin);
-            image.StreamSource = ms;
-            image.EndInit();
-            image.Freeze();
-
-            return image;
+                return image;
+            }
         }
 
         public abstract object Convert(object value, Type targetType, object parameter, CultureInfo culture);


### PR DESCRIPTION
Closes #4660

Using the advice from this [SO thread](https://stackoverflow.com/questions/33532680/disposing-a-memory-stream-properly-wpf-image-conversion), this seems to work. However, the memory profiling seems to have paradoxically resulted in a slight memory increase, but that might be due to extraneous factors. 

Suggestions welcome to positively prove this helped the matter. 