### PR TITLE
Added the ClearSearchCommand to the SearchBox ValueContainer.

### DIFF
--- a/Rubberduck.Core/UI/Controls/SearchBox.xaml
+++ b/Rubberduck.Core/UI/Controls/SearchBox.xaml
@@ -24,7 +24,11 @@
                  Panel.ZIndex="2" 
                  VerticalContentAlignment="Center"
                  Width="Auto"
-                 Grid.Row="0" Grid.Column="0"/>
+                 Grid.Row="0" Grid.Column="0">
+            <TextBox.InputBindings>
+                <KeyBinding Command="{Binding Path=ClearSearchCommand}" Key="Esc"/>
+            </TextBox.InputBindings>
+        </TextBox>
         <!-- this is the actual hint container, it's BELOW the displaying control -->
         <TextBox Text="{Binding Path=Hint, ElementName=Root, Mode=OneWay}" 
                  Background="{Binding Path=Background, ElementName=Root}" 
@@ -44,6 +48,11 @@
                     </Style.Triggers>
                 </Style>
             </TextBox.Style>
+            <TextBox.InputBindings>
+                <KeyBinding Key="Esc"
+                Modifiers="Control" 
+                Command="{Binding ClearSearchCommand}" />
+            </TextBox.InputBindings>
         </TextBox>
         <Button Name="SearchButton"  Grid.Column="1" Command="{Binding ClearSearchCommand}" 
                 BorderBrush="{x:Static SystemColors.ControlLightBrush}"


### PR DESCRIPTION
Closes #5137 

You are now able to clear a SearchBox with a key press, not just a button press, by using the Esc key. See example below. This applies to the Code Explorer, To-Do Explorer and the Inspections window.

https://gyazo.com/4d5722a60b4ecac38db112a0dbcdda05