### PR TITLE
Correct the missed conditional for LOAD_USER_COM_PROJECTS

### DIFF
--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -239,10 +239,7 @@ namespace Rubberduck.Parsing.VBA
             _parserStateManager.SetStatusAndFireStateChanged(this, ParserState.LoadingReference, token);
             token.ThrowIfCancellationRequested();
 
-            RefreshUserComProjects(toParse, newProjectIds);
-            token.ThrowIfCancellationRequested();
-
-            SyncDeclarationsFromUserComProjects(toParse, token, toReresolveReferences);
+            ProcessUserComProjects(ref token, ref toParse, ref toReresolveReferences, ref newProjectIds);
 
             SyncComReferences(toParse, token, toReresolveReferences);
             token.ThrowIfCancellationRequested();
@@ -335,6 +332,17 @@ namespace Rubberduck.Parsing.VBA
             //This is the point where the change of the overall state to Ready is triggered on the success path.
             _parserStateManager.EvaluateOverallParserState(token);
             token.ThrowIfCancellationRequested();
+        }
+
+        //TODO: Remove the conditional compilation after loading from typelibs actually works.
+        //TODO: Improve the handling to avoid host crashing. See https://github.com/rubberduck-vba/Rubberduck/issues/5217
+        [Conditional("LOAD_USER_COM_PROJECTS")]
+        private void ProcessUserComProjects(ref CancellationToken token, ref IReadOnlyCollection<QualifiedModuleName> toParse, ref HashSet<QualifiedModuleName> toReresolveReferences, ref IReadOnlyCollection<string> newProjectIds)
+        {
+            RefreshUserComProjects(toParse, newProjectIds);
+            token.ThrowIfCancellationRequested();
+
+            SyncDeclarationsFromUserComProjects(toParse, token, toReresolveReferences);
         }
 
         private void SyncComReferences(IReadOnlyCollection<QualifiedModuleName> toParse, CancellationToken token, HashSet<QualifiedModuleName> toReresolveReferences)


### PR DESCRIPTION
In the PR #5182 there was a block for `LOAD_USER_COM_PROJECTS` that got deleted but didn't get refactored. As per #5217 this is now the suspect for crashing.

This PR put it back in its own back. Note that `ref` are used to preserve the current semantics now that it's in its own method. Added a comment as well. 