### PR TITLE
Fix member attributes recovery for properties

### DIFF
--- a/Rubberduck.Core/UI/Notifiers/MemberAttributeRecoveryFailureNotifier.cs
+++ b/Rubberduck.Core/UI/Notifiers/MemberAttributeRecoveryFailureNotifier.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Rubberduck.Interaction;
 using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
 using Rubberduck.VBEditor;
 
 namespace Rubberduck.UI.Notifiers
@@ -44,7 +46,7 @@ namespace Rubberduck.UI.Notifiers
             }
         }
 
-        public void NotifyMembersForRecoveryNotFound(IEnumerable<QualifiedMemberName> membersNotFound)
+        public void NotifyMembersForRecoveryNotFound(IEnumerable<(QualifiedMemberName memberName, DeclarationType memberType)> membersNotFound)
         {
             var message = MembersNotFoundMessage(membersNotFound);
             var caption = Resources.RubberduckUI.MemberAttributeRecoveryFailureCaption;
@@ -52,10 +54,11 @@ namespace Rubberduck.UI.Notifiers
             _messageBox.NotifyWarn(message, caption);
         }
 
-        private string MembersNotFoundMessage(IEnumerable<QualifiedMemberName> membersNotFound)
+        private string MembersNotFoundMessage(IEnumerable<(QualifiedMemberName memberName, DeclarationType memberType)> membersNotFound)
         {
-            var missingMemberList = $"{Environment.NewLine}{string.Join(Environment.NewLine, membersNotFound)}";
-            return string.Format(Resources.RubberduckUI.MemberAttributeRecoveryMembersNotFoundMessage, missingMemberList); ;
+            var missingMemberTexts = membersNotFound.Select(tpl => $"{tpl.memberName} ({tpl.memberType})");
+            var missingMemberList = $"{Environment.NewLine}{string.Join(Environment.NewLine, missingMemberTexts)}";
+            return string.Format(Resources.RubberduckUI.MemberAttributeRecoveryMembersNotFoundMessage, missingMemberList);
         }
     }
 }

--- a/Rubberduck.Parsing/Rewriter/IMemberAttributeRecoveryFailureNotifier.cs
+++ b/Rubberduck.Parsing/Rewriter/IMemberAttributeRecoveryFailureNotifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.Symbols;
 using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.Rewriter
@@ -6,6 +7,6 @@ namespace Rubberduck.Parsing.Rewriter
     public interface IMemberAttributeRecoveryFailureNotifier
     {
         void NotifyRewriteFailed(RewriteSessionState rewriteSessionState);
-        void NotifyMembersForRecoveryNotFound(IEnumerable<QualifiedMemberName> membersNotFound);
+        void NotifyMembersForRecoveryNotFound(IEnumerable<(QualifiedMemberName memberName, DeclarationType memberType)> membersNotFound);
     }
 }

--- a/Rubberduck.Parsing/Rewriter/MemberAttributeRecoverer.cs
+++ b/Rubberduck.Parsing/Rewriter/MemberAttributeRecoverer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,15 +20,17 @@ namespace Rubberduck.Parsing.Rewriter
         private IRewritingManager _rewritingManager;
         private readonly IMemberAttributeRecoveryFailureNotifier _failureNotifier;
 
-        private readonly
-            IDictionary<QualifiedModuleName, IDictionary<string, HashSet<AttributeNode>>> _attributesToRecover
-                = new Dictionary<QualifiedModuleName, IDictionary<string, HashSet<AttributeNode>>>();
-        private readonly HashSet<QualifiedMemberName> _missingMembers = new HashSet<QualifiedMemberName>();
+        private readonly IDictionary<QualifiedModuleName, IDictionary<(string memberName, DeclarationType memberType), HashSet<AttributeNode>>> _attributesToRecover
+                = new Dictionary<QualifiedModuleName, IDictionary<(string memberName, DeclarationType memberType), HashSet<AttributeNode>>>();
+        private readonly HashSet<(QualifiedMemberName memberName, DeclarationType memberType)> _missingMembers = new HashSet<(QualifiedMemberName memberName, DeclarationType memberType)>();
 
         private readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-        public MemberAttributeRecoverer(IDeclarationFinderProvider declarationFinderProvider,
-            IParseManager parseManager, IAttributesUpdater attributesUpdater, IMemberAttributeRecoveryFailureNotifier failureNotifier)
+        public MemberAttributeRecoverer(
+            IDeclarationFinderProvider declarationFinderProvider,
+            IParseManager parseManager, 
+            IAttributesUpdater attributesUpdater, 
+            IMemberAttributeRecoveryFailureNotifier failureNotifier)
         {
             _declarationFinderProvider = declarationFinderProvider;
             _parseManager = parseManager;
@@ -83,7 +86,7 @@ namespace Rubberduck.Parsing.Rewriter
                 var attributesByMember = declarationsByModule[module]
                     .Where(decl => decl.Attributes.Any())
                     .ToDictionary(
-                        decl => decl.IdentifierName,
+                        decl => (decl.IdentifierName, decl.DeclarationType),
                         decl => (HashSet<AttributeNode>)decl.Attributes);
                 _attributesToRecover.Add(module, attributesByMember);
             }
@@ -154,12 +157,12 @@ namespace Rubberduck.Parsing.Rewriter
             _parseManager.OnParseCancellationRequested(this);
         }
 
-        private void RecoverAttributes(IRewriteSession rewriteSession, QualifiedModuleName module, IDictionary<string, HashSet<AttributeNode>> attributesByMember)
+        private void RecoverAttributes(IRewriteSession rewriteSession, QualifiedModuleName module, IDictionary<(string memberName, DeclarationType memberType), HashSet<AttributeNode>> attributesByMember)
         {
             var membersWithAttributesToRecover = attributesByMember.Keys.ToHashSet();
             var declarationFinder = _declarationFinderProvider.DeclarationFinder;
             var declarationsWithAttributesToRecover = declarationFinder.Members(module)
-                .Where(decl => membersWithAttributesToRecover.Contains(decl.IdentifierName) 
+                .Where(decl => membersWithAttributesToRecover.Contains((decl.IdentifierName, decl.DeclarationType)) 
                                && decl.ParentScopeDeclaration.DeclarationType.HasFlag(DeclarationType.Module))
                 .ToList();
 
@@ -167,28 +170,28 @@ namespace Rubberduck.Parsing.Rewriter
             {
                 var membersWithoutDeclarations = MembersWithoutDeclarations(membersWithAttributesToRecover, declarationsWithAttributesToRecover);
                 LogFailureToRecoverAllAttributes(module, membersWithoutDeclarations);
-                _missingMembers.UnionWith(membersWithoutDeclarations.Select(memberName => new QualifiedMemberName(module, memberName)));
+                _missingMembers.UnionWith(membersWithoutDeclarations.Select(tpl => (new QualifiedMemberName(module, tpl.memberName), tpl.memberType)));
             }
 
             foreach (var declaration in declarationsWithAttributesToRecover)
             {
-                RecoverAttributes(rewriteSession, declaration, attributesByMember[declaration.IdentifierName]);
+                RecoverAttributes(rewriteSession, declaration, attributesByMember[(declaration.IdentifierName, declaration.DeclarationType)]);
             }
         }
 
-        private static ICollection<string> MembersWithoutDeclarations(HashSet<string> membersWithAttributesToRecover, IEnumerable<Declaration> declarationsWithAttributesToRecover)
+        private static ICollection<(string memberName, DeclarationType memberType)> MembersWithoutDeclarations(HashSet<(string memberName, DeclarationType memberType)> membersWithAttributesToRecover, IEnumerable<Declaration> declarationsWithAttributesToRecover)
         {
             var membersWithoutDeclarations = membersWithAttributesToRecover.ToHashSet();
-            membersWithoutDeclarations.ExceptWith(declarationsWithAttributesToRecover.Select(decl => decl.IdentifierName));
+            membersWithoutDeclarations.ExceptWith(declarationsWithAttributesToRecover.Select(decl => (decl.IdentifierName, decl.DeclarationType)));
             return membersWithoutDeclarations;
         }
 
-        private void LogFailureToRecoverAllAttributes(QualifiedModuleName module, IEnumerable<string> membersWithoutDeclarations)
+        private void LogFailureToRecoverAllAttributes(QualifiedModuleName module, IEnumerable<(string memberName, DeclarationType memberType)> membersWithoutDeclarations)
         {
             _logger.Warn("Could not recover the attributes for all members because one or more members could no longer be found.");
-            foreach (var member in membersWithoutDeclarations)
+            foreach (var (memberName, memberType) in membersWithoutDeclarations)
             {
-                _logger.Trace($"Could not recover the attributes for member {member} in module {module} because a member of that name exists no longer.");
+                _logger.Trace($"Could not recover the attributes for member {memberName} of type {memberType} in module {module} because a member of that name and type exists no longer.");
             }
         }
 

--- a/RubberduckTests/Inspections/EmptyModuleInspectionTests.cs
+++ b/RubberduckTests/Inspections/EmptyModuleInspectionTests.cs
@@ -49,7 +49,7 @@ DefBool B: DefByte Y: DefInt I: DefLng L: DefLngLng N: DefLngPtr P: DefCur C: De
         }
 
         [TestCase("Private Function Foo() As String\r\nEnd Function")]
-        [TestCase("Private Sub Foo() As String\r\nEnd Sub")]
+        [TestCase("Private Sub Foo()\r\nEnd Sub")]
         [TestCase("Public Property Get Foo()\r\nEnd Property")]
         [TestCase("Public Property Set Foo(rhs As Variant)\r\nEnd Property")]
         [TestCase("Public Property Let Foo(rhs As Variant)\r\nEnd Property")]


### PR DESCRIPTION
Closes #5222

Now, the key used to identify members is (memberName, memberType) instead od just memberName. This is necessary because Get, Let and Set properties share the same name.