### PR TITLE
Avoid Invalid Cast exception in EmptyMethodInspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyMethodInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyMethodInspection.cs
@@ -43,7 +43,7 @@ namespace Rubberduck.Inspections.Concrete
 
             return State.DeclarationFinder.UserDeclarations(DeclarationType.Member)
                 .Where(member => !allInterfaces.Any(userInterface => userInterface.QualifiedModuleName == member.QualifiedModuleName)
-                                 && !((ModuleBodyElementDeclaration)member).Block.ContainsExecutableStatements())
+                                 && !(member is ModuleBodyElementDeclaration mbe && mbe.Block.ContainsExecutableStatements()))
 
                 .Select(result => new DeclarationInspectionResult(this,
                                         string.Format(InspectionResults.EmptyMethodInspection,


### PR DESCRIPTION
This PR addresses the invalid cast exception reported by @daFreeMan in chat.

> 2019-10-16 12:03:10.8715;WARN-2.4.1.5086;Rubberduck.Inspections.Rubberduck.Inspections.Inspector;System.InvalidCastException: Unable to cast object of type 'Rubberduck.Parsing.Symbols.ExternalProcedureDeclaration' to type 'Rubberduck.Parsing.Symbols.ModuleBodyElementDeclaration'.
>    at Rubberduck.Inspections.Concrete.EmptyMethodInspection.<>c__DisplayClass1_0.<DoGetInspectionResults>b__0(Declaration member) in C:\projects\rubberduck\Rubberduck.CodeAnalysis\Inspections\Concrete\EmptyMethodInspection.cs:line 45
>    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
>    at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
>    at System.Linq.Enumerable.Count[TSource](IEnumerable`1 source)
>    at Rubberduck.Inspections.Abstract.InspectionBase.GetInspectionResults(CancellationToken token) in C:\projects\rubberduck\Rubberduck.CodeAnalysis\Inspections\Abstract\InspectionBase.cs:line 112
>    at Rubberduck.Inspections.Rubberduck.Inspections.Inspector.RunInspection(IInspection inspection, ConcurrentBag`1 allIssues, CancellationToken token) in C:\projects\rubberduck\Rubberduck.CodeAnalysis\Inspections\Inspector.cs:line 179;System.InvalidCastException: Unable to cast object of type 'Rubberduck.Parsing.Symbols.ExternalProcedureDeclaration' to type 'Rubberduck.Parsing.Symbols.ModuleBodyElementDeclaration'.
>    at Rubberduck.Inspections.Concrete.EmptyMethodInspection.<>c__DisplayClass1_0.<DoGetInspectionResults>b__0(Declaration member) in C:\projects\rubberduck\Rubberduck.CodeAnalysis\Inspections\Concrete\EmptyMethodInspection.cs:line 45
>    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
>    at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
>    at System.Linq.Enumerable.Count[TSource](IEnumerable`1 source)
>    at Rubberduck.Inspections.Abstract.InspectionBase.GetInspectionResults(CancellationToken token) in C:\projects\rubberduck\Rubberduck.CodeAnalysis\Inspections\Abstract\InspectionBase.cs:line 112
>    at Rubberduck.Inspections.Rubberduck.Inspections.Inspector.RunInspection(IInspection inspection, ConcurrentBag`1 allIssues, CancellationToken token) in C:\projects\rubberduck\Rubberduck.CodeAnalysis\Inspections\Inspector.cs:line 179