### PR TITLE
Fix enum member resolution

### DIFF
--- a/Rubberduck.Parsing/Binding/Bindings/MemberAccessDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/MemberAccessDefaultBinding.cs
@@ -34,7 +34,7 @@ namespace Rubberduck.Parsing.Binding
                   parent,
                   expression,
                   null,
-                  Identifier.GetName(expression.unrestrictedIdentifier()),
+                  expression.unrestrictedIdentifier().GetText(),
                   statementContext,
                   unrestrictedNameContext)
         {

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
@@ -829,7 +829,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
         public override void EnterEnumerationStmt_Constant(VBAParser.EnumerationStmt_ConstantContext context)
         {
             AddDeclaration(CreateDeclaration(
-                context.identifier().GetText(),
+                WithBracketsRemoved(context.identifier().GetText()),
                 "Long",
                 Accessibility.Implicit,
                 DeclarationType.EnumerationMember,
@@ -838,6 +838,16 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                 false,
                 null,
                 null));
+        }
+
+        private static string WithBracketsRemoved(string enumElementName)
+        {
+            if (enumElementName.StartsWith("[") && enumElementName.EndsWith("]"))
+            {
+                return enumElementName.Substring(1, enumElementName.Length - 2);
+            }
+
+            return enumElementName;
         }
 
         public override void EnterOptionPrivateModuleStmt(VBAParser.OptionPrivateModuleStmtContext context)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -123,8 +123,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             bool isSetAssignment)
         {
             var callSiteContext = expression.Context;
-            var identifier = expression.Context.GetText();
             var callee = expression.ReferencedDeclaration;
+            var identifier = callee.IdentifierName;
             var selection = callSiteContext.GetSelection();
             expression.ReferencedDeclaration.AddReference(
                 module,
@@ -163,8 +163,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             }
 
             var callSiteContext = expression.UnrestrictedNameContext;
-            var identifier = expression.UnrestrictedNameContext.GetText();
             var callee = expression.ReferencedDeclaration;
+            var identifier = callee.IdentifierName;
             var selection = callSiteContext.GetSelection();
             expression.ReferencedDeclaration.AddReference(
                 module,

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -6915,6 +6915,7 @@ End Function
         [Test]
         [TestCase("nonHiddenElement")]
         [TestCase("[nonHiddenElement]")]
+        [TestCase("")]
         public void NonHiddenBracketedEnumVariableHasCorrectName(string enumElementName)
         {
             var moduleCode = $@"
@@ -6937,9 +6938,13 @@ End Enum
         [Category("Grammar")]
         [Category("Resolver")]
         [Test]
+        [TestCase("nonHiddenElement", "SomeEnum.nonHiddenElement", 1)]
+        [TestCase("[nonHiddenElement]", "SomeEnum.[nonHiddenElement]", 0)]
+        [TestCase("[nonHiddenElement]", "SomeEnum.[[nonHiddenElement]]", 1)]
         [TestCase("nonHiddenElement", "nonHiddenElement", 1)]
-        [TestCase("[nonHiddenElement]", "[nonHiddenElement]", 0)]
         [TestCase("[nonHiddenElement]", "[[nonHiddenElement]]", 1)]
+        [TestCase("", "SomeEnum.[]", 1)]
+        [TestCase("", "[]", 1)]
         public void NonHiddenBracketedEnumVariableHasReference(string enumElementName, string referenceText, int expectedNumberOfReferences)
         {
             var moduleCode = $@"
@@ -6948,7 +6953,7 @@ Private Enum SomeEnum
 End Enum
 
 Private Function Test() As Variant
-    Debug.Print SomeEnum.{referenceText}
+    Debug.Print {referenceText}
 End Function
 ";
 
@@ -7022,6 +7027,46 @@ End Function
                     .Single(reference => reference.Declaration.DeclarationType == DeclarationType.EnumerationMember);
 
                 Assert.AreEqual("enumElement", enumMemberReference.IdentifierName);
+            }
+        }
+
+        [Category("Grammar")]
+        [Category("Resolver")]
+        [Test]
+        [TestCase("TestModule.[Foo]", "Foo")]
+        [TestCase("TestModule.[Bar] 23", "Bar")]
+        [TestCase("Debug.Print TestModule.[Baz](42)", "Baz")]
+        [TestCase("[Foo]", "Foo")]
+        [TestCase("[Bar] 23", "Bar")]
+        [TestCase("Debug.Print [Baz](42)", "Baz")]
+        public void BracketedMemberExpressionCorrectReferencedIdentifierName(string statement, string expectedReferenceText)
+        {
+            var moduleCode = $@"
+Private Sub Foo()
+End Sub
+
+Private Sub Bar(arg As Long)
+End Sub
+
+Private Function Baz(arg As Long) As Long
+End Function
+
+Private Function Test() As Variant
+    {statement}
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(moduleCode, "TestModule", out _);
+
+            using (var state = Resolve(vbe.Object))
+            {
+                var module = state.DeclarationFinder
+                    .AllModules.Single(qmn => qmn.ComponentType == ComponentType.StandardModule);
+                var enumMemberReference = state.DeclarationFinder
+                    .IdentifierReferences(module)
+                    .Single(reference => reference.Declaration.DeclarationType.HasFlag(DeclarationType.Member));
+
+                Assert.AreEqual(expectedReferenceText, enumMemberReference.IdentifierName);
             }
         }
     }


### PR DESCRIPTION
Closes #3238

This PR changes the identifier name on enum elements defined with enclosing brackets to the text withing the outermost enclosing brackets. This agrees withe the handling of the VBE as can be seen from the IntelliSense dropdown.

Moreover, the `IdentifierName` of references with bracketed members is changed to that of the referenced declaration. Having it include the brackets and thus differing from that of the declaration is rather surprising.