### PR TITLE
Misc bug fixes

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitDefaultMemberAccessInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitDefaultMemberAccessInspection.cs
@@ -45,6 +45,7 @@ namespace Rubberduck.Inspections.Concrete
     ///     arg.ConnectionString = bar
     /// End Sub
     /// ]]>
+    /// </example>
     public sealed class ImplicitDefaultMemberAccessInspection : IdentifierReferenceInspectionBase
     {
         public ImplicitDefaultMemberAccessInspection(RubberduckParserState state)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitUnboundDefaultMemberAccessInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitUnboundDefaultMemberAccessInspection.cs
@@ -24,6 +24,7 @@ namespace Rubberduck.Inspections.Concrete
     ///     bar = arg
     /// End Sub
     /// ]]>
+    /// </example>
     /// <example hasresult="true">
     /// <![CDATA[
     /// Public Sub DoSomething(ByVal arg As Object)
@@ -39,6 +40,7 @@ namespace Rubberduck.Inspections.Concrete
     ///     bar = arg.SomeValueReturningMember
     /// End Sub
     /// ]]>
+    /// </example>
     /// <example hasresult="false">
     /// <![CDATA[
     /// Public Sub DoSomething(ByVal arg As Object)


### PR DESCRIPTION
Closes #5241 

Prevent crashing on 64-bit systems due to VBA putting random values in the `lpvarValue`, confounding the `IntPtr.Zero` check. There is no apparent pattern to why it's doing it but it is consistently in the high 32-bit part, so we can look at the low 32-bit and determine if it's really a pointer or not. 

Note: The Com projects are not enabled still. 

Additionally fixes missing XML tags. 2 Warnings weeded. 