### PR TITLE
Update GeneralSettings header instructions

### DIFF
--- a/Rubberduck.Core/UI/Settings/GeneralSettingsView.cs
+++ b/Rubberduck.Core/UI/Settings/GeneralSettingsView.cs
@@ -1,0 +1,11 @@
+﻿using Rubberduck.Resources;
+
+namespace Rubberduck.UI.Settings
+{
+    class GeneralSettingsView : SettingsView
+    {
+        public override string Instructions => string.Format(base.Instructions, 
+            RubberduckUI.SaveAndClose, 
+            RubberduckUI.CancelButtonText);
+    }
+}

--- a/Rubberduck.Core/UI/Settings/SettingsForm.cs
+++ b/Rubberduck.Core/UI/Settings/SettingsForm.cs
@@ -37,7 +37,7 @@ namespace Rubberduck.UI.Settings
 
             ViewModel = new SettingsControlViewModel(messageBox, configService,
                 config,
-                new SettingsView
+                new GeneralSettingsView
                 {
                     Control = new GeneralSettings(viewModelFactory.Create<Rubberduck.Settings.GeneralSettings>(config)),
                     View = SettingsViews.GeneralSettings

--- a/Rubberduck.Core/UI/Settings/SettingsView.cs
+++ b/Rubberduck.Core/UI/Settings/SettingsView.cs
@@ -6,7 +6,7 @@ namespace Rubberduck.UI.Settings
     public class SettingsView
     {
         public string Label => SettingsUI.ResourceManager.GetString("PageHeader_" + View);
-        public string Instructions => SettingsUI.ResourceManager.GetString("PageInstructions_" + View, CultureInfo.CurrentUICulture);
+        public virtual string Instructions => SettingsUI.ResourceManager.GetString("PageInstructions_" + View, CultureInfo.CurrentUICulture);
         public ISettingsView Control { get; set; }
         public SettingsViews View { get; set; }
     }

--- a/Rubberduck.Resources/Settings/SettingsUI.Designer.cs
+++ b/Rubberduck.Resources/Settings/SettingsUI.Designer.cs
@@ -313,7 +313,7 @@ namespace Rubberduck.Resources.Settings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Click [Ok] to close the window and apply changes, or [Cancel] to discard them..
+        ///   Looks up a localized string similar to Click [{0}] to close the window and apply changes, or [{1}] to discard them..
         /// </summary>
         public static string PageInstructions_GeneralSettings {
             get {

--- a/Rubberduck.Resources/Settings/SettingsUI.resx
+++ b/Rubberduck.Resources/Settings/SettingsUI.resx
@@ -199,7 +199,7 @@
     <value>Configure which autocompletions are enabled.</value>
   </data>
   <data name="PageInstructions_GeneralSettings" xml:space="preserve">
-    <value>Click [Ok] to close the window and apply changes, or [Cancel] to discard them.</value>
+    <value>Click [{0}] to close the window and apply changes, or [{1}] to discard them.</value>
   </data>
   <data name="PageInstructions_IndenterSettings" xml:space="preserve">
     <value>Configure indenter settings.</value>


### PR DESCRIPTION
Subclassed GeneralSettingsView to allow header instructions and button text to remain synchronized for further updates.

Instructions were a bit off previously with a recent PR.
![General settings out of sync](https://user-images.githubusercontent.com/26076874/67990832-50efde00-fbf4-11e9-88f5-e73fe572cbfa.png)
