### PR TITLE
SC style import commands

### DIFF
--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -385,6 +385,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         public CopyResultsCommand CopyResultsCommand { get; set; }
         public CommandBase ExpandAllSubnodesCommand { get; }
         public ImportCommand ImportCommand { get; set; }
+        public UpdateFromFilesCommand UpdateFromFilesCommand { get; set; }
         public ExportCommand ExportCommand { get; set; }
         public ExportAllCommand ExportAllCommand { get; set; }
         public DeleteCommand DeleteCommand { get; set; }

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -386,6 +386,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         public CommandBase ExpandAllSubnodesCommand { get; }
         public ImportCommand ImportCommand { get; set; }
         public UpdateFromFilesCommand UpdateFromFilesCommand { get; set; }
+        public ReplaceProjectContentsFromFilesCommand ReplaceProjectContentsFromFilesCommand { get; set; }
         public ExportCommand ExportCommand { get; set; }
         public ExportAllCommand ExportAllCommand { get; set; }
         public DeleteCommand DeleteCommand { get; set; }

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -13,6 +13,7 @@ using Rubberduck.UI.CodeExplorer.Commands;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Input;
 using Rubberduck.Parsing.UIContext;
 using Rubberduck.Templates;
@@ -229,10 +230,11 @@ namespace Rubberduck.Navigation.CodeExplorer
         {
             Unparsed = false;
 
-            if (e.State == ParserState.Ready)
+            if (e.State == ParserState.Ready && e.OldState != ParserState.Busy)
             {
                 // Finished up resolving references, so we can now update the reference nodes.
                 //We have to wait for the task to guarantee that no new parse starts invalidating all cached components.
+                //CAUTION: This must not be executed from the UI thread!!!
                 _uiDispatcher.StartTask(() =>
                 {
                     var referenceFolders = Projects.SelectMany(node =>

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -454,6 +454,17 @@
                       Command="{Binding OpenProjectPropertiesCommand}"
                       CommandParameter="{Binding SelectedItem, Mode=OneWay}" />
                     <Separator />
+                    <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=SyncProject}">
+                        <MenuItem.Icon>
+                            <Image Source="{StaticResource SyncImage}" />
+                        </MenuItem.Icon>
+                        <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=UpdateFromFiles}"
+                                  Command="{Binding UpdateFromFilesCommand}"
+                                  CommandParameter="{Binding SelectedItem, Mode=OneWay}" />
+                        <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=ReplaceFromFiles}"
+                                  Command="{Binding ReplaceProjectContentsFromFilesCommand}"
+                                  CommandParameter="{Binding SelectedItem, Mode=OneWay}" />
+                    </MenuItem>
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_AddModule}"
                           ItemsSource="{StaticResource AddModuleCommands}">
                         <MenuItem.Icon>

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.Parsing.VBA;
 using Rubberduck.Resources;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
@@ -24,15 +26,18 @@ namespace Rubberduck.UI.CodeExplorer.Commands
         private readonly IFileSystemBrowserFactory _dialogFactory;
         private readonly IList<string> _importableExtensions;
         private readonly string _filterExtensions;
+        private readonly IParseManager _parseManager;
 
         public ImportCommand(
-            IVBE vbe, 
-            IFileSystemBrowserFactory dialogFactory, 
-            IVbeEvents vbeEvents) 
+            IVBE vbe,
+            IFileSystemBrowserFactory dialogFactory,
+            IVbeEvents vbeEvents,
+            IParseManager parseManager)
             : base(vbeEvents)
         {
             _vbe = vbe;
             _dialogFactory = dialogFactory;
+            _parseManager = parseManager;
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
 
@@ -44,6 +49,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             _filterExtensions = string.Join("; ", _importableExtensions.Select(ext => $"*.{ext}"));
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
+            AddToOnExecuteEvaluation(SpecialEvaluateCanExecute);
         }
 
         public sealed override IEnumerable<Type> ApplicableNodeTypes => ApplicableNodes;
@@ -61,37 +67,42 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             }
         }
 
-        protected override void OnExecute(object parameter)
+        private (IVBProject project, bool needsDisposal) TargetProject(object parameter)
         {
-            if (!CanExecute(parameter))
+            var targetProject = TargetProjectFromParameter(parameter);
+            if (targetProject != null)
             {
-                return;
+                return (targetProject, false);
             }
 
-            var usingFreshProjectWrapper = false;
-            var project = (parameter as CodeExplorerItemViewModel)?.Declaration?.Project;
+            targetProject = TargetProjectFromVbe();
 
-            if (project == null)
+            return (targetProject, targetProject != null);
+        }
+
+        private static IVBProject TargetProjectFromParameter(object parameter)
+        {
+            return (parameter as CodeExplorerItemViewModel)?.Declaration?.Project;
+        }
+
+        private IVBProject TargetProjectFromVbe()
+        {
+            if (_vbe.ProjectsCount == 1)
             {
-                if (_vbe.ProjectsCount == 1)
+                using (var projects = _vbe.VBProjects)
                 {
-                    usingFreshProjectWrapper = true;
-                    using (var projects = _vbe.VBProjects)
-                    {
-                        project = projects[1];
-                    }
-                }
-                else if (ThereIsAValidActiveProject())
-                {
-                    usingFreshProjectWrapper = true;
-                    project = _vbe.ActiveVBProject;
-                }
-                else
-                {
-                    return;
+                    return projects[1];
                 }
             }
 
+            var activeProject = _vbe.ActiveVBProject;
+            return activeProject != null && !activeProject.IsWrappingNullReference
+                ? activeProject
+                : null;
+        }
+
+        protected virtual ICollection<string> FilesToImport(object parameter)
+        {
             using (var dialog = _dialogFactory.CreateOpenFileDialog())
             {
                 dialog.AddExtension = true;
@@ -100,42 +111,71 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 dialog.CheckPathExists = true;
                 dialog.Multiselect = true;
                 dialog.ShowHelp = false;
-                dialog.Title = RubberduckUI.ImportCommand_OpenDialog_Title;
-                dialog.Filter = 
+                dialog.Title = FileDialogTitle;
+                dialog.Filter =
                     $"{RubberduckUI.ImportCommand_OpenDialog_Filter_VBFiles} ({_filterExtensions})|{_filterExtensions}|" +
                     $"{RubberduckUI.ImportCommand_OpenDialog_Filter_AllFiles}, (*.*)|*.*";
 
-                if (project == null || dialog.ShowDialog() != DialogResult.OK)
+                if (dialog.ShowDialog() != DialogResult.OK)
                 {
-                    if (usingFreshProjectWrapper)
-                    {
-                        project?.Dispose();
-                    }
-                    return;
+                    return new List<string>();
                 }
 
-                var fileExists = dialog.FileNames.Select(s => s.Split('.').Last());
-                if (fileExists.Any(fileExt => !_importableExtensions.Contains(fileExt)))
+                var fileNames = dialog.FileNames;
+                var fileExtensions = fileNames.Select(Path.GetExtension);
+                if (fileExtensions.Any(fileExt => !_importableExtensions.Contains(fileExt)))
                 {
-                    if (usingFreshProjectWrapper)
-                    {
-                        project.Dispose();
-                    }
-                    return;
+                    return new List<string>();
                 }
 
-                foreach (var filename in dialog.FileNames)
+                return fileNames;
+            }
+        }
+
+        protected virtual string FileDialogTitle => RubberduckUI.ImportCommand_OpenDialog_Title;
+
+        private void ImportFilesWithSuspension(IEnumerable<string> filesToImport, IVBProject targetProject)
+        {
+            var suspensionResult = _parseManager.OnSuspendParser(this, new[] {ParserState.Ready}, () => ImportFiles(filesToImport, targetProject));
+            if (suspensionResult != SuspensionResult.Completed)
+            {
+                Logger.Warn("File import failed due to suspension failure.");
+            }
+        }
+
+        protected virtual void ImportFiles(ICollection<string> filesToImport, IVBProject targetProject)
+        {
+            using (var components = targetProject.VBComponents)
+            {
+                foreach (var filename in filesToImport)
                 {
-                    using (var components = project.VBComponents)
-                    {
-                        components.Import(filename);
-                    }
+                    //We have to dispose the return value.
+                    using (components.Import(filename)) {}
                 }
             }
+        }
 
-            if (usingFreshProjectWrapper)
+        protected override void OnExecute(object parameter)
+        {
+            var (targetProject, targetProjectNeedsDisposal) = TargetProject(parameter);
+
+            if (targetProject == null)
             {
-                project.Dispose();
+                return;
+            }
+
+            var filesToImport = FilesToImport(parameter);
+
+            if (!filesToImport.Any())
+            {
+                return;
+            }
+
+            ImportFilesWithSuspension(filesToImport, targetProject);
+
+            if (targetProjectNeedsDisposal)
+            {
+                targetProject.Dispose();
             }
         }
     }

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
@@ -41,11 +41,11 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
 
-            _importableExtensions =
-                vbe.Kind == VBEKind.Hosted
-                    ? new List<string> {".bas", ".cls", ".frm", ".doccls"} // VBA 
-                    : new List<string> {".bas", ".cls", ".frm", ".ctl", ".pag", ".dob"}; // VB6
+            ComponentTypeForExtension =  vbe.Kind == VBEKind.Hosted
+                                            ? VBAComponentTypeForExtension
+                                            : VB6ComponentTypeForExtension;
 
+            _importableExtensions = ComponentTypeForExtension.Keys.ToList();
             _filterExtensions = string.Join("; ", _importableExtensions.Select(ext => $"*{ext}"));
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
@@ -179,5 +179,27 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 targetProject.Dispose();
             }
         }
+
+        protected IDictionary<string, ComponentType> ComponentTypeForExtension { get; }
+
+        private static IDictionary<string, ComponentType> VBAComponentTypeForExtension = new Dictionary<string, ComponentType>
+        {
+            [".bas"] = ComponentType.StandardModule,
+            [".cls"] = ComponentType.ClassModule,
+            [".frm"] = ComponentType.UserForm
+            //TODO: find out what ".doccls" corresponds to.
+            //[".doccls"] = ???
+        };
+
+        private static IDictionary<string, ComponentType> VB6ComponentTypeForExtension = new Dictionary<string, ComponentType>
+        {
+            [".bas"] = ComponentType.StandardModule,
+            [".cls"] = ComponentType.ClassModule,
+            [".frm"] = ComponentType.VBForm,
+            //TODO: double check whether the guesses below are correct.
+            [".ctl"] = ComponentType.UserControl,
+            [".pag"] = ComponentType.PropPage,
+            [".dob"] = ComponentType.DocObject,
+        };
     }
 }

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
@@ -43,10 +43,10 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
             _importableExtensions =
                 vbe.Kind == VBEKind.Hosted
-                    ? new List<string> {"bas", "cls", "frm", "doccls"} // VBA 
-                    : new List<string> {"bas", "cls", "frm", "ctl", "pag", "dob"}; // VB6
+                    ? new List<string> {".bas", ".cls", ".frm", ".doccls"} // VBA 
+                    : new List<string> {".bas", ".cls", ".frm", ".ctl", ".pag", ".dob"}; // VB6
 
-            _filterExtensions = string.Join("; ", _importableExtensions.Select(ext => $"*.{ext}"));
+            _filterExtensions = string.Join("; ", _importableExtensions.Select(ext => $"*{ext}"));
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
             AddToOnExecuteEvaluation(SpecialEvaluateCanExecute);
@@ -125,6 +125,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 var fileExtensions = fileNames.Select(Path.GetExtension);
                 if (fileExtensions.Any(fileExt => !_importableExtensions.Contains(fileExt)))
                 {
+                    //TODO: report this to the user.
                     return new List<string>();
                 }
 
@@ -134,7 +135,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         protected virtual string FileDialogTitle => RubberduckUI.ImportCommand_OpenDialog_Title;
 
-        private void ImportFilesWithSuspension(IEnumerable<string> filesToImport, IVBProject targetProject)
+        private void ImportFilesWithSuspension(ICollection<string> filesToImport, IVBProject targetProject)
         {
             var suspensionResult = _parseManager.OnSuspendParser(this, new[] {ParserState.Ready}, () => ImportFiles(filesToImport, targetProject));
             if (suspensionResult != SuspensionResult.Completed)

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ReplaceProjectContentsFromFilesCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ReplaceProjectContentsFromFilesCommand.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Rubberduck.Interaction;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.Resources;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
@@ -13,16 +15,29 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             IVBE vbe, 
             IFileSystemBrowserFactory dialogFactory, 
             IVbeEvents vbeEvents, 
-            IParseManager parseManager) 
-            :base(vbe, dialogFactory, vbeEvents, parseManager)
-        {}
+            IParseManager parseManager,
+            IMessageBox messageBox) 
+            :base(vbe, dialogFactory, vbeEvents, parseManager, messageBox)
+        { }
+
+        protected override string DialogsTitle => RubberduckUI.ReplaceProjectContentsFromFilesCommand_DialogCaption;
 
         protected override void ImportFiles(ICollection<string> filesToImport, IVBProject targetProject)
         {
-            //TODO: Ask for confirmation to delete the project contents and replace them with the selected modules.
+            if (!UserConfirmsToReplaceProjectContents(targetProject))
+            {
+                return;
+            }
 
             RemoveReimportableComponents(targetProject);
             base.ImportFiles(filesToImport, targetProject);
+        }
+
+        private bool UserConfirmsToReplaceProjectContents(IVBProject project)
+        {
+            var projectName = project.Name;
+            var message = string.Format(RubberduckUI.ReplaceProjectContentsFromFilesCommand_DialogCaption, projectName);
+            return MessageBox.ConfirmYesNo(message, DialogsTitle, false);
         }
 
         private void RemoveReimportableComponents(IVBProject project)

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ReplaceProjectContentsFromFilesCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ReplaceProjectContentsFromFilesCommand.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.Events;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.UI.CodeExplorer.Commands
+{
+    public class ReplaceProjectContentsFromFilesCommand : ImportCommand
+    {
+        public ReplaceProjectContentsFromFilesCommand(
+            IVBE vbe, 
+            IFileSystemBrowserFactory dialogFactory, 
+            IVbeEvents vbeEvents, 
+            IParseManager parseManager) 
+            :base(vbe, dialogFactory, vbeEvents, parseManager)
+        {}
+
+        protected override void ImportFiles(ICollection<string> filesToImport, IVBProject targetProject)
+        {
+            //TODO: Ask for confirmation to delete the project contents and replace them with the selected modules.
+
+            RemoveReimportableComponents(targetProject);
+            base.ImportFiles(filesToImport, targetProject);
+        }
+
+        private void RemoveReimportableComponents(IVBProject project)
+        {
+            var importableComponentTypes = ComponentTypeForExtension.Values;
+            using(var components = project.VBComponents)
+            {
+                foreach(var component in components)
+                {
+                    using (component)
+                    {
+                        if (importableComponentTypes.Contains(component.Type))
+                        {
+                            components.Remove(component);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ReplaceProjectContentsFromFilesCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ReplaceProjectContentsFromFilesCommand.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.Events;
+using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
@@ -25,14 +27,15 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         private void RemoveReimportableComponents(IVBProject project)
         {
-            var importableComponentTypes = ComponentTypeForExtension.Values;
+            var reimportableComponentTypes = ComponentTypeForExtension.Values
+                .Where(componentType => componentType != ComponentType.Document);
             using(var components = project.VBComponents)
             {
                 foreach(var component in components)
                 {
                     using (component)
                     {
-                        if (importableComponentTypes.Contains(component.Type))
+                        if (reimportableComponentTypes.Contains(component.Type))
                         {
                             components.Remove(component);
                         }

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/UpdateFromFileCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/UpdateFromFileCommand.cs
@@ -1,0 +1,155 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.Events;
+using Rubberduck.VBEditor.ComManagement;
+using Rubberduck.VBEditor.Extensions;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.UI.CodeExplorer.Commands
+{
+    public class UpdateFromFilesCommand : ImportCommand
+    {
+        private readonly IDeclarationFinderProvider _declarationFinderProvider;
+        private readonly IProjectsProvider _projectsProvider;
+        private readonly IModuleNameFromFileExtractor _moduleNameFromFileExtractor;
+
+        public UpdateFromFilesCommand(
+            IVBE vbe,
+            IFileSystemBrowserFactory dialogFactory,
+            IVbeEvents vbeEvents,
+            IParseManager parseManager,
+            IDeclarationFinderProvider declarationFinderProvider,
+            IProjectsProvider projectsProvider,
+            IModuleNameFromFileExtractor moduleNameFromFileExtractor)
+            : base(vbe, dialogFactory, vbeEvents, parseManager)
+        {
+            _projectsProvider = projectsProvider;
+            _declarationFinderProvider = declarationFinderProvider;
+            _moduleNameFromFileExtractor = moduleNameFromFileExtractor;
+        }
+
+        protected override void ImportFiles(ICollection<string> filesToImport, IVBProject targetProject)
+        {
+            var finder = _declarationFinderProvider.DeclarationFinder;
+
+            var moduleNames = ModuleNames(filesToImport);
+
+            if (!ValuesAreUnique(moduleNames))
+            {
+                //TODO: report this to the user.
+                return;
+            }
+
+            var modules = Modules(moduleNames, targetProject.ProjectId, finder);
+
+            //TODO: abort if the component type of the to be removed component does not match the file extension.
+
+            using (var components = targetProject.VBComponents)
+            {
+                foreach (var filename in filesToImport)
+                {
+                    if (modules.TryGetValue(filename, out var module))
+                    {
+                        var component = _projectsProvider.Component(module);
+                        components.Remove(component);
+                    }
+
+                    //We have to dispose the return value.
+                    using (components.Import(filename)) { }
+                }
+            }
+        }
+
+        private Dictionary<string, string> ModuleNames(ICollection<string> filenames)
+        {
+            var moduleNames = new Dictionary<string, string>();
+            foreach(var filename in filenames)
+            {
+                if (moduleNames.ContainsKey(filename))
+                {
+                    continue;
+                }
+
+                var moduleName = ModuleName(filename);
+                if(moduleName != null)
+                {
+                    moduleNames.Add(filename, moduleName);
+                }
+            }
+
+            return moduleNames;
+        }
+
+        private string ModuleName(string filename)
+        {
+            return _moduleNameFromFileExtractor.ModuleName(filename);
+        }
+
+        private Dictionary<string, QualifiedModuleName> Modules(IDictionary<string, string> moduleNames, string projectId, DeclarationFinder finder)
+        {
+            var modules = new Dictionary<string, QualifiedModuleName>();
+            foreach (var (fileName, moduleName) in moduleNames)
+            {
+                var module = Module(moduleName, projectId, finder);
+                if (module.HasValue)
+                {
+                    modules.Add(fileName, module.Value);
+                }
+            }
+
+            return modules;
+        }
+
+        private bool ValuesAreUnique(Dictionary<string, string> moduleNames)
+        {
+            return moduleNames
+                .GroupBy(kvp => kvp.Value)
+                .All(moduleNameGroup => moduleNameGroup.Count() == 1);
+        }
+
+        private QualifiedModuleName? Module(string moduleName, string projectId, DeclarationFinder finder)
+        {
+            foreach(var module in finder.AllModules)
+            {
+                if(module.ProjectId.Equals(projectId)
+                    && module.ComponentName.Equals(moduleName))
+                {
+                    return module;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public interface IModuleNameFromFileExtractor
+    {
+        string ModuleName(string filename);
+    }
+
+    public class ModuleNameFromFileExtractor : IModuleNameFromFileExtractor
+    {
+        public string ModuleName(string filename)
+        {
+            if (!File.Exists(filename))
+            {
+                return null;
+            }
+
+            var contents = File.ReadLines(filename, Encoding.Default);
+            var nameLine = contents.FirstOrDefault(line => line.StartsWith("Attribute VB_Name = "));
+            if (nameLine == null)
+            {
+                return Path.GetFileNameWithoutExtension(filename);
+            }
+
+            //The format is Attribute VB_Name = "ModuleName"
+            return nameLine.Substring("Attribute VB_Name = ".Length + 1, nameLine.Length - "Attribute VB_Name = ".Length - 2);
+        }
+    }
+}

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/UpdateFromFileCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/UpdateFromFileCommand.cs
@@ -47,7 +47,11 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
             var modules = Modules(moduleNames, targetProject.ProjectId, finder);
 
-            //TODO: abort if the component type of the to be removed component does not match the file extension.
+            if(!modules.All(kvp => HasMatchingFileExtension(kvp.Key, kvp.Value)))
+            {
+                //TODO: report this to the user.
+                return;
+            }
 
             using (var components = targetProject.VBComponents)
             {
@@ -124,6 +128,14 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             }
 
             return null;
+        }
+
+        private bool HasMatchingFileExtension(string filename, QualifiedModuleName module)
+        {
+            var fileExtension = Path.GetExtension(filename);
+            return ComponentTypeForExtension.TryGetValue(fileExtension, out var componentType)
+                ? module.ComponentType.Equals(componentType)
+                : false;
         }
     }
 

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
@@ -1012,12 +1012,30 @@ namespace Rubberduck.Resources.CodeExplorer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace Contents from Files....
+        /// </summary>
+        public static string ReplaceFromFiles {
+            get {
+                return ResourceManager.GetString("ReplaceFromFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         public static System.Drawing.Bitmap status_offline {
             get {
                 object obj = ResourceManager.GetObject("status_offline", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync Project.
+        /// </summary>
+        public static string SyncProject {
+            get {
+                return ResourceManager.GetString("SyncProject", resourceCulture);
             }
         }
         
@@ -1038,6 +1056,15 @@ namespace Rubberduck.Resources.CodeExplorer {
             get {
                 object obj = ResourceManager.GetObject("ui_tab_content", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update Components from Files....
+        /// </summary>
+        public static string UpdateFromFiles {
+            get {
+                return ResourceManager.GetString("UpdateFromFiles", resourceCulture);
             }
         }
     }

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.de.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.de.resx
@@ -289,7 +289,7 @@
     <value>Projekt synchronisieren</value>
   </data>
   <data name="UpdateFromFiles" xml:space="preserve">
-    <value>Komponenten aus Dateien updaten...</value>
+    <value>Komponenten aus Dateien aktualisieren...</value>
   </data>
   <data name="ReplaceFromFiles" xml:space="preserve">
     <value>Projektinhalt durch Dateiinhalt ersetzen... </value>

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.de.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.de.resx
@@ -285,4 +285,13 @@
   <data name="CodeExplorer_LibraryReferences" xml:space="preserve">
     <value>Referenzen zu Biblotheken</value>
   </data>
+  <data name="SyncProject" xml:space="preserve">
+    <value>Projekt synchronisieren</value>
+  </data>
+  <data name="UpdateFromFiles" xml:space="preserve">
+    <value>Komponenten aus Dateien updaten...</value>
+  </data>
+  <data name="ReplaceFromFiles" xml:space="preserve">
+    <value>Projektinhalt durch Dateiinhalt ersetzen... </value>
+  </data>
 </root>

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
@@ -440,4 +440,13 @@ Continue?</value>
     
 {0}</value>
   </data>
+  <data name="SyncProject" xml:space="preserve">
+    <value>Sync Project</value>
+  </data>
+  <data name="UpdateFromFiles" xml:space="preserve">
+    <value>Update Components from Files...</value>
+  </data>
+  <data name="ReplaceFromFiles" xml:space="preserve">
+    <value>Replace Contents from Files...</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.Designer.cs
+++ b/Rubberduck.Resources/RubberduckUI.Designer.cs
@@ -3887,7 +3887,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Really delete the contents of project &apos;{0}&apos; and replace it with the contents of the selected files?.
+        ///   Looks up a localized string similar to Do you really want to delete the contents of project &apos;{0}&apos; and replace them with the contents of the selected files?.
         /// </summary>
         public static string ReplaceProjectContentsFromFilesCommand_ConfirmationMessage {
             get {

--- a/Rubberduck.Resources/RubberduckUI.Designer.cs
+++ b/Rubberduck.Resources/RubberduckUI.Designer.cs
@@ -1829,6 +1829,17 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The extension of the file &apos;{0}&apos; is not supported.
+        ///
+        ///Import aborted..
+        /// </summary>
+        public static string ImportCommand_UnsupportedFileExtensions {
+            get {
+                return ResourceManager.GetString("ImportCommand_UnsupportedFileExtensions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Current Project.
         /// </summary>
         public static string IndentCurrentProject {
@@ -3876,6 +3887,24 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Really delete the contents of project &apos;{0}&apos; and replace it with the contents of the selected files?.
+        /// </summary>
+        public static string ReplaceProjectContentsFromFilesCommand_ConfirmationMessage {
+            get {
+                return ResourceManager.GetString("ReplaceProjectContentsFromFilesCommand_ConfirmationMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace Project Content from Files.
+        /// </summary>
+        public static string ReplaceProjectContentsFromFilesCommand_DialogCaption {
+            get {
+                return ResourceManager.GetString("ReplaceProjectContentsFromFilesCommand_DialogCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Resolving....
         /// </summary>
         public static string ResolutionProgress {
@@ -4330,6 +4359,59 @@ namespace Rubberduck.Resources {
         public static string Type {
             get {
                 return ResourceManager.GetString("Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update Components from Files.
+        /// </summary>
+        public static string UpdateFromFilesCommand_DialogCaption {
+            get {
+                return ResourceManager.GetString("UpdateFromFilesCommand_DialogCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The component type of the existing component &apos;{0}&apos; does not agree with that indicated by the extension of file &apos;{1}&apos;.
+        ///
+        ///Update aborted..
+        /// </summary>
+        public static string UpdateFromFilesCommand_DifferentComponentType {
+            get {
+                return ResourceManager.GetString("UpdateFromFilesCommand_DifferentComponentType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There is no existing document module with name &apos;{0}&apos;; file &apos;{1}&apos; cannot be imported.
+        ///
+        ///Update aborted..
+        /// </summary>
+        public static string UpdateFromFilesCommand_DocumentDoesNotExist {
+            get {
+                return ResourceManager.GetString("UpdateFromFilesCommand_DocumentDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple files contain code for the component &apos;{0}&apos;.
+        ///
+        ///Update aborted..
+        /// </summary>
+        public static string UpdateFromFilesCommand_DuplicateModule {
+            get {
+                return ResourceManager.GetString("UpdateFromFilesCommand_DuplicateModule", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There is no user form with name &apos;{0}&apos;; no code behind can be updated from file &apos;{1}&apos;.
+        ///
+        ///Update aborted..
+        /// </summary>
+        public static string UpdateFromFilesCommand_UserFormDoesNotExist {
+            get {
+                return ResourceManager.GetString("UpdateFromFilesCommand_UserFormDoesNotExist", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/RubberduckUI.de.resx
+++ b/Rubberduck.Resources/RubberduckUI.de.resx
@@ -993,9 +993,9 @@ Möchten sie die Einstellungen in Rubberduck importieren?</value>
     <value>Sie verwenden momentan Rubberduck Version {0}.
 Version {1}({2}) ist nun verfügbar.
 
-Um den Change Log anzuschauen und Rubberduck manuell abzudaten, klicke 'Ja'.
+Um den Change Log anzuschauen und Rubberduck manuell zu aktualisieren, klicken Sie 'Ja'.
 
-Dieses Fenster wird angezeigt, da Versionschecks aktiviert sind. Diese können unter Rubberduck &gt; Einstellungen deaktiviert werden.</value>
+Dieses Fenster wird angezeigt, da Aktualisierungsüberprüfungen aktiviert sind. Diese können unter Rubberduck &gt; Einstellungen deaktiviert werden.</value>
   </data>
   <data name="AssignedByValDialog_NewNameAlreadyUsedFormat" xml:space="preserve">
     <value>'{0}' ist in diesem Kontext bereits verfügbar.</value>
@@ -1451,7 +1451,7 @@ Import abgebrochen.</value>
     <value>Soll der Inhalt von Project '{0}' wirklich gelöscht und durch den Inhalt der ausgewählten Dateien ersetzt werden?</value>
   </data>
   <data name="UpdateFromFilesCommand_DialogCaption" xml:space="preserve">
-    <value>Komponenten mit Inhalt der Dateien überschreiben</value>
+    <value>Komponenten aus Dateien aktualisieren</value>
   </data>
   <data name="UpdateFromFilesCommand_DuplicateModule" xml:space="preserve">
     <value>Mehrere Dateien enthalten Code für die Komponente '{0}'.
@@ -1469,7 +1469,7 @@ Import abgebrochen.</value>
 Import abgebrochen.</value>
   </data>
   <data name="UpdateFromFilesCommand_UserFormDoesNotExist" xml:space="preserve">
-    <value>Es existiert keine Userform mit namens '{0}', s.d. kein Codebehind einer Userform aus der Datei '{1}' überschrieben werden kann.
+    <value>Es existiert keine Userform namens '{0}', s.d. kein Codebehind einer Userform aus der Datei '{1}' überschrieben werden kann.
 
 Import abgebrochen.</value>
   </data>

--- a/Rubberduck.Resources/RubberduckUI.de.resx
+++ b/Rubberduck.Resources/RubberduckUI.de.resx
@@ -1434,4 +1434,38 @@ ACHTUNG: Ein Neustart ist nötig, damit die Änderungen wirksam werden.</value>
   <data name="References_BrowseButtonText" xml:space="preserve">
     <value>Durchsuchen...</value>
   </data>
+  <data name="ImportCommand_UnsupportedFileExtensions" xml:space="preserve">
+    <value>Die Dateierweiterung der Datei '{0}' wird nicht unterstützt.
+
+Import abgebrochen.</value>
+  </data>
+  <data name="ReplaceProjectContentsFromFilesCommand_DialogCaption" xml:space="preserve">
+    <value>Projektinhalt durch Inhalt von Dateien ersetzen </value>
+  </data>
+  <data name="ReplaceProjectContentsFromFilesCommand_ConfirmationMessage" xml:space="preserve">
+    <value>Soll der Inhalt von Project '{0}' wirklich gelöscht und durch den Inhalt der ausgewählten Dateien ersetzt werden?</value>
+  </data>
+  <data name="UpdateFromFilesCommand_DialogCaption" xml:space="preserve">
+    <value>Komponenten mit Inhalt der Dateien überschreiben</value>
+  </data>
+  <data name="UpdateFromFilesCommand_DuplicateModule" xml:space="preserve">
+    <value>Mehrere Dateien enthalten Code für die Komponente '{0}'.
+
+Import abgebrochen.</value>
+  </data>
+  <data name="UpdateFromFilesCommand_DifferentComponentType" xml:space="preserve">
+    <value>Der Komponententyp der existierenden Komponente '{0}' stimmt nicht mit dem dem zur Dateierweiterung der Datei '{1}' gehörenden überein.
+
+Import abgebrochen.</value>
+  </data>
+  <data name="UpdateFromFilesCommand_DocumentDoesNotExist" xml:space="preserve">
+    <value>Es existiert kein Dokumentenmodul namens '{0}', s.d. die Datei '{1}' nicht importiert werden kann.
+
+Import abgebrochen.</value>
+  </data>
+  <data name="UpdateFromFilesCommand_UserFormDoesNotExist" xml:space="preserve">
+    <value>Es existiert keine Userform mit namens '{0}', s.d. kein Codebehind einer Userform aus der Datei '{1}' überschrieben werden kann.
+
+Import abgebrochen.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.de.resx
+++ b/Rubberduck.Resources/RubberduckUI.de.resx
@@ -990,7 +990,12 @@ Möchten sie die Einstellungen in Rubberduck importieren?</value>
     <value>Fenstersichtbarkeit beim Start</value>
   </data>
   <data name="VersionCheck_NewVersionAvailable" xml:space="preserve">
-    <value>Rubberduck Version {0} ist jetzt verfügbar! Wollen sie jetzt die Release Notes prüfen?</value>
+    <value>Sie verwenden momentan Rubberduck Version {0}.
+Version {1}({2}) ist nun verfügbar.
+
+Um den Change Log anzuschauen und Rubberduck manuell abzudaten, klicke 'Ja'.
+
+Dieses Fenster wird angezeigt, da Versionschecks aktiviert sind. Diese können unter Rubberduck &gt; Einstellungen deaktiviert werden.</value>
   </data>
   <data name="AssignedByValDialog_NewNameAlreadyUsedFormat" xml:space="preserve">
     <value>'{0}' ist in diesem Kontext bereits verfügbar.</value>
@@ -1467,5 +1472,8 @@ Import abgebrochen.</value>
     <value>Es existiert keine Userform mit namens '{0}', s.d. kein Codebehind einer Userform aus der Datei '{1}' überschrieben werden kann.
 
 Import abgebrochen.</value>
+  </data>
+  <data name="SaveAndClose" xml:space="preserve">
+    <value>Speichern &amp; Schließen</value>
   </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.resx
+++ b/Rubberduck.Resources/RubberduckUI.resx
@@ -1656,4 +1656,44 @@ NOTE: Restart is required for the setting to take effect.</value>
   <data name="VersionCheck_BuildType_Release" xml:space="preserve">
     <value>release</value>
   </data>
+  <data name="ImportCommand_UnsupportedFileExtensions" xml:space="preserve">
+    <value>The extension of the file '{0}' is not supported.
+
+Import aborted.</value>
+    <comment>{0} filename of unsupported file</comment>
+  </data>
+  <data name="ReplaceProjectContentsFromFilesCommand_DialogCaption" xml:space="preserve">
+    <value>Replace Project Content from Files</value>
+  </data>
+  <data name="ReplaceProjectContentsFromFilesCommand_ConfirmationMessage" xml:space="preserve">
+    <value>Really delete the contents of project '{0}' and replace it with the contents of the selected files?</value>
+    <comment>{0} project name</comment>
+  </data>
+  <data name="UpdateFromFilesCommand_DialogCaption" xml:space="preserve">
+    <value>Update Components from Files</value>
+  </data>
+  <data name="UpdateFromFilesCommand_DuplicateModule" xml:space="preserve">
+    <value>Multiple files contain code for the component '{0}'.
+
+Update aborted.</value>
+    <comment>{0} module name</comment>
+  </data>
+  <data name="UpdateFromFilesCommand_DifferentComponentType" xml:space="preserve">
+    <value>The component type of the existing component '{0}' does not agree with that indicated by the extension of file '{1}'.
+
+Update aborted.</value>
+    <comment>{0} module name, {1} filename</comment>
+  </data>
+  <data name="UpdateFromFilesCommand_DocumentDoesNotExist" xml:space="preserve">
+    <value>There is no existing document module with name '{0}'; file '{1}' cannot be imported.
+
+Update aborted.</value>
+    <comment>{0} module name, {1} filename</comment>
+  </data>
+  <data name="UpdateFromFilesCommand_UserFormDoesNotExist" xml:space="preserve">
+    <value>There is no user form with name '{0}'; no code behind can be updated from file '{1}'.
+
+Update aborted.</value>
+    <comment>{0} module name, {1} filename</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.resx
+++ b/Rubberduck.Resources/RubberduckUI.resx
@@ -1666,7 +1666,7 @@ Import aborted.</value>
     <value>Replace Project Content from Files</value>
   </data>
   <data name="ReplaceProjectContentsFromFilesCommand_ConfirmationMessage" xml:space="preserve">
-    <value>Really delete the contents of project '{0}' and replace it with the contents of the selected files?</value>
+    <value>Do you really want to delete the contents of project '{0}' and replace them with the contents of the selected files?</value>
     <comment>{0} project name</comment>
   </data>
   <data name="UpdateFromFilesCommand_DialogCaption" xml:space="preserve">

--- a/Rubberduck.VBEEditor/Extensions/ComponentTypeExtensions.cs
+++ b/Rubberduck.VBEEditor/Extensions/ComponentTypeExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace Rubberduck.VBEditor.Extensions
@@ -10,12 +11,18 @@ namespace Rubberduck.VBEditor.Extensions
         public const string FormBinaryExtension = ".frx";
         public const string DocClassExtension = ".doccls";
 
+        //TODO: double check whether the guesses below are correct.
+        public const string UserControlExtension = ".ctl";
+        public const string PropertyPageExtension = ".pag";
+        public const string DocObjectExtension = ".dob";
+
         /// <summary>
         /// Returns the proper file extension for the Component Type.
         /// </summary>
         /// <remarks>Document classes should properly have a ".cls" file extension.
         /// However, because they cannot be removed and imported like other component types, we need to make a distinction.</remarks>
         /// <param name="componentType"></param>
+        /// <param name="vbeKind"></param>
         /// <returns>File extension that includes a preceeding "dot" (.) </returns>
         public static string FileExtension(this ComponentType componentType)
         {
@@ -30,10 +37,40 @@ namespace Rubberduck.VBEditor.Extensions
                 case ComponentType.Document:
                     // documents should technically be a ".cls", but we need to be able to tell them apart.
                     return DocClassExtension;
-                case ComponentType.ActiveXDesigner:
+                case ComponentType.PropPage:
+                    return PropertyPageExtension;
+                case ComponentType.UserControl:
+                    return UserControlExtension;
+                case ComponentType.DocObject:
+                    return DocObjectExtension;
                 default:
                     return string.Empty;
             }
         }
+
+        public static IDictionary<string, ComponentType> ComponentTypeForExtension(VBEKind vbeKind)
+        {
+            return vbeKind == VBEKind.Hosted
+                ? VBAComponentTypeForExtension
+                : VB6ComponentTypeForExtension;
+        }
+
+        private static readonly IDictionary<string, ComponentType> VBAComponentTypeForExtension = new Dictionary<string, ComponentType>
+        {
+            [StandardExtension] = ComponentType.StandardModule,
+            [ClassExtension] = ComponentType.ClassModule,
+            [FormExtension] = ComponentType.UserForm,
+            [DocClassExtension] = ComponentType.Document
+        };
+
+        private static readonly IDictionary<string, ComponentType> VB6ComponentTypeForExtension = new Dictionary<string, ComponentType>
+        {
+            [StandardExtension] = ComponentType.StandardModule,
+            [ClassExtension] = ComponentType.ClassModule,
+            [FormExtension] = ComponentType.VBForm,
+            [UserControlExtension] = ComponentType.UserControl,
+            [PropertyPageExtension] = ComponentType.PropPage,
+            [DocObjectExtension] = ComponentType.DocObject,
+        };
     }
 }

--- a/Rubberduck.VBEEditor/Utility/ModuleNameFromFileExtractor.cs
+++ b/Rubberduck.VBEEditor/Utility/ModuleNameFromFileExtractor.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text;
+using Rubberduck.VBEditor.Extensions;
+
+namespace Rubberduck.VBEditor.Utility
+{
+    public interface IModuleNameFromFileExtractor
+    {
+        string ModuleName(string filename);
+    }
+
+    public class ModuleNameFromFileExtractor : IModuleNameFromFileExtractor
+    {
+        public string ModuleName(string filename)
+        {
+            if (!File.Exists(filename))
+            {
+                return null;
+            }
+
+            //We cannot read binary files.
+            if(ComponentTypeExtensions.FormBinaryExtension.Equals(Path.GetExtension(filename)))
+            {
+                return Path.GetFileNameWithoutExtension(filename);
+            }
+
+            var contents = File.ReadLines(filename, Encoding.Default);
+            var nameLine = contents.FirstOrDefault(line => line.StartsWith("Attribute VB_Name = "));
+            if (nameLine == null)
+            {
+                return Path.GetFileNameWithoutExtension(filename);
+            }
+
+            //The format is Attribute VB_Name = "ModuleName"
+            return nameLine.Substring("Attribute VB_Name = ".Length + 1, nameLine.Length - "Attribute VB_Name = ".Length - 2);
+        }
+    }
+}

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBComponents.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBComponents.cs
@@ -72,7 +72,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 
         public IVBComponent ImportSourceFile(string path)
         {
-            throw new NotSupportedException("ImportSourceFile not supported in VB6");
+            //Since we have no special handling as in VBA, we just forward to Import.
+            return Import(path);
         }
 
         public void RemoveSafely(IVBComponent component)

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBComponents.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBComponents.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using Rubberduck.VBEditor.Utility;
 using VB = Microsoft.Vbe.Interop;
 
 // ReSharper disable once CheckNamespace - Special dispensation due to conflicting file vs namespace priorities
@@ -14,6 +15,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 {
     public sealed class VBComponents : SafeEventedComWrapper<VB.VBComponents, VB._dispVBComponentsEvents>, IVBComponents, VB._dispVBComponentsEvents
     {
+        private readonly IModuleNameFromFileExtractor _moduleNameFromFileExtractor = new ModuleNameFromFileExtractor();
+
         public VBComponents(VB.VBComponents target, bool rewrapping = false) 
             : base(target, rewrapping)
         {
@@ -82,7 +85,6 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             }
 
             var ext = Path.GetExtension(path);
-            var name = Path.GetFileNameWithoutExtension(path);
             if (!File.Exists(path))
             {
                 return null;
@@ -94,6 +96,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                     return null;
                 case ComponentTypeExtensions.DocClassExtension:
                 {
+                    var name = _moduleNameFromFileExtractor.ModuleName(path);
                     IVBComponent component = null;
                     try
                     {
@@ -116,6 +119,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 }
                 case ComponentTypeExtensions.FormExtension:
                 {
+                    var name = _moduleNameFromFileExtractor.ModuleName(path);
                     IVBComponent component = null;
                     try
                     {

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -339,7 +339,7 @@ namespace RubberduckTests.CodeExplorer
 
         public void ExecuteImportCommand()
         {
-            ViewModel.ImportCommand = new ImportCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object);
+            ViewModel.ImportCommand = new ImportCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State);
             ViewModel.ImportCommand.Execute(ViewModel.SelectedItem);
         }
 

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -384,6 +384,12 @@ namespace RubberduckTests.CodeExplorer
             ViewModel.UpdateFromFilesCommand.Execute(ViewModel.SelectedItem);
         }
 
+        public void ExecuteReplaceProjectContentsFromFilesCommand()
+        {
+            ViewModel.ReplaceProjectContentsFromFilesCommand = new ReplaceProjectContentsFromFilesCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State);
+            ViewModel.ReplaceProjectContentsFromFilesCommand.Execute(ViewModel.SelectedItem);
+        }
+
         public void ExecuteExportAllCommand()
         {
             if (ViewModel.ExportAllCommand is null)

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -370,23 +370,33 @@ namespace RubberduckTests.CodeExplorer
             ViewModel.AddTestModuleWithStubsCommand.Execute(ViewModel.SelectedItem);
         }
 
-        public void ExecuteImportCommand()
+        public void ExecuteImportCommand(Mock<IMessageBox> mockMessageBock = null)
         {
-            ViewModel.ImportCommand = new ImportCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State);
+            var messageBox = mockMessageBock?.Object ?? new Mock<IMessageBox>().Object;
+            ViewModel.ImportCommand = new ImportCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State, messageBox);
             ViewModel.ImportCommand.Execute(ViewModel.SelectedItem);
         }
 
-        public void ExecuteUpdateFromFileCommand(Func<string, string> fileNameToModuleNameConverter)
+        public void ExecuteUpdateFromFileCommand(Func<string, string> fileNameToModuleNameConverter, Mock<IMessageBox> mockMessageBock = null)
         {
+            var messageBox = mockMessageBock?.Object ?? new Mock<IMessageBox>().Object;
             var mockModuleNameExtractor = new Mock<IModuleNameFromFileExtractor>();
             mockModuleNameExtractor.Setup(m => m.ModuleName(It.IsAny<string>())).Returns((string filename) => fileNameToModuleNameConverter(filename));
-            ViewModel.UpdateFromFilesCommand = new UpdateFromFilesCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State, State, State.ProjectsProvider, mockModuleNameExtractor.Object);
+            ViewModel.UpdateFromFilesCommand = new UpdateFromFilesCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State, State, State.ProjectsProvider, mockModuleNameExtractor.Object, messageBox);
             ViewModel.UpdateFromFilesCommand.Execute(ViewModel.SelectedItem);
         }
 
-        public void ExecuteReplaceProjectContentsFromFilesCommand()
+        public void ExecuteReplaceProjectContentsFromFilesCommand(Mock<IMessageBox> mockMessageBock = null)
         {
-            ViewModel.ReplaceProjectContentsFromFilesCommand = new ReplaceProjectContentsFromFilesCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State);
+            var messageBoxMock = mockMessageBock;
+            if (messageBoxMock == null)
+            {
+                messageBoxMock = new Mock<IMessageBox>();
+                messageBoxMock
+                    .Setup(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                    .Returns(true);
+            }
+            ViewModel.ReplaceProjectContentsFromFilesCommand = new ReplaceProjectContentsFromFilesCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State, messageBoxMock.Object);
             ViewModel.ReplaceProjectContentsFromFilesCommand.Execute(ViewModel.SelectedItem);
         }
 

--- a/RubberduckTests/Mocks/MockProjectBuilder.cs
+++ b/RubberduckTests/Mocks/MockProjectBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Moq;
 using Rubberduck.Parsing.Grammar;
@@ -211,18 +212,18 @@ namespace RubberduckTests.Mocks
 
             result.Setup(m => m.Import(It.IsAny<string>())).Callback((string s) =>
             {
-                var parts = s.Split('.').ToList();
+                var extension = Path.GetExtension(s);
                 var types = new Dictionary<string, ComponentType>
                 {
-                    {"bas", ComponentType.StandardModule},
-                    {"cls", ComponentType.ClassModule},
-                    {"frm", ComponentType.UserForm}
+                    {".bas", ComponentType.StandardModule},
+                    {".cls", ComponentType.ClassModule},
+                    {".frm", ComponentType.UserForm}
                 };
 
                 ComponentType type;
-                types.TryGetValue(parts.Last(), out type);
+                types.TryGetValue(extension, out type);
 
-                _componentsMock.Add(CreateComponentMock(s.Split('\\').Last(), type, string.Empty, new Selection(), null, out var codeModule));
+                _componentsMock.Add(CreateComponentMock(Path.GetFileNameWithoutExtension(s), type, string.Empty, new Selection(), null, out var codeModule));
                 _codeModuleMocks.Add(codeModule);
             });
 


### PR DESCRIPTION
Closes #4781

This PR introduces two new import commands, `ReplaceProjectContentsFromFilesCommand` and `UpdateFromFilesCommand`. The first removes all reimportable components from the target project before importing from the selected files. (A confirmation dialog is planned.) The second one removes existing components with the same component name before importing from file. This will abort, if either a component name exists multiple times in the files to import or the file extension of the file to import for a component name does not correspond to the component type of an existing component of the same name.

The user interaction around the confirmation and aborting the import still has to be implemented, as well as the inclusion into the context menu. However, I wanted to get this out for review already since I need some feedback on the relationship of the file extensions and component types. Is my understanding that they are 1:1 correct? What does `.doccls` correspond to and is my guess for VB6 correct?