### PR TITLE
Make the UI dispatcher more deadlock safe

### DIFF
--- a/Rubberduck.Parsing/UIContext/UiDispatcher.cs
+++ b/Rubberduck.Parsing/UIContext/UiDispatcher.cs
@@ -126,6 +126,12 @@ namespace Rubberduck.Parsing.UIContext
         {
             CheckInitialization();
 
+            if (_contextProvider.UiContext == SynchronizationContext.Current)
+            {
+                action.Invoke();
+                return Task.CompletedTask;
+            }
+
             return Task.Factory.StartNew(action, token, options, _contextProvider.UiTaskScheduler);
         }
 
@@ -140,6 +146,12 @@ namespace Rubberduck.Parsing.UIContext
         public Task<T> StartTask<T>(Func<T> func, CancellationToken token, TaskCreationOptions options = TaskCreationOptions.None)
         {
             CheckInitialization();
+
+            if (_contextProvider.UiContext == SynchronizationContext.Current)
+            {
+                var returnValue = func();
+                return Task.FromResult(returnValue);
+            }
 
             return Task.Factory.StartNew(func, token, options, _contextProvider.UiTaskScheduler);
         }


### PR DESCRIPTION
This PR changes the behaviour of `UiDispatcher.StartTask` in case we are already on the UI synchronization context/ In this case, it will perform the requested action immediately and return a completed task. This removes the potential deadlock from creating a new task from the UI thread and then waiting for it.