### PR TITLE
Fixes around deadlocks

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Results/IdentifierReferenceInspectionResult.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Results/IdentifierReferenceInspectionResult.cs
@@ -34,8 +34,8 @@ namespace Rubberduck.Inspections.Results
 
         public override bool ChangesInvalidateResult(ICollection<QualifiedModuleName> modifiedModules)
         {
-            return modifiedModules.Contains(Target.QualifiedModuleName)
-                || base.ChangesInvalidateResult(modifiedModules);
+            return Target != null && modifiedModules.Contains(Target.QualifiedModuleName)
+                   || base.ChangesInvalidateResult(modifiedModules);
         }
     }
 }

--- a/Rubberduck.Core/UI/Command/RunSelectedTestMethodCommand.cs
+++ b/Rubberduck.Core/UI/Command/RunSelectedTestMethodCommand.cs
@@ -50,7 +50,8 @@ namespace Rubberduck.UI.Command
 
         private bool IsTestMethod(Declaration member)
         {
-            return member.DeclarationType == DeclarationType.Procedure
+            return member != null 
+                   && member.DeclarationType == DeclarationType.Procedure
                    && member.Annotations.Any(parseTreeAnnotation =>
                        parseTreeAnnotation.Annotation is TestMethodAnnotation);
         }

--- a/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
+++ b/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.UnitTesting
     // FIXME litter logging around here
     internal class TestEngine : ITestEngine
     {
-        private static readonly ParserState[] AllowedRunStates = 
+        protected static readonly ParserState[] AllowedRunStates = 
         {
             ParserState.Ready
         };
@@ -171,7 +171,7 @@ namespace Rubberduck.UnitTesting
             CancellationRequested = true;
         }
 
-        private void RunInternal(IEnumerable<TestMethod> tests)
+        protected virtual void RunInternal(IEnumerable<TestMethod> tests)
         {
             if (!CanRun)
             {
@@ -199,15 +199,15 @@ namespace Rubberduck.UnitTesting
             }
         }
 
-        private void RunWhileSuspended(IEnumerable<TestMethod> tests)
+        protected void RunWhileSuspended(IEnumerable<TestMethod> tests)
         {
             //Running the tests has to be done on the UI thread, so we push the task to it from within suspension of the parser.
             //We have to wait for the completion to make sure that the suspension only ends after tests have been completed.
-            var testTask = _uiDispatcher.StartTask(() => RunWhileSuspendedOnUIThread(tests));
+            var testTask = _uiDispatcher.StartTask(() => RunWhileSuspendedOnUiThread(tests));
             testTask.Wait();
         }
 
-        private void RunWhileSuspendedOnUIThread(IEnumerable<TestMethod> tests)
+        private void RunWhileSuspendedOnUiThread(IEnumerable<TestMethod> tests)
         {
             var testMethods = tests as IList<TestMethod> ?? tests.ToList();
             if (!testMethods.Any())

--- a/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
+++ b/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
@@ -20,8 +20,6 @@ namespace Rubberduck.UnitTesting
     {
         private static readonly ParserState[] AllowedRunStates = 
         {
-            ParserState.ResolvedDeclarations,
-            ParserState.ResolvingReferences,
             ParserState.Ready
         };
 

--- a/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
+++ b/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using NLog;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
@@ -176,7 +177,8 @@ namespace Rubberduck.UnitTesting
             {
                 return;
             }
-            _state.OnSuspendParser(this, AllowedRunStates, () => RunWhileSuspended(tests));
+            //We push the suspension to a background thread to avoid potential deadlocks if a parse is still running.
+            Task.Run(() => _state.OnSuspendParser(this, AllowedRunStates, () => RunWhileSuspended(tests)));
         }
 
         private void EnsureRubberduckIsReferencedForEarlyBoundTests()
@@ -198,6 +200,14 @@ namespace Rubberduck.UnitTesting
         }
 
         private void RunWhileSuspended(IEnumerable<TestMethod> tests)
+        {
+            //Running the tests has to be done on the UI thread, so we push the task to it from within suspension of the parser.
+            //We have to wait for the completion to make sure that the suspension only ends after tests have been completed.
+            var testTask = _uiDispatcher.StartTask(() => RunWhileSuspendedOnUIThread(tests));
+            testTask.Wait();
+        }
+
+        private void RunWhileSuspendedOnUIThread(IEnumerable<TestMethod> tests)
         {
             var testMethods = tests as IList<TestMethod> ?? tests.ToList();
             if (!testMethods.Any())

--- a/RubberduckTests/UnitTesting/MockedTestEngine.cs
+++ b/RubberduckTests/UnitTesting/MockedTestEngine.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using Rubberduck.Parsing.UIContext;
@@ -47,8 +48,17 @@ End Sub";
 
         private MockedTestEngine()
         {
-            Dispatcher.Setup(d => d.InvokeAsync(It.IsAny<Action>())).Callback((Action action) => action.Invoke()).Verifiable();
-            
+            Dispatcher.Setup(d => d.InvokeAsync(It.IsAny<Action>()))
+                .Callback((Action action) => action.Invoke())
+                .Verifiable();
+            Dispatcher.Setup(d => d.StartTask(It.IsAny<Action>(), It.IsAny<TaskCreationOptions>()))
+                .Returns((Action action, TaskCreationOptions options) =>
+                    {
+                        action.Invoke();
+                        return Task.CompletedTask;
+                    })
+                .Verifiable();
+
             TypeLib.Setup(tlm => tlm.Dispose()).Verifiable();
             WrapperProvider.Setup(p => p.TypeLibWrapperFromProject(It.IsAny<string>())).Returns(TypeLib.Object).Verifiable();
 
@@ -64,7 +74,7 @@ End Sub";
 
             Vbe = builder.Build();
             ParserState = MockParser.Create(Vbe.Object).State;
-            TestEngine = new TestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object);
+            TestEngine = new SynchronouslySuspendingTestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object);
         }
 
         public MockedTestEngine(IReadOnlyList<string> moduleNames, IReadOnlyList<int> methodCounts) : this()
@@ -87,7 +97,7 @@ End Sub";
             project.AddProjectToVbeBuilder();
             Vbe = builder.Build();
             ParserState = MockParser.Create(Vbe.Object).State;
-            TestEngine = new TestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object);
+            TestEngine = new SynchronouslySuspendingTestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object);
         }
 
         public MockedTestEngine(int testMethodCount) 
@@ -246,5 +256,32 @@ Public Sub TestCleanup()
     'this method runs after every test in the module.
 End Sub
 ";
+
+        private class SynchronouslySuspendingTestEngine : TestEngine
+        {
+            private readonly RubberduckParserState _state;
+
+            public SynchronouslySuspendingTestEngine(
+                RubberduckParserState state,
+                IFakesFactory fakesFactory,
+                IVBEInteraction declarationRunner,
+                ITypeLibWrapperProvider wrapperProvider,
+                IUiDispatcher uiDispatcher,
+                IVBE vbe)
+                : base(state, fakesFactory, declarationRunner, wrapperProvider, uiDispatcher, vbe)
+            {
+                _state = state;
+            }
+
+            protected override void RunInternal(IEnumerable<TestMethod> tests)
+            {
+                if (!CanRun)
+                {
+                    return;
+                }
+                //We have to do this on the same thread here to guarantee that the actions runs before the assert in the unit tests is called.
+                _state.OnSuspendParser(this, AllowedRunStates, () => RunWhileSuspended(tests));
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #5053

This PR fixes a few bugs around hanging RD. 
The main change is in the test engine, which now requests the suspension on a background thread and pushes to the UI thread from within the suspension action. This avoids the deadlock experienced in #5053. Since we cannot execute the tests before the parse has ended anyway, the states in which the tests can be run has been restricted to `Ready` only. 

In addition, this PR fixes to NREs I introduced in earlier PRs. One is in the `CanExecute` method of the `RunSelectedTestMethodCommand`, which did not handle that nothing at all might be selected. The second one is in `ChangesInvalidateIsnpectionResult` on `IdentifierReferenceInspectionResult`, which assumed that the `Target` declaration could never be `null`. This is no longer true since the results for the `UnboundDefaultMemberAccess` inspections do not have a referenced declaration. 

Fixing this last NRE seems to have removed one condition under which the code inspection window would fall into a permanent busy state and the command bar's state changed handler for the `Ready` state would never be reached.