### PR TITLE
Fix scroll bars in test and inspection reults windows

### DIFF
--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -33,7 +33,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+    <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
         <Grid UseLayoutRounding="True">
             <Grid.RowDefinitions>
                 <RowDefinition Height="30"/>
@@ -201,10 +201,11 @@
                                SelectedItem="{Binding SelectedItem}"
                                SelectionUnit="FullRow"
                                ItemsSource="{Binding Results, NotifyOnSourceUpdated=True}"
+                               RequestBringIntoView="InspectionResultsGrid_RequestBringIntoView"
                                VirtualizingPanel.IsVirtualizingWhenGrouping="True"
                                ScrollViewer.CanContentScroll="True" 
                                ScrollViewer.VerticalScrollBarVisibility="Auto"
-                               ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                               ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <DataGrid.RowDetailsTemplate>
                     <DataTemplate>
                         <Grid>

--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
@@ -75,7 +75,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+    <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="30"/>
@@ -355,7 +355,11 @@
                                        SelectionMode="Extended"
                                        ShowGroupingItemCount="True"
                                        InitialExpandedState="True"
-                                       RequestBringIntoView="TestGrid_RequestBringIntoView">
+                                       RequestBringIntoView="TestGrid_RequestBringIntoView"
+                                       VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                                       ScrollViewer.CanContentScroll="True" 
+                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                       ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                         <DataGrid.Columns>
                             <DataGridTemplateColumn Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_Outcome}">
                                 <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
Closes #5265
Closes #5302

This fixes several problems with the scroll bars in the results windows. The basic problem was that the recently introduced scroll viewer around the entire control had vertical scrolling enabled. This took precedence over the grouping grid's own vertical scroll viewer. 

Now, the data grid can be scrolled independently again and the scroll wheel works again as well. Hopefully, this also improves the performance of the windows by making virtualization work properly again. As an addition, the fix for the test results to not move the horizontal scroll bar on selection of an item was ported to the inspection results window.

The control is not ideal now since the vertical scroll bar vanishes when scrolling to the left horizontally, but I do not know how to fix that.