### PR TITLE
Scroll viewer again

### DIFF
--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -33,201 +33,62 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
-        <Grid UseLayoutRounding="True">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="30"/>
-                <RowDefinition Height="*" MinHeight="64" />
-                <RowDefinition Height="5"/>
-                <RowDefinition Height="Auto" MinHeight="48"/>
-            </Grid.RowDefinitions>
 
-            <ToolBarTray Grid.Row="0" IsLocked="True">
+    <Grid UseLayoutRounding="True">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="*" MinHeight="64" />
+            <RowDefinition Height="5"/>
+            <RowDefinition Height="Auto" MinHeight="48"/>
+        </Grid.RowDefinitions>
 
-                <ToolBar Style="{StaticResource ToolBarWithOverflowOnlyShowingWhenNeededStyle}">
-                    <ToolBar.Resources>
-                        <codeInspections:InspectionFilterToBooleanConverter x:Key="InspectionTypeToBooleanConverter" />
-                        <codeInspections:InspectionResultGroupingToBooleanConverter x:Key="GroupingToBooleanConverter" />
-                        <Style x:Key="ToolBarToggleStyle" TargetType="ToggleButton">
-                            <Setter Property="Margin" Value="2" />
-                            <Setter Property="BorderBrush" Value="{x:Static SystemColors.ActiveBorderBrush}" />
-                        </Style>
-                        <BitmapImage x:Key="CopyResultsImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/document-copy.png" />
-                        <BitmapImage x:Key="SettingsImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/gear.png" />
-                        <BitmapImage x:Key="RefreshImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/arrow-circle-double.png" />
-                        <BitmapImage x:Key="FixImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/tick.png" />
+        <Border Grid.Row="0" Grid.RowSpan="3" Background="#FFEEF5FD" />
 
-                        <BitmapImage x:Key="GroupByInspectionTypeImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/block.png" />
-                        <BitmapImage x:Key="GroupByInspectionImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/light-bulb-code.png" />
-                        <BitmapImage x:Key="GroupByLocationImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Custom/PNG/ObjectClass.png" />
-                        <BitmapImage x:Key="GroupBySeverityImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Custom/PNG/Severity.png" />
+        <ToolBarTray Grid.Row="0" IsLocked="True">
+            <ToolBar Style="{StaticResource ToolBarWithOverflowOnlyShowingWhenNeededStyle}">
+                <ToolBar.Resources>
+                    <codeInspections:InspectionFilterToBooleanConverter x:Key="InspectionTypeToBooleanConverter" />
+                    <codeInspections:InspectionResultGroupingToBooleanConverter x:Key="GroupingToBooleanConverter" />
+                    <Style x:Key="ToolBarToggleStyle" TargetType="ToggleButton">
+                        <Setter Property="Margin" Value="2" />
+                        <Setter Property="BorderBrush" Value="{x:Static SystemColors.ActiveBorderBrush}" />
+                    </Style>
+                    <BitmapImage x:Key="CopyResultsImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/document-copy.png" />
+                    <BitmapImage x:Key="SettingsImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/gear.png" />
+                    <BitmapImage x:Key="RefreshImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/arrow-circle-double.png" />
+                    <BitmapImage x:Key="FixImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/tick.png" />
 
-                        <BitmapImage x:Key="FilterImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/Funnel.png" />
-                        <BitmapImage x:Key="FilterByHintImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/information-white.png" />
-                        <BitmapImage x:Key="FilterBySuggestionImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/information.png" />
-                        <BitmapImage x:Key="FilterByWarningImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/exclamation.png" />
-                        <BitmapImage x:Key="FilterByErrorImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/cross-circle.png" />
+                    <BitmapImage x:Key="GroupByInspectionTypeImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/block.png" />
+                    <BitmapImage x:Key="GroupByInspectionImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/light-bulb-code.png" />
+                    <BitmapImage x:Key="GroupByLocationImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Custom/PNG/ObjectClass.png" />
+                    <BitmapImage x:Key="GroupBySeverityImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Custom/PNG/Severity.png" />
 
-                        <BitmapImage x:Key="ExpandAllImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/expand-all.png" />
-                        <BitmapImage x:Key="CollapseAllImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/collapse-all.png" />
-                    </ToolBar.Resources>
+                    <BitmapImage x:Key="FilterImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/Funnel.png" />
+                    <BitmapImage x:Key="FilterByHintImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/information-white.png" />
+                    <BitmapImage x:Key="FilterBySuggestionImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/information.png" />
+                    <BitmapImage x:Key="FilterByWarningImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/exclamation.png" />
+                    <BitmapImage x:Key="FilterByErrorImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/cross-circle.png" />
 
-                    <Button Command="{Binding RefreshCommand}">
-                        <Image Source="{StaticResource RefreshImage}" />
-                    </Button>
+                    <BitmapImage x:Key="ExpandAllImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/expand-all.png" />
+                    <BitmapImage x:Key="CollapseAllImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/collapse-all.png" />
+                </ToolBar.Resources>
 
-                    <Separator />
-                    <Menu Background="Transparent">
-                        <MenuItem VerticalAlignment="Center"
+                <Button Command="{Binding RefreshCommand}">
+                    <Image Source="{StaticResource RefreshImage}" />
+                </Button>
+
+                <Separator />
+                <Menu Background="Transparent">
+                    <MenuItem VerticalAlignment="Center"
                               HeaderTemplate="{StaticResource MenuItemHeaderDropdownIndicatorTemplate}"
                               ItemsSource="{Binding QuickFixes}" Background="Transparent">
-                            <MenuItem.Icon>
-                                <Image Source="{StaticResource FixImage}" />
-                            </MenuItem.Icon>
-                            <MenuItem.Header>
-                                <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Fix}" />
-                            </MenuItem.Header>
-                            <MenuItem.ItemContainerStyle>
-                                <Style TargetType="{x:Type MenuItem}">
-                                    <Setter Property="Icon">
-                                        <Setter.Value>
-                                            <Image Source="{Binding Fix, Converter={StaticResource QuickFixIconConverter}}" />
-                                        </Setter.Value>
-                                    </Setter>
-                                    <Setter Property="Command" Value="{Binding Command}" />
-                                    <Setter Property="CommandParameter" Value="{Binding Fix}" />
-                                    <Setter Property="Header" Value="{Binding Description}" />
-                                    <Setter Property="Background" Value="Transparent"></Setter>
-                                </Style>
-                            </MenuItem.ItemContainerStyle>
-                        </MenuItem>
-                    </Menu>
-
-                    <Separator />
-
-                    <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_GroupingStyle}" VerticalContentAlignment="Center" />
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByInspectionType}"
-                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Type}}">
-                        <Image Source="{StaticResource GroupByInspectionTypeImage}" />
-                    </ToggleButton>
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByName}"
-                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Name}}">
-                        <Image Source="{StaticResource GroupByInspectionImage}" />
-                    </ToggleButton>
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByLocation}"
-                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Location}}">
-                        <Image Source="{StaticResource GroupByLocationImage}" />
-                    </ToggleButton>
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_BySeverity}"
-                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Severity}}">
-                        <Image Source="{StaticResource GroupBySeverityImage}" />
-                    </ToggleButton>
-
-                    <Separator />
-
-                    <Image Source="{StaticResource FilterImage}" />
-
-                    <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_Filter}" VerticalContentAlignment="Center" />
-
-                    <controls:SearchBox Width="100"
-                                    Text="{Binding InspectionDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-
-                    <Label Content="{Resx ResxName=Rubberduck.Resources.Inspections.InspectionsUI ,Key=CodeInspection_SeverityFilter}" />
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByError}"
-                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Error}}">
-                        <Image Source="{StaticResource FilterByErrorImage}" />
-                    </ToggleButton>
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByWarning}"
-                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Warning}}">
-                        <Image Source="{StaticResource FilterByWarningImage}" />
-                    </ToggleButton>
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterBySuggestion}"
-                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Suggestion}}">
-                        <Image Source="{StaticResource FilterBySuggestionImage}" />
-                    </ToggleButton>
-
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
-                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByHint}"
-                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Hint}}">
-                        <Image Source="{StaticResource FilterByHintImage}" />
-                    </ToggleButton>
-
-                    <Separator />
-
-                    <Button Name="CollapseAll" Command="{Binding CollapseAllCommand}" Margin="2"
-                        ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_CollapseAll}">
-                        <Image Source="{StaticResource CollapseAllImage}" />
-                    </Button>
-
-                    <Button Name="ExpandAll" Command="{Binding ExpandAllCommand}" Margin="2"
-                        ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_ExpandAll}">
-                        <Image Source="{StaticResource ExpandAllImage}" />
-                    </Button>
-
-                    <Separator />
-
-                    <Button Command="{Binding CopyResultsCommand}">
-                        <Image Source="{StaticResource CopyResultsImage}" />
-                        <Button.ToolTip>
-                            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_CopyToolTip}" />
-                        </Button.ToolTip>
-                    </Button>
-
-                    <Separator />
-
-                    <Button ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Settings}" Command="{Binding OpenInspectionSettings}" BorderThickness="0" Background="Transparent">
-                        <Image Source="{StaticResource SettingsImage}" />
-                    </Button>
-                </ToolBar>
-            </ToolBarTray>
-
-            <controls:GroupingGrid x:Name="InspectionResultsGrid"
-                               Grid.Row="1"
-                               ShowGroupingItemCount="True"
-                               SelectedItem="{Binding SelectedItem}"
-                               SelectionUnit="FullRow"
-                               ItemsSource="{Binding Results, NotifyOnSourceUpdated=True}"
-                               RequestBringIntoView="InspectionResultsGrid_RequestBringIntoView"
-                               VirtualizingPanel.IsVirtualizingWhenGrouping="True"
-                               ScrollViewer.CanContentScroll="True" 
-                               ScrollViewer.VerticalScrollBarVisibility="Auto"
-                               ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                <DataGrid.RowDetailsTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Rectangle Fill="Transparent" />
-                            <GridViewRowPresenter/>
-                        </Grid>
-                    </DataTemplate>
-                </DataGrid.RowDetailsTemplate>
-                <DataGrid.Columns>
-                    <DataGridTemplateColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=CodeInspectionResults_Type}">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate DataType="abstract1:IInspectionResult">
-                                <Image Source="{Binding Inspection, Converter={StaticResource InspectionIconConverter}, Mode=OneTime}" Width="16" Height="16" />
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=CodeInspectionResults_Issue}" Binding="{Binding Description, Mode=OneTime}" />
-                    <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=CodeInspectionResults_Location}" Binding="{Binding QualifiedSelection.QualifiedName, Mode=OneTime, Converter={StaticResource GroupingGridLocationConverter}}" />
-                </DataGrid.Columns>
-                <DataGrid.ContextMenu>
-                    <ContextMenu ItemsSource="{Binding PlacementTarget.DataContext.QuickFixes, RelativeSource={RelativeSource Self}}">
-                        <ContextMenu.Resources>
+                        <MenuItem.Icon>
+                            <Image Source="{StaticResource FixImage}" />
+                        </MenuItem.Icon>
+                        <MenuItem.Header>
+                            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Fix}" />
+                        </MenuItem.Header>
+                        <MenuItem.ItemContainerStyle>
                             <Style TargetType="{x:Type MenuItem}">
                                 <Setter Property="Icon">
                                     <Setter.Value>
@@ -237,25 +98,167 @@
                                 <Setter Property="Command" Value="{Binding Command}" />
                                 <Setter Property="CommandParameter" Value="{Binding Fix}" />
                                 <Setter Property="Header" Value="{Binding Description}" />
-                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="Background" Value="Transparent"></Setter>
                             </Style>
-                        </ContextMenu.Resources>
-                    </ContextMenu>
-                </DataGrid.ContextMenu>
-                <i:Interaction.Behaviors>
-                    <controls:GroupItemExpandedBehavior ExpandedState="{Binding ExpandedState, Mode=TwoWay}" />
-                </i:Interaction.Behaviors>
-            </controls:GroupingGrid>
+                        </MenuItem.ItemContainerStyle>
+                    </MenuItem>
+                </Menu>
 
-            <controls:EmptyUIRefresh Grid.Row="1" Visibility="{Binding Unparsed, Converter={StaticResource BoolToVisibility}}" />
-            <controls:BusyIndicator Grid.Row="1" Width="120" Height="120" Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibility}}" />
+                <Separator />
 
-            <GridSplitter Grid.Row="2" Height="5" ShowsPreview="True" Cursor="SizeNS" HorizontalAlignment="Stretch"/>
+                <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_GroupingStyle}" VerticalContentAlignment="Center" />
 
-            <Border Grid.Row="3" BorderThickness="0,1,0,0" BorderBrush="DimGray">
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByInspectionType}"
+                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Type}}">
+                    <Image Source="{StaticResource GroupByInspectionTypeImage}" />
+                </ToggleButton>
 
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByName}"
+                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Name}}">
+                    <Image Source="{StaticResource GroupByInspectionImage}" />
+                </ToggleButton>
+
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByLocation}"
+                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Location}}">
+                    <Image Source="{StaticResource GroupByLocationImage}" />
+                </ToggleButton>
+
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_BySeverity}"
+                              IsChecked="{Binding Path=Grouping, Converter={StaticResource GroupingToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultGrouping.Severity}}">
+                    <Image Source="{StaticResource GroupBySeverityImage}" />
+                </ToggleButton>
+
+                <Separator />
+
+                <Image Source="{StaticResource FilterImage}" />
+
+                <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_Filter}" VerticalContentAlignment="Center" />
+
+                <controls:SearchBox Width="100"
+                                    Text="{Binding InspectionDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                <Label Content="{Resx ResxName=Rubberduck.Resources.Inspections.InspectionsUI ,Key=CodeInspection_SeverityFilter}" />
+
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByError}"
+                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Error}}">
+                    <Image Source="{StaticResource FilterByErrorImage}" />
+                </ToggleButton>
+
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByWarning}"
+                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Warning}}">
+                    <Image Source="{StaticResource FilterByWarningImage}" />
+                </ToggleButton>
+
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterBySuggestion}"
+                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Suggestion}}">
+                    <Image Source="{StaticResource FilterBySuggestionImage}" />
+                </ToggleButton>
+
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                              ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_FilterByHint}"
+                              IsChecked="{Binding Path=SelectedFilters, Converter={StaticResource InspectionTypeToBooleanConverter}, ConverterParameter={x:Static codeInspections:InspectionResultsFilter.Hint}}">
+                    <Image Source="{StaticResource FilterByHintImage}" />
+                </ToggleButton>
+
+                <Separator />
+
+                <Button Name="CollapseAll" Command="{Binding CollapseAllCommand}" Margin="2"
+                        ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_CollapseAll}">
+                    <Image Source="{StaticResource CollapseAllImage}" />
+                </Button>
+
+                <Button Name="ExpandAll" Command="{Binding ExpandAllCommand}" Margin="2"
+                        ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_ExpandAll}">
+                    <Image Source="{StaticResource ExpandAllImage}" />
+                </Button>
+
+                <Separator />
+
+                <Button Command="{Binding CopyResultsCommand}">
+                    <Image Source="{StaticResource CopyResultsImage}" />
+                    <Button.ToolTip>
+                        <TextBlock Text="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_CopyToolTip}" />
+                    </Button.ToolTip>
+                </Button>
+
+                <Separator />
+
+                <Button ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Settings}" Command="{Binding OpenInspectionSettings}" BorderThickness="0" Background="Transparent">
+                    <Image Source="{StaticResource SettingsImage}" />
+                </Button>
+            </ToolBar>
+        </ToolBarTray>
+        <Border Grid.Row="1">
+            <Grid>
+                <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
+                    <controls:GroupingGrid x:Name="InspectionResultsGrid"
+                                           ShowGroupingItemCount="True"
+                                           SelectedItem="{Binding SelectedItem}"
+                                           SelectionUnit="FullRow"
+                                           ItemsSource="{Binding Results, NotifyOnSourceUpdated=True}"
+                                           RequestBringIntoView="InspectionResultsGrid_RequestBringIntoView"
+                                           VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                                           ScrollViewer.CanContentScroll="True" 
+                                           ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                           ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                        <DataGrid.RowDetailsTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Rectangle Fill="Transparent" />
+                                    <GridViewRowPresenter/>
+                                </Grid>
+                            </DataTemplate>
+                        </DataGrid.RowDetailsTemplate>
+                        <DataGrid.Columns>
+                            <DataGridTemplateColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=CodeInspectionResults_Type}">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate DataType="abstract1:IInspectionResult">
+                                        <Image Source="{Binding Inspection, Converter={StaticResource InspectionIconConverter}, Mode=OneTime}" Width="16" Height="16" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=CodeInspectionResults_Issue}" Binding="{Binding Description, Mode=OneTime}" />
+                            <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=CodeInspectionResults_Location}" Binding="{Binding QualifiedSelection.QualifiedName, Mode=OneTime, Converter={StaticResource GroupingGridLocationConverter}}" />
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu ItemsSource="{Binding PlacementTarget.DataContext.QuickFixes, RelativeSource={RelativeSource Self}}">
+                                <ContextMenu.Resources>
+                                    <Style TargetType="{x:Type MenuItem}">
+                                        <Setter Property="Icon">
+                                            <Setter.Value>
+                                                <Image Source="{Binding Fix, Converter={StaticResource QuickFixIconConverter}}" />
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Setter Property="Command" Value="{Binding Command}" />
+                                        <Setter Property="CommandParameter" Value="{Binding Fix}" />
+                                        <Setter Property="Header" Value="{Binding Description}" />
+                                        <Setter Property="Background" Value="Transparent" />
+                                    </Style>
+                                </ContextMenu.Resources>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                        <i:Interaction.Behaviors>
+                            <controls:GroupItemExpandedBehavior ExpandedState="{Binding ExpandedState, Mode=TwoWay}" />
+                        </i:Interaction.Behaviors>
+                    </controls:GroupingGrid>
+                </ScrollViewer>
+                <controls:EmptyUIRefresh Visibility="{Binding Unparsed, Converter={StaticResource BoolToVisibility}}" />
+                <controls:BusyIndicator Width="120" Height="120" Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibility}}" />
+            </Grid>
+        </Border>
+
+        <GridSplitter Grid.Row="2" Height="5" ShowsPreview="True" Cursor="SizeNS" HorizontalAlignment="Stretch"/>
+
+        <Border Grid.Row="3" BorderThickness="0,1,0,0" BorderBrush="DimGray">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <StackPanel Orientation="Vertical" MinHeight="48" Background="WhiteSmoke">
-
                     <Grid Margin="4" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="25" />
@@ -292,9 +295,8 @@
                             Content="{Resx ResxName=Rubberduck.Resources.Inspections.InspectionsUI, Key=DisableThisInspection}" />
                     </WrapPanel>
                 </StackPanel>
-            </Border>
-
-        </Grid>
-    </ScrollViewer>
+            </ScrollViewer>
+        </Border>
+    </Grid>
 
 </UserControl>

--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
@@ -75,281 +75,282 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="30"/>
-                <RowDefinition Height="10"/>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
 
-            <Border Grid.Row="0" Grid.RowSpan="3" Background="#FFEEF5FD" />
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="10"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-            <ToolBarTray Grid.Row="0" IsLocked="True">
-                <ToolBar Style="{StaticResource ToolBarWithOverflowOnlyShowingWhenNeededStyle}">
-                    <ToolBar.Resources>
-                        <local:TestExplorerGroupingBooleanConverter x:Key="OutcomeConverter" />
-                        <local:TestExplorerGroupingBooleanConverter x:Key="LocationConverter" />
-                        <local:TestExplorerGroupingBooleanConverter x:Key="CategoryConverter" />
-                        <local:TestExplorerOutcomeFilterToBooleanConverter x:Key="OutcomeFilterConverter" />
-                        <Style x:Key="ToolBarToggleStyle" TargetType="ToggleButton">
-                            <Setter Property="Margin" Value="2" />
-                            <Setter Property="BorderBrush" Value="{x:Static SystemColors.ActiveBorderBrush}" />
-                        </Style>
-                        <Style TargetType="Image">
-                            <Setter Property="Height" Value="16" />
-                        </Style>
-                    </ToolBar.Resources>
+        <Border Grid.Row="0" Grid.RowSpan="3" Background="#FFEEF5FD" />
 
-                    <Button Command="{Binding RefreshCommand}" >
-                        <Image Source="{StaticResource RefreshImage}" Style="{StaticResource ToolbarImageOpacity}" />
-                    </Button>
+        <ToolBarTray Grid.Row="0" IsLocked="True">
+            <ToolBar Style="{StaticResource ToolBarWithOverflowOnlyShowingWhenNeededStyle}">
+                <ToolBar.Resources>
+                    <local:TestExplorerGroupingBooleanConverter x:Key="OutcomeConverter" />
+                    <local:TestExplorerGroupingBooleanConverter x:Key="LocationConverter" />
+                    <local:TestExplorerGroupingBooleanConverter x:Key="CategoryConverter" />
+                    <local:TestExplorerOutcomeFilterToBooleanConverter x:Key="OutcomeFilterConverter" />
+                    <Style x:Key="ToolBarToggleStyle" TargetType="ToggleButton">
+                        <Setter Property="Margin" Value="2" />
+                        <Setter Property="BorderBrush" Value="{x:Static SystemColors.ActiveBorderBrush}" />
+                    </Style>
+                    <Style TargetType="Image">
+                        <Setter Property="Height" Value="16" />
+                    </Style>
+                </ToolBar.Resources>
 
-                    <Separator />
+                <Button Command="{Binding RefreshCommand}" >
+                    <Image Source="{StaticResource RefreshImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                </Button>
 
-                    <Menu Background="Transparent">
-                        <MenuItem VerticalAlignment="Center"
+                <Separator />
+
+                <Menu Background="Transparent">
+                    <MenuItem VerticalAlignment="Center"
                               HeaderTemplate="{StaticResource MenuItemHeaderDropdownIndicatorTemplate}"
                               IsEnabled="{Binding Model.IsBusy, Converter={StaticResource InvertBoolValue}}">
+                        <MenuItem.Icon>
+                            <Image Source="{StaticResource RunImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                        </MenuItem.Icon>
+                        <MenuItem.Header>
+                            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuButtonText}" />
+                        </MenuItem.Header>
+                        <MenuItem Command="{Binding RunAllTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuAllTests}">
                             <MenuItem.Icon>
-                                <Image Source="{StaticResource RunImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                                <Image Source="{StaticResource RunAllTestsImage}" />
                             </MenuItem.Icon>
-                            <MenuItem.Header>
-                                <TextBlock Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuButtonText}" />
-                            </MenuItem.Header>
-                            <MenuItem Command="{Binding RunAllTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuAllTests}">
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource RunAllTestsImage}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <Separator />
-                            <MenuItem Command="{Binding RunNotExecutedTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuNotRunTests}" >
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource RunNotRunTestsImage}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Command="{Binding RunSelectedTestsCommand}" 
+                        </MenuItem>
+                        <Separator />
+                        <MenuItem Command="{Binding RunNotExecutedTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuNotRunTests}" >
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource RunNotRunTestsImage}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Command="{Binding RunSelectedTestsCommand}" 
                                   CommandParameter="{Binding ElementName=TestGrid, Path=SelectedItems}"
                                   Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer ,Key=TestExplorer_RunMenuSelectedTests}" >
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource RunSelectedTestImage}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Command="{Binding RunInconclusiveTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuInconclusiveTests}" >
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource RunInconclusiveTestsImage}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Command="{Binding RunPassedTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuPassedTests}" >
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource RunPassedTestsImage}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Command="{Binding RunFailedTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuFailedTests}">
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource RunFailedTestsImage}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <Separator />
-                            <MenuItem Command="{Binding RepeatLastRunCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuLastRunTests}">
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource RepeatLastRunImage}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource RunSelectedTestImage}" />
+                            </MenuItem.Icon>
                         </MenuItem>
-                    </Menu>
+                        <MenuItem Command="{Binding RunInconclusiveTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuInconclusiveTests}" >
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource RunInconclusiveTestsImage}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Command="{Binding RunPassedTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuPassedTests}" >
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource RunPassedTestsImage}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Command="{Binding RunFailedTestsCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuFailedTests}">
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource RunFailedTestsImage}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <Separator />
+                        <MenuItem Command="{Binding RepeatLastRunCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_RunMenuLastRunTests}">
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource RepeatLastRunImage}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                    </MenuItem>
+                </Menu>
 
-                    <Separator />
+                <Separator />
 
-                    <Button Command="{Binding CancelTestRunCommand}" >
-                        <Image Source="{StaticResource StopImage}" Style="{StaticResource ToolbarImageOpacity}" />
-                    </Button>
+                <Button Command="{Binding CancelTestRunCommand}" >
+                    <Image Source="{StaticResource StopImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                </Button>
 
-                    <Separator />
+                <Separator />
 
-                    <Button Command="{Binding ResetResultsCommand}" >
-                        <Image Source="{StaticResource ResetResultsImage}" Style="{StaticResource ToolbarImageOpacity}" />
-                        <Button.ToolTip>
-                            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_ResetButtonTooltip}" />
-                        </Button.ToolTip>
-                    </Button>
+                <Button Command="{Binding ResetResultsCommand}" >
+                    <Image Source="{StaticResource ResetResultsImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                    <Button.ToolTip>
+                        <TextBlock Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_ResetButtonTooltip}" />
+                    </Button.ToolTip>
+                </Button>
 
-                    <Separator />
+                <Separator />
 
-                    <Menu Background="Transparent">
-                        <MenuItem VerticalAlignment="Center"
+                <Menu Background="Transparent">
+                    <MenuItem VerticalAlignment="Center"
                               HeaderTemplate="{StaticResource MenuItemHeaderDropdownIndicatorTemplate}"
                               IsEnabled="{Binding Model.IsBusy, Converter={StaticResource InvertBoolValue}}">
-                            <MenuItem.Icon>
-                                <Image Source="{StaticResource AddIcon}" Style="{StaticResource ToolbarImageOpacity}" />
-                            </MenuItem.Icon>
-                            <MenuItem.Header>
-                                <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Add}" />
-                            </MenuItem.Header>
-                            <MenuItem Command="{Binding AddTestModuleCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_AddTestModule}">
-                            </MenuItem>
-                            <Separator />
-                            <MenuItem Command="{Binding AddTestMethodCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_AddTestMethod}">
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource AddTestMethodIcon}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Command="{Binding AddErrorTestMethodCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_AddExpectedErrorTestMethod}">
-                                <MenuItem.Icon>
-                                    <Image Source="{StaticResource AddErrorTestMethodIcon}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
+                        <MenuItem.Icon>
+                            <Image Source="{StaticResource AddIcon}" Style="{StaticResource ToolbarImageOpacity}" />
+                        </MenuItem.Icon>
+                        <MenuItem.Header>
+                            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Add}" />
+                        </MenuItem.Header>
+                        <MenuItem Command="{Binding AddTestModuleCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_AddTestModule}">
                         </MenuItem>
-                    </Menu>
+                        <Separator />
+                        <MenuItem Command="{Binding AddTestMethodCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_AddTestMethod}">
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource AddTestMethodIcon}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Command="{Binding AddErrorTestMethodCommand}" Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_AddExpectedErrorTestMethod}">
+                            <MenuItem.Icon>
+                                <Image Source="{StaticResource AddErrorTestMethodIcon}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                    </MenuItem>
+                </Menu>
 
-                    <Separator />
+                <Separator />
 
-                    <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_GroupingStyle}" VerticalContentAlignment="Center" />
+                <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_GroupingStyle}" VerticalContentAlignment="Center" />
 
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByOutcome}"
                               IsChecked="{Binding Path=TestGrouping, Converter={StaticResource OutcomeConverter}, ConverterParameter={x:Static local:TestExplorerGrouping.Outcome}}">
-                        <Image Source="{StaticResource GroupByOutcomeImage}" />
-                    </ToggleButton>
+                    <Image Source="{StaticResource GroupByOutcomeImage}" />
+                </ToggleButton>
 
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByLocation}"
                               IsChecked="{Binding Path=TestGrouping, Converter={StaticResource LocationConverter}, ConverterParameter={x:Static local:TestExplorerGrouping.Location}}">
-                        <Image Source="{StaticResource GroupByLocationImage}" />
-                    </ToggleButton>
+                    <Image Source="{StaticResource GroupByLocationImage}" />
+                </ToggleButton>
 
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingStyle_ByCategory}"
                               IsChecked="{Binding Path=TestGrouping, Converter={StaticResource CategoryConverter}, ConverterParameter={x:Static local:TestExplorerGrouping.Category}}">
-                        <Image Source="{StaticResource GroupByCategoryImage}" />
-                    </ToggleButton>
+                    <Image Source="{StaticResource GroupByCategoryImage}" />
+                </ToggleButton>
 
-                    <Separator />
+                <Separator />
 
-                    <Image Source="{StaticResource FilterImage}" />
+                <Image Source="{StaticResource FilterImage}" />
 
-                    <Label Content="{Resx Key=TestExplorer_Filter, ResxName=Rubberduck.Resources.UnitTesting.TestExplorer}" />
-                    <controls:SearchBox Width="100"
+                <Label Content="{Resx Key=TestExplorer_Filter, ResxName=Rubberduck.Resources.UnitTesting.TestExplorer}" />
+                <controls:SearchBox Width="100"
                                     Text="{Binding TestNameFilter, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" />
 
-                    <Label Content="{Resx Key=TestExplorer_Outcome, ResxName=Rubberduck.Resources.UnitTesting.TestExplorer}" />
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                <Label Content="{Resx Key=TestExplorer_Outcome, ResxName=Rubberduck.Resources.UnitTesting.TestExplorer}" />
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=TestOutcome_Unknown}"
                               IsChecked="{Binding Path=OutcomeFilter, Converter={StaticResource OutcomeFilterConverter}, ConverterParameter={x:Static local:TestExplorerOutcomeFilter.Unknown}}" >
-                        <Image Source="{StaticResource OutcomeUnknown}" />
-                    </ToggleButton>
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                    <Image Source="{StaticResource OutcomeUnknown}" />
+                </ToggleButton>
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=TestOutcome_Fail}"
                               IsChecked="{Binding Path=OutcomeFilter, Converter={StaticResource OutcomeFilterConverter}, ConverterParameter={x:Static local:TestExplorerOutcomeFilter.Fail}}" >
-                        <Image Source="{StaticResource OutcomeFail}" />
-                    </ToggleButton>
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                    <Image Source="{StaticResource OutcomeFail}" />
+                </ToggleButton>
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=TestOutcome_Inconclusive}"
                               IsChecked="{Binding Path=OutcomeFilter, Converter={StaticResource OutcomeFilterConverter}, ConverterParameter={x:Static local:TestExplorerOutcomeFilter.Inconclusive}}" >
-                        <Image Source="{StaticResource OutcomeInconclusive}" />
-                    </ToggleButton>
-                    <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
+                    <Image Source="{StaticResource OutcomeInconclusive}" />
+                </ToggleButton>
+                <ToggleButton Style="{StaticResource ToolBarToggleStyle}"
                               ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=TestOutcome_Succeeded}"
                               IsChecked="{Binding Path=OutcomeFilter, Converter={StaticResource OutcomeFilterConverter}, ConverterParameter={x:Static local:TestExplorerOutcomeFilter.Succeeded}}" >
-                        <Image Source="{StaticResource OutcomeSucceeded}" />
-                    </ToggleButton>
+                    <Image Source="{StaticResource OutcomeSucceeded}" />
+                </ToggleButton>
 
-                    <Separator />
+                <Separator />
 
-                    <Button Name="CollapseAll" Command="{Binding CollapseAllCommand}" Margin="2"
+                <Button Name="CollapseAll" Command="{Binding CollapseAllCommand}" Margin="2"
                         ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_CollapseAll}">
-                        <Image Source="{StaticResource CollapseAllImage}" Style="{StaticResource ToolbarImageOpacity}" />
-                    </Button>
+                    <Image Source="{StaticResource CollapseAllImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                </Button>
 
-                    <Button Name="ExpandAll" Command="{Binding ExpandAllCommand}" Margin="2"
+                <Button Name="ExpandAll" Command="{Binding ExpandAllCommand}" Margin="2"
                         ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=InspectionResults_ExpandAll}">
-                        <Image Source="{StaticResource ExpandAllImage}" Style="{StaticResource ToolbarImageOpacity}" />
-                    </Button>
+                    <Image Source="{StaticResource ExpandAllImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                </Button>
 
-                    <Separator />
+                <Separator />
 
-                    <Button Command="{Binding CopyResultsCommand}">
-                        <Image Source="{StaticResource CopyResultsImage}" Style="{StaticResource ToolbarImageOpacity}" />
-                        <Button.ToolTip>
-                            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_CopyToolTip}" />
-                        </Button.ToolTip>
-                    </Button>
+                <Button Command="{Binding CopyResultsCommand}">
+                    <Image Source="{StaticResource CopyResultsImage}" Style="{StaticResource ToolbarImageOpacity}" />
+                    <Button.ToolTip>
+                        <TextBlock Text="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_CopyToolTip}" />
+                    </Button.ToolTip>
+                </Button>
 
-                    <Separator />
+                <Separator />
 
-                    <Button ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Settings}" Command="{Binding OpenTestSettingsCommand}" BorderThickness="0" Background="Transparent">
-                        <Image Source="{StaticResource SettingsImage}" />
-                    </Button>
-                </ToolBar>
-            </ToolBarTray>
+                <Button ToolTip="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=Settings}" Command="{Binding OpenTestSettingsCommand}" BorderThickness="0" Background="Transparent">
+                    <Image Source="{StaticResource SettingsImage}" />
+                </Button>
+            </ToolBar>
+        </ToolBarTray>
 
-            <ProgressBar Height="6"
+        <ProgressBar Height="6"
                      Grid.Row="1"
                      Margin="2"
                      Background="DimGray" 
                      Maximum="{Binding Model.CurrentRunTestCount, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
                      Value="{Binding Model.ExecutedCount, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
-                <ProgressBar.Foreground>
-                    <SolidColorBrush Color="{Binding Model.ProgressBarColor, UpdateSourceTrigger=PropertyChanged}" />
-                </ProgressBar.Foreground>
-            </ProgressBar>
+            <ProgressBar.Foreground>
+                <SolidColorBrush Color="{Binding Model.ProgressBarColor, UpdateSourceTrigger=PropertyChanged}" />
+            </ProgressBar.Foreground>
+        </ProgressBar>
 
-            <Border Grid.Row="2" Padding="2">
-                <StackPanel Orientation="Horizontal">
-                    <StackPanel.Resources>
-                        <converters:NonZeroToVisibilityConverter x:Key="NonZeroToVisibility"/>
-                        <BitmapImage x:Key="IgnoredTestImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/minus-white.png" />
-                        <BitmapImage x:Key="InconclusiveTestImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/exclamation.png" />
-                        <BitmapImage x:Key="EasterEggTestImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/skull-mad.png" />
-                        <Style x:Key="ResultsTestOutcomeStyle" TargetType="TextBlock" >
-                            <Setter Property="Margin" Value="4,0,12,0"/>
-                            <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
-                            <Setter Property="VerticalAlignment" Value="Center"/>
-                        </Style>
-                        <Style x:Key="TestOutcomeIconStyle" TargetType="Image">
-                            <Setter Property="Height" Value="16"/>
-                            <Setter Property="Width" Value="16" />
-                            <Setter Property="VerticalAlignment" Value="Center"/>
-                            <Setter Property="Margin" Value="3"/>
-                        </Style>
-                    </StackPanel.Resources>
-                    <TextBlock Margin="2" Padding="4,2,4,2" FontWeight="Bold" VerticalAlignment="Center"
+        <Border Grid.Row="2" Padding="2">
+            <StackPanel Orientation="Horizontal">
+                <StackPanel.Resources>
+                    <converters:NonZeroToVisibilityConverter x:Key="NonZeroToVisibility"/>
+                    <BitmapImage x:Key="IgnoredTestImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/minus-white.png" />
+                    <BitmapImage x:Key="InconclusiveTestImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/exclamation.png" />
+                    <BitmapImage x:Key="EasterEggTestImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/skull-mad.png" />
+                    <Style x:Key="ResultsTestOutcomeStyle" TargetType="TextBlock" >
+                        <Setter Property="Margin" Value="4,0,12,0"/>
+                        <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
+                        <Setter Property="VerticalAlignment" Value="Center"/>
+                    </Style>
+                    <Style x:Key="TestOutcomeIconStyle" TargetType="Image">
+                        <Setter Property="Height" Value="16"/>
+                        <Setter Property="Width" Value="16" />
+                        <Setter Property="VerticalAlignment" Value="Center"/>
+                        <Setter Property="Margin" Value="3"/>
+                    </Style>
+                </StackPanel.Resources>
+                <TextBlock Margin="2" Padding="4,2,4,2" FontWeight="Bold" VerticalAlignment="Center"
                            Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestOutcome_SummaryCaption}"/>
-                    <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}" Text="{Binding Model.LastTestRunSummary, Mode=OneWay}"/>
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestFailedCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}" >
-                        <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource RunFailedTestsImage}" Margin="4,0,4,0"/>
-                        <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
+                <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}" Text="{Binding Model.LastTestRunSummary, Mode=OneWay}"/>
+                <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestFailedCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}" >
+                    <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource RunFailedTestsImage}" Margin="4,0,4,0"/>
+                    <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
                         <Run Text="{Binding Model.LastTestFailedCount, Mode=OneWay}"/>
                         <Run Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestOutcome_Failed}"/>
-                        </TextBlock>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestIgnoredCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}">
-                        <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource IgnoredTestImage}" />
-                        <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
+                    </TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestIgnoredCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}">
+                    <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource IgnoredTestImage}" />
+                    <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
                         <Run Text="{Binding Model.LastTestIgnoredCount, Mode=OneWay}"/>
                         <Run Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestOutcome_Ignored}"/>
-                        </TextBlock>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestInconclusiveCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}">
-                        <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource InconclusiveTestImage}" />
-                        <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
+                    </TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestInconclusiveCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}">
+                    <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource InconclusiveTestImage}" />
+                    <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
                         <Run Text="{Binding Model.LastTestInconclusiveCount, Mode=OneWay}" />
                         <Run Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestOutcome_Inconclusive}"/>
-                        </TextBlock>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestSucceededCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}">
-                        <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource RunPassedTestsImage}" />
-                        <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
+                    </TextBlock>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Visibility="{Binding Model.LastTestSucceededCount, Mode=OneWay, Converter={StaticResource NonZeroToVisibility}}">
+                    <Image Style="{StaticResource TestOutcomeIconStyle}" Source="{StaticResource RunPassedTestsImage}" />
+                    <TextBlock Style="{StaticResource ResultsTestOutcomeStyle}">
                         <Run Text="{Binding Model.LastTestSucceededCount, Mode=OneWay}"/>
                         <Run Text="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestOutcome_Succeeded}"/>
-                        </TextBlock>
-                    </StackPanel>
+                    </TextBlock>
                 </StackPanel>
-            </Border>
+            </StackPanel>
+        </Border>
 
-            <Border Grid.Row="3" Padding="2">
-                <Grid>
+        <Border Grid.Row="3" Padding="2">
+            <Grid>
+                <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
                     <controls:GroupingGrid x:Name="TestGrid"
                                        ItemsSource="{Binding Tests}"
                                        SelectionMode="Extended"
@@ -464,10 +465,10 @@
                             <controls:GroupItemExpandedBehavior ExpandedState="{Binding ExpandedState, Mode=TwoWay}" />
                         </i:Interaction.Behaviors>
                     </controls:GroupingGrid>
-                </Grid>
-            </Border>
-            <controls:BusyIndicator Grid.Row="3" Width="120" Height="120" Visibility="{Binding Model.IsRefreshing, Converter={StaticResource BoolToVisibility}}" />
-        </Grid>
-    </ScrollViewer>
+                </ScrollViewer>
+            </Grid>
+        </Border>
+        <controls:BusyIndicator Grid.Row="3" Width="120" Height="120" Visibility="{Binding Model.IsRefreshing, Converter={StaticResource BoolToVisibility}}" />
+    </Grid>
 
 </UserControl>


### PR DESCRIPTION
This fixes the scroll viewers in both the TestExplorerControl and The InspectionResultsControl.

The fix is to move them directly around the grouping grid. When doing this, one has to be careful to move the grouping grind into some container that can be attached to a grid because specifying a grid row inside a scrollviewer apparently attaches the control to nowhere at all and thus stops it from displaying. To handle this, I moved the grouping grid for the inspection results into a grid inside a border, which I attached to the main grid row.

In addition, added a vertical scrollviewer to the bottom panel since is can overflow to the bottom if the user resizes the window. This leads to some rows not being visible, wich is not always apparent from the contents of the control. Now, the vertical scroll bar indicates that the content is larger than the visible area.

Two small irritating things that remain are that the grouping grid scroll viewer reacts to the width of the loaded content, no matter whether the group is collapses or not and that one has to scroll to the right to see the vertical scroll bar. However, I think we cannot do a lot about that.

Before change:
![before_scrollviewer_move](https://user-images.githubusercontent.com/22868956/71297425-cd48a700-2383-11ea-892b-484e7b0948bc.jpg)

After change (no scroll):
![after_scrollviewer_move_no_scroll](https://user-images.githubusercontent.com/22868956/71297452-e05b7700-2383-11ea-8186-3848771f780f.jpg)

After change (with scroll):
![after_scrollviewer_move_with_scroll](https://user-images.githubusercontent.com/22868956/71297480-ee10fc80-2383-11ea-93bb-613daa3af529.jpg)

