### PR TITLE
Let AddComponentService optionally take a component name

### DIFF
--- a/Rubberduck.VBEEditor/Utility/IAddComponentService.cs
+++ b/Rubberduck.VBEEditor/Utility/IAddComponentService.cs
@@ -4,7 +4,7 @@ namespace Rubberduck.VBEditor.Utility
 {
     public interface IAddComponentService
     {
-        void AddComponent(string projectId, ComponentType componentType, string code = null, string additionalPrefixInModule = null);
-        void AddComponentWithAttributes(string projectId, ComponentType componentType, string code, string prefixInModule = null);
+        void AddComponent(string projectId, ComponentType componentType, string code = null, string additionalPrefixInModule = null, string componentName = null);
+        void AddComponentWithAttributes(string projectId, ComponentType componentType, string code, string prefixInModule = null, string componentName = null);
     }
 }


### PR DESCRIPTION
So far, the `IAddComponentService` did not provide a possibility to name the new component. This is unfortunate, since the component is not returned, in order to shield the using code from using SCWs. 

This PR changes this by adding an optional parameter for the component name. That the name actually gets assigned is not fully guaranteed since a name collision will cause a `COMException`, which will be logged ans swallowed.  It is the callers responsibility to make sure that no component of the desired name already exists.