### PR TITLE
Fix FunctionReturnValue(Always)DiscardedInspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueAlwaysDiscardedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueAlwaysDiscardedInspection.cs
@@ -144,7 +144,14 @@ namespace Rubberduck.Inspections.Concrete
                 ? methodCall
                 : context;
             var memberAccessParent = ownFunctionCallExpression.GetAncestor<VBAParser.MemberAccessExprContext>();
-            return memberAccessParent == null;
+            if (memberAccessParent != null)
+            {
+                return false;
+            }
+
+            //If we are in an output list, the value is used somewhere in defining the argument.
+            var outputListParent = context.GetAncestor<VBAParser.OutputListContext>();
+            return outputListParent == null;
         }
 
         protected override string ResultDescription(Declaration declaration)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueDiscardedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueDiscardedInspection.cs
@@ -82,7 +82,9 @@ namespace Rubberduck.Inspections.Concrete
                 return false;
             }
 
-            return true;
+            //If we are in an output list, the value is used somewhere in defining the argument.
+            var outputListParent = context.GetAncestor<VBAParser.OutputListContext>();
+            return outputListParent == null;
         }
 
         protected override string ResultDescription(IdentifierReference reference)

--- a/RubberduckTests/Inspections/FunctionReturnValueAlwaysDiscardedInspectionTests.cs
+++ b/RubberduckTests/Inspections/FunctionReturnValueAlwaysDiscardedInspectionTests.cs
@@ -326,6 +326,23 @@ End Sub
         [Test]
         [Category("Inspections")]
         [Category("Unused Value")]
+        public void OutputListFunctionCall_DoesNotReturnResult()
+        {
+            const string code = @"
+Public Function Foo(ByVal bar As String) As Integer
+    Foo = 42
+End Function
+
+Public Sub Baz()
+    Debug.Print Foo(""Test"")
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(code).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category("Unused Value")]
         public void IgnoresBuiltInFunctions_DoesNotReturnResult()
         {
             const string code = @"

--- a/RubberduckTests/Inspections/FunctionReturnValueDiscardedInspectionTests.cs
+++ b/RubberduckTests/Inspections/FunctionReturnValueDiscardedInspectionTests.cs
@@ -284,6 +284,23 @@ End Sub
         [Test]
         [Category("Inspections")]
         [Category("Unused Value")]
+        public void FunctionReturnValueDiscarded_DoesNotReturnResult_OutputListFunctionCall()
+        {
+            const string code = @"
+Public Function Foo(ByVal bar As String) As Integer
+    Foo = 42
+End Function
+
+Public Sub Baz()
+    Debug.Print Foo(""Test"")
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(code).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category("Unused Value")]
         public void FunctionReturnValueDiscarded_DoesNotReturnResult_IgnoresBuiltInFunctions()
         {
             const string code = @"


### PR DESCRIPTION
I forgot to handle output lists in addition to argument lists. This PR rectifies this.