### PR TITLE
Additional top level exception handling and better status message sequencing

### DIFF
--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/AppCommandBarBase.cs
@@ -37,7 +37,13 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             }
             catch (COMException exception)
             {
-                Logger.Error(exception,$"COMException while finding child with tag '{tag}'.");
+                Logger.Error(exception, $"COMException while finding child with tag '{tag}' in the command bar.");
+            }
+            catch (InvalidCastException exception)
+            {
+                //This exception will be encountered whenever the registration of the command bar control not correct in the system.
+                //See issue #5349 at https://github.com/rubberduck-vba/Rubberduck/issues/5349
+                Logger.Error(exception, $"Invalid cast exception while finding child with tag '{tag}' in the command bar.");
             }
             return null;
         }

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -171,7 +171,7 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             }
 
             _selectionService.SelectionChanged -= OnSelectionChange;
-            _state.StateChanged -= OnParserStateChanged;
+            _state.StateChangedHighPriority -= OnParserStateChanged;
             _state.StatusMessageUpdate -= OnParserStatusMessageUpdate;
 
             RemoveCommandBar();

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -99,49 +99,39 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
         private void SetStatusLabelCaption(string caption, int? errorCount = null)
         {
-            //This try-catch block guarantees that problems with the COM registration of the command bar classes
-            //only affect the status label text instead of aborting the status change or even crashing the host.
-            //See issue #5349 at https://github.com/rubberduck-vba/Rubberduck/issues/5349
-            try
+            var reparseCommandButton =
+                FindChildByTag(typeof(ReparseCommandMenuItem).FullName) as ReparseCommandMenuItem;
+            if (reparseCommandButton == null)
             {
-                var reparseCommandButton =
-                    FindChildByTag(typeof(ReparseCommandMenuItem).FullName) as ReparseCommandMenuItem;
-                if (reparseCommandButton == null)
-                {
-                    return;
-                }
-
-                var showErrorsCommandButton =
-                    FindChildByTag(typeof(ShowParserErrorsCommandMenuItem).FullName) as ShowParserErrorsCommandMenuItem;
-                if (showErrorsCommandButton == null)
-                {
-                    return;
-                }
-
-                _uiDispatcher.Invoke(() =>
-                {
-                    try
-                    {
-                        reparseCommandButton.SetCaption(caption);
-                        reparseCommandButton.SetToolTip(string.Format(RubberduckUI.ReparseToolTipText, caption));
-                        if (errorCount.HasValue && errorCount.Value > 0)
-                        {
-                            showErrorsCommandButton.SetToolTip(
-                                string.Format(RubberduckUI.ParserErrorToolTipText, errorCount.Value));
-                        }
-                    }
-                    catch (Exception exception)
-                    {
-                        Logger.Error(exception,
-                            "Exception thrown trying to set the status label caption on the UI thread.");
-                    }
-                });
-                Localize();
+                return;
             }
-            catch (COMException exception)
+
+            var showErrorsCommandButton =
+                FindChildByTag(typeof(ShowParserErrorsCommandMenuItem).FullName) as ShowParserErrorsCommandMenuItem;
+            if (showErrorsCommandButton == null)
             {
-                Logger.Error(exception, "COMException thrown trying to set the status label caption.");
+                return;
             }
+
+            _uiDispatcher.Invoke(() =>
+            {
+                try
+                {
+                    reparseCommandButton.SetCaption(caption);
+                    reparseCommandButton.SetToolTip(string.Format(RubberduckUI.ReparseToolTipText, caption));
+                    if (errorCount.HasValue && errorCount.Value > 0)
+                    {
+                        showErrorsCommandButton.SetToolTip(
+                            string.Format(RubberduckUI.ParserErrorToolTipText, errorCount.Value));
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Logger.Error(exception,
+                        "Exception thrown trying to set the status label caption on the UI thread.");
+                }
+            });
+            Localize();
         }
 
         private void SetContextSelectionCaption(string caption, int contextReferenceCount, string description)

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -429,6 +429,20 @@ namespace Rubberduck.UI.Inspections
 
         private async void RefreshInspections(CancellationToken token)
         {
+            //We have to catch all exceptions here since this method is a fire-and-forget async action.
+            //Accordingly, any exception bubbling out of this method will likely take down the runtime and, thus, crash the host.
+            try
+            {
+                await RefreshInspections_Internal(token);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex,"Unhandled exception when refreshing inspection results.");
+            }
+        }
+
+        private async Task RefreshInspections_Internal(CancellationToken token)
+        {
             var stopwatch = Stopwatch.StartNew();
             IsBusy = true;
 


### PR DESCRIPTION
This PR does two things.

First, it introduces more high level exception handling. More precisely, we now log and swallow exceptions in the async void responsible for refreshing inspection results. Anything bubbling out there would most likely take down the host, as observed in #5349. Moreover, `FindChildByTag` called when changing the status message on the command bar now also handles `InvalidCastException`s.  This should guarantee that the COM registration issues in #5349 only affect the status label and nothing else.


I also added to this PR a second small improvement. I introduced a second event for status changes whose handler is executed before the usual one, basically giving it a higher priority. This allows to guarantee that the status label update always runs first by only registering its handler to the high priority event. In contrast, the execution order of a single handler is not guaranteed and an implementation detail. So far, this led to the inspections being refreshed before the status update with the effect that the status label change to _Inspecting_ was overwritten immediately instead of after finishing to execute the inspections. 