### PR TITLE
ProcedureNotUsedInspection ignores declarations that have ITestAnnotations

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureNotUsedInspection.cs
@@ -6,6 +6,7 @@ using Rubberduck.Inspections.Results;
 using Rubberduck.JunkDrawer.Extensions;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Resources.Inspections;
+using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 
@@ -99,7 +100,8 @@ namespace Rubberduck.Inspections.Concrete
                 || IsPublicModuleMember(modules, declaration)
                 || IsClassLifeCycleHandler(enumerable, declaration)
                 || interfaceMembers.Contains(declaration)
-                || interfaceImplementingMembers.Contains(declaration);
+                || interfaceImplementingMembers.Contains(declaration)
+                || declaration.Annotations.Any(x => x.Annotation is ITestAnnotation);
 
             return result;
         }

--- a/Rubberduck.Parsing/Annotations/Concrete/ModuleCleanupAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/ModuleCleanupAnnotation.cs
@@ -7,7 +7,7 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Marks a method that the test engine will execute after all unit tests in a test module have executed.
     /// </summary>
-    public sealed class ModuleCleanupAnnotation : AnnotationBase
+    public sealed class ModuleCleanupAnnotation : AnnotationBase, ITestAnnotation
     {
         public ModuleCleanupAnnotation()
             : base("ModuleCleanup", AnnotationTarget.Member)

--- a/Rubberduck.Parsing/Annotations/Concrete/ModuleInitializeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/ModuleInitializeAnnotation.cs
@@ -7,7 +7,7 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Marks a method that the test engine will execute before executing the first unit test in a test module.
     /// </summary>
-    public sealed class ModuleInitializeAnnotation : AnnotationBase
+    public sealed class ModuleInitializeAnnotation : AnnotationBase, ITestAnnotation
     {
         public ModuleInitializeAnnotation()
             : base("ModuleInitialize", AnnotationTarget.Member)

--- a/Rubberduck.Parsing/Annotations/Concrete/TestCleanupAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/TestCleanupAnnotation.cs
@@ -7,7 +7,7 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Marks a method that the test engine will execute after executing each unit test in a test module.
     /// </summary>
-    public sealed class TestCleanupAnnotation : AnnotationBase
+    public sealed class TestCleanupAnnotation : AnnotationBase, ITestAnnotation
     {
         public TestCleanupAnnotation()
             : base("TestCleanup", AnnotationTarget.Member)

--- a/Rubberduck.Parsing/Annotations/Concrete/TestInitializeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/TestInitializeAnnotation.cs
@@ -7,7 +7,7 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Marks a method that the test engine will execute before executing each unit test in a test module.
     /// </summary>
-    public sealed class TestInitializeAnnotation : AnnotationBase
+    public sealed class TestInitializeAnnotation : AnnotationBase, ITestAnnotation
     {
         public TestInitializeAnnotation()
             : base("TestInitialize", AnnotationTarget.Member)

--- a/Rubberduck.Parsing/Annotations/Concrete/TestMethodAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/TestMethodAnnotation.cs
@@ -10,7 +10,7 @@ namespace Rubberduck.Parsing.Annotations
     /// <summary>
     /// Marks a method that the test engine will execute as a unit test.
     /// </summary>
-    public sealed class TestMethodAnnotation : AnnotationBase
+    public sealed class TestMethodAnnotation : AnnotationBase, ITestAnnotation
     {
         public TestMethodAnnotation()
             : base("TestMethod", AnnotationTarget.Member)

--- a/Rubberduck.Parsing/Annotations/ITestAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ITestAnnotation.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rubberduck.Parsing.Annotations
+{
+    public interface ITestAnnotation
+    {
+    }
+}

--- a/Rubberduck.Parsing/Annotations/ITestAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ITestAnnotation.cs
@@ -1,6 +1,6 @@
 ﻿namespace Rubberduck.Parsing.Annotations
 {
-    public interface ITestAnnotation
+    public interface ITestAnnotation : IAnnotation
     {
     }
 }

--- a/Rubberduck.Parsing/Annotations/ITestAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/ITestAnnotation.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Rubberduck.Parsing.Annotations
+﻿namespace Rubberduck.Parsing.Annotations
 {
     public interface ITestAnnotation
     {

--- a/RubberduckTests/Inspections/ProcedureNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/ProcedureNotUsedInspectionTests.cs
@@ -111,6 +111,23 @@ End Sub";
             Assert.AreEqual(0, InspectionResultsForModules(modules).Count(result => result.Target.DeclarationType == DeclarationType.Procedure));
         }
 
+        [TestCase("@TestMethod(\"TestCategory\")")]
+        [TestCase("@ModuleInitialize")]
+        [TestCase("@ModuleCleanup")]
+        [TestCase("@TestInitialize")]
+        [TestCase("@TestCleanup")]
+        [Category("Inspections")]
+        public void ProcedureNotUsed_NoResultForTestRelatedMethods(string annotationText)
+        {
+            string inputCode =
+                $@"
+'{annotationText}
+Private Sub TestRelatedMethod()
+End Sub";
+            
+            Assert.AreEqual(0, InspectionResultsForModules(("TestClass", inputCode, ComponentType.StandardModule)).Count());
+        }
+
         [TestCase("Class_Initialize")]
         [TestCase("class_initialize")]
         [TestCase("Class_Terminate")]


### PR DESCRIPTION
Closes #5281

**Reason for the change:**

As seen in #5281, annotations that are meant to be used in tests were allowing `ProcedureNotUsedInspection`s to pop-up where they did not make sense.

**Description of change:**

1. Marked test annotations with a marking interface.
2. Ignored annotations with the marking interface for declarations of the `ProcedureNotUsedInspection`.
