### PR TITLE
Hotkey Mod Label: Exclude Disabled Hotkeys

### DIFF
--- a/Rubberduck.Core/UI/Settings/GeneralSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/GeneralSettingsViewModel.cs
@@ -112,7 +112,7 @@ namespace Rubberduck.UI.Settings
         {
             get
             {
-                return _hotkeys.Any(s => !s.IsValid);
+                return _hotkeys.Any(s => !s.IsValid && s.IsEnabled);
             }
         }
 


### PR DESCRIPTION
Closes #5259 

**Description of Problem:**

When a hotkey is disabled & does not have a modifier, the hotkey modification label is displayed, but it is expected to be displayed only when the hotkey is enabled.

**Proposed Solution:**

Excluding disabled hotkeys when determining which hotkeys should display the modification label. Thanks for narrowing the search for me @Vogel612.