### PR TITLE
Replace string ReferenceLibrary keys

### DIFF
--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -6820,7 +6820,7 @@ End Function
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Class1", ComponentType.ClassModule, classCode)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -6853,7 +6853,7 @@ End Function
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Class1", ComponentType.ClassModule, classCode)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -6890,7 +6890,7 @@ End Function
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Class1", ComponentType.ClassModule, classCode)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -6927,7 +6927,7 @@ End Function
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Class1", ComponentType.ClassModule, classCode)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -6964,7 +6964,7 @@ End Function
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Class1", ComponentType.ClassModule, classCode)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 

--- a/RubberduckTests/Inspections/ApplicationWorksheetFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/ApplicationWorksheetFunctionInspectionTests.cs
@@ -5,6 +5,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -12,7 +13,7 @@ namespace RubberduckTests.Inspections
     public class ApplicationWorksheetFunctionInspectionTests : InspectionTestsBase
     {
         private IEnumerable<IInspectionResult> GetInspectionResultsUsingExcelLibrary(string inputCode)
-            => InspectionResultsForModules(("Module1", inputCode, ComponentType.StandardModule), "Excel");
+            => InspectionResultsForModules(("Module1", inputCode, ComponentType.StandardModule), ReferenceLibrary.Excel);
 
         [Test]
         [Category("Inspections")]

--- a/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
@@ -5,6 +5,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -348,7 +349,7 @@ End Sub
         }
 
         private IEnumerable<IInspectionResult> InspectionResults(string inputCode)
-            => InspectionResultsForModules(("Module1", inputCode, ComponentType.StandardModule), "Excel");
+            => InspectionResultsForModules(("Module1", inputCode, ComponentType.StandardModule), ReferenceLibrary.Excel);
 
         protected override IInspection InspectionUnderTest(RubberduckParserState state)
         {

--- a/RubberduckTests/Inspections/ExcelUdfNameIsValidCellReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcelUdfNameIsValidCellReferenceInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -106,7 +107,7 @@ End {1}
         }
 
         private int InspectionResultCount(string inputCode, ComponentType moduleType)
-            => InspectionResultsForModules(("UnderTest", inputCode, moduleType), "Excel").Count();
+            => InspectionResultsForModules(("UnderTest", inputCode, moduleType), ReferenceLibrary.Excel).Count();
 
         protected override IInspection InspectionUnderTest(RubberduckParserState state)
         {

--- a/RubberduckTests/Inspections/HostSpecificExpressionInspectionTests.cs
+++ b/RubberduckTests/Inspections/HostSpecificExpressionInspectionTests.cs
@@ -22,7 +22,7 @@ Public Sub DoSomething()
     [A1] = 42
 End Sub
 ";
-            var vbe = MockVbeBuilder.BuildFromModules(("Module1", code, ComponentType.StandardModule), new string[] { "VBA", "Excel" });
+            var vbe = MockVbeBuilder.BuildFromModules(("Module1", code, ComponentType.StandardModule), new ReferenceLibrary[] { ReferenceLibrary.VBA, ReferenceLibrary.Excel });
             var mockHost = new Mock<IHostApplication>();
             mockHost.SetupGet(m => m.ApplicationName).Returns("Excel");
             vbe.Setup(m => m.HostApplication()).Returns(() => mockHost.Object);

--- a/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -21,7 +22,7 @@ namespace RubberduckTests.Inspections
 End Sub
 ";
             var modules = new(string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, "Excel").Count());
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
         }
 
         [Test]
@@ -35,7 +36,7 @@ End Sub
 End Sub
 ";
             var modules = new (string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, "Excel").Count());
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
         }
 
         [Test]
@@ -49,7 +50,7 @@ End Sub
 End Sub
 ";
             var modules = new (string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, "Excel").Count());
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
         }
 
         [Test]
@@ -63,7 +64,7 @@ End Sub
 End Sub
 ";
             var modules = new (string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, "Excel").Count());
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
         }
 
         [Test]
@@ -80,7 +81,7 @@ End Sub
 ";
 
             var modules = new(string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(0, InspectionResultsForModules(modules, "Excel").Count());
+            Assert.AreEqual(0, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
         }
 
         [Test]

--- a/RubberduckTests/Inspections/ImplicitActiveWorkbookReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitActiveWorkbookReferenceInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -181,7 +182,7 @@ End Sub";
         private int ArrangeAndGetInspectionCount(string code)
         {
             var modules = new(string, string, ComponentType)[] { ("Module1", code, ComponentType.StandardModule) };
-            return InspectionResultsForModules(modules, "Excel").Count();
+            return InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count();
         }
 
         [Test]

--- a/RubberduckTests/Inspections/InspectionTestsBase.cs
+++ b/RubberduckTests/Inspections/InspectionTestsBase.cs
@@ -30,13 +30,13 @@ namespace RubberduckTests.Inspections
             return InspectionResults(vbe);
         }
 
-        public IEnumerable<IInspectionResult> InspectionResultsForModules((string name, string content, ComponentType componentType) module, params string[] libraries)
+        public IEnumerable<IInspectionResult> InspectionResultsForModules((string name, string content, ComponentType componentType) module, params ReferenceLibrary[] libraries)
             => InspectionResultsForModules(new (string, string, ComponentType)[] { module }, libraries);
 
-        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, string library)
-            => InspectionResultsForModules(modules, new string[] { library });
+        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, ReferenceLibrary library)
+            => InspectionResultsForModules(modules, new ReferenceLibrary[] { library });
 
-        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<string> libraries)
+        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<ReferenceLibrary> libraries)
         {
             var vbe = MockVbeBuilder.BuildFromModules(modules, libraries).Object;
             return InspectionResults(vbe);

--- a/RubberduckTests/Inspections/IsMissingOnInappropriateArgumentInspectionTests.cs
+++ b/RubberduckTests/Inspections/IsMissingOnInappropriateArgumentInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -208,7 +209,7 @@ End Function
                 ("Module1", code, ComponentType.StandardModule)
             };
 
-            return InspectionResultsForModules(modules, "VBA").Count();
+            return InspectionResultsForModules(modules, ReferenceLibrary.VBA).Count();
         }
 
         protected override IInspection InspectionUnderTest(RubberduckParserState state)

--- a/RubberduckTests/Inspections/IsMissingWithNonArgumentParameterInspectionTests.cs
+++ b/RubberduckTests/Inspections/IsMissingWithNonArgumentParameterInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -130,7 +131,7 @@ End Function
                 ("Module1", code, ComponentType.StandardModule)
             };
 
-            return InspectionResultsForModules(modules, "VBA").Count();
+            return InspectionResultsForModules(modules, ReferenceLibrary.VBA).Count();
         }
 
         protected override IInspection InspectionUnderTest(RubberduckParserState state)

--- a/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
+++ b/RubberduckTests/Inspections/MemberNotOnInterfaceInspectionTests.cs
@@ -11,7 +11,7 @@ namespace RubberduckTests.Inspections
     [TestFixture]
     public class MemberNotOnInterfaceInspectionTests : InspectionTestsBase
     {
-        private int ArrangeParserAndGetResultCount(string inputCode, string library)
+        private int ArrangeParserAndGetResultCount(string inputCode, ReferenceLibrary library = ReferenceLibrary.Scripting)
             => InspectionResultsForModules(("Codez", inputCode, ComponentType.StandardModule), library).Count();
 
         [Test]
@@ -24,7 +24,7 @@ namespace RubberduckTests.Inspections
     Set dict = New Dictionary
     dict.NonMember
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -37,7 +37,7 @@ End Sub";
     Set dict = New Dictionary
     dict.NonMember
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -48,7 +48,7 @@ End Sub";
                 @"Sub Foo()
     Application.NonMember
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Excel"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, ReferenceLibrary.Excel));
         }
 
         [Test]
@@ -59,7 +59,7 @@ End Sub";
                 @"Sub Foo(dict As Dictionary)
     dict.NonMember
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -72,7 +72,7 @@ End Sub";
     Set dict = New Dictionary
     Debug.Print dict.Count
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -84,7 +84,7 @@ End Sub";
     Dim x As File
     Debug.Print x.NonMember
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -98,7 +98,7 @@ End Sub";
         .NonMember
     End With
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -111,7 +111,7 @@ End Sub";
     Set dict = New Dictionary
     dict!SomeIdentifier = 42
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -125,7 +125,7 @@ End Sub";
         !SomeIdentifier = 42
     End With
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -136,7 +136,7 @@ End Sub";
                 @"Sub Foo()
     Dim dict As Scripting.Dictionary
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -150,7 +150,7 @@ End Sub";
     '@Ignore MemberNotOnInterface
     dict.NonMember
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -163,7 +163,7 @@ End Sub";
         .FooBar
     End With
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -180,7 +180,7 @@ End Sub
 
 Private Sub Bar(baz As Long)
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -197,7 +197,7 @@ End Sub
 
 Private Function Bar(baz As Long) As Variant
 End Function";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -214,7 +214,7 @@ End Sub
 
 Private Function Bar(baz As Long) As Variant
 End Function";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -231,7 +231,7 @@ End Sub
 
 Private Function Bar(baz As Long) As Variant
 End Function";
-            Assert.AreEqual(2, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(2, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -248,7 +248,7 @@ End Sub
 
 Private Function Bar(baz As Long) As Variant
 End Function";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -265,7 +265,7 @@ End Sub
 
 Private Function Bar(baz As Long) As Variant
 End Function";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -282,7 +282,7 @@ End Sub
 
 Private Function Bar(baz As Long) As Variant
 End Function";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -299,7 +299,7 @@ End Sub
 
 Private Function Bar(baz As Long) As Variant
 End Function";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -319,7 +319,7 @@ End Function
 
 Private Sub Barr(baz As Long)
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -339,7 +339,7 @@ End Function
 
 Private Sub Barr(baz As Long)
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -359,7 +359,7 @@ End Function
 
 Private Sub Barr(baz As Long)
 End Sub";
-            Assert.AreEqual(3, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(3, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -379,7 +379,7 @@ End Function
 
 Private Sub Barr(baz As Long)
 End Sub";
-            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(1, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -392,7 +392,7 @@ End Sub";
         !FooBar = 42
     End With
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -405,7 +405,7 @@ End Sub";
         .Add 42, 42
     End With
 End Sub";
-            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode, "Scripting"));
+            Assert.AreEqual(0, ArrangeParserAndGetResultCount(inputCode));
         }
 
         [Test]
@@ -443,7 +443,7 @@ End Sub
             var projectBuilder = vbeBuilder.ProjectBuilder("testproject", ProjectProtection.Unprotected);
             projectBuilder.MockUserFormBuilder("UserForm1", userForm1Code).AddFormToProjectBuilder()
                 .AddComponent("ReferencingModule", ComponentType.StandardModule, analyzedCode)
-                .AddReference("MSForms", MockVbeBuilder.LibraryPathMsForms, 2, 0, true);
+                .AddReference(ReferenceLibrary.MsForms);
 
             vbeBuilder.AddProject(projectBuilder.Build());
             var vbe = vbeBuilder.Build();
@@ -464,7 +464,7 @@ End Sub";
             var vbeBuilder = new MockVbeBuilder();
             var projectBuilder = vbeBuilder.ProjectBuilder("testproject", ProjectProtection.Unprotected);
             projectBuilder.MockUserFormBuilder("UserForm1", inputCode).AddFormToProjectBuilder()
-                .AddReference("MSForms", MockVbeBuilder.LibraryPathMsForms, 2, 0, true);
+                .AddReference(ReferenceLibrary.MsForms);
 
             vbeBuilder.AddProject(projectBuilder.Build());
             var vbe = vbeBuilder.Build();

--- a/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
+++ b/RubberduckTests/Inspections/ObjectVariableNotSetInspectionTests.cs
@@ -5,6 +5,7 @@ using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -140,7 +141,7 @@ Private Sub Workbook_Open()
     target = Range(""A1"")
     target.Value = ""all good""
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.Excel);
         }
 
         [Test]
@@ -156,7 +157,7 @@ Private Sub TestSub(ByRef testParam As Variant)
     testParam = target
     testParam.Add 100
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "VBA");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.VBA);
         }
 
         [Test]
@@ -192,7 +193,7 @@ End Sub
 Private Sub TestSub(ByRef testParam As Variant)
     testParam = New Collection     
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "VBA");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.VBA);
         }
 
         [Test]
@@ -225,7 +226,7 @@ Private Sub Workbook_Open()
     target.Value = ""forgot something?""
 
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.Excel);
         }
 
         [Test]
@@ -243,7 +244,7 @@ Private Sub Workbook_Open()
     target.Value = ""All good""
 
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.Excel);
         }
 
         [Test]
@@ -285,7 +286,7 @@ Private Sub TestSelfAssigned()
     Dim arg1 As new Collection
     arg1.Add 7
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "VBA");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.VBA);
         }
 
         [Test]
@@ -342,7 +343,7 @@ End Sub";
 Private Function Test() As Collection
     Test = New Collection
 End Function";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "VBA");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.VBA);
         }
 
         [Test]
@@ -493,7 +494,7 @@ Private Sub Test()
     bar.Add ""x"", ""x""
     foo = ""Test"" & bar.Item(""x"")
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "VBA");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.VBA);
         }
 
         [Test]
@@ -527,7 +528,7 @@ Private Sub Test()
     Dim bar As Variant    
     bar = foo
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "Excel");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.Excel);
         }
 
         [Test]
@@ -543,7 +544,7 @@ Private Sub Test()
     bar = foo
 End Sub";
             //The default member of Recordset is Fields, which is an object.
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.AdoDb);
         }
 
         [Test]
@@ -559,7 +560,7 @@ Private Sub Test()
     foo = bar
 End Sub";
             //The default member of Recordset is Fields, which is an object and only has a paramterized default member.
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.AdoDb);
         }
 
         [Test]
@@ -573,7 +574,7 @@ Private Sub Test()
     Dim foo As Variant  
     foo = New Connection
 End Sub";
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.AdoDb);
         }
 
         [Test]
@@ -588,7 +589,7 @@ Private Sub Test()
     foo = New Recordset
 End Sub";
             //The default member of Recordset is Fields, which is an object.
-            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, "ADODB");
+            AssertInputCodeYieldsExpectedInspectionResultCount(input, expectResultCount, ReferenceLibrary.AdoDb);
         }
 
         [Test]
@@ -1410,7 +1411,7 @@ End Function
             return new ObjectVariableNotSetInspection(state);
         }
 
-        private void AssertInputCodeYieldsExpectedInspectionResultCount(string inputCode, int expected, params string[] testLibraries)
+        private void AssertInputCodeYieldsExpectedInspectionResultCount(string inputCode, int expected, params ReferenceLibrary[] testLibraries)
         {
             var inspectionResults = InspectionResultsForModules(("Class1", inputCode, ComponentType.ClassModule), testLibraries);
             Assert.AreEqual(expected, inspectionResults.Count());

--- a/RubberduckTests/Inspections/ParameterNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterNotUsedInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -74,7 +75,7 @@ End Sub";
                 ("Module1", inputCode, ComponentType.StandardModule),
             };
 
-            Assert.AreEqual(0, InspectionResultsForModules(modules, "ADODB").Count());
+            Assert.AreEqual(0, InspectionResultsForModules(modules, ReferenceLibrary.AdoDb).Count());
         }
 
         [Test]

--- a/RubberduckTests/Inspections/ShadowedDeclarationInspectionTests.cs
+++ b/RubberduckTests/Inspections/ShadowedDeclarationInspectionTests.cs
@@ -5127,7 +5127,7 @@ Public {sameName} As String";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestClass", ComponentType.ClassModule, code)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -5153,7 +5153,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestClass", ComponentType.ClassModule, code)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -5178,7 +5178,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestClass", ComponentType.ClassModule, code)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -5213,7 +5213,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestClass", ComponentType.ClassModule, code)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -5247,7 +5247,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestClass", ComponentType.ClassModule, code)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .AddProjectToVbeBuilder()
                 .Build();
 

--- a/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
+++ b/RubberduckTests/Inspections/SheetAccessedUsingStringInspectionTests.cs
@@ -194,7 +194,7 @@ End Sub";
                         CreateVBComponentPropertyMock("CodeName", "Sheet1").Object
                     })
                 .AddReference("ReferencedProject", string.Empty, 0, 0)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .Build();
 
             var vbe = builder.AddProject(referencedProject).AddProject(project).Build();

--- a/RubberduckTests/Inspections/UnassignedVariableUsageInspectionTests.cs
+++ b/RubberduckTests/Inspections/UnassignedVariableUsageInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -303,7 +304,7 @@ Sub DoSomething()
     bar = Len(foo)
 End Sub
 ";
-            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), "VBA");
+            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), ReferenceLibrary.VBA);
             Assert.AreEqual(0, inspectionResults.Count());
         }
 
@@ -318,7 +319,7 @@ Sub DoSomething()
     bar = LenB(foo)
 End Sub
 ";
-            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), "VBA");
+            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), ReferenceLibrary.VBA);
             Assert.AreEqual(0, inspectionResults.Count());
         }
 
@@ -334,7 +335,7 @@ Sub DoSomething()
     bar = foo + 5
 End Sub
 ";
-            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), "VBA");
+            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), ReferenceLibrary.VBA);
             Assert.AreEqual(1, inspectionResults.Count());
         }
 
@@ -350,7 +351,7 @@ Sub DoSomething()
     bar = foo + 5
 End Sub
 ";
-            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), "VBA");
+            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), ReferenceLibrary.VBA);
             Assert.AreEqual(1, inspectionResults.Count());
         }
 
@@ -365,7 +366,7 @@ Sub DoSomething()
     bar = Len(foo + 5)
 End Sub
 ";
-            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), "VBA");
+            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), ReferenceLibrary.VBA);
             Assert.AreEqual(1, inspectionResults.Count());
         }
 
@@ -380,7 +381,7 @@ Sub DoSomething()
     bar = LenB(foo + 5)
 End Sub
 ";
-            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), "VBA");
+            var inspectionResults = InspectionResultsForModules(("TestModule", code, ComponentType.StandardModule), ReferenceLibrary.VBA);
             Assert.AreEqual(1, inspectionResults.Count());
         }
 

--- a/RubberduckTests/Inspections/UndeclaredVariableInspectionTests.cs
+++ b/RubberduckTests/Inspections/UndeclaredVariableInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -20,7 +21,7 @@ namespace RubberduckTests.Inspections
     Debug.Print a
 End Sub";
 
-            Assert.AreEqual(1, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), "VBA").Count());
+            Assert.AreEqual(1, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), ReferenceLibrary.VBA).Count());
         }
 
         [Test]
@@ -34,7 +35,7 @@ End Sub";
     Debug.Print a
 End Sub";
 
-            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), "VBA").Count());
+            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), ReferenceLibrary.VBA).Count());
         }
 
         [Test]
@@ -49,7 +50,7 @@ Sub Test()
     Debug.Print a
 End Sub";
 
-            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), "VBA").Count());
+            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), ReferenceLibrary.VBA).Count());
         }
 
         [Test]
@@ -81,7 +82,7 @@ End Sub";
     Debug.Print a
 End Sub";
 
-            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), "VBA").Count());
+            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), ReferenceLibrary.VBA).Count());
         }
 
         [Test]

--- a/RubberduckTests/Inspections/UntypedFunctionUsageInspectionTests.cs
+++ b/RubberduckTests/Inspections/UntypedFunctionUsageInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.Inspections.Concrete;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.Parsing.Inspections.Abstract;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -20,7 +21,7 @@ namespace RubberduckTests.Inspections
     str = Left(""test"", 1)
 End Sub";
 
-            Assert.AreEqual(1, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), "VBA").Count());
+            Assert.AreEqual(1, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), ReferenceLibrary.VBA).Count());
         }
 
         [Test]
@@ -33,7 +34,7 @@ End Sub";
     str = Left$(""test"", 1)
 End Sub";
 
-            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), "VBA").Count());
+            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), ReferenceLibrary.VBA).Count());
         }
 
         [Test]
@@ -48,7 +49,7 @@ End Sub";
     str = Left(""test"", 1)
 End Sub";
 
-            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), "VBA").Count());
+            Assert.AreEqual(0, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule), ReferenceLibrary.VBA).Count());
         }
 
         [Test]

--- a/RubberduckTests/Inspections/UseMeaningfulNameInspectionTests.cs
+++ b/RubberduckTests/Inspections/UseMeaningfulNameInspectionTests.cs
@@ -161,7 +161,7 @@ End Sub";
 
         private IEnumerable<IInspectionResult> InspectionResultsForModules(params (string name, string content, ComponentType componentType)[] modules)
         {
-            var vbe = MockVbeBuilder.BuildFromModules("TestProject", modules, Enumerable.Empty<string>());
+            var vbe = MockVbeBuilder.BuildFromModules("TestProject", modules, Enumerable.Empty<ReferenceLibrary>());
             return InspectionResults(vbe.Object);
         }
 

--- a/RubberduckTests/Inspections/ValueRequiredInspectionTests.cs
+++ b/RubberduckTests/Inspections/ValueRequiredInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.CodeAnalysis.Inspections.Concrete;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -382,7 +383,7 @@ End Function
                 ("Module1", moduleCode, ComponentType.StandardModule),
             };
 
-            Assert.IsFalse(InspectionResultsForModules(modules, "VBA").Any());
+            Assert.IsFalse(InspectionResultsForModules(modules, ReferenceLibrary.VBA).Any());
         }
 
         protected override IInspection InspectionUnderTest(RubberduckParserState state)

--- a/RubberduckTests/Mocks/MockProjectBuilder.cs
+++ b/RubberduckTests/Mocks/MockProjectBuilder.cs
@@ -43,7 +43,7 @@ namespace RubberduckTests.Mocks
         }
 
         public MockProjectBuilder(string name, string filename, ProjectProtection protection, ProjectType projectType, Func<IVBE> getVbe, MockVbeBuilder mockVbeBuilder)
-        :this(
+        : this(
             name,
             filename,
             Guid.NewGuid().ToString(),
@@ -102,6 +102,17 @@ namespace RubberduckTests.Mocks
             _codeModuleMocks.Add(codeModule);
             _getVbe().ActiveCodePane = component.Object.CodeModule.CodePane;
             return this;
+        }
+
+        /// <summary>
+        /// Adds a mock reference to the project.
+        /// </summary>
+        /// <param name="referenceLibrary">The reference library's enum.</param>
+        /// <returns>Returns the <see cref="MockProjectBuilder"/> instance.</returns>
+        public MockProjectBuilder AddReference(ReferenceLibrary referenceLibrary)
+        {
+            var (name, path, versionMajor, versionMinor, isBuiltIn) = MockVbeBuilder.ReferenceLibraries[referenceLibrary];
+            return AddReference(name, path, versionMajor, versionMinor, isBuiltIn);
         }
 
         /// <summary>
@@ -191,7 +202,7 @@ namespace RubberduckTests.Mocks
             result.Setup(m => m[It.IsAny<int>()]).Returns<int>(index => Components.ElementAt(index));
             result.Setup(m => m[It.IsAny<string>()]).Returns<string>(name => Components.Single(item => item.Name == name));
             result.SetupGet(m => m.Count).Returns(() => Components.Count);
-            
+
             result.Setup(m => m.Add(It.IsAny<ComponentType>()))
                 .Callback((ComponentType c) =>
                 {
@@ -272,7 +283,7 @@ namespace RubberduckTests.Mocks
             return result;
         }
 
-        private Mock<IVBComponent> CreateComponentMock(string name, ComponentType type, string content, Selection selection, 
+        private Mock<IVBComponent> CreateComponentMock(string name, ComponentType type, string content, Selection selection,
             IEnumerable<IProperty> properties, out Mock<ICodeModule> moduleMock)
         {
             var result = new Mock<IVBComponent>();
@@ -356,7 +367,7 @@ namespace RubberduckTests.Mocks
 
             codeModule.Setup(m => m.GetLines(It.IsAny<Selection>()))
                 .Returns((Selection selection) => string.Join(Environment.NewLine, lines.Skip(selection.StartLine - 1).Take(selection.LineCount)));
-            
+
             codeModule.Setup(m => m.GetLines(It.IsAny<int>(), It.IsAny<int>()))
                 .Returns<int, int>((start, count) => string.Join(Environment.NewLine, lines.Skip(start - 1).Take(count)));
 

--- a/RubberduckTests/Mocks/MockVbeBuilder.cs
+++ b/RubberduckTests/Mocks/MockVbeBuilder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -11,6 +10,28 @@ using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace RubberduckTests.Mocks
 {
+    public enum ReferenceLibrary
+    {
+        VBA,
+        Excel,
+        MsOffice,
+        StdOle,
+        MsForms,
+        VBIDE,
+        Scripting,
+        Regex,
+        MsXml,
+        ShDoc,
+        AdoDb,
+        AdoRecordset,
+    }
+
+    public static class ReferenceLibraryExtensions
+    {
+        public static string Name(this ReferenceLibrary val) => MockVbeBuilder.ReferenceLibraryIdentifiers[val].Name;
+        public static string Path(this ReferenceLibrary val) => MockVbeBuilder.ReferenceLibraryIdentifiers[val].Path;
+    }
+
     /// <summary>
     /// Builds a mock <see cref="IVBE"/>.
     /// </summary>
@@ -20,50 +41,34 @@ namespace RubberduckTests.Mocks
         public const string TestProjectName = "TestProject1";
         public const string TestModuleName = "TestModule1";
         private readonly Mock<IVBE> _vbe;
-        private readonly Mock<IVbeEvents> _vbeEvents;
 
-        #region standard library paths (referenced in all VBA projects hosted in Microsoft Excel)
-        public static readonly string LibraryPathVBA = @"C:\PROGRA~1\COMMON~1\MICROS~1\VBA\VBA7.1\VBE7.DLL";      // standard library, priority locked
-        public static readonly string LibraryPathMsExcel = @"C:\Program Files\Microsoft Office\Office15\EXCEL.EXE";   // mock host application, priority locked
-        public static readonly string LibraryPathMsOffice = @"C:\Program Files\Common Files\Microsoft Shared\OFFICE15\MSO.DLL";
-        public static readonly string LibraryPathStdOle = @"C:\Windows\System32\stdole2.tlb";
-        public static readonly string LibraryPathMsForms = @"C:\Windows\system32\FM20.DLL"; // standard in projects with a UserForm module
-        #endregion
-
-        public static readonly string LibraryPathVBIDE = @"C:\Program Files (x86)\Common Files\Microsoft Shared\VBA\VBA6\VBE6EXT.OLB";
-        public static readonly string LibraryPathScripting = @"C:\Windows\System32\scrrun.dll";
-        public static readonly string LibraryPathRegex = @"C:\Windows\System32\vbscript.dll\3";
-        public static readonly string LibraryPathMsXml = @"C:\Windows\System32\msxml6.dll";
-        public static readonly string LibraryPathShDoc = @"C:\Windows\System32\ieframe.dll";
-        public static readonly string LibraryPathAdoDb = @"C:\Program Files\Common Files\System\ado\msado15.dll";
-        public static readonly string LibraryPathAdoRecordset = @"C:\Program Files\Common Files\System\ado\msador15.dll";
-
-        public static readonly Dictionary<string, string> LibraryPaths = new Dictionary<string, string>
+        public static Dictionary<ReferenceLibrary, (string Name, string Path)> ReferenceLibraryIdentifiers = new Dictionary<ReferenceLibrary, (string Name, string Path)>()
         {
-            ["VBA"] = LibraryPathVBA,
-            ["Excel"] = LibraryPathMsExcel,
-            ["Office"] = LibraryPathMsOffice,
-            ["stdole"] = LibraryPathStdOle,
-            ["MSForms"] = LibraryPathMsForms,
-            ["VBIDE"] = LibraryPathVBIDE,
-            ["Scripting"] = LibraryPathScripting,
-            ["VBScript_RegExp_55"] = LibraryPathRegex,
-            ["MSXML2"] = LibraryPathMsXml,
-            ["SHDocVw"] = LibraryPathShDoc,
-            ["ADODB"] = LibraryPathAdoDb,
-            ["ADOR"] = LibraryPathAdoRecordset
+            //standard library paths (referenced in all VBA projects hosted in Microsoft Excel)
+            [ReferenceLibrary.VBA] = ("VBA", @"C:\PROGRA~1\COMMON~1\MICROS~1\VBA\VBA7.1\VBE7.DLL"), //standard library, priority locked"
+            [ReferenceLibrary.Excel] = ("Excel", @"C:\Program Files\Microsoft Office\Office15\EXCEL.EXE"), // mock host application, priority locked
+            [ReferenceLibrary.MsOffice] = ("Office", @"C:\Program Files\Common Files\Microsoft Shared\OFFICE15\MSO.DLL"),
+            [ReferenceLibrary.StdOle] = ("stdole", @"C:\Windows\System32\stdole2.tlb"),
+            [ReferenceLibrary.MsForms] = ("MSForms", @"C:\Windows\system32\FM20.DLL"),  // standard in projects with a UserForm module
+            //end standard library paths
+            [ReferenceLibrary.VBIDE] = ("VBIDE", @"C:\Program Files (x86)\Common Files\Microsoft Shared\VBA\VBA6\VBE6EXT.OLB"),
+            [ReferenceLibrary.Scripting] = ("Scripting", @"C:\Windows\System32\scrrun.dll"),
+            [ReferenceLibrary.Regex] = ("VBScript_RegExp_55", @"C:\Windows\System32\vbscript.dll\3"),
+            [ReferenceLibrary.MsXml] = ("MSXML2", @"C:\Windows\System32\msxml6.dll"),
+            [ReferenceLibrary.ShDoc] = ("SHDocVw", @"C:\Windows\System32\ieframe.dll"),
+            [ReferenceLibrary.AdoDb] = ("ADODB", @"C:\Program Files\Common Files\System\ado\msado15.dll"),
+            [ReferenceLibrary.AdoRecordset] = ("ADOR", @"C:\Program Files\Common Files\System\ado\msador15.dll"),
         };
 
-        private static readonly Dictionary<string, Func<MockProjectBuilder, MockProjectBuilder>> AddReference = new Dictionary<string, Func<MockProjectBuilder, MockProjectBuilder>>
+        internal static readonly Dictionary<ReferenceLibrary, (string name, string path, int versionMajor, int versionMinor, bool isBuiltIn)> ReferenceLibraries = new Dictionary<ReferenceLibrary, (string name, string path, int versionMajor, int versionMinor, bool isBuiltIn)>
         {
-            ["Excel"] = (MockProjectBuilder builder) => builder.AddReference("Excel", LibraryPathMsExcel, 1, 8, true),
-            ["VBA"] = (MockProjectBuilder builder) => builder.AddReference("VBA", LibraryPathVBA, 4, 2, true),
-            ["Scripting"] = (MockProjectBuilder builder) => builder.AddReference("Scripting", LibraryPathScripting, 1, 0, true),
-            ["ADODB"] = (MockProjectBuilder builder) => builder.AddReference("ADODB", LibraryPathAdoDb, 6, 1, false),
-            ["MSForms"] = (MockProjectBuilder builder) => builder.AddReference("MSForms", LibraryPathMsForms, 2, 0, true),
+            [ReferenceLibrary.VBA] = (ReferenceLibrary.VBA.Name(), ReferenceLibrary.VBA.Path(), 4, 2, true),
+            [ReferenceLibrary.Excel] = (ReferenceLibrary.Excel.Name(), ReferenceLibrary.Excel.Path(), 1, 8, true),
+            [ReferenceLibrary.Scripting] = (ReferenceLibrary.Scripting.Name(), ReferenceLibrary.Scripting.Path(), 1, 0, true),
+            [ReferenceLibrary.AdoDb] = (ReferenceLibrary.AdoDb.Name(), ReferenceLibrary.AdoDb.Path(), 6, 1, false),
+            [ReferenceLibrary.MsForms] = (ReferenceLibrary.MsForms.Name(), ReferenceLibrary.MsForms.Path(), 2, 0, true),
         };
 
-        //private Mock<IWindows> _vbWindows;
         private readonly Windows _windows = new Windows();
         private readonly ICollection<IVBProject> _projects = new List<IVBProject>();
 
@@ -160,7 +165,7 @@ namespace RubberduckTests.Mocks
 
             if (referenceStdLibs)
             {
-                builder.AddReference("VBA", LibraryPathVBA, 4, 2, true);
+                builder.AddReference(ReferenceLibrary.VBA);
             }
 
             var project = builder.Build();
@@ -194,24 +199,24 @@ namespace RubberduckTests.Mocks
         /// Builds a mock VBE containing a single "TestProject1" with multiple modules.
         /// </summary>
         public static Mock<IVBE> BuildFromModules(IEnumerable<(string name, string content, ComponentType componentType)> modules)
-            => BuildFromModules(modules, Enumerable.Empty<string>());
+            => BuildFromModules(modules, Enumerable.Empty<ReferenceLibrary>());
 
         /// <summary>
         /// Builds a mock VBE containing a single "TestProject1" with one module and one or more libraries.
         /// </summary>
-        public static Mock<IVBE> BuildFromModules((string name, string content, ComponentType componentType) module, params string[] libraries)
-            => BuildFromModules(new (string, string, ComponentType)[] { module }, libraries);
+        public static Mock<IVBE> BuildFromModules((string name, string content, ComponentType componentType) module, params ReferenceLibrary[] libraries)
+            => BuildFromModules(new(string, string, ComponentType)[] { module }, libraries);
 
         /// <summary>
         /// Builds a mock VBE containing a single "TestProject1" with multiple modules and libraries.
         /// </summary>
-        public static Mock<IVBE> BuildFromModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<string> libraryNames)
-            => BuildFromModules(TestProjectName, modules, libraryNames);
+        public static Mock<IVBE> BuildFromModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<ReferenceLibrary> libraries)
+            => BuildFromModules(TestProjectName, modules, libraries);
 
         /// <summary>
         /// Builds a mock VBE containing one project with multiple modules and libraries.
         /// </summary>
-        public static Mock<IVBE> BuildFromModules(string projectName, IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<string> libraryNames)
+        public static Mock<IVBE> BuildFromModules(string projectName, IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<ReferenceLibrary> referenceLibraries)
         {
             var vbeBuilder = new MockVbeBuilder();
 
@@ -221,9 +226,10 @@ namespace RubberduckTests.Mocks
                 builder.AddComponent(name, componentType, content);
             }
 
-            foreach (var name in libraryNames)
+            foreach (var refLibrary in referenceLibraries)
             {
-                AddReference[name](builder);
+                var (name, path, versionMajor, versionMinor, isBuiltIn) = ReferenceLibraries[refLibrary];
+                builder.AddReference(name, path, versionMajor, versionMinor, isBuiltIn);
             }
 
             var project = builder.Build();
@@ -263,7 +269,7 @@ namespace RubberduckTests.Mocks
             vbe.Setup(m => m.Windows).Returns(() => _windows);
             vbe.SetupProperty(m => m.ActiveCodePane);
             vbe.SetupProperty(m => m.ActiveVBProject);
-            
+
             vbe.SetupGet(m => m.SelectedVBComponent).Returns(() => vbe.Object.ActiveCodePane?.CodeModule?.Parent);
             vbe.Setup(m => m.GetActiveSelection()).Returns(() => vbe.Object.ActiveCodePane?.GetQualifiedSelection());
             vbe.SetupGet(m => m.ActiveWindow).Returns(() => vbe.Object.ActiveCodePane.Window);
@@ -289,8 +295,8 @@ namespace RubberduckTests.Mocks
 
         private static ICommandBars DummyCommandBars()
         {
-            var commandBars = new Mock<ICommandBars>(); 
- 
+            var commandBars = new Mock<ICommandBars>();
+
             var dummyCommandBar = DummyCommandBar();
 
             commandBars.SetupGet(m => m[It.IsAny<int>()]).Returns(dummyCommandBar);
@@ -333,7 +339,7 @@ namespace RubberduckTests.Mocks
 
             result.Setup(m => m.GetEnumerator()).Returns(() => _projects.GetEnumerator());
             result.As<IEnumerable>().Setup(m => m.GetEnumerator()).Returns(() => _projects.GetEnumerator());
-            
+
             result.Setup(m => m[It.IsAny<int>()]).Returns<int>(value => _projects.ElementAt(value));
             result.SetupGet(m => m.Count).Returns(() => _projects.Count);
 
@@ -370,7 +376,7 @@ namespace RubberduckTests.Mocks
 
             result.Setup(m => m.GetEnumerator()).Returns(() => _codePanes.GetEnumerator());
             result.As<IEnumerable>().Setup(m => m.GetEnumerator()).Returns(() => _codePanes.GetEnumerator());
-            
+
             result.Setup(m => m[It.IsAny<int>()]).Returns<int>(value => _codePanes.ElementAt(value));
             result.SetupGet(m => m.Count).Returns(() => _codePanes.Count);
 

--- a/RubberduckTests/QuickFixes/AccessSheetUsingCodeNameQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AccessSheetUsingCodeNameQuickFixTests.cs
@@ -207,7 +207,7 @@ End Sub";
                         CreateVBComponentPropertyMock("Name", "Name").Object,
                         CreateVBComponentPropertyMock("CodeName", "CodeName").Object
                     })
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .Build();
 
             component = project.Object.VBComponents[0];

--- a/RubberduckTests/QuickFixes/ApplicationWorksheetFunctionQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ApplicationWorksheetFunctionQuickFixTests.cs
@@ -93,7 +93,7 @@ End Sub
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, code)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .Build();
 
             var vbe = builder.AddProject(project).Build().Object;

--- a/RubberduckTests/QuickFixes/ExpandBangNotationQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ExpandBangNotationQuickFixTests.cs
@@ -193,7 +193,7 @@ End Sub
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -224,7 +224,7 @@ End Sub
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build();
 

--- a/RubberduckTests/QuickFixes/ExpandDefaultMemberQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/ExpandDefaultMemberQuickFixTests.cs
@@ -667,7 +667,7 @@ End Sub
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -700,7 +700,7 @@ End Sub
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build();
 
@@ -731,7 +731,7 @@ End Sub
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, moduleCode)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build();
 

--- a/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
@@ -738,7 +738,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("MyClass", ComponentType.ClassModule, inputCode)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .Build();
             var vbe = builder.AddProject(project).Build();
 
@@ -1152,7 +1152,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", "TestProject1", ProjectProtection.Unprotected)
                 .AddComponent("Class1", ComponentType.ClassModule, inputCode)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .Build();
             var component = project.Object.VBComponents[0];
             var vbe = builder.AddProject(project).Build();
@@ -1165,7 +1165,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, inputCode)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .Build();
 
             var vbe = builder.AddProject(project).Build();

--- a/RubberduckTests/QuickFixes/IsMissingOnInappropriateArgumentQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/IsMissingOnInappropriateArgumentQuickFixTests.cs
@@ -448,7 +448,7 @@ End Sub
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("TestProject1", "TestProject1", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, code)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .Build();
             var vbe = builder.AddProject(project).Build();
             component = project.Object.VBComponents.First();

--- a/RubberduckTests/QuickFixes/UntypedFunctionUsageQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/UntypedFunctionUsageQuickFixTests.cs
@@ -33,7 +33,7 @@ End Sub";
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("MyClass", ComponentType.ClassModule, inputCode)
-                .AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 2, true)
+                .AddReference(ReferenceLibrary.VBA)
                 .Build();
             var vbe = builder.AddProject(project).Build();
 

--- a/RubberduckTests/QuickFixes/UseSetKeywordForObjectAssignmentQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/UseSetKeywordForObjectAssignmentQuickFixTests.cs
@@ -149,7 +149,7 @@ End Sub
             var builder = new MockVbeBuilder();
             var project = builder.ProjectBuilder("VBAProject", ProjectProtection.Unprotected)
                 .AddComponent("Module1", ComponentType.StandardModule, code)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .Build();
 
             var vbe = builder.AddProject(project).Build().Object;

--- a/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
+++ b/RubberduckTests/Refactoring/MoveCloserToUsageTests.cs
@@ -824,7 +824,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("Module", ComponentType.StandardModule, inputCode)
-                .AddReference("EXCEL", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build()
                 .Object;

--- a/RubberduckTests/Refactoring/Rename/RenameTests.cs
+++ b/RubberduckTests/Refactoring/Rename/RenameTests.cs
@@ -3205,8 +3205,8 @@ End Property";
 
             if (useLibraries)
             {
-                enclosingProjectBuilder.AddReference("VBA", MockVbeBuilder.LibraryPathVBA, 4, 1, true);
-                enclosingProjectBuilder.AddReference("EXCEL", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true);
+                enclosingProjectBuilder.AddReference(ReferenceLibrary.VBA);
+                enclosingProjectBuilder.AddReference(ReferenceLibrary.Excel);
             }
 
             foreach (var testModuleDefinition in testModuleDefinitions)

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -673,7 +673,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestModule", ComponentType.StandardModule, code)
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build();
 

--- a/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
+++ b/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
@@ -523,7 +523,7 @@ End Sub";
             var vbe = new MockVbeBuilder()
                 .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
                 .AddComponent("TestModule", ComponentType.StandardModule, code, new Selection(5, 16))
-                .AddReference("Excel", MockVbeBuilder.LibraryPathMsExcel, 1, 8, true)
+                .AddReference(ReferenceLibrary.Excel)
                 .AddProjectToVbeBuilder()
                 .Build();
 


### PR DESCRIPTION
Take 2:  Original PR #5364 was reverted.  This PR introduces an enum of reference libraries. The move away from string literal keys was discussed within #5226 as a follow up PR. Tests have been updated to use the library enums.