### PR TITLE
Remove the project SCW from ProjectDeclaration

### DIFF
--- a/Rubberduck.Core/CodeAnalysis/CodeMetrics/CodeMetricsViewModel.cs
+++ b/Rubberduck.Core/CodeAnalysis/CodeMetrics/CodeMetricsViewModel.cs
@@ -84,7 +84,7 @@ namespace Rubberduck.CodeAnalysis.CodeMetrics
 
                 foreach (var project in adding)
                 {
-                    var model = new CodeExplorerProjectViewModel(project, ref updates, _state, _vbe, false);
+                    var model = new CodeExplorerProjectViewModel(project, ref updates, _state, _vbe, _state.ProjectsProvider,false);
                     Projects.Add(model);
                 }
             }).Wait();

--- a/Rubberduck.Core/Formatters/DeclarationFormatter.cs
+++ b/Rubberduck.Core/Formatters/DeclarationFormatter.cs
@@ -21,7 +21,7 @@ namespace Rubberduck.Formatters
         public string ToClipboardString()
         {
             return string.Format(RubberduckUI.CodeExplorer_IExportable_DeclarationFormat,
-                _declaration.Project.Name,
+                _declaration.ProjectName,
                 _declaration.CustomFolder,
                 _declaration.ComponentName,
                 _declaration.DeclarationType,

--- a/Rubberduck.Core/Formatters/InspectionResultFormatter.cs
+++ b/Rubberduck.Core/Formatters/InspectionResultFormatter.cs
@@ -8,10 +8,12 @@ namespace Rubberduck.Formatters
     public class InspectionResultFormatter : IExportable
     {
         private readonly IInspectionResult _inspectionResult;
+        private readonly string _documentName;
 
-        public InspectionResultFormatter(IInspectionResult inspectionResult)
+        public InspectionResultFormatter(IInspectionResult inspectionResult, string documentName)
         {
             _inspectionResult = inspectionResult;
+            _documentName = documentName;
         }
 
         public object[] ToArray()
@@ -28,30 +30,10 @@ namespace Rubberduck.Formatters
             };
         }
 
-        /// <summary>
-        /// WARNING: This property can have side effects. It can change the ActiveVBProject if the result has a null Declaration, 
-        /// which causes a flicker in the VBE. This should only be called if it is *absolutely* necessary.
-        /// </summary>
         public string ToClipboardString()
         {
             var module = _inspectionResult.QualifiedSelection.QualifiedName;
-            var documentName = _inspectionResult.Target != null
-                ? _inspectionResult.Target.ProjectDisplayName
-                : string.Empty;
-
-            //todo: Find a sane way to reimplement this.
-            //if (string.IsNullOrEmpty(documentName))
-            //{
-            //    var component = module.Component;
-            //    documentName = component != null 
-            //        ? component.ParentProject.ProjectDisplayName 
-            //        : string.Empty;
-            //}
-
-            if (string.IsNullOrEmpty(documentName))
-            {
-                documentName = Path.GetFileName(module.ProjectPath);
-            }
+            var documentName = _documentName;
 
             return string.Format(
                 InspectionsUI.QualifiedSelectionInspection,

--- a/Rubberduck.Core/Formatters/InspectionResultFormatter.cs
+++ b/Rubberduck.Core/Formatters/InspectionResultFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using Rubberduck.Common;
 using Rubberduck.Parsing.Inspections.Abstract;
-using Rubberduck.Inspections.Abstract;
 using System.IO;
 using Rubberduck.Resources.Inspections;
 

--- a/Rubberduck.Core/Formatters/InspectionResultFormatter.cs
+++ b/Rubberduck.Core/Formatters/InspectionResultFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using Rubberduck.Common;
 using Rubberduck.Parsing.Inspections.Abstract;
-using System.IO;
 using Rubberduck.Resources.Inspections;
 
 namespace Rubberduck.Formatters

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
@@ -5,6 +5,7 @@ using Rubberduck.AddRemoveReferences;
 using Rubberduck.Navigation.Folders;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
@@ -21,17 +22,20 @@ namespace Rubberduck.Navigation.CodeExplorer
         };
 
         private readonly IVBE _vbe;
+        private readonly IProjectsProvider _projectsProvider;
 
         public CodeExplorerProjectViewModel(
             Declaration project, 
             ref List<Declaration> declarations, 
             RubberduckParserState state, 
             IVBE vbe, 
+            IProjectsProvider projectsProvider,
             bool references = true) 
             : base(null, project)
         {
-            State = state;         
+            State = state;
             _vbe = vbe;
+            _projectsProvider = projectsProvider;
             ShowReferences = references;
 
             SetName();
@@ -58,7 +62,7 @@ namespace Rubberduck.Navigation.CodeExplorer
                     return base.FontWeight;
                 }
 
-                var project = State.ProjectsProvider.Project(Declaration.ProjectId);
+                var project = _projectsProvider.Project(Declaration.ProjectId);
                 if (project == null)
                 {
                     return base.FontWeight;
@@ -158,7 +162,7 @@ namespace Rubberduck.Navigation.CodeExplorer
                 return new List<ReferenceModel>();
             }
 
-            var project = State.ProjectsProvider.Project(Declaration.ProjectId);
+            var project = _projectsProvider.Project(Declaration.ProjectId);
             if (project == null)
             {
                 return new List<ReferenceModel>();

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using Rubberduck.AddRemoveReferences;

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
@@ -22,7 +22,13 @@ namespace Rubberduck.Navigation.CodeExplorer
 
         private readonly IVBE _vbe;
 
-        public CodeExplorerProjectViewModel(Declaration project, ref List<Declaration> declarations, RubberduckParserState state, IVBE vbe, bool references = true) : base(null, project)
+        public CodeExplorerProjectViewModel(
+            Declaration project, 
+            ref List<Declaration> declarations, 
+            RubberduckParserState state, 
+            IVBE vbe, 
+            bool references = true) 
+            : base(null, project)
         {
             State = state;         
             _vbe = vbe;
@@ -47,7 +53,13 @@ namespace Rubberduck.Navigation.CodeExplorer
         {
             get
             {
-                if (_vbe.Kind == VBEKind.Hosted || Declaration.Project == null)
+                if (_vbe.Kind == VBEKind.Hosted || Declaration == null)
+                {
+                    return base.FontWeight;
+                }
+
+                var project = State.ProjectsProvider.Project(Declaration.ProjectId);
+                if (project == null)
                 {
                     return base.FontWeight;
                 }
@@ -55,7 +67,9 @@ namespace Rubberduck.Navigation.CodeExplorer
                 using (var vbProjects = _vbe.VBProjects)
                 using (var startProject = vbProjects?.StartProject)
                 {
-                    return Declaration.Project.Equals(startProject) ? FontWeights.Bold : base.FontWeight;
+                    return project.Equals(startProject) 
+                        ? FontWeights.Bold 
+                        : base.FontWeight;
                 }
             }
         }
@@ -139,7 +153,12 @@ namespace Rubberduck.Navigation.CodeExplorer
 
         private List<ReferenceModel> GetProjectReferenceModels()
         {
-            var project = Declaration?.Project;
+            if (Declaration == null)
+            {
+                return new List<ReferenceModel>();
+            }
+
+            var project = State.ProjectsProvider.Project(Declaration.ProjectId);
             if (project == null)
             {
                 return new List<ReferenceModel>();

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerProjectViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using Rubberduck.AddRemoveReferences;
@@ -193,9 +194,22 @@ namespace Rubberduck.Navigation.CodeExplorer
             _name = Declaration?.IdentifierName ?? string.Empty;
 
             // F' the flicker. Digging into the properties has some even more evil side-effects, and is a performance nightmare by comparison.
-            _displayName = Declaration?.ProjectDisplayName ?? string.Empty;
+            _displayName = DisplayName(Declaration);
 
             OnNameChanged();
+        }
+
+        private string DisplayName(Declaration declaration)
+        {
+            if (declaration == null)
+            {
+                return string.Empty;
+            }
+
+            var project = _projectsProvider.Project(declaration.ProjectId);
+            return project != null 
+                ? project.ProjectDisplayName 
+                : string.Empty;
         }
 
         private static readonly List<DeclarationType> UntrackedTypes = new List<DeclarationType>

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -286,7 +286,7 @@ namespace Rubberduck.Navigation.CodeExplorer
 
                 foreach (var project in adding)
                 {
-                    var model = new CodeExplorerProjectViewModel(project, ref updates, _state, _vbe) { Filter = Search };
+                    var model = new CodeExplorerProjectViewModel(project, ref updates, _state, _vbe, _state.ProjectsProvider) { Filter = Search };
                     Projects.Add(model);
                 }
 

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -13,7 +13,6 @@ using Rubberduck.UI.CodeExplorer.Commands;
 using Rubberduck.UI.Command;
 using Rubberduck.VBEditor.SafeComWrappers;
 using System.Windows;
-using System.Windows.Forms;
 using System.Windows.Input;
 using Rubberduck.Parsing.UIContext;
 using Rubberduck.Templates;
@@ -305,12 +304,12 @@ namespace Rubberduck.Navigation.CodeExplorer
                 return;
             }
 
-            var componentProject = _state.ProjectsProvider.Project(e.Module.ProjectId);
+            var componentProjectId = e.Module.ProjectId;
             
             var module = Projects.OfType<CodeExplorerProjectViewModel>()
-                .FirstOrDefault(p => p.Declaration.Project?.Equals(componentProject) ?? false)?.Children
-                .OfType<CodeExplorerComponentViewModel>().FirstOrDefault(component =>
-                    component.QualifiedSelection?.QualifiedName.Equals(e.Module) ?? false);
+                .FirstOrDefault(p => p.Declaration?.ProjectId.Equals(componentProjectId) ?? false)?.Children
+                .OfType<CodeExplorerComponentViewModel>()
+                .FirstOrDefault(component => component.QualifiedSelection?.QualifiedName.Equals(e.Module) ?? false);
 
             if (module == null)
             {

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesPresenterFactory.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesPresenterFactory.cs
@@ -147,7 +147,7 @@ namespace Rubberduck.UI.AddRemoveReferences
 
             return (model != null)
                 ? new AddRemoveReferencesPresenter(
-                    new AddRemoveReferencesDialog(new AddRemoveReferencesViewModel(model, _reconciler, _browser)))
+                    new AddRemoveReferencesDialog(new AddRemoveReferencesViewModel(model, _reconciler, _browser, _projectsProvider)))
                 : null;                 
         }
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddClassModuleCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddClassModuleCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -7,8 +8,11 @@ namespace Rubberduck.UI.CodeExplorer.Commands
     public class AddClassModuleCommand : AddComponentCommandBase
     {
         public AddClassModuleCommand(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents) { }
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
+        {}
 
         public override IEnumerable<ProjectType> AllowableProjectTypes => ProjectTypes.All;
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddComponentCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -19,12 +20,16 @@ namespace Rubberduck.UI.CodeExplorer.Commands
         };
 
         private readonly ICodeExplorerAddComponentService _addComponentService;
+        private readonly IProjectsProvider _projectsProvider;
 
         protected AddComponentCommandBase(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
             : base(vbeEvents)
         {
             _addComponentService = addComponentService;
+            _projectsProvider = projectsProvider;
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
@@ -50,8 +55,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
             try
             {
-                var project = node.Declaration.Project;
-                return AllowableProjectTypes.Contains(project.Type);
+                var project = _projectsProvider.Project(node.Declaration.ProjectId);
+                return project != null 
+                       && AllowableProjectTypes.Contains(project.Type);
             }
             catch (COMException)
             {

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddMDIFormCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddMDIFormCommand.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
@@ -12,10 +13,16 @@ namespace Rubberduck.UI.CodeExplorer.Commands
     {
         private static readonly ProjectType[] Types = { ProjectType.StandardExe, ProjectType.ActiveXExe };
 
+        private readonly IProjectsProvider _projectsProvider;
+
         public AddMDIFormCommand(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents) 
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
         {
+            _projectsProvider = projectsProvider;
+
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
 
@@ -30,7 +37,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 return false;
             }
 
-            var project = node.Declaration?.Project;
+            var project = node.Declaration != null
+                ? _projectsProvider.Project(node.Declaration.ProjectId)
+                : null;
 
             return EvaluateCanExecuteForProject(project);
         }

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddPropertyPageCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddPropertyPageCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -7,8 +8,11 @@ namespace Rubberduck.UI.CodeExplorer.Commands
     public class AddPropertyPageCommand : AddComponentCommandBase
     {
         public AddPropertyPageCommand(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents) { }
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
+        {}
 
         public override IEnumerable<ProjectType> AllowableProjectTypes => ProjectTypes.VB6;
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddStdModuleCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddStdModuleCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -7,8 +8,10 @@ namespace Rubberduck.UI.CodeExplorer.Commands
     public class AddStdModuleCommand : AddComponentCommandBase
     {
         public AddStdModuleCommand(
-        ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents)
+        ICodeExplorerAddComponentService addComponentService, 
+        IVbeEvents vbeEvents,
+        IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
         { }
 
         public override IEnumerable<ProjectType> AllowableProjectTypes => ProjectTypes.All;

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddTemplateCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddTemplateCommand.cs
@@ -6,6 +6,7 @@ using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.Templates;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.UI.Command;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace Rubberduck.UI.CodeExplorer.Commands
@@ -30,15 +31,18 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         private readonly ITemplateProvider _provider;
         private readonly ICodeExplorerAddComponentService _addComponentService;
+        private readonly IProjectsProvider _projectsProvider;
 
         public AddTemplateCommand(
                 ICodeExplorerAddComponentService addComponentService, 
                 ITemplateProvider provider, 
-                IVbeEvents vbeEvents) 
+                IVbeEvents vbeEvents,
+                IProjectsProvider projectsProvider) 
                 : base(vbeEvents)
         {
             _provider = provider;
             _addComponentService = addComponentService;
+            _projectsProvider = projectsProvider;
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
@@ -75,8 +79,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 return false;
             }
 
-            var project = node.Declaration.Project;
-            return AllowableProjectTypes.Contains(project.Type);
+            var project = _projectsProvider.Project(node.Declaration.ProjectId);
+            return project != null 
+                   && AllowableProjectTypes.Contains(project.Type);
         }
 
         protected override void OnExecute(object parameter)

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddUserControlCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddUserControlCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -7,8 +8,10 @@ namespace Rubberduck.UI.CodeExplorer.Commands
     public class AddUserControlCommand : AddComponentCommandBase
     {
         public AddUserControlCommand(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents)
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
         { }
 
         public override IEnumerable<ProjectType> AllowableProjectTypes => ProjectTypes.VB6;

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddUserDocumentCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddUserDocumentCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -9,8 +10,10 @@ namespace Rubberduck.UI.CodeExplorer.Commands
         private static readonly ProjectType[] Types = { ProjectType.ActiveXExe, ProjectType.ActiveXDll };
 
         public AddUserDocumentCommand(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents)
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
         { }
 
         public override IEnumerable<ProjectType> AllowableProjectTypes => Types;

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddUserFormCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddUserFormCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -7,8 +8,10 @@ namespace Rubberduck.UI.CodeExplorer.Commands
     public class AddUserFormCommand : AddComponentCommandBase
     {
         public AddUserFormCommand(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents)
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
         { }
 
         public override IEnumerable<ProjectType> AllowableProjectTypes => ProjectTypes.VBA;

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddVBFormCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddVBFormCommand.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 
@@ -9,8 +10,10 @@ namespace Rubberduck.UI.CodeExplorer.Commands
     public class AddVBFormCommand : AddComponentCommandBase
     {
         public AddVBFormCommand(
-            ICodeExplorerAddComponentService addComponentService, IVbeEvents vbeEvents) 
-            : base(addComponentService, vbeEvents)
+            ICodeExplorerAddComponentService addComponentService, 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
+            : base(addComponentService, vbeEvents, projectsProvider)
         { }
 
         public override IEnumerable<ProjectType> AllowableProjectTypes => ProjectTypes.VB6;

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ImportCommand.cs
@@ -102,9 +102,12 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             return (targetProject, targetProject != null);
         }
 
-        private static IVBProject TargetProjectFromParameter(object parameter)
+        private IVBProject TargetProjectFromParameter(object parameter)
         {
-            return (parameter as CodeExplorerItemViewModel)?.Declaration?.Project;
+            var declaration = (parameter as CodeExplorerItemViewModel)?.Declaration;
+            return declaration != null 
+                ? _projectsProvider.Project(declaration.ProjectId)
+                : null;
         }
 
         private IVBProject TargetProjectFromVbe()

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/OpenProjectPropertiesCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/OpenProjectPropertiesCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
@@ -18,13 +19,16 @@ namespace Rubberduck.UI.CodeExplorer.Commands
         };
 
         private readonly IVBE _vbe;
+        private readonly IProjectsProvider _projectsProvider;
 
         public OpenProjectPropertiesCommand(
             IVBE vbe, 
-            IVbeEvents vbeEvents) 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
             : base(vbeEvents)
         {
             _vbe = vbe;
+            _projectsProvider = projectsProvider;
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
@@ -67,7 +71,13 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                         return;
                     }
 
-                    var nodeProject = node.Declaration?.Project;
+                    var nodeProjectId = node.Declaration?.ProjectId;
+                    if (nodeProjectId == null)
+                    {
+                        return;
+                    }
+
+                    var nodeProject = _projectsProvider.Project(nodeProjectId);
                     if (nodeProject == null)
                     {
                         return; //The project declaration has been disposed, i.e. the project has been removed already.

--- a/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
+++ b/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Windows.Forms;
 using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.Resources;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
@@ -12,15 +13,18 @@ namespace Rubberduck.UI.Command.ComCommands
     {
         private readonly IVBE _vbe;
         private readonly IFileSystemBrowserFactory _factory;
+        private readonly IProjectsProvider _projectsProvider;
 
         public ExportAllCommand(
             IVBE vbe, 
             IFileSystemBrowserFactory folderBrowserFactory, 
-            IVbeEvents vbeEvents) 
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider) 
             : base(vbeEvents)
         {
             _vbe = vbe;
             _factory = folderBrowserFactory;
+            _projectsProvider = projectsProvider;
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
@@ -32,7 +36,8 @@ namespace Rubberduck.UI.Command.ComCommands
                 return false;
             }
 
-            if (!(parameter is CodeExplorerProjectViewModel) && parameter is CodeExplorerItemViewModel)
+            if (!(parameter is CodeExplorerProjectViewModel) 
+                && parameter is CodeExplorerItemViewModel)
             {
                 return false;
             }
@@ -40,7 +45,10 @@ namespace Rubberduck.UI.Command.ComCommands
             switch (parameter)
             {
                 case CodeExplorerProjectViewModel projectNode:
-                    return Evaluate(projectNode.Declaration.Project);
+                    var nodeProject = projectNode.Declaration != null
+                        ? _projectsProvider.Project(projectNode.Declaration.ProjectId)
+                        : null;
+                    return Evaluate(nodeProject);
                 case IVBProject project:
                     return Evaluate(project);
             }
@@ -69,8 +77,15 @@ namespace Rubberduck.UI.Command.ComCommands
         {
             switch (parameter)
             {
-                case CodeExplorerProjectViewModel projectNode when projectNode.Declaration.Project != null:
-                    Export(projectNode.Declaration.Project);
+                case CodeExplorerProjectViewModel projectNode:
+                    var nodeProject = projectNode.Declaration != null
+                        ? _projectsProvider.Project(projectNode.Declaration.ProjectId)
+                        : null;
+                    if (nodeProject == null)
+                    {
+                        return;
+                    }
+                    Export(nodeProject);
                     break;
                 case IVBProject vbproject:
                     Export(vbproject);

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using System.Windows.Data;
 using System.Windows.Input;
 using NLog;
 using Rubberduck.Common;
+using Rubberduck.Formatters;
 using Rubberduck.Inspections.Abstract;
 using Rubberduck.Interaction.Navigation;
 using Rubberduck.JunkDrawer.Extensions;
@@ -666,7 +668,11 @@ namespace Rubberduck.UI.Inspections
                 return;
             }
 
-            var resultArray = Results.OfType<IExportable>().Select(result => result.ToArray()).ToArray();
+            var resultArray = Results
+                .OfType<IInspectionResult>()
+                .Select(result => new InspectionResultFormatter(result, DocumentName(result)))
+                .Select(formattedResult => formattedResult.ToArray())
+                .ToArray();
 
             var resource = resultArray.Length == 1
                 ? Resources.RubberduckUI.CodeInspections_NumberOfIssuesFound_Singular
@@ -674,7 +680,12 @@ namespace Rubberduck.UI.Inspections
 
             var title = string.Format(resource, DateTime.Now.ToString(CultureInfo.InvariantCulture), resultArray.Count());
 
-            var textResults = title + Environment.NewLine + string.Join(string.Empty, Results.OfType<IExportable>().Select(result => result.ToClipboardString() + Environment.NewLine).ToArray());
+            var resultTexts = Results
+                .OfType<IInspectionResult>()
+                .Select(result => new InspectionResultFormatter(result, DocumentName(result)))
+                .Select(formattedResult => $"{formattedResult.ToClipboardString()}{Environment.NewLine}")
+                .ToArray();
+            var textResults = $"{title}{Environment.NewLine}{string.Join(string.Empty, resultTexts)}";
             var csvResults = ExportFormatter.Csv(resultArray, title, ColumnInformation);
             var htmlResults = ExportFormatter.HtmlClipboardFragment(resultArray, title, ColumnInformation);
             var rtfResults = ExportFormatter.RTF(resultArray, title);
@@ -689,6 +700,20 @@ namespace Rubberduck.UI.Inspections
             _clipboard.AppendString(DataFormats.UnicodeText, textResults);
 
             _clipboard.Flush();
+        }
+
+        private string DocumentName(IInspectionResult result)
+        {
+            var module = result.QualifiedSelection.QualifiedName;
+            var projectId = module.ProjectId;
+            var project = _state.ProjectsProvider.Project(projectId);
+
+            if (project == null)
+            {
+                return Path.GetFileName(module.ProjectPath);
+            }
+
+            return project.ProjectDisplayName;
         }
 
         private bool CanExecuteCopyResultsCommand(object parameter)

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -20,7 +20,6 @@ using Rubberduck.Parsing.Inspections;
 using Rubberduck.Parsing.Inspections.Abstract;
 using Rubberduck.Parsing.UIContext;
 using Rubberduck.Parsing.VBA;
-using Rubberduck.Parsing.VBA.Extensions;
 using Rubberduck.Settings;
 using Rubberduck.SettingsProvider;
 using Rubberduck.UI.Command;
@@ -669,7 +668,7 @@ namespace Rubberduck.UI.Inspections
 
             var resultArray = Results.OfType<IExportable>().Select(result => result.ToArray()).ToArray();
 
-            var resource = resultArray.Count() == 1
+            var resource = resultArray.Length == 1
                 ? Resources.RubberduckUI.CodeInspections_NumberOfIssuesFound_Singular
                 : Resources.RubberduckUI.CodeInspections_NumberOfIssuesFound_Plural;
 

--- a/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -249,7 +249,9 @@ namespace Rubberduck.UI.ToDoItems
 
             ColumnInfo[] columnInfos = { new ColumnInfo("Type"), new ColumnInfo("Description"), new ColumnInfo("Project"), new ColumnInfo("Component"), new ColumnInfo("Line", hAlignment.Right), new ColumnInfo("Column", hAlignment.Right) };
 
-            var resultArray = _items.OfType<IExportable>().Select(result => result.ToArray()).ToArray();
+            var resultArray = _items
+                .Select(item => new ToDoItemFormatter(item))
+                .Select(formattedItem => formattedItem.ToArray()).ToArray();
 
             var resource = _items.Count == 1
                 ? ToDoExplorerUI.ToDoExplorer_NumberOfIssuesFound_Singular
@@ -257,7 +259,11 @@ namespace Rubberduck.UI.ToDoItems
 
             var title = string.Format(resource, DateTime.Now.ToString(CultureInfo.InvariantCulture), _items.Count);
 
-            var textResults = title + Environment.NewLine + string.Join(string.Empty, _items.OfType<IExportable>().Select(result => result.ToClipboardString() + Environment.NewLine).ToArray());
+            var itemTexts = _items
+                .Select(item => new ToDoItemFormatter(item))
+                .Select(formattedItem => $"{formattedItem.ToClipboardString()}{Environment.NewLine}")
+                .ToArray();
+            var textResults = $"{title}{Environment.NewLine}{string.Join(string.Empty, itemTexts)}";
             var csvResults = ExportFormatter.Csv(resultArray, title, columnInfos);
             var htmlResults = ExportFormatter.HtmlClipboardFragment(resultArray, title, columnInfos);
             var rtfResults = ExportFormatter.RTF(resultArray, title);

--- a/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestModuleCommand.cs
+++ b/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestModuleCommand.cs
@@ -3,6 +3,7 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.UI.Command.ComCommands;
 using Rubberduck.UnitTesting.CodeGeneration;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
@@ -17,17 +18,20 @@ namespace Rubberduck.UI.UnitTesting.ComCommands
     {
         private readonly RubberduckParserState _state;
         private readonly ITestCodeGenerator _codeGenerator;
+        private readonly IProjectsProvider _projectsProvider;
 
         public AddTestModuleCommand(
             IVBE vbe, 
             RubberduckParserState state, 
             ITestCodeGenerator codeGenerator,
-            IVbeEvents vbeEvents)
+            IVbeEvents vbeEvents,
+            IProjectsProvider projectsProvider)
             : base(vbeEvents)
         {
             Vbe = vbe;
             _state = state;
             _codeGenerator = codeGenerator;
+            _projectsProvider = projectsProvider;
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
@@ -78,7 +82,8 @@ namespace Rubberduck.UI.UnitTesting.ComCommands
                     _codeGenerator.AddTestModuleToProject(project);
                     break;
                 case Declaration declaration when parameterIsModuleDeclaration:
-                    _codeGenerator.AddTestModuleToProject(declaration.Project, declaration);
+                    var declarationProject = _projectsProvider.Project(declaration.ProjectId);
+                    _codeGenerator.AddTestModuleToProject(declarationProject, declaration);
                     break;
                 default:
                     using (var project = GetProject())

--- a/Rubberduck.Parsing/Symbols/Declaration.cs
+++ b/Rubberduck.Parsing/Symbols/Declaration.cs
@@ -415,14 +415,6 @@ namespace Rubberduck.Parsing.Symbols
         public QualifiedSelection QualifiedSelection => new QualifiedSelection(QualifiedName.QualifiedModuleName, Selection);
 
         /// <summary>
-        /// Gets a reference to the VBProject the declaration is made in.
-        /// </summary>
-        /// <remarks>
-        /// This property is intended to differenciate identically-named VBProjects.
-        /// </remarks>
-        public virtual IVBProject Project => ParentDeclaration.Project;
-
-        /// <summary>
         /// Gets a unique identifier for the VBProject the declaration is made in.
         /// </summary>
         public string ProjectId { get; }

--- a/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
@@ -10,6 +10,7 @@ namespace Rubberduck.Parsing.Symbols
     public sealed class ProjectDeclaration : Declaration, IDisposable
     {
         private readonly List<ProjectReference> _projectReferences;
+        private readonly IVBProject _project;
 
         public ProjectDeclaration(
             QualifiedMemberName qualifiedName,
@@ -57,15 +58,6 @@ namespace Rubberduck.Parsing.Symbols
             }
         }
 
-        private readonly IVBProject _project;
-        /// <summary>
-        /// Gets a reference to the VBProject the declaration is made in.
-        /// </summary>
-        /// <remarks>
-        /// This property is intended to differenciate identically-named VBProjects.
-        /// </remarks>
-        public override IVBProject Project => IsDisposed ? null : _project;
-
         public void AddProjectReference(string referencedProjectId, int priority)
         {
             if (_projectReferences.Any(p => p.ReferencedProjectId == referencedProjectId))
@@ -97,7 +89,6 @@ namespace Rubberduck.Parsing.Symbols
                 return _displayName;
             }
         }
-
 
         public bool IsDisposed { get; private set; }
 

--- a/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
@@ -3,20 +3,17 @@ using Rubberduck.Parsing.ComReflection;
 using Rubberduck.VBEditor;
 using System.Collections.Generic;
 using System.Linq;
-using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.Symbols
 {
     public sealed class ProjectDeclaration : Declaration, IDisposable
     {
         private readonly List<ProjectReference> _projectReferences;
-        private readonly IVBProject _project;
 
         public ProjectDeclaration(
             QualifiedMemberName qualifiedName,
             string name,
-            bool isUserDefined,
-            IVBProject project)
+            bool isUserDefined)
             : base(
                   qualifiedName,
                   null,
@@ -34,12 +31,11 @@ namespace Rubberduck.Parsing.Symbols
                   null,
                   isUserDefined)
         {
-            _project = project;
             _projectReferences = new List<ProjectReference>();
         }
 
         public ProjectDeclaration(ComProject project, QualifiedModuleName module)
-            : this(module.QualifyMemberName(project.Name), project.Name, false, null)
+            : this(module.QualifyMemberName(project.Name), project.Name, false)
         {
             Guid = project.Guid;
             MajorVersion = project.MajorVersion;
@@ -70,24 +66,6 @@ namespace Rubberduck.Parsing.Symbols
         public void ClearProjectReferences()
         {
             _projectReferences.Clear();
-        }
-
-        private string _displayName;
-        /// <summary>
-        /// WARNING: This property has side effects. It changes the ActiveVBProject, which causes a flicker in the VBE.
-        /// This should only be called if it is *absolutely* necessary.
-        /// </summary>
-        public override string ProjectDisplayName
-        {
-            get
-            {
-                if (_displayName != null)
-                {
-                    return _displayName;
-                }
-                _displayName = !IsDisposed && _project != null ? _project.ProjectDisplayName : string.Empty;
-                return _displayName;
-            }
         }
 
         public bool IsDisposed { get; private set; }

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
@@ -80,7 +80,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
 
             var qualifiedModuleName = new QualifiedModuleName(project);
             var qualifiedName = qualifiedModuleName.QualifyMemberName(project.Name);
-            var projectDeclaration = new ProjectDeclaration(qualifiedName, qualifiedName.MemberName, true, project);
+            var projectDeclaration = new ProjectDeclaration(qualifiedName, qualifiedName.MemberName, true);
 
             return projectDeclaration;
         }

--- a/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
+++ b/Rubberduck.UnitTesting/UnitTesting/TestEngine.cs
@@ -12,6 +12,7 @@ using Rubberduck.Parsing.UIContext;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.VBA.Extensions;
 using Rubberduck.Resources.UnitTesting;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.ComManagement.TypeLibs.Abstract;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
@@ -33,6 +34,7 @@ namespace Rubberduck.UnitTesting
         private readonly ITypeLibWrapperProvider _wrapperProvider;
         private readonly IUiDispatcher _uiDispatcher;
         private readonly IVBE _vbe;
+        private readonly IProjectsProvider _projectsProvider;
 
         private Dictionary<TestMethod, TestOutcome> _knownOutcomes = new Dictionary<TestMethod, TestOutcome>();
         private List<TestMethod> _lastRun = new List<TestMethod>();
@@ -53,7 +55,8 @@ namespace Rubberduck.UnitTesting
             IVBEInteraction declarationRunner, 
             ITypeLibWrapperProvider wrapperProvider, 
             IUiDispatcher uiDispatcher,
-            IVBE vbe)
+            IVBE vbe,
+            IProjectsProvider projectsProvider)
         {
             Debug.WriteLine("TestEngine created.");
             _state = state;
@@ -62,6 +65,7 @@ namespace Rubberduck.UnitTesting
             _wrapperProvider = wrapperProvider;
             _uiDispatcher = uiDispatcher;
             _vbe = vbe;
+            _projectsProvider = projectsProvider;
 
             _state.StateChanged += StateChangedHandler;
         }
@@ -209,11 +213,11 @@ namespace Rubberduck.UnitTesting
                 .Where(member => member.AsTypeName == "Rubberduck.PermissiveAssertClass"
                                  || member.AsTypeName == "Rubberduck.AssertClass")
                 .Select(member => member.ProjectId)
-                .ToHashSet();
-            var projectsUsingAddInLibrary = _state.DeclarationFinder
-                .UserDeclarations(DeclarationType.Project)
-                .Where(declaration => projectIdsOfMembersUsingAddInLibrary.Contains(declaration.ProjectId))
-                .Select(declaration => declaration.Project);
+                .Distinct();
+
+            var projectsUsingAddInLibrary = projectIdsOfMembersUsingAddInLibrary
+                .Select(projectId => _projectsProvider.Project(projectId))
+                .Where(project => project != null);
 
             foreach (var project in projectsUsingAddInLibrary)
             {

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProject.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/VBProject.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -165,11 +166,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             }
         }
 
-        private static readonly Regex CaptionProjectRegex = new Regex(@"^(?:[^-]+)(?:\s-\s)(?<project>.+)(?:\s-\s.*)?$");
-        private static readonly Regex OpenModuleRegex = new Regex(@"^(?<project>.+)(?<module>\s-\s\[.*\((Code|UserForm)\)\])$");
         private string _displayName;
         /// <summary>
-        /// WARNING: This property has side effects. It changes the ActiveVBProject, which causes a flicker in the VBE.
+        /// WARNING: This property might have has side effects. If the filename cannot be accessed, it changes the ActiveVBProject, which causes a flicker in the VBE.
         /// This should only be called if it is *absolutely* necessary.
         /// </summary>
         public string ProjectDisplayName
@@ -187,32 +186,116 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                     return _displayName;
                 }
 
-                var vbe = VBE;
-                var activeProject = vbe.ActiveVBProject;
-                var mainWindow = vbe.MainWindow;
-                {
-                    try
-                    {
-                        if (Target.HelpFile != activeProject.HelpFile)
-                        {
-                            vbe.ActiveVBProject = this;
-                        }
+                _displayName = DisplayNameFromFileName();
 
-                        var caption = mainWindow.Caption;
+                if (string.IsNullOrEmpty(_displayName))
+                {
+                    _displayName = DisplayNameFromWindowCaption();
+                }
+
+                if (string.IsNullOrEmpty(_displayName)
+                    || _displayName.EndsWith("..."))
+                {
+                    var nameFromBuildFileName = DisplayNameFromBuildFileName();
+                    if (!string.IsNullOrEmpty(nameFromBuildFileName)
+                        && nameFromBuildFileName.Length > _displayName.Length - 3) //Otherwise, we got more of the name from the previous attempt.
+                    {
+                        _displayName = nameFromBuildFileName;
+                    }
+                }
+
+                return _displayName;
+            }
+        }
+
+        private string DisplayNameFromFileName()
+        {
+            return Path.GetFileName(FileName);
+        }
+
+        private string DisplayNameFromBuildFileName()
+        {
+            var pseudoDllName = Path.GetFileName(BuildFileName);
+            return pseudoDllName == null || pseudoDllName.Length <= 4 //Should not happen as the string should always end in .DLL.
+                ? string.Empty
+                : pseudoDllName.Substring(0, pseudoDllName.Length - 4);
+        }
+
+        private static readonly Regex CaptionProjectRegex = new Regex(@"^(?:[^-]+)(?:\s-\s)(?<project>.+)(?:\s-\s.*)?$");
+        private static readonly Regex OpenModuleRegex = new Regex(@"^(?<project>.+)(?<module>\s-\s\[.*\((Code|UserForm)\)\])$");
+        private static readonly Regex PartialOpenModuleRegex = new Regex(@"^(?<project>.+)(\s-\s\[)");
+        private static readonly Regex NearlyOnlyProject = new Regex(@"^(?<project>.+)(\s-?\s?)$");
+
+        private string DisplayNameFromWindowCaption()
+        {
+            using (var vbe = VBE)
+            using (var activeProject = vbe.ActiveVBProject)
+            using (var mainWindow = vbe.MainWindow)
+            {
+                try
+                {
+                    if (ProjectId != activeProject.ProjectId)
+                    {
+                        vbe.ActiveVBProject = this;
+                    }
+
+                    var caption = mainWindow.Caption;
+                    if (caption.Length > 99)
+                    {
+                        //The value returned will be truncated at character 99 and the rest is garbage due to a bug in the VBE API.
+                        caption = caption.Substring(0, 99);
+
                         if (CaptionProjectRegex.IsMatch(caption))
                         {
-                            caption = CaptionProjectRegex.Matches(caption)[0].Groups["project"].Value;
-                            _displayName = OpenModuleRegex.IsMatch(caption)
-                                ? OpenModuleRegex.Matches(caption)[0].Groups["project"].Value
-                                : caption;
+                            var projectRelatedPartOfCaption = CaptionProjectRegex
+                                .Matches(caption)[0]
+                                .Groups["project"]
+                                .Value;
+
+                            if (PartialOpenModuleRegex.IsMatch(projectRelatedPartOfCaption))
+                            {
+                                return PartialOpenModuleRegex
+                                    .Matches(projectRelatedPartOfCaption)[0]
+                                    .Groups["project"]
+                                    .Value;
+                            }
+
+                            if (NearlyOnlyProject.IsMatch(projectRelatedPartOfCaption))
+                            {
+                                return NearlyOnlyProject
+                                    .Matches(projectRelatedPartOfCaption)[0]
+                                    .Groups["project"]
+                                    .Value;
+                            }
+
+                            return $"{projectRelatedPartOfCaption}...";
                         }
                     }
-                    catch
+                    else
                     {
-                        _displayName = string.Empty;
+                        if (CaptionProjectRegex.IsMatch(caption))
+                        {
+                            var projectRelatedPartOfCaption = CaptionProjectRegex
+                                .Matches(caption)[0]
+                                .Groups["project"]
+                                .Value;
+
+                            if (OpenModuleRegex.IsMatch(projectRelatedPartOfCaption))
+                            {
+                                return OpenModuleRegex
+                                    .Matches(projectRelatedPartOfCaption)[0]
+                                    .Groups["project"]
+                                    .Value;
+                            }
+                        }
                     }
-                    return _displayName;
                 }
+                catch
+                {
+                    return string.Empty;
+                }
+
+                return string.Empty;
             }
         }
 

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBProject.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBProject.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
@@ -164,11 +165,9 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             }
         }
 
-        private static readonly Regex CaptionProjectRegex = new Regex(@"^(?:[^-]+)(?:\s-\s)(?<project>.+)(?:\s-\s.*)?$");
-        private static readonly Regex OpenModuleRegex = new Regex(@"^(?<project>.+)(?<module>\s-\s\[.*\((Code|UserForm)\)\])$");
         private string _displayName;
         /// <summary>
-        /// WARNING: This property has side effects. It changes the ActiveVBProject, which causes a flicker in the VBE.
+        /// WARNING: This property might have has side effects. If the filename cannot be accessed, it changes the ActiveVBProject, which causes a flicker in the VBE.
         /// This should only be called if it is *absolutely* necessary.
         /// </summary>
         public string ProjectDisplayName
@@ -186,32 +185,116 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                     return _displayName;
                 }
 
-                using (var vbe = VBE)
-                using (var activeProject = vbe.ActiveVBProject)
-                using (var mainWindow = vbe.MainWindow)
-                {
-                    try
-                    {
-                        if (Target.HelpFile != activeProject.HelpFile)
-                        {
-                            vbe.ActiveVBProject = this;
-                        }
+                _displayName = DisplayNameFromFileName();
 
-                        var caption = mainWindow.Caption;
+                if (string.IsNullOrEmpty(_displayName))
+                {
+                    _displayName = DisplayNameFromWindowCaption();
+                }
+
+                if (string.IsNullOrEmpty(_displayName)
+                    || _displayName.EndsWith("..."))
+                {
+                    var nameFromBuildFileName = DisplayNameFromBuildFileName();
+                    if (!string.IsNullOrEmpty(nameFromBuildFileName) 
+                        && nameFromBuildFileName.Length > _displayName.Length - 3) //Otherwise, we got more of the name from the previous attempt.
+                    {
+                        _displayName = nameFromBuildFileName;
+                    }
+                }
+
+                return _displayName;
+            }
+        }
+
+        private string DisplayNameFromFileName()
+        {
+            return Path.GetFileName(FileName);
+        }
+
+        private string DisplayNameFromBuildFileName()
+        {
+            var pseudoDllName = Path.GetFileName(BuildFileName);
+            return pseudoDllName == null || pseudoDllName.Length <= 4 //Should not happen as the string should always end in .DLL.
+                ? string.Empty
+                : pseudoDllName.Substring(0, pseudoDllName.Length - 4);
+        }
+
+        private static readonly Regex CaptionProjectRegex = new Regex(@"^(?:[^-]+)(?:\s-\s)(?<project>.+)(?:\s-\s.*)?$");
+        private static readonly Regex OpenModuleRegex = new Regex(@"^(?<project>.+)(?<module>\s-\s\[.*\((Code|UserForm)\)\])$");
+        private static readonly Regex PartialOpenModuleRegex = new Regex(@"^(?<project>.+)(\s-\s\[)");
+        private static readonly Regex NearlyOnlyProject = new Regex(@"^(?<project>.+)(\s-?\s?)$");
+
+        private string DisplayNameFromWindowCaption()
+        {
+            using (var vbe = VBE)
+            using (var activeProject = vbe.ActiveVBProject)
+            using (var mainWindow = vbe.MainWindow)
+            {
+                try
+                {
+                    if (ProjectId != activeProject.ProjectId)
+                    {
+                        vbe.ActiveVBProject = this;
+                    }
+
+                    var caption = mainWindow.Caption;
+                    if (caption.Length > 99)
+                    {
+                        //The value returned will be truncated at character 99 and the rest is garbage due to a bug in the VBE API.
+                        caption = caption.Substring(0, 99);
+
                         if (CaptionProjectRegex.IsMatch(caption))
                         {
-                            caption = CaptionProjectRegex.Matches(caption)[0].Groups["project"].Value;
-                            _displayName = OpenModuleRegex.IsMatch(caption)
-                                ? OpenModuleRegex.Matches(caption)[0].Groups["project"].Value
-                                : caption;
+                            var projectRelatedPartOfCaption = CaptionProjectRegex
+                                .Matches(caption)[0]
+                                .Groups["project"]
+                                .Value;
+
+                            if (PartialOpenModuleRegex.IsMatch(projectRelatedPartOfCaption))
+                            {
+                                return PartialOpenModuleRegex
+                                    .Matches(projectRelatedPartOfCaption)[0]
+                                    .Groups["project"]
+                                    .Value;
+                            }
+
+                            if (NearlyOnlyProject.IsMatch(projectRelatedPartOfCaption))
+                            {
+                                return NearlyOnlyProject
+                                    .Matches(projectRelatedPartOfCaption)[0]
+                                    .Groups["project"]
+                                    .Value;
+                            }
+
+                            return $"{projectRelatedPartOfCaption}...";
                         }
                     }
-                    catch
+                    else
                     {
-                        _displayName = string.Empty;
+                        if (CaptionProjectRegex.IsMatch(caption))
+                        {
+                            var projectRelatedPartOfCaption = CaptionProjectRegex
+                                .Matches(caption)[0]
+                                .Groups["project"]
+                                .Value;
+
+                            if (OpenModuleRegex.IsMatch(projectRelatedPartOfCaption))
+                            {
+                                return OpenModuleRegex
+                                    .Matches(projectRelatedPartOfCaption)[0]
+                                    .Groups["project"]
+                                    .Value;
+                            }
+                        }
                     }
-                    return _displayName;
                 }
+                catch
+                {
+                    return string.Empty;
+                }
+
+                return string.Empty;
             }
         }
 

--- a/RubberduckTests/AddRemoveReferences/AddRemoveReferencesSetup.cs
+++ b/RubberduckTests/AddRemoveReferences/AddRemoveReferencesSetup.cs
@@ -14,6 +14,7 @@ using Rubberduck.SettingsProvider;
 using Rubberduck.UI;
 using Rubberduck.UI.AddRemoveReferences;
 using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using RubberduckTests.Mocks;
@@ -112,7 +113,12 @@ namespace RubberduckTests.AddRemoveReferences
 
         public static ReferenceReconciler ArrangeReferenceReconciler(ReferenceSettings settings = null)
         {
-            return ArrangeReferenceReconciler(settings, out _, out _);
+            return ArrangeReferenceReconciler(settings, null, out _, out _);
+        }
+
+        public static ReferenceReconciler ArrangeReferenceReconciler(IProjectsProvider projectsProvider, ReferenceSettings settings = null)
+        {
+            return ArrangeReferenceReconciler(settings, projectsProvider, out _, out _);
         }
 
         public static ReferenceReconciler ArrangeReferenceReconciler(
@@ -120,9 +126,18 @@ namespace RubberduckTests.AddRemoveReferences
             out Mock<IMessageBox> messageBox,
             out Mock<IComLibraryProvider> libraryProvider)
         {
+            return ArrangeReferenceReconciler(settings, null, out messageBox, out libraryProvider);
+        }
+
+        public static ReferenceReconciler ArrangeReferenceReconciler(
+            ReferenceSettings settings,
+            IProjectsProvider projectsprovider,
+            out Mock<IMessageBox> messageBox,
+            out Mock<IComLibraryProvider> libraryProvider)
+        {
             messageBox = new Mock<IMessageBox>();
             libraryProvider = new Mock<IComLibraryProvider>();
-            return new ReferenceReconciler(messageBox.Object, GetReferenceSettingsProvider(settings), libraryProvider.Object);
+            return new ReferenceReconciler(messageBox.Object, GetReferenceSettingsProvider(settings), libraryProvider.Object, projectsprovider);
         }
 
         public static void SetupIComLibraryProvider(Mock<IComLibraryProvider> provider, ReferenceInfo reference, string path, string description = "")
@@ -164,10 +179,10 @@ namespace RubberduckTests.AddRemoveReferences
 
         public static ProjectDeclaration ArrangeMocksAndGetProject()
         {
-            return ArrangeMocksAndGetProject(out _, out _);
+            return ArrangeMocksAndGetProject(out _, out _, out _);
         }
 
-        public static ProjectDeclaration ArrangeMocksAndGetProject(out MockProjectBuilder projectBuilder, out Mock<IReferences> references)
+        public static ProjectDeclaration ArrangeMocksAndGetProject(out MockProjectBuilder projectBuilder, out Mock<IReferences> references, out IProjectsProvider projectsProvider)
         {
             var builder = new MockVbeBuilder();
 
@@ -183,8 +198,14 @@ namespace RubberduckTests.AddRemoveReferences
 
             builder.AddProject(projectBuilder.Build());
 
-            var parser = MockParser.CreateAndParse(builder.Build().Object);
-            return parser.AllUserDeclarations.OfType<ProjectDeclaration>().Single();
+            var state = MockParser.CreateAndParse(builder.Build().Object);
+
+            projectsProvider = state.ProjectsProvider;
+
+            return state.DeclarationFinder
+                .UserDeclarations(DeclarationType.Project)
+                .OfType<ProjectDeclaration>()
+                .Single();
         }
 
         public static Mock<IAddRemoveReferencesModel> ArrangeParsedAddRemoveReferencesModel(
@@ -192,9 +213,10 @@ namespace RubberduckTests.AddRemoveReferences
             List<ReferenceModel> output, 
             List<ReferenceModel> registered, 
             out Mock<IReferences> references,
-            out MockProjectBuilder projectBuilder)
+            out MockProjectBuilder projectBuilder,
+            out IProjectsProvider projectsProvider)
         {
-            var declaration = ArrangeMocksAndGetProject(out projectBuilder, out references);
+            var declaration = ArrangeMocksAndGetProject(out projectBuilder, out references, out projectsProvider);
 
             var model = ArrangeAddRemoveReferencesModel(input, output, GetDefaultReferenceSettings());
             model.Setup(m => m.Project).Returns(declaration);
@@ -233,7 +255,7 @@ namespace RubberduckTests.AddRemoveReferences
         {
             var registered = LibraryReferenceInfoList.Select(reference => new ReferenceModel(reference, ReferenceKind.TypeLibrary)).ToList();
 
-            var declaration = ArrangeMocksAndGetProject(out _, out var references);
+            var declaration = ArrangeMocksAndGetProject(out _, out var references, out var projectsProvider);
             var settings = GetNonDefaultReferenceSettings();
 
             var priority = 1;
@@ -258,7 +280,7 @@ namespace RubberduckTests.AddRemoveReferences
             }
 
             var model = new AddRemoveReferencesModel(null, declaration, allReferences, settings);
-            var reconciler = ArrangeReferenceReconciler(settings, out _, out libraryProvider);
+            var reconciler = ArrangeReferenceReconciler(settings, projectsProvider, out _, out libraryProvider);
             browserFactory = new Mock<IFileSystemBrowserFactory>();
 
             return new AddRemoveReferencesViewModel(model, reconciler, browserFactory.Object);

--- a/RubberduckTests/AddRemoveReferences/AddRemoveReferencesSetup.cs
+++ b/RubberduckTests/AddRemoveReferences/AddRemoveReferencesSetup.cs
@@ -283,7 +283,7 @@ namespace RubberduckTests.AddRemoveReferences
             var reconciler = ArrangeReferenceReconciler(settings, projectsProvider, out _, out libraryProvider);
             browserFactory = new Mock<IFileSystemBrowserFactory>();
 
-            return new AddRemoveReferencesViewModel(model, reconciler, browserFactory.Object);
+            return new AddRemoveReferencesViewModel(model, reconciler, browserFactory.Object, projectsProvider);
         }
 
         public static void SetupMockedOpenDialog(this Mock<IFileSystemBrowserFactory> factory, string filename, DialogResult result)

--- a/RubberduckTests/AddRemoveReferences/AddRemoveReferencesViewModelTests.cs
+++ b/RubberduckTests/AddRemoveReferences/AddRemoveReferencesViewModelTests.cs
@@ -136,7 +136,7 @@ namespace RubberduckTests.AddRemoveReferences
             var model = new AddRemoveReferencesModel(null, declaration, SearchReferencesList, settings);
             var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler(settings);
 
-            var viewModel = new AddRemoveReferencesViewModel(model, reconciler, new Mock<IFileSystemBrowserFactory>().Object);
+            var viewModel = new AddRemoveReferencesViewModel(model, reconciler, new Mock<IFileSystemBrowserFactory>().Object, null);
             viewModel.SelectedFilter = ReferenceFilter.ComTypes.ToString();
             viewModel.Search = input;
 

--- a/RubberduckTests/AddRemoveReferences/ReferenceReconcilerTests.cs
+++ b/RubberduckTests/AddRemoveReferences/ReferenceReconcilerTests.cs
@@ -332,8 +332,8 @@ namespace RubberduckTests.AddRemoveReferences
         [Category("AddRemoveReferences")]
         public void ReconcileReferences_ReturnsEmptyWithoutNewReferences()
         {
-            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(null, null, null, out _, out _);
-            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler();
+            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(null, null, null, out _, out _, out var projectsProvider);
+            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler(projectsProvider);
 
             var output = reconciler.ReconcileReferences(model.Object);
 
@@ -344,8 +344,8 @@ namespace RubberduckTests.AddRemoveReferences
         [Category("AddRemoveReferences")]
         public void ReconcileReferencesOverload_ReturnsEmptyWithoutNewReferences()
         {
-            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(null, null, null, out _, out _);
-            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler();
+            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(null, null, null, out _, out _, out var projectsProvider);
+            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler(projectsProvider);
             var output = reconciler.ReconcileReferences(model.Object, null);
 
             Assert.IsEmpty(output);
@@ -358,8 +358,8 @@ namespace RubberduckTests.AddRemoveReferences
             var newReferences = AddRemoveReferencesSetup.LibraryReferenceInfoList
                 .Select(reference => new ReferenceModel(reference, ReferenceKind.TypeLibrary)).ToList();
 
-            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(null, newReferences, null, out _, out _);
-            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler();
+            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(null, newReferences, null, out _, out _, out var projectsProvider);
+            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler(projectsProvider);
 
             var pinned = newReferences.First();
             pinned.IsPinned = true;
@@ -377,8 +377,9 @@ namespace RubberduckTests.AddRemoveReferences
             var newReferences = AddRemoveReferencesSetup.LibraryReferenceInfoList
                 .Select(reference => new ReferenceModel(reference, ReferenceKind.TypeLibrary)).ToList();
 
-            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(newReferences, newReferences, newReferences, out var references, out var builder);
-            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler();
+            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(newReferences, newReferences, newReferences, out var references, out var builder, out var projectsProvider);
+
+            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler(projectsProvider);
 
             var priority = references.Object.Count;
             foreach (var item in newReferences)
@@ -398,8 +399,8 @@ namespace RubberduckTests.AddRemoveReferences
         public void ReconcileReferences_RemoveNotCalledOnBuiltIn()
         {
             var registered = AddRemoveReferencesSetup.DummyReferencesList;
-            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(registered, registered, registered, out var references, out _);
-            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler();
+            var model = AddRemoveReferencesSetup.ArrangeParsedAddRemoveReferencesModel(registered, registered, registered, out var references, out _, out var projectsProvider);
+            var reconciler = AddRemoveReferencesSetup.ArrangeReferenceReconciler(projectsProvider);
 
             var vba = references.Object.First(lib => lib.Name.Equals("VBA"));
             var excel = references.Object.First(lib => lib.Name.Equals("Excel"));

--- a/RubberduckTests/CodeExplorer/CodeExplorerCustomFolderViewModelTests.cs
+++ b/RubberduckTests/CodeExplorer/CodeExplorerCustomFolderViewModelTests.cs
@@ -22,13 +22,16 @@ namespace RubberduckTests.CodeExplorer
             var folderPath = structure.First().Folder;
             var path = folderPath.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _);
-            var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
-
-            foreach (var name in path)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _, out var state);
+            using (state)
             {
-                Assert.AreEqual(name, folder.Name);
-                folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
+
+                foreach (var name in path)
+                {
+                    Assert.AreEqual(name, folder.Name);
+                    folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                }
             }
         }
 
@@ -43,14 +46,17 @@ namespace RubberduckTests.CodeExplorer
             var folderPath = structure.First().Folder;
             var path = folderPath.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _);
-            var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
-
-            var depth = 1;
-            foreach (var _ in path)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _, out var state);
+            using (state)
             {
-                Assert.AreEqual(string.Join(FolderExtensions.FolderDelimiter.ToString(), path.Take(depth++)), folder.FullPath);
-                folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
+
+                var depth = 1;
+                foreach (var _ in path)
+                {
+                    Assert.AreEqual(string.Join(FolderExtensions.FolderDelimiter.ToString(), path.Take(depth++)), folder.FullPath);
+                    folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                }
             }
         }
 
@@ -65,13 +71,17 @@ namespace RubberduckTests.CodeExplorer
             var folderPath = structure.First().Folder;
             var path = folderPath.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _);
-            var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
-
-            foreach (var _ in path)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _, out var state);
+            using (state)
             {
-                Assert.AreEqual(folder.FullPath, folder.PanelTitle);
-                folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
+
+                foreach (var _ in path)
+                {
+                    Assert.AreEqual(folder.FullPath, folder.PanelTitle);
+                    folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                }
             }
         }
 
@@ -86,13 +96,17 @@ namespace RubberduckTests.CodeExplorer
             var folderPath = structure.First().Folder;
             var path = folderPath.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _);
-            var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
-
-            foreach (var _ in path)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _, out var state);
+            using (state)
             {
-                Assert.AreEqual($"'@Folder(\"{folder.FullPath}\")", folder.FolderAttribute);
-                folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
+
+                foreach (var _ in path)
+                {
+                    Assert.AreEqual($"'@Folder(\"{folder.FullPath}\")", folder.FolderAttribute);
+                    folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                }
             }
         }
 
@@ -107,13 +121,17 @@ namespace RubberduckTests.CodeExplorer
             var folderPath = structure.First().Folder;
             var path = folderPath.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _);
-            var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
-
-            foreach (var _ in path)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _, out var state);
+            using (state)
             {
-                Assert.AreEqual(folder.FolderAttribute, folder.Description);
-                folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
+
+                foreach (var _ in path)
+                {
+                    Assert.AreEqual(folder.FolderAttribute, folder.Description);
+                    folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                }
             }
         }
 
@@ -128,14 +146,18 @@ namespace RubberduckTests.CodeExplorer
             var folderPath = structure.First().Folder;
             var path = folderPath.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _);
-            var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
-
-            var depth = 1;
-            foreach (var _ in path)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out _, out var state);
+            using (state)
             {
-                Assert.AreEqual(depth++, folder.FolderDepth);
-                folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref declarations);
+
+                var depth = 1;
+                foreach (var _ in path)
+                {
+                    Assert.AreEqual(depth++, folder.FolderDepth);
+                    folder = folder.Children.OfType<CodeExplorerCustomFolderViewModel>().FirstOrDefault();
+                }
             }
         }
 
@@ -147,17 +169,23 @@ namespace RubberduckTests.CodeExplorer
             const string folderName = "Asdf";
 
             var testFolder = (Name: CodeExplorerTestSetup.TestModuleName, Folder: folderName);
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _);
-            var children = declarations.SelectMany(declaration => declaration.IdentifierName.ToCharArray()).Distinct().ToList();
-
-            var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
-
-            var nonMatching = testCharacters.ToCharArray().Except(folderName.ToLowerInvariant().ToCharArray().Union(children));
-
-            foreach (var character in nonMatching.Select(letter => letter.ToString()))
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _, out var state);
+            using (state)
             {
-                folder.Filter = character;
-                Assert.IsTrue(folder.Filtered);
+                var children = declarations.SelectMany(declaration => declaration.IdentifierName.ToCharArray())
+                    .Distinct().ToList();
+
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
+
+                var nonMatching = testCharacters.ToCharArray()
+                    .Except(folderName.ToLowerInvariant().ToCharArray().Union(children));
+
+                foreach (var character in nonMatching.Select(letter => letter.ToString()))
+                {
+                    folder.Filter = character;
+                    Assert.IsTrue(folder.Filtered);
+                }
             }
         }
 
@@ -168,20 +196,24 @@ namespace RubberduckTests.CodeExplorer
             const string folderName = "Foobar";
 
             var testFolder = (Name: CodeExplorerTestSetup.TestModuleName, Folder: folderName);
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _);
-
-            var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
-
-            for (var characters = 1; characters <= folderName.Length; characters++)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _, out var state);
+            using (state)
             {
-                folder.Filter = folderName.Substring(0, characters);
-                Assert.IsFalse(folder.Filtered);
-            }
 
-            for (var position = folderName.Length - 2; position > 0; position--)
-            {
-                folder.Filter = folderName.Substring(position);
-                Assert.IsFalse(folder.Filtered);
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
+
+                for (var characters = 1; characters <= folderName.Length; characters++)
+                {
+                    folder.Filter = folderName.Substring(0, characters);
+                    Assert.IsFalse(folder.Filtered);
+                }
+
+                for (var position = folderName.Length - 2; position > 0; position--)
+                {
+                    folder.Filter = folderName.Substring(position);
+                    Assert.IsFalse(folder.Filtered);
+                }
             }
         }
 
@@ -192,21 +224,25 @@ namespace RubberduckTests.CodeExplorer
             const string folderName = "Foobar";
 
             var testFolder = (Name: CodeExplorerTestSetup.TestModuleName, Folder: folderName);
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _);
-
-            var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
-            var childName = folder.Children.First().Name;
-
-            for (var characters = 1; characters <= childName.Length; characters++)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _, out var state);
+            using (state)
             {
-                folder.Filter = childName.Substring(0, characters);
-                Assert.IsFalse(folder.Filtered);
-            }
 
-            for (var position = childName.Length - 2; position > 0; position--)
-            {
-                folder.Filter = childName.Substring(position);
-                Assert.IsFalse(folder.Filtered);
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
+                var childName = folder.Children.First().Name;
+
+                for (var characters = 1; characters <= childName.Length; characters++)
+                {
+                    folder.Filter = childName.Substring(0, characters);
+                    Assert.IsFalse(folder.Filtered);
+                }
+
+                for (var position = childName.Length - 2; position > 0; position--)
+                {
+                    folder.Filter = childName.Substring(position);
+                    Assert.IsFalse(folder.Filtered);
+                }
             }
         }
 
@@ -217,17 +253,21 @@ namespace RubberduckTests.CodeExplorer
             const string folderName = "Foobar";
 
             var testFolder = (Name: CodeExplorerTestSetup.TestModuleName, Folder: folderName);
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _);
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _, out var state);
+            using (state)
+            {
 
-            var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
-            var childName = folder.Children.First().Name;
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations);
+                var childName = folder.Children.First().Name;
 
-            folder.IsExpanded = false;
-            folder.Filter = childName;
-            Assert.IsTrue(folder.IsExpanded);
+                folder.IsExpanded = false;
+                folder.Filter = childName;
+                Assert.IsTrue(folder.IsExpanded);
 
-            folder.Filter = string.Empty;
-            Assert.IsFalse(folder.IsExpanded);
+                folder.Filter = string.Empty;
+                Assert.IsFalse(folder.IsExpanded);
+            }
         }
 
         [Test]
@@ -243,14 +283,17 @@ namespace RubberduckTests.CodeExplorer
             const string folderName = "Foo";
 
             var testFolder = (Name: CodeExplorerTestSetup.TestModuleName, Folder: folderName);
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _);
-
-            var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _, out var state);
+            using (state)
             {
-                SortOrder = order
-            };
 
-            Assert.AreEqual(CodeExplorerItemComparer.Name.GetType(), folder.SortComparer.GetType());
+                var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations)
+                {
+                    SortOrder = order
+                };
+
+                Assert.AreEqual(CodeExplorerItemComparer.Name.GetType(), folder.SortComparer.GetType());
+            }
         }
 
         [Test]
@@ -260,14 +303,17 @@ namespace RubberduckTests.CodeExplorer
             const string folderName = "Foo";
 
             var testFolder = (Name: CodeExplorerTestSetup.TestModuleName, Folder: folderName);
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _);
-
-            var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations)
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(new List<(string Name, string Folder)> { testFolder }, out _, out var state);
+            using (state)
             {
-                IsErrorState = true
-            };
 
-            Assert.IsFalse(folder.IsErrorState);
+                var folder = new CodeExplorerCustomFolderViewModel(null, folderName, folderName, null, ref declarations)
+                {
+                    IsErrorState = true
+                };
+
+                Assert.IsFalse(folder.IsErrorState);
+            }
         }
 
         [Test]
@@ -306,12 +352,18 @@ namespace RubberduckTests.CodeExplorer
             var root = structure.First().Folder;
             var path = root.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out var projectDeclaration);
-            var contents = CodeExplorerProjectViewModel.ExtractTrackedDeclarationsForProject(projectDeclaration, ref declarations);
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out var projectDeclaration, out var state);
+            using (state)
+            {
+                var contents =
+                    CodeExplorerProjectViewModel.ExtractTrackedDeclarationsForProject(projectDeclaration,
+                        ref declarations);
 
-            var folder = new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref contents);
+                var folder =
+                    new CodeExplorerCustomFolderViewModel(null, path.First(), path.First(), null, ref contents);
 
-            AssertFolderStructureIsCorrect(folder, structure);
+                AssertFolderStructureIsCorrect(folder, structure);
+            }
         }
 
         [Test]
@@ -350,17 +402,23 @@ namespace RubberduckTests.CodeExplorer
             var root = structure.First().Folder;
             var path = root.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out var projectDeclaration);
-            var synchronizing = CodeExplorerProjectViewModel.ExtractTrackedDeclarationsForProject(projectDeclaration, ref declarations);
-            var component = synchronizing.TestComponentDeclarations(structure.Last().Name);
-            var contents = synchronizing.Except(component).ToList();
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out var projectDeclaration, out var state);
+            using (state)
+            {
+                var synchronizing =
+                    CodeExplorerProjectViewModel.ExtractTrackedDeclarationsForProject(projectDeclaration,
+                        ref declarations);
+                var component = synchronizing.TestComponentDeclarations(structure.Last().Name);
+                var contents = synchronizing.Except(component).ToList();
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref contents, null, null);
-            var folder = project.Children.OfType<CodeExplorerCustomFolderViewModel>().Single(item => item.Name.Equals(path.First()));
+                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref contents, state, null, state.ProjectsProvider);
+                var folder = project.Children.OfType<CodeExplorerCustomFolderViewModel>()
+                    .Single(item => item.Name.Equals(path.First()));
 
-            project.Synchronize(ref synchronizing);
+                project.Synchronize(ref synchronizing);
 
-            AssertFolderStructureIsCorrect(folder, structure);
+                AssertFolderStructureIsCorrect(folder, structure);
+            }
         }
 
         [Test]
@@ -399,17 +457,23 @@ namespace RubberduckTests.CodeExplorer
             var root = structure.First().Folder;
             var path = root.Split(FolderExtensions.FolderDelimiter);
 
-            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out var projectDeclaration);
-            var contents = CodeExplorerProjectViewModel.ExtractTrackedDeclarationsForProject(projectDeclaration, ref declarations);
-            var component = contents.TestComponentDeclarations(structure.Last().Name);
-            var synchronizing = contents.Except(component).ToList();
+            var declarations = CodeExplorerTestSetup.TestProjectWithFolderStructure(structure, out var projectDeclaration, out var state);
+            using (state)
+            {
+                var contents =
+                    CodeExplorerProjectViewModel.ExtractTrackedDeclarationsForProject(projectDeclaration,
+                        ref declarations);
+                var component = contents.TestComponentDeclarations(structure.Last().Name);
+                var synchronizing = contents.Except(component).ToList();
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref contents, null, null);
-            var folder = project.Children.OfType<CodeExplorerCustomFolderViewModel>().Single(item => item.Name.Equals(path.First()));
+                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref contents, state, null, state.ProjectsProvider);
+                var folder = project.Children.OfType<CodeExplorerCustomFolderViewModel>()
+                    .Single(item => item.Name.Equals(path.First()));
 
-            project.Synchronize(ref synchronizing);
+                project.Synchronize(ref synchronizing);
 
-            AssertFolderStructureIsCorrect(folder, structure.Take(structure.Count - 1).ToList());
+                AssertFolderStructureIsCorrect(folder, structure.Take(structure.Count - 1).ToList());
+            }
         }
 
         private static void AssertFolderStructureIsCorrect(CodeExplorerCustomFolderViewModel underTest, List<(string Name, string Folder)> structure)

--- a/RubberduckTests/CodeExplorer/CodeExplorerProjectViewModelTests.cs
+++ b/RubberduckTests/CodeExplorer/CodeExplorerProjectViewModelTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using NUnit.Framework;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Rubberduck.AddRemoveReferences;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Navigation.CodeExplorer;
@@ -21,7 +20,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             Assert.AreSame(projectDeclaration, project.Declaration);
         }
@@ -33,7 +32,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             Assert.AreEqual(CodeExplorerTestSetup.TestProjectOneName, project.Name);
         }
@@ -45,7 +44,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             Assert.IsFalse(string.IsNullOrEmpty(project.NameWithSignature));
         }
@@ -57,7 +56,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             Assert.IsFalse(string.IsNullOrEmpty(project.PanelTitle));
         }
@@ -69,7 +68,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             Assert.IsTrue(project.IsExpanded);
         }
@@ -81,7 +80,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             Assert.IsFalse(string.IsNullOrEmpty(project.ToolTip));
         }
@@ -99,7 +98,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null)
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider)
             {
                 SortOrder = order
             };
@@ -117,7 +116,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null)
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider)
             {
                 Filter = filter
             };
@@ -173,7 +172,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
             var folder = project.Children.OfType<CodeExplorerCustomFolderViewModel>().Single();
 
             Assert.AreEqual(projectDeclaration.IdentifierName, folder.Name);
@@ -187,7 +186,7 @@ namespace RubberduckTests.CodeExplorer
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
             // ReSharper disable once UnusedVariable
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             Assert.AreEqual(0, declarations.Count);
         }
@@ -200,7 +199,7 @@ namespace RubberduckTests.CodeExplorer
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
             var updates = declarations.ToList();
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             project.Synchronize(ref updates);
 
@@ -216,7 +215,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
             var updates = CodeExplorerTestSetup.TestProjectOneDeclarations;
             project.Synchronize(ref updates);
 
@@ -230,7 +229,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
             var updates = CodeExplorerTestSetup.TestProjectTwoDeclarations;
             project.Synchronize(ref updates);
 
@@ -252,7 +251,7 @@ namespace RubberduckTests.CodeExplorer
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
             var results = declarations.ToList();
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             var expected = 
                 CodeExplorerProjectViewModel.ExtractTrackedDeclarationsForProject(projectDeclaration, ref results)
@@ -273,7 +272,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
             var updates = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var results = updates.ToList();
 
@@ -302,7 +301,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations
                 .TestProjectWithComponentDeclarations(new[] { component },out var projectDeclaration);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             var updates = CodeExplorerTestSetup.TestProjectOneDeclarations
                 .TestProjectWithComponentDeclarations(new[] { component, added }, out _).ToList();
@@ -335,7 +334,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations
                 .TestProjectWithComponentDeclarations(new[] { component }, out var projectDeclaration);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             var updates = CodeExplorerTestSetup.TestProjectOneDeclarations
                 .TestProjectWithComponentDeclarations(new[] { component, added }, out _);
@@ -359,7 +358,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
 
             var updates = CodeExplorerTestSetup.TestProjectOneDeclarations.TestProjectWithComponentRemoved(removed);
             var expected = updates.Select(declaration => declaration.QualifiedName.ToString())
@@ -382,7 +381,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
             if (project.Declaration is null)
             {
                 Assert.Inconclusive("Project declaration is null. Fix test setup and see why no other tests failed.");
@@ -401,7 +400,7 @@ namespace RubberduckTests.CodeExplorer
             var declarations = CodeExplorerTestSetup.TestProjectOneDeclarations;
             var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+            var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null, CodeExplorerTestSetup.ProjectOneProvider);
             if (project.Declaration is null)
             {
                 Assert.Inconclusive("Project declaration is null. Fix test setup and see why no other tests failed.");
@@ -426,7 +425,7 @@ namespace RubberduckTests.CodeExplorer
             {
                 var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, state, null, state.ProjectsProvider);
 
                 var libraryFolder = project.Children.OfType<CodeExplorerReferenceFolderViewModel>()
                     .SingleOrDefault(folder => folder.ReferenceKind == ReferenceKind.TypeLibrary);
@@ -454,7 +453,7 @@ namespace RubberduckTests.CodeExplorer
 
                 var expected = GetReferencesFromProjectDeclaration(projectDeclaration, state.ProjectsProvider).Select(reference => reference.Name).ToList();
 
-                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, state, null, state.ProjectsProvider);
                 project.Synchronize(ref updates);
 
                 var actual = GetReferencesFromProjectViewModel(project).OrderBy(reference => reference.Priority).Select(reference => reference.Name);
@@ -477,7 +476,7 @@ namespace RubberduckTests.CodeExplorer
                 var updates = declarations.ToList();
                 var projectDeclaration = declarations.First(declaration => declaration.DeclarationType == DeclarationType.Project);
 
-                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, null, null);
+                var project = new CodeExplorerProjectViewModel(projectDeclaration, ref declarations, state, null, state.ProjectsProvider);
 
                 var references = state.ProjectsProvider.Project(projectDeclaration.ProjectId).References;
                 foreach (var reference in references.ToList())

--- a/RubberduckTests/CodeExplorer/CodeExplorerTestSetup.cs
+++ b/RubberduckTests/CodeExplorer/CodeExplorerTestSetup.cs
@@ -5,6 +5,8 @@ using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;
 using System.Collections.Generic;
 using System.Linq;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.UI.Command.MenuItems.ParentMenus;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using RubberduckTests.AddRemoveReferences;
 
@@ -173,7 +175,7 @@ namespace RubberduckTests.CodeExplorer
             ProjectTwo = parser.AllUserDeclarations.ToList();
         }
 
-        public static List<Declaration> GetProjectDeclarationsWithReferences(bool libraries, bool projects)
+        public static List<Declaration> GetProjectDeclarationsWithReferences(bool libraries, bool projects, out RubberduckParserState state)
         {
             var builder = new MockVbeBuilder();
 
@@ -197,8 +199,8 @@ namespace RubberduckTests.CodeExplorer
             }
 
             builder.AddProject(project.Build());
-            var parser = MockParser.CreateAndParse(builder.Build().Object);
-            return parser.AllUserDeclarations.ToList();
+            state = MockParser.CreateAndParse(builder.Build().Object);
+            return state.AllUserDeclarations.ToList();
         }
 
         public static List<Declaration> GetAllChildDeclarations(this ICodeExplorerNode node)

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -210,7 +210,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddStdModuleCommand()
         {
-            ViewModel.AddStdModuleCommand = new AddStdModuleCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddStdModuleCommand = new AddStdModuleCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -234,7 +234,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddClassModuleCommand()
         {
-            ViewModel.AddClassModuleCommand = new AddClassModuleCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddClassModuleCommand = new AddClassModuleCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -249,7 +249,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddUserFormCommand()
         {
-            ViewModel.AddUserFormCommand = new AddUserFormCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddUserFormCommand = new AddUserFormCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -264,7 +264,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddVbFormCommand()
         {
-            ViewModel.AddVBFormCommand = new AddVBFormCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddVBFormCommand = new AddVBFormCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -279,7 +279,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddMdiFormCommand()
         {
-            ViewModel.AddMDIFormCommand = new AddMDIFormCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddMDIFormCommand = new AddMDIFormCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -294,7 +294,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddUserControlCommand()
         {
-            ViewModel.AddUserControlCommand = new AddUserControlCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddUserControlCommand = new AddUserControlCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -309,7 +309,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddPropertyPageCommand()
         {
-            ViewModel.AddPropertyPageCommand = new AddPropertyPageCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddPropertyPageCommand = new AddPropertyPageCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -324,7 +324,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementAddUserDocumentCommand()
         {
-            ViewModel.AddUserDocumentCommand = new AddUserDocumentCommand(AddComponentService(), VbeEvents.Object);
+            ViewModel.AddUserDocumentCommand = new AddUserDocumentCommand(AddComponentService(), VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -341,7 +341,7 @@ namespace RubberduckTests.CodeExplorer
         {
             var indenter = new Indenter(null, () => IndenterSettingsTests.GetMockIndenterSettings());
             var codeGenerator = new TestCodeGenerator(Vbe.Object, State, MessageBox.Object, _interaction.Object, _unitTestSettingsProvider.Object, indenter, null);
-            ViewModel.AddTestModuleCommand = new AddTestComponentCommand(Vbe.Object, State, codeGenerator, VbeEvents.Object);
+            ViewModel.AddTestModuleCommand = new AddTestComponentCommand(Vbe.Object, State, codeGenerator, VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -450,7 +450,7 @@ namespace RubberduckTests.CodeExplorer
 
         public MockedCodeExplorer ImplementExportAllCommand()
         {
-            ViewModel.ExportAllCommand = new ExportAllCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object);
+            ViewModel.ExportAllCommand = new ExportAllCommand(Vbe.Object, BrowserFactory.Object, VbeEvents.Object, State.ProjectsProvider);
             return this;
         }
 
@@ -503,7 +503,13 @@ namespace RubberduckTests.CodeExplorer
         {
             ViewModel.CodeExplorerExtractInterfaceCommand = new CodeExplorerExtractInterfaceCommand(
                 new Rubberduck.Refactorings.ExtractInterface.ExtractInterfaceRefactoring(
-                    State, State, null, null, null, _uiDispatcher.Object),
+                    State, 
+                    State, 
+                    null, 
+                    null, 
+                    null, 
+                    _uiDispatcher.Object,
+                    State.ProjectsProvider),
                 State, null, VbeEvents.Object);
             return this;
         }

--- a/RubberduckTests/Commands/ExportAllCommandTests.cs
+++ b/RubberduckTests/Commands/ExportAllCommandTests.cs
@@ -6,6 +6,7 @@ using Rubberduck.VBEditor.SafeComWrappers;
 using RubberduckTests.Mocks;
 using System.Linq;
 using System.Windows.Forms;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
@@ -409,16 +410,21 @@ namespace RubberduckTests.Commands
             project2.Verify(m => m.ExportSourceFiles(_path), Times.Never);
         }
 
-        private static ExportAllCommand ArrangeExportAllCommand(Mock<IVBE> vbe,
-            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory)
+        private static ExportAllCommand ArrangeExportAllCommand(
+            Mock<IVBE> vbe,
+            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory,
+            IProjectsProvider projectsProvider = null)
         {
-            return ArrangeExportAllCommand(vbe, mockFolderBrowserFactory, MockVbeEvents.CreateMockVbeEvents(vbe));
+            return ArrangeExportAllCommand(vbe, mockFolderBrowserFactory, MockVbeEvents.CreateMockVbeEvents(vbe), projectsProvider);
         }
 
-        private static ExportAllCommand ArrangeExportAllCommand(Mock<IVBE> vbe,
-            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory, Mock<IVbeEvents> vbeEvents)
+        private static ExportAllCommand ArrangeExportAllCommand(
+            Mock<IVBE> vbe, 
+            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory, 
+            Mock<IVbeEvents> vbeEvents,
+            IProjectsProvider projectsProvider)
         {
-            return new ExportAllCommand(vbe.Object, mockFolderBrowserFactory.Object, vbeEvents.Object);
+            return new ExportAllCommand(vbe.Object, mockFolderBrowserFactory.Object, vbeEvents.Object, projectsProvider);
         }
     }
 }

--- a/RubberduckTests/Commands/RefactorCommands/ExtractInterfaceCommandTests.cs
+++ b/RubberduckTests/Commands/RefactorCommands/ExtractInterfaceCommandTests.cs
@@ -170,7 +170,7 @@ End Property";
             uiDispatcherMock
                 .Setup(m => m.Invoke(It.IsAny<Action>()))
                 .Callback((Action action) => action.Invoke());
-            var refactoring = new ExtractInterfaceRefactoring(state, state, factory, rewritingManager, selectionService, uiDispatcherMock.Object);
+            var refactoring = new ExtractInterfaceRefactoring(state, state, factory, rewritingManager, selectionService, uiDispatcherMock.Object, state.ProjectsProvider);
             var notifier = new ExtractInterfaceFailedNotifier(msgBox);
             return new RefactorExtractInterfaceCommand(refactoring, notifier, state, selectionService);
         }

--- a/RubberduckTests/Commands/UnitTestCommandTests.cs
+++ b/RubberduckTests/Commands/UnitTestCommandTests.cs
@@ -475,7 +475,7 @@ End Enum
         // TODO: Remove the temporal copuling with other Arrange*
         private AddTestModuleCommand ArrangeAddTestModuleCommand(Mock<IVBE> vbe, RubberduckParserState state, ITestCodeGenerator generator, Mock<IVbeEvents> vbeEvents)
         {
-            return new AddTestModuleCommand(vbe.Object, state, ArrangeCodeGenerator(vbe.Object, state), vbeEvents.Object);
+            return new AddTestModuleCommand(vbe.Object, state, ArrangeCodeGenerator(vbe.Object, state), vbeEvents.Object, state.ProjectsProvider);
         }
 
         // TODO: Remove the temporal coupling with other Arrange*

--- a/RubberduckTests/Grammar/ResolverTests.cs
+++ b/RubberduckTests/Grammar/ResolverTests.cs
@@ -1495,10 +1495,11 @@ End Sub
             using (var state = Resolve(code))
             {
 
-                var declaration = state.AllUserDeclarations.Single(item =>
-                    item.DeclarationType == DeclarationType.UserDefinedType);
+                var declaration = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.UserDefinedType)
+                    .Single();
 
-                if (declaration.Project.Name != declaration.IdentifierName)
+                if (Declaration.GetProjectParent(declaration).IdentifierName != declaration.IdentifierName)
                 {
                     Assert.Inconclusive("UDT should be named after project.");
                 }
@@ -1534,7 +1535,7 @@ End Sub
                 var declaration = state.AllUserDeclarations.Single(item =>
                     item.DeclarationType == DeclarationType.UserDefinedType);
 
-                if (declaration.Project.Name != declaration.IdentifierName)
+                if (Declaration.GetProjectParent(declaration).IdentifierName != declaration.IdentifierName)
                 {
                     Assert.Inconclusive("UDT should be named after project.");
                 }
@@ -1568,7 +1569,7 @@ End Sub
                 var declaration = state.AllUserDeclarations.Single(item =>
                     item.DeclarationType == DeclarationType.Variable);
 
-                if (declaration.Project.Name != declaration.AsTypeName)
+                if (Declaration.GetProjectParent(declaration).IdentifierName != declaration.AsTypeName)
                 {
                     Assert.Inconclusive("variable should be named after project.");
                 }
@@ -1636,7 +1637,7 @@ End Sub
                 var declaration = state.AllUserDeclarations.Single(item =>
                     item.DeclarationType == DeclarationType.UserDefinedTypeMember
                     && item.IdentifierName == "Foo"
-                    && item.AsTypeName == item.Project.Name
+                    && item.AsTypeName == Declaration.GetProjectParent(item).IdentifierName
                     && item.IdentifierName == item.ParentDeclaration.IdentifierName);
 
                 var usages = declaration.References.Where(item =>
@@ -1857,7 +1858,7 @@ End Sub
 
                 var declaration = state.AllUserDeclarations.Single(item =>
                     item.DeclarationType == DeclarationType.Project
-                    && item.IdentifierName == item.Project.Name);
+                    && item.IdentifierName == Declaration.GetProjectParent(item).IdentifierName);
 
                 var usages = declaration.References.Where(item =>
                     item.ParentScoping.IdentifierName == "DoSomething");

--- a/RubberduckTests/Refactoring/ExtractInterfaceTests.cs
+++ b/RubberduckTests/Refactoring/ExtractInterfaceTests.cs
@@ -424,7 +424,7 @@ End Sub
             uiDispatcherMock
                 .Setup(m => m.Invoke(It.IsAny<Action>()))
                 .Callback((Action action) => action.Invoke());
-            return new ExtractInterfaceRefactoring(state, state, factory, rewritingManager, selectionService, uiDispatcherMock.Object, state.ProjectsProvider);
+            return new ExtractInterfaceRefactoring(state, state, factory, rewritingManager, selectionService, uiDispatcherMock.Object, state?.ProjectsProvider);
         }
     }
 }

--- a/RubberduckTests/Refactoring/ExtractInterfaceTests.cs
+++ b/RubberduckTests/Refactoring/ExtractInterfaceTests.cs
@@ -424,7 +424,7 @@ End Sub
             uiDispatcherMock
                 .Setup(m => m.Invoke(It.IsAny<Action>()))
                 .Callback((Action action) => action.Invoke());
-            return new ExtractInterfaceRefactoring(state, state, factory, rewritingManager, selectionService, uiDispatcherMock.Object);
+            return new ExtractInterfaceRefactoring(state, state, factory, rewritingManager, selectionService, uiDispatcherMock.Object, state.ProjectsProvider);
         }
     }
 }

--- a/RubberduckTests/Symbols/AccessibilityCheckTests.cs
+++ b/RubberduckTests/Symbols/AccessibilityCheckTests.cs
@@ -23,7 +23,7 @@ namespace RubberduckTests.Symbols
             private static ProjectDeclaration GetTestProject(string name)
             {
                 var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName(), name);
-                return new ProjectDeclaration(qualifiedProjectName, name, true, null);
+                return new ProjectDeclaration(qualifiedProjectName, name, true);
             }
 
                 private static QualifiedModuleName StubQualifiedModuleName()

--- a/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ClassModuleDeclarationTests.cs
@@ -22,7 +22,7 @@ namespace RubberduckTests.Symbols
             private static ProjectDeclaration GetTestProject(string name)
             {
                 var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName(), name);
-                return new ProjectDeclaration(qualifiedProjectName, name, true, null);
+                return new ProjectDeclaration(qualifiedProjectName, name, true);
             }
 
                 private static QualifiedModuleName StubQualifiedModuleName()

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -1583,7 +1583,7 @@ End Property
         private static ProjectDeclaration GetTestProject(string name)
         {
             var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName("proj"), name);
-            return new ProjectDeclaration(qualifiedProjectName, name, true, null);
+            return new ProjectDeclaration(qualifiedProjectName, name, true);
         }
 
         private static QualifiedModuleName StubQualifiedModuleName(string name)

--- a/RubberduckTests/Symbols/ProceduralModuleDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ProceduralModuleDeclarationTests.cs
@@ -21,7 +21,7 @@ namespace RubberduckTests.Symbols
             private static ProjectDeclaration GetTestProject(string name)
             {
                 var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName(), name);
-                return new ProjectDeclaration(qualifiedProjectName, name, true, null);
+                return new ProjectDeclaration(qualifiedProjectName, name, true);
             }
 
                 private static QualifiedModuleName StubQualifiedModuleName()

--- a/RubberduckTests/Symbols/ProjectDeclarationTests.cs
+++ b/RubberduckTests/Symbols/ProjectDeclarationTests.cs
@@ -20,7 +20,7 @@ namespace RubberduckTests.Symbols
             private static ProjectDeclaration GetTestProject(string name)
             {
                 var qualifiedProjectName = new QualifiedMemberName(StubQualifiedModuleName(), name);
-                return new ProjectDeclaration(qualifiedProjectName, name, true, null);
+                return new ProjectDeclaration(qualifiedProjectName, name, true);
             }
 
                 private static QualifiedModuleName StubQualifiedModuleName()

--- a/RubberduckTests/UnitTesting/MockedTestEngine.cs
+++ b/RubberduckTests/UnitTesting/MockedTestEngine.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Rubberduck.Parsing.UIContext;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.UnitTesting;
+using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.ComManagement.TypeLibs.Abstract;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
@@ -74,7 +75,7 @@ End Sub";
 
             Vbe = builder.Build();
             ParserState = MockParser.Create(Vbe.Object).State;
-            TestEngine = new SynchronouslySuspendingTestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object);
+            TestEngine = new SynchronouslySuspendingTestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object, ParserState.ProjectsProvider);
         }
 
         public MockedTestEngine(IReadOnlyList<string> moduleNames, IReadOnlyList<int> methodCounts) : this()
@@ -97,7 +98,7 @@ End Sub";
             project.AddProjectToVbeBuilder();
             Vbe = builder.Build();
             ParserState = MockParser.Create(Vbe.Object).State;
-            TestEngine = new SynchronouslySuspendingTestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object);
+            TestEngine = new SynchronouslySuspendingTestEngine(ParserState, _fakesFactory.Object, VbeInteraction.Object, WrapperProvider.Object, Dispatcher.Object, Vbe.Object, ParserState.ProjectsProvider);
         }
 
         public MockedTestEngine(int testMethodCount) 
@@ -267,8 +268,9 @@ End Sub
                 IVBEInteraction declarationRunner,
                 ITypeLibWrapperProvider wrapperProvider,
                 IUiDispatcher uiDispatcher,
-                IVBE vbe)
-                : base(state, fakesFactory, declarationRunner, wrapperProvider, uiDispatcher, vbe)
+                IVBE vbe,
+                IProjectsProvider projectsProvider)
+                : base(state, fakesFactory, declarationRunner, wrapperProvider, uiDispatcher, vbe, projectsProvider)
             {
                 _state = state;
             }


### PR DESCRIPTION
Closes #5206
Closes #4811
Closes #4095
Closes #5292

This PR removes the `IVbProject` SCW from the `ProjectDeclaration`, which is the last COM wrapper remaining on declarations. All users of the corresponding property were refactored to use an `IProjectdProvider` instead to get the project based on the project id. The same is true for `ProjectDisplayName` on the `ProjectDeclaration`. There is the exception of the `InspectionResultFormatter`, which now gets the document name fed as an additional constructor parameter.

When implementing the according changes, I realized that this implementation of `IExportable` and the one in the ToDo Explorer were not wired up correctly, which should be the root cause of #5292. After the adjustments, clipboard exports worked again as expected.

In addition, the implementations of `IVbProject.ProjectDisplayName` have been enhanced to never show characters from random memory and to show the correct document name in next to all cases. Now, we first try to get it from the filename. If that fails, moste likely because the document has never been saved, we try to use the caption, but with an enhanced handling of the case that triggers the VBE API bug. Finally, if we only get part of the name, we fall back to the `BuildFileName` without the extension.