### PR TITLE
Add string extension to convert from VBA string literals to strings 

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/Excel/SheetAccessedUsingStringInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/Excel/SheetAccessedUsingStringInspection.cs
@@ -100,7 +100,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.Excel
             }
 
             var projectId = reference.QualifiedModuleName.ProjectId;
-            var sheetName = sheetNameArgumentLiteralExpressionContext.GetText().UnQuote();
+            var sheetName = sheetNameArgumentLiteralExpressionContext.GetText().FromVbaStringLiteral();
             var codeName = CodeNameOfVBComponentMatchingSheetName(projectId, sheetName);
 
             if (codeName == null)

--- a/Rubberduck.JunkDrawer/Output/StringExtensions.cs
+++ b/Rubberduck.JunkDrawer/Output/StringExtensions.cs
@@ -66,6 +66,16 @@ namespace Rubberduck.Common
             return $"\"{input}\"";
         }
 
+        public static string FromVbaStringLiteral(this string input)
+        {
+            return input.UnQuote().Replace("\"\"", "\"");
+        }
+
+        public static string ToVbaStringLiteral(this string input)
+        {
+            return input.Replace("\"", "\"\"");
+        }
+
         public static bool TryMatchHungarianNotationCriteria(this string identifier, out string nonHungarianName)
         {
             nonHungarianName = identifier;

--- a/Rubberduck.Parsing/Annotations/Concrete/ObsoleteAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/ObsoleteAnnotation.cs
@@ -20,7 +20,7 @@ namespace Rubberduck.Parsing.Annotations
             var args = arguments.ToList();
 
             ReplacementDocumentation = args.Any()
-                ? args[0].UnQuote()
+                ? args[0]
                 : string.Empty;
 
             return base.ProcessAnnotationArguments(args);

--- a/Rubberduck.Parsing/Annotations/Concrete/TestMethodAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/TestMethodAnnotation.cs
@@ -15,7 +15,7 @@ namespace Rubberduck.Parsing.Annotations
 
         public IReadOnlyList<string> ProcessAnnotationArguments(IEnumerable<string> arguments)
         {
-            var firstParameter = arguments.FirstOrDefault()?.UnQuote();
+            var firstParameter = arguments.FirstOrDefault();
             var result = new List<string>();
             if (!string.IsNullOrWhiteSpace(firstParameter))
             {

--- a/Rubberduck.UnitTesting/UnitTesting/TestMethod.cs
+++ b/Rubberduck.UnitTesting/UnitTesting/TestMethod.cs
@@ -25,8 +25,8 @@ namespace Rubberduck.UnitTesting
         {
             get
             {
-                var testMethodAnnotation = Declaration.Annotations.Where(pta => pta.Annotation is TestMethodAnnotation).First();
-                var argument = testMethodAnnotation.AnnotationArguments.FirstOrDefault()?.UnQuote();
+                var testMethodAnnotation = Declaration.Annotations.First(pta => pta.Annotation is TestMethodAnnotation);
+                var argument = testMethodAnnotation.AnnotationArguments.FirstOrDefault()?.FromVbaStringLiteral();
 
                 var categorization = string.IsNullOrWhiteSpace(argument)
                     ? TestExplorer.TestExplorer_Uncategorized 


### PR DESCRIPTION
….and back

This is used to fix SheetAccessUsingStringInspection in case the sheet name contains a double quote.