### PR TITLE
Create ExcessiveInterfaceMembersInspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ExcessiveInterfaceMembersInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ExcessiveInterfaceMembersInspection.cs
@@ -1,0 +1,98 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+using Rubberduck.CodeAnalysis.Inspections.Abstract;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Resources.Inspections;
+
+namespace Rubberduck.CodeAnalysis.Inspections.Concrete 
+{
+    /// <summary>
+    /// Identifies class modules that define an interface with an excessive number of public members and reminds users about Interface Segregation Principle.
+    /// </summary>
+    /// <why>
+    /// Interfaces should not be designed to continually grow new members; we should be keeping them small, specific, and specialized.
+    /// </why>
+    /// <example hasResult="false">
+    /// <module name="MyModule" type="Class Module">
+    /// <![CDATA[
+    /// Option Explicit
+    /// '@Interface
+    ///
+    /// Public Sub DoSomething()
+    /// 
+    /// End Sub
+    /// ]]>
+    /// </module>
+    /// </example>
+    /// <example hasResult="true">
+    /// <module name="MyModule" type="Class Module">
+    /// <![CDATA[
+    /// Option Explicit
+    /// '@Interface
+    ///
+    /// Public Sub DoSomething1()
+    /// 
+    /// End Sub
+    /// 
+    /// Public Sub DoSomething2()
+    /// 
+    /// End Sub
+    /// 
+    /// '...
+    /// 
+    /// Public Sub DoSomethingNGreaterThanMaxPublicMemberCount()
+    ///  
+    /// End Sub
+    /// ]]>
+    /// </module>
+    /// </example>
+    /// 
+    internal sealed class ExcessiveInterfaceMembersInspection : DeclarationInspectionBase<int>
+    {
+        private const int PublicMemberLimit = 10; //todo: make setting rather than constant
+
+        public ExcessiveInterfaceMembersInspection(IDeclarationFinderProvider declarationFinderProvider)
+            : base(declarationFinderProvider, DeclarationType.ClassModule)
+        {}
+
+        protected override (bool isResult, int properties) IsResultDeclarationWithAdditionalProperties(Declaration declaration, DeclarationFinder finder)
+        {
+            if (!(declaration is ClassModuleDeclaration classModule && classModule.IsInterface))
+        {
+                return (false, 0);
+            }
+
+            return HasExcessiveMembers(classModule);
+        }
+
+        private static (bool, int) HasExcessiveMembers(ClassModuleDeclaration declaration)
+        {
+            var _publicmembers = declaration.Members.Where(member =>
+            {
+                int acc = (int)member.Accessibility;
+                return acc >= (int)Accessibility.Implicit && acc <= (int)Accessibility.Global;
+            });
+
+            var count = _publicmembers.Where(member => member.DeclarationType != DeclarationType.Event)
+                                  .Where(member => member.DeclarationType != DeclarationType.PropertyGet || NoMatchingSetter(member, _publicmembers))
+                                  .Count();
+
+            return (count > PublicMemberLimit, count);
+        }
+
+        private static bool NoMatchingSetter(Declaration property, IEnumerable<Declaration> members) =>
+            !members.Any(member => (member.IdentifierName == property.IdentifierName) && (member != property));
+
+        protected override string ResultDescription(Declaration declaration, int memberCount) 
+        {
+            var identifierName = declaration.IdentifierName;
+
+            return string.Format(
+                InspectionResults.ExcessiveInterfaceMembersInspection,
+                identifierName,
+                memberCount);
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ExcessiveInterfaceMembersInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ExcessiveInterfaceMembersInspection.cs
@@ -5,6 +5,11 @@ using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Resources.Inspections;
+using Rubberduck.SettingsProvider;
+
+//todo:
+//finish implementing settings
+//implement quickfix
 
 namespace Rubberduck.CodeAnalysis.Inspections.Concrete 
 {
@@ -51,12 +56,19 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
     /// 
     internal sealed class ExcessiveInterfaceMembersInspection : DeclarationInspectionBase<int>
     {
-        private const int PublicMemberLimit = 10; //todo: make setting rather than constant
+        private static int PublicMemberLimit;
 
-        public ExcessiveInterfaceMembersInspection(IDeclarationFinderProvider declarationFinderProvider)
+        public ExcessiveInterfaceMembersInspection(IDeclarationFinderProvider declarationFinderProvider) //constructor for actual inspection that does not allow for changing from the default limit of 10; this should be removed when settings is fully implemented
             : base(declarationFinderProvider, DeclarationType.ClassModule)
-        {}
+        {
+            PublicMemberLimit = 10;
+        }
 
+        public ExcessiveInterfaceMembersInspection(IDeclarationFinderProvider declarationFinderProvider, IConfigurationService<int> settings) //constructor only for unit test; should become only constructor once settings is fully implemented
+            : base (declarationFinderProvider, DeclarationType.ClassModule) 
+        {
+            PublicMemberLimit = settings.Read();
+        }
         protected override (bool isResult, int properties) IsResultDeclarationWithAdditionalProperties(Declaration declaration, DeclarationFinder finder)
         {
             if (!(declaration is ClassModuleDeclaration classModule && classModule.IsInterface))

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ExcessiveInterfaceMembersInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ExcessiveInterfaceMembersInspection.cs
@@ -76,7 +76,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         protected override (bool isResult, int properties) IsResultDeclarationWithAdditionalProperties(Declaration declaration, DeclarationFinder finder)
         {
             if (!(declaration is ClassModuleDeclaration classModule && classModule.IsInterface))
-        {
+            {
                 return (false, 0);
             }
 

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplementedInterfaceMemberInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplementedInterfaceMemberInspection.cs
@@ -53,11 +53,11 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 return (false, null);
             }
 
-            var implementedMembers = HasImplementedMembers(declaration, finder);
+            var implementedMembers = FindImplementedMembers(declaration, finder);
             return (implementedMembers.Count() > 0, implementedMembers);
         }
 
-        private IEnumerable<ModuleBodyElementDeclaration> HasImplementedMembers(Declaration declaration, DeclarationFinder finder) 
+        private IEnumerable<ModuleBodyElementDeclaration> FindImplementedMembers(Declaration declaration, DeclarationFinder finder) 
         {
             var moduleBodyElements = finder.Members(declaration, DeclarationType.Member)
                 .OfType<ModuleBodyElementDeclaration>();
@@ -69,7 +69,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         protected override string ResultDescription(Declaration declaration, IEnumerable<ModuleBodyElementDeclaration> results)
         {
             var identifierName = declaration.IdentifierName;
-            var memberResultsString = FormatResults(results);
+            var memberResultsString = FormatConcreteImplementationsList(results);
 
             return string.Format(
                 InspectionResults.ImplementedInterfaceMemberInspection,
@@ -77,19 +77,9 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 memberResultsString);
         }
 
-        private static string FormatResults(IEnumerable<ModuleBodyElementDeclaration> results)
+        private static string FormatConcreteImplementationsList(IEnumerable<ModuleBodyElementDeclaration> results)
         {
-            List<string> items = new List<string>();
-
-            foreach (ModuleBodyElementDeclaration elem in results)
-            {
-                var memberType = Resources.RubberduckUI.ResourceManager
-                    .GetString("DeclarationType_" + elem.DeclarationType)
-                    .Capitalize();
-
-                items.Add($"{elem.IdentifierName} ({memberType})");
-            }
-
+            var items = results.Select(result => $"{result.IdentifierName} ({Resources.RubberduckUI.ResourceManager.GetString("DeclarationType_" + result.DeclarationType).Capitalize()})");
             return string.Join(", ", items);
         }
     }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/WriteOnlyPropertyInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/WriteOnlyPropertyInspection.cs
@@ -51,7 +51,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         {
             var setters = RelevantDeclarationsInModule(module, finder)
                 .Where(declaration => IsResultDeclaration(declaration, finder))
-                .GroupBy(declaration => declaration.DeclarationType)
+                .GroupBy(declaration => declaration.QualifiedName)
                 .Select(grouping => grouping.First()); // don't get both Let and Set accessors
 
             return setters

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Inspections {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InspectionInfo {
@@ -273,6 +273,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string ExcelUdfNameIsValidCellReferenceInspection {
             get {
                 return ResourceManager.GetString("ExcelUdfNameIsValidCellReferenceInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interfaces should be designed to be small, specific, and specialized. Reducing the number of public members makes a more straightforward API that is easier to work with, and adheres to the Interface Segregation Principle..
+        /// </summary>
+        public static string ExcessiveInterfaceMembersInspection {
+            get {
+                return ResourceManager.GetString("ExcessiveInterfaceMembersInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -442,4 +442,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="SuperfluousAnnotationArgumentInspection" xml:space="preserve">
     <value>An annotation has more arguments than allowed; superfluous arguments are ignored.</value>
   </data>
+  <data name="ExcessiveInterfaceMembersInspection" xml:space="preserve">
+    <value>Interfaces should be designed to be small, specific, and specialized. Reducing the number of public members makes a more straightforward API that is easier to work with, and adheres to the Interface Segregation Principle.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Inspections {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InspectionNames {
@@ -273,6 +273,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string ExcelUdfNameIsValidCellReferenceInspection {
             get {
                 return ResourceManager.GetString("ExcelUdfNameIsValidCellReferenceInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interface has too many public members..
+        /// </summary>
+        public static string ExcessiveInterfaceMembersInspection {
+            get {
+                return ResourceManager.GetString("ExcessiveInterfaceMembersInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -446,4 +446,7 @@
   <data name="SuperfluousAnnotationArgumentInspection" xml:space="preserve">
     <value>Superfluous annotation arguments</value>
   </data>
+  <data name="ExcessiveInterfaceMembersInspection" xml:space="preserve">
+    <value>Interface has too many public members.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Inspections {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InspectionResults {
@@ -277,6 +277,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Class/interface &apos;{0}&apos; has too many public members ({1})..
+        /// </summary>
+        public static string ExcessiveInterfaceMembersInspection {
+            get {
+                return ResourceManager.GetString("ExcessiveInterfaceMembersInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Return value of function &apos;{0}&apos; is never used..
         /// </summary>
         public static string FunctionReturnValueAlwaysDiscardedInspection {
@@ -331,7 +340,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Interface class module &apos;{2}&apos; contains a concrete implementation for {0} &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Interface &apos;{0}&apos; contains a concrete implementation for the following member(s): {1}.
         /// </summary>
         public static string ImplementedInterfaceMemberInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
@@ -400,7 +400,8 @@ In memoriam, 1972-2018</value>
     <value>{0} '{1}' neobsahuje žádné spustitelné příkazy.</value>
   </data>
   <data name="ImplementedInterfaceMemberInspection" xml:space="preserve">
-    <value>Modul třídy rozhraní '{2}' obsahuje konkrétní implementaci pro {0} '{1}'.</value>
+    <value>Rozhraní  '{0}' obsahuje konkrétní implementaci pro: {1}</value>
+    <comment>I tried...  English =&gt; Interface '{0}' contains a concrete implementation for the following member(s): {1}</comment>
   </data>
   <data name="ArgumentWithIncompatibleObjectTypeInspection" xml:space="preserve">
     <value>Argument '{2}' typu '{3}' je předán parametru '{0}' jako nekompatibilní typ '{1}'.</value>

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -393,7 +393,8 @@ In Memoriam, 1972-2018</value>
     <value>{0} '{1}'  enthält keine ausführbaren Anweisungen.</value>
   </data>
   <data name="ImplementedInterfaceMemberInspection" xml:space="preserve">
-    <value>Die Interface-Klasse '{2}' enthält eine Implementierung für die  {0} '{1}'.</value>
+    <value>Die Interface-Klasse '{0}' enthält eine Implementierung für diese Mitglieder: {1}</value>
+    <comment>I tried... English =&gt; Interface '{0}' contains a concrete implementation for the following member(s): {1}</comment>
   </data>
   <data name="ValueRequiredInspection" xml:space="preserve">
     <value>An einer Stelle, die einen Wert verlangt, wird der Ausdruck '{0}' vom Objekttyp '{1}'  verwendet, der keinen passendes Standardmember hat.</value>

--- a/Rubberduck.Resources/Inspections/InspectionResults.es.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.es.resx
@@ -375,4 +375,7 @@ En memoria, 1972-2018</value>
   <data name="OnErrorGoToMinusOneInspection" xml:space="preserve">
     <value>En error GoTo -1 encontrado</value>
   </data>
+  <data name="ImplementedInterfaceMemberInspection" xml:space="preserve">
+    <value>La interfaz '{0}' contiene una implementación concreta por estos miembros: {1}</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.fr.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.fr.resx
@@ -406,7 +406,8 @@ In memoriam, 1972-2018</value>
     <value>{0} '{1}' ne contient aucune instruction exécutable.</value>
   </data>
   <data name="ImplementedInterfaceMemberInspection" xml:space="preserve">
-    <value>L'interface abstraite définie par '{2}' contient une implémentation concrète pour {0} '{1}'.</value>
+    <value>L'interface '{0}' contient une implémentation concrète pour ces membres: {1}</value>
+    <comment>I tried... English =&gt; Interface '{0}' contains a concrete implementation for the following member(s): {1}</comment>
   </data>
   <data name="ArgumentWithIncompatibleObjectTypeInspection" xml:space="preserve">
     <value>L'argument '{2}', de type '{3}', est passé au paramètre '{0}', du type incompatible '{1}'.</value>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -436,7 +436,7 @@ In memoriam, 1972-2018</value>
   </data>
   <data name="ImplementedInterfaceMemberInspection" xml:space="preserve">
     <value>Interface '{0}' contains a concrete implementation for the following member(s): {1}</value>
-    <comment>{0} interface class name; {1} formatted string of results</comment>
+    <comment>{0} interface class name; {1} formatted list of members with concrete implementations</comment>
   </data>
   <data name="ArgumentWithIncompatibleObjectTypeInspection" xml:space="preserve">
     <value>The argument '{2}' of type '{3}' is passed to the parameter '{0}' of the incompatible type '{1}'.</value>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -435,8 +435,8 @@ In memoriam, 1972-2018</value>
     <comment>{0} Method kind, {1} Method name</comment>
   </data>
   <data name="ImplementedInterfaceMemberInspection" xml:space="preserve">
-    <value>Interface class module '{2}' contains a concrete implementation for {0} '{1}'.</value>
-    <comment>{0} Method kind, {1} Method name, {2} interface class module name</comment>
+    <value>Interface '{0}' contains a concrete implementation for the following member(s): {1}</value>
+    <comment>{0} interface class name; {1} formatted string of results</comment>
   </data>
   <data name="ArgumentWithIncompatibleObjectTypeInspection" xml:space="preserve">
     <value>The argument '{2}' of type '{3}' is passed to the parameter '{0}' of the incompatible type '{1}'.</value>
@@ -512,5 +512,9 @@ In memoriam, 1972-2018</value>
   <data name="SuperfluousAnnotationArgumentInspection" xml:space="preserve">
     <value>The annotation '{0}' was expected to have less arguments.</value>
     <comment>{0} annotation name</comment>
+  </data>
+  <data name="ExcessiveInterfaceMembersInspection" xml:space="preserve">
+    <value>Class/interface '{0}' has too many public members ({1}).</value>
+    <comment>{0} class name; {1} public member count</comment>
   </data>
 </root>

--- a/RubberduckTests/Inspections/ExcessiveInterfaceMembersInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcessiveInterfaceMembersInspectionTests.cs
@@ -13,13 +13,12 @@ namespace RubberduckTests.Inspections
 {
     class ExcessiveInterfaceMembersInspectionTests : InspectionTestsBase 
     {
-        private static List<(string, string, ComponentType)> modules = new List<(string, string, ComponentType)> {
-            (null, null, ComponentType.ClassModule),
-            ("Class2","Implements Class1", ComponentType.ClassModule) };
-
         private int AssessCode(string testCode) 
         {
-            modules[0] = ("Class1", testCode, ComponentType.ClassModule);
+            var modules = new List<(string, string, ComponentType)> {
+                ("Class1", testCode, ComponentType.ClassModule),
+                ("Class2", "Implements Class1", ComponentType.ClassModule) };
+
             return InspectionResultsForModules(modules, ReferenceLibrary.Scripting).Count();
         }
 
@@ -96,7 +95,7 @@ namespace RubberduckTests.Inspections
 
         [Test]
         [Category("Inspections")]
-        public void ExcessiveInterfaceMembers_ReadWriteProperty()
+        public void ExcessiveInterfaceMembers_ReadWritePropertyStandard()
         {
             const string testCode =
 
@@ -105,6 +104,43 @@ namespace RubberduckTests.Inspections
 
                 Public Property Get Foo1() As Variant
                 End Property
+
+                Public Function Foo2()
+                End Function";
+
+            Assert.AreEqual(0, AssessCode(testCode));
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcessiveInterfaceMembers_ReadWritePropertyDoubleSetter() 
+        {
+            const string testCode =
+
+                @"Public Property Let Foo1(bar1 As Variant)
+                End Property
+
+                Public Property Set Foo1(bar1 As Variant)
+                End Property
+
+                Public Property Get Foo1() As Variant
+                End Property
+
+                Public Function Foo2()
+                End Function";
+
+            Assert.AreEqual(0, AssessCode(testCode));
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcessiveInterfaceMembers_Field() 
+        {
+            const string testCode =
+
+                @"Public Event Event1()
+                
+                Public Foo1 As Integer
 
                 Public Function Foo2()
                 End Function";

--- a/RubberduckTests/Inspections/ExcessiveInterfaceMembersInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcessiveInterfaceMembersInspectionTests.cs
@@ -26,16 +26,16 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void ExcessiveInterfaceMembers_Standard() 
         {
-            const string testCode =
+            const string testCode = @"
 
-                @"Public Sub Foo1()
-                End Sub
+Public Sub Foo1()
+End Sub
 
-                Public Sub Foo2()
-                End Sub
+Public Sub Foo2()
+End Sub
 
-                Public Function Foo3()
-                End Function";
+Public Function Foo3()
+End Function";
 
             Assert.AreEqual(1, AssessCode(testCode));
         }
@@ -44,15 +44,15 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void ExcessiveInterfaceMembers_IgnoreEvent() 
         {
-            const string testCode =
+            const string testCode = @"
 
-                @"Public Event Event1()
+Public Event Event1()
 
-                Public Sub Foo1()
-                End Sub
+Public Sub Foo1()
+End Sub
 
-                Public Function Foo2()
-                End Function";
+Public Function Foo2()
+End Function";
 
             Assert.AreEqual(0, AssessCode(testCode));
         }
@@ -61,16 +61,16 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void ExcessiveInterfaceMembers_OnlySetters() 
         {
-            const string testCode =
+            const string testCode = @"
 
-                @"Public Property Let Foo1(bar1 As Integer)
-                End Property
+Public Property Let Foo1(bar1 As Integer)
+End Property
 
-                Public Property Set Foo2(bar2 As Object)
-                End Property
+Public Property Set Foo2(bar2 As Object)
+End Property
 
-                Public Function Foo3()
-                End Function";
+Public Function Foo3()
+End Function";
 
             Assert.AreEqual(1, AssessCode(testCode));
         }
@@ -79,16 +79,16 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void ExcessiveInterfaceMembers_OnlyGetter()
         {
-            const string testCode =
+            const string testCode = @"
 
-                @"Public Property Get Foo1() As Integer
-                End Property
+Public Property Get Foo1() As Integer
+End Property
 
-                Public Sub Foo2()
-                End Sub
+Public Sub Foo2()
+End Sub
 
-                Public Function Foo3()
-                End Function";
+Public Function Foo3()
+End Function";
 
             Assert.AreEqual(1, AssessCode(testCode));
         }
@@ -97,16 +97,16 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void ExcessiveInterfaceMembers_ReadWritePropertyStandard()
         {
-            const string testCode =
+            const string testCode = @"
 
-                @"Public Property Let Foo1(bar1 As Variant)
-                End Property
+Public Property Let Foo1(bar1 As Variant)
+End Property
 
-                Public Property Get Foo1() As Variant
-                End Property
+Public Property Get Foo1() As Variant
+End Property
 
-                Public Function Foo2()
-                End Function";
+Public Function Foo2()
+End Function";
 
             Assert.AreEqual(0, AssessCode(testCode));
         }
@@ -115,19 +115,19 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void ExcessiveInterfaceMembers_ReadWritePropertyDoubleSetter() 
         {
-            const string testCode =
+            const string testCode = @"
 
-                @"Public Property Let Foo1(bar1 As Variant)
-                End Property
+Public Property Let Foo1(bar1 As Variant)
+End Property
 
-                Public Property Set Foo1(bar1 As Variant)
-                End Property
+Public Property Set Foo1(bar1 As Variant)
+End Property
 
-                Public Property Get Foo1() As Variant
-                End Property
+Public Property Get Foo1() As Variant
+End Property
 
-                Public Function Foo2()
-                End Function";
+Public Function Foo2()
+End Function";
 
             Assert.AreEqual(0, AssessCode(testCode));
         }
@@ -136,14 +136,14 @@ namespace RubberduckTests.Inspections
         [Category("Inspections")]
         public void ExcessiveInterfaceMembers_Field() 
         {
-            const string testCode =
+            const string testCode = @"
 
-                @"Public Event Event1()
+Public Event Event1()
                 
-                Public Foo1 As Integer
+Public Foo1 As Integer
 
-                Public Function Foo2()
-                End Function";
+Public Function Foo2()
+End Function";
 
             Assert.AreEqual(0, AssessCode(testCode));
         }

--- a/RubberduckTests/Inspections/ExcessiveInterfaceMembersInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcessiveInterfaceMembersInspectionTests.cs
@@ -1,0 +1,127 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Moq;
+using Rubberduck.SettingsProvider;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+using Rubberduck.Parsing.VBA;
+using System.Collections.Generic;
+using Rubberduck.CodeAnalysis.Inspections;
+using Rubberduck.CodeAnalysis.Inspections.Concrete;
+
+namespace RubberduckTests.Inspections 
+{
+    class ExcessiveInterfaceMembersInspectionTests : InspectionTestsBase 
+    {
+        private static List<(string, string, ComponentType)> modules = new List<(string, string, ComponentType)> {
+            (null, null, ComponentType.ClassModule),
+            ("Class2","Implements Class1", ComponentType.ClassModule) };
+
+        private int AssessCode(string testCode) 
+        {
+            modules[0] = ("Class1", testCode, ComponentType.ClassModule);
+            return InspectionResultsForModules(modules, ReferenceLibrary.Scripting).Count();
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcessiveInterfaceMembers_Standard() 
+        {
+            const string testCode =
+
+                @"Public Sub Foo1()
+                End Sub
+
+                Public Sub Foo2()
+                End Sub
+
+                Public Function Foo3()
+                End Function";
+
+            Assert.AreEqual(1, AssessCode(testCode));
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcessiveInterfaceMembers_IgnoreEvent() 
+        {
+            const string testCode =
+
+                @"Public Event Event1()
+
+                Public Sub Foo1()
+                End Sub
+
+                Public Function Foo2()
+                End Function";
+
+            Assert.AreEqual(0, AssessCode(testCode));
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcessiveInterfaceMembers_OnlySetters() 
+        {
+            const string testCode =
+
+                @"Public Property Let Foo1(bar1 As Integer)
+                End Property
+
+                Public Property Set Foo2(bar2 As Object)
+                End Property
+
+                Public Function Foo3()
+                End Function";
+
+            Assert.AreEqual(1, AssessCode(testCode));
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcessiveInterfaceMembers_OnlyGetter()
+        {
+            const string testCode =
+
+                @"Public Property Get Foo1() As Integer
+                End Property
+
+                Public Sub Foo2()
+                End Sub
+
+                Public Function Foo3()
+                End Function";
+
+            Assert.AreEqual(1, AssessCode(testCode));
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcessiveInterfaceMembers_ReadWriteProperty()
+        {
+            const string testCode =
+
+                @"Public Property Let Foo1(bar1 As Variant)
+                End Property
+
+                Public Property Get Foo1() As Variant
+                End Property
+
+                Public Function Foo2()
+                End Function";
+
+            Assert.AreEqual(0, AssessCode(testCode));
+        }
+
+        private Mock<IConfigurationService<int>> GetInspectionSettings()
+        {
+            var settings = new Mock<IConfigurationService<int>>();
+            settings.Setup(s => s.Read()).Returns(2);
+            return settings;
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state) 
+        {
+            return new ExcessiveInterfaceMembersInspection(state, GetInspectionSettings().Object);
+        }
+    }
+}

--- a/RubberduckTests/Inspections/WriteOnlyPropertyInspectionTests.cs
+++ b/RubberduckTests/Inspections/WriteOnlyPropertyInspectionTests.cs
@@ -43,7 +43,7 @@ End Property
 Property Set Foo(value)
 End Property";
 
-            Assert.AreEqual(2, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule)).Count());
+            Assert.AreEqual(1, InspectionResultsForModules(("MyClass", inputCode, ComponentType.ClassModule)).Count());
         }
 
         [Test]


### PR DESCRIPTION
This is to close issue #4923. The code is not complete, but I thought it was at the point it was best to get the review process started. I have left a comment beginning with "note" at all pertinent issues. The primary concern is the logic for returning an inspection result; I do not know how the case of property get/let should be handled (are they two members or one?) or enough about `Declaration` yet to fully implement something to account for treating them as one member. Note that I only accounted for a `Public` declaration because I thought that `Global` was not a valid modifier on a class member declaration, but if there there other items in the `Accessibility` enum that should trigger the inspection I don't think it will be very hard to adapt. I have added the resources to the resource manager in my version in VS but didn't know how they should be edited into the `.resx` files on GH. Other notes should be fairly self-explanatory but obviously I'll be happy to clarify anything as needed.