### PR TITLE
Prohibit dragging and dropping a folder into itself

### DIFF
--- a/Rubberduck.Core/UI/CodeExplorer/Commands/DragAndDrop/CodeExplorerMoveToFolderDragAndDropCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/DragAndDrop/CodeExplorerMoveToFolderDragAndDropCommand.cs
@@ -31,7 +31,8 @@ namespace Rubberduck.UI.CodeExplorer.Commands.DragAndDrop
         {
             var (targetFolder, node) = (ValueTuple<string, ICodeExplorerNode>)parameter;
             return !string.IsNullOrEmpty(targetFolder)
-                   && (node is CodeExplorerCustomFolderViewModel
+                   && (node is CodeExplorerCustomFolderViewModel folderViewModel
+                       && folderViewModel.FullPath != targetFolder
                     || node is CodeExplorerComponentViewModel componentViewModel
                         && componentViewModel.Declaration is ModuleDeclaration);
         }


### PR DESCRIPTION
Closes #5473

![CannotDragFolderIntoItself](https://user-images.githubusercontent.com/22868956/80249324-e59e3a80-8671-11ea-8f35-c6cb1ceb0c57.gif)
