### PR TITLE
Stop suppressing RequestBringIntoView in InspectionResultsControl

### DIFF
--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -200,7 +200,6 @@
                                            SelectedItem="{Binding SelectedItem}"
                                            SelectionUnit="FullRow"
                                            ItemsSource="{Binding Results, NotifyOnSourceUpdated=True}"
-                                           RequestBringIntoView="InspectionResultsGrid_RequestBringIntoView"
                                            VirtualizingPanel.IsVirtualizingWhenGrouping="True"
                                            ScrollViewer.CanContentScroll="True" 
                                            ScrollViewer.VerticalScrollBarVisibility="Auto"


### PR DESCRIPTION
This reverts one of the two changes in the PR introducing the problems observed in issue #5442.

This PR serves to generate a prerelease to investigate whether this solves the problem for those affected by the problem; unfortunately, I have not been able to reproduce it myself.