### PR TITLE
Improve EncapsulateField property name TextBox content alignment

### DIFF
--- a/Rubberduck.Core/UI/Refactorings/EncapsulateField/EncapsulateFieldView.xaml
+++ b/Rubberduck.Core/UI/Refactorings/EncapsulateField/EncapsulateFieldView.xaml
@@ -144,6 +144,7 @@
                                          Text="{Binding Path=PropertyName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                          TabIndex="1" Margin="10,5"
                                          VerticalAlignment="Center" 
+                                         VerticalContentAlignment="Center"
                                          Height="22" />
                                 <Image Grid.Row="1" Style="{StaticResource InvalidNameIconStyle}"
                                        Visibility="{Binding Path=SelectionHasValidEncapsulationAttributes, Converter={StaticResource BoolToHiddenVisibility}}" />


### PR DESCRIPTION
Closes #5447 

Simple fix, one-liner.  #5447 and title says it all.