### PR TITLE
Fix for two NREs

### DIFF
--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerViewModel.cs
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerViewModel.cs
@@ -256,6 +256,7 @@ namespace Rubberduck.UI.UnitTesting
 
             return false;
         }
+
         public bool CanExecuteUnignoreSelectedTests(object obj)
         {
             if (!Model.IsBusy && obj is IList viewModels && viewModels.Count > 0)
@@ -273,12 +274,14 @@ namespace Rubberduck.UI.UnitTesting
 
             return groupItems.Cast<TestMethodViewModel>().Count(test => test.Method.IsIgnored) != groupItems.Count;
         }
+
         public bool CanExecuteUnignoreGroupCommand(object obj)
         {
             var groupItems = MouseOverGroup?.Items
-                             ?? GroupContainingSelectedTest(MouseOverTest).Items;
-
-            return groupItems.Cast<TestMethodViewModel>().Any(test => test.Method.IsIgnored);
+                             ?? GroupContainingSelectedTest(MouseOverTest)?.Items;
+            
+            return groupItems != null 
+                   && groupItems.Cast<TestMethodViewModel>().Any(test => test.Method.IsIgnored);
         }
         
         #region Commands

--- a/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
+++ b/RubberduckTests/Inspections/ExcelMemberMayReturnNothingInspectionTests.cs
@@ -28,6 +28,22 @@ End Sub
 
         [Test]
         [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_WithMemberAccessOnFind()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    With ws.UsedRange
+        foo = .Find(""foo"").Row
+    End With
+End Sub
+";
+            Assert.AreEqual(1, InspectionResults(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ExcelMemberMayReturnNothing_Ignored_DoesNotReturnResult()
         {
             const string inputCode =
@@ -104,6 +120,25 @@ End Sub
     Set ws = Sheet1
     Dim result As Range
     Set result = ws.UsedRange.Find(""foo"")
+    result.Value = ""bar""
+End Sub
+";
+
+            Assert.AreEqual(1, InspectionResults(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExcelMemberMayReturnNothing_ReturnsResult_AssignedAndNotTested_FromWithMemberAccess()
+        {
+            const string inputCode =
+                @"Sub UnderTest()
+    Dim ws As Worksheet
+    Set ws = Sheet1
+    Dim result As Range
+    With ws.UsedRange
+        Set result = .Find(""foo"")
+    End With
     result.Value = ""bar""
 End Sub
 ";


### PR DESCRIPTION
This PR fixes the two NREs discovered in the log posted for #5493. One of them might have an impact on the issue, the other certainly not.

The fix for the inspection base class does not cover all possible situations. However, it covers those for the currently sole implementation and adds a doc-comment explaining the remaining restriction.