### PR TITLE
Remove handler for RequestBringIntoView from TestExplorer

### DIFF
--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
@@ -333,9 +333,8 @@
 	                                       SelectionMode="Extended"
 	                                       ShowGroupingItemCount="True"
 	                                       InitialExpandedState="True"
-	                                       RequestBringIntoView="TestGrid_RequestBringIntoView"
 	                                       VirtualizingPanel.IsVirtualizingWhenGrouping="True"
-	                                       ScrollViewer.CanContentScroll="True" 
+	                                       ScrollViewer.CanContentScroll="False" 
 	                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
 	                                       ScrollViewer.HorizontalScrollBarVisibility="Disabled">
 	                    <DataGrid.Columns>


### PR DESCRIPTION
This PR is another stab at resolving issue  #5442 

Not swallowing that event in the test explorer made the sample project provided in the issue stop freezing for me. (In PR #5482, it had already been removed from the inspection results window, but not from the test explorer as it had been added in a different PR than the one introducing the issue, probably a later one.)

I hope this change also works for other people.

Once we know that it really works in the field, we might reintroduce a handler, but using a better scheme than swallowing the event to handle the original problem for which the handler has been added.