### PR TITLE
Rename folder CE command

### DIFF
--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -126,6 +126,9 @@
     <Compile Update="UI\Refactorings\MoveToFolder\MoveMultipleToFolderView.xaml.cs">
       <DependentUpon>MoveMultipleToFolderView.xaml</DependentUpon>
     </Compile>
+    <Compile Update="UI\Refactorings\RenameFolder\RenameFolderView.xaml.cs">
+      <DependentUpon>RenameFolderView.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/Abstract/CodeExplorerInteractiveRefactoringCommandBase.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/Abstract/CodeExplorerInteractiveRefactoringCommandBase.cs
@@ -1,0 +1,38 @@
+﻿using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings;
+using Rubberduck.UI.Command.Refactorings.Notifiers;
+using Rubberduck.VBEditor.Events;
+
+namespace Rubberduck.UI.CodeExplorer.Commands.Abstract
+{
+    public abstract class CodeExplorerInteractiveRefactoringCommandBase<TModel> : CodeExplorerRefactoringCommandBase<TModel>
+        where TModel : class, IRefactoringModel
+    {
+        private readonly IRefactoringAction<TModel> _refactoringAction;
+        private readonly IRefactoringUserInteraction<TModel> _refactoringUserInteraction;
+        private readonly IRefactoringFailureNotifier _failureNotifier;
+
+        protected CodeExplorerInteractiveRefactoringCommandBase(
+            IRefactoringAction<TModel> refactoringAction,
+            IRefactoringUserInteraction<TModel> refactoringUserInteraction,
+            IRefactoringFailureNotifier failureNotifier,
+            IParserStatusProvider parserStatusProvider,
+            IVbeEvents vbeEvents)
+            : base(refactoringAction, failureNotifier, parserStatusProvider, vbeEvents)
+        {
+            _refactoringUserInteraction = refactoringUserInteraction;
+            _refactoringAction = refactoringAction;
+            _failureNotifier = failureNotifier;
+        }
+
+        protected abstract TModel InitialModelFromParameter(object parameter);
+        protected abstract void ValidateInitialModel(TModel model);
+
+        protected override TModel ModelFromParameter(object parameter)
+        {
+            var initialModel = InitialModelFromParameter(parameter);
+            ValidateInitialModel(initialModel);
+            return _refactoringUserInteraction.UserModifiedModel(initialModel);
+        }
+    }
+}

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/Abstract/CodeExplorerRefactoringCommandBase.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/Abstract/CodeExplorerRefactoringCommandBase.cs
@@ -1,0 +1,61 @@
+﻿using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.Exceptions;
+using Rubberduck.UI.Command.Refactorings.Notifiers;
+using Rubberduck.VBEditor.Events;
+
+namespace Rubberduck.UI.CodeExplorer.Commands.Abstract
+{
+    public abstract class CodeExplorerRefactoringCommandBase<TModel> : CodeExplorerCommandBase
+        where TModel : class, IRefactoringModel
+    {
+        private readonly IParserStatusProvider _parserStatusProvider;
+
+        private readonly IRefactoringAction<TModel> _refactoringAction;
+        private readonly IRefactoringFailureNotifier _failureNotifier;
+
+        protected CodeExplorerRefactoringCommandBase(
+            IRefactoringAction<TModel> refactoringAction,
+            IRefactoringFailureNotifier failureNotifier,
+            IParserStatusProvider parserStatusProvider,
+            IVbeEvents vbeEvents)
+            : base(vbeEvents)
+        {
+            _refactoringAction = refactoringAction;
+            _failureNotifier = failureNotifier;
+
+            _parserStatusProvider = parserStatusProvider;
+
+            AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
+        }
+
+        private bool SpecialEvaluateCanExecute(object parameter)
+        {
+            return _parserStatusProvider.Status == ParserState.Ready;
+        }
+
+        protected abstract TModel ModelFromParameter(object parameter);
+        protected abstract void ValidateModel(TModel model);
+
+        protected override void OnExecute(object parameter)
+        {
+            if (!CanExecute(parameter))
+            {
+                return;
+            }
+
+            try
+            {
+                var model = ModelFromParameter(parameter);
+                ValidateModel(model);
+                _refactoringAction.Refactor(model);
+            }
+            catch (RefactoringAbortedException)
+            { }
+            catch (RefactoringException exception)
+            {
+                _failureNotifier.Notify(exception);
+            }
+        }
+    }
+}

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerMoveToFolderCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerMoveToFolderCommand.cs
@@ -24,8 +24,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             RefactoringUserInteraction<IMoveMultipleToFolderPresenter, MoveMultipleToFolderModel> moveToFolderInteraction,
             MoveToFolderRefactoringFailedNotifier failureNotifier, 
             IParserStatusProvider parserStatusProvider, 
-            IVbeEvents vbeEvents) 
-            : base(moveFolders, moveToFolder, failureNotifier, parserStatusProvider, vbeEvents)
+            IVbeEvents vbeEvents,
+            RubberduckParserState state) 
+            : base(moveFolders, moveToFolder, failureNotifier, parserStatusProvider, vbeEvents, state)
         {
             _moveFoldersInteraction = moveFoldersInteraction;
             _moveToFolderInteraction = moveToFolderInteraction;

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/DragAndDrop/CodeExplorerMoveToFolderDragAndDropCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/DragAndDrop/CodeExplorerMoveToFolderDragAndDropCommand.cs
@@ -6,6 +6,7 @@ using Rubberduck.JunkDrawer.Extensions;
 using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings.Exceptions;
 using Rubberduck.Refactorings.MoveFolder;
 using Rubberduck.Refactorings.MoveToFolder;
 using Rubberduck.Resources;
@@ -27,8 +28,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands.DragAndDrop
             IParserStatusProvider parserStatusProvider, 
             IVbeEvents vbeEvents,
             IMessageBox messageBox,
-            IDeclarationFinderProvider declarationFinderProvider) 
-            : base(moveFolders, moveToFolder, failureNotifier, parserStatusProvider, vbeEvents)
+            IDeclarationFinderProvider declarationFinderProvider,
+            RubberduckParserState state) 
+            : base(moveFolders, moveToFolder, failureNotifier, parserStatusProvider, vbeEvents, state)
         {
             _declarationFinderProvider = declarationFinderProvider;
             _messageBox = messageBox;
@@ -69,6 +71,11 @@ namespace Rubberduck.UI.CodeExplorer.Commands.DragAndDrop
             {
                 model.TargetFolder = targetFolder;
             }
+            else
+            {
+                throw new RefactoringAbortedException();
+            }
+
             return model;
         }
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/RenameFolderCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/RenameFolderCommand.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.JunkDrawer.Extensions;
+using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.Exceptions;
+using Rubberduck.Refactorings.RenameFolder;
+using Rubberduck.UI.CodeExplorer.Commands.Abstract;
+using Rubberduck.UI.Command.Refactorings.Notifiers;
+using Rubberduck.VBEditor.Events;
+
+namespace Rubberduck.UI.CodeExplorer.Commands
+{
+    public class RenameFolderCommand : CodeExplorerInteractiveRefactoringCommandBase<RenameFolderModel>
+    {
+        private static readonly Type[] ApplicableNodes =
+        {
+            typeof(CodeExplorerCustomFolderViewModel)
+        };
+
+        private RubberduckParserState _state;
+
+        public RenameFolderCommand(
+            RenameFolderRefactoringAction refactoringAction,
+            RefactoringUserInteraction<IRenameFolderPresenter, RenameFolderModel> userInteraction,
+            RenameFolderFailedNotifier failureNotifier,
+            IParserStatusProvider parserStatusProvider,
+            IVbeEvents vbeEvents,
+            RubberduckParserState state)
+            : base(refactoringAction, userInteraction, failureNotifier, parserStatusProvider, vbeEvents)
+        {
+            _state = state;
+        }
+
+        public override IEnumerable<Type> ApplicableNodeTypes => ApplicableNodes;
+
+        protected override RenameFolderModel InitialModelFromParameter(object parameter)
+        {
+            if (!(parameter is CodeExplorerCustomFolderViewModel folderModel))
+            {
+                throw new ArgumentException(nameof(parameter));
+            }
+
+            return ModelFromNode(folderModel);
+        }
+
+        private static RenameFolderModel ModelFromNode(CodeExplorerCustomFolderViewModel folderModel)
+        {
+            var folder = folderModel.FullPath;
+            var containedModules = ContainedModules(folderModel);
+            var initialSubFolder = folder.SubFolderName();
+            return new RenameFolderModel(folder, containedModules, initialSubFolder);
+        }
+
+        private static ICollection<ModuleDeclaration> ContainedModules(ICodeExplorerNode itemModel)
+        {
+            if (itemModel is CodeExplorerComponentViewModel componentModel)
+            {
+                var component = componentModel.Declaration;
+                return component is ModuleDeclaration moduleDeclaration
+                    ? new List<ModuleDeclaration> { moduleDeclaration }
+                    : new List<ModuleDeclaration>();
+            }
+
+            return itemModel.Children
+                .SelectMany(ContainedModules)
+                .ToList();
+        }
+
+        protected override void ValidateInitialModel(RenameFolderModel model)
+        {
+            var firstStaleAffectedModules = model.ModulesToMove
+                .FirstOrDefault(module => _state.IsNewOrModified(module.QualifiedModuleName));
+            if (firstStaleAffectedModules != null)
+            {
+                throw new AffectedModuleIsStaleException(firstStaleAffectedModules.QualifiedModuleName);
+            }
+        }
+
+        protected override void ValidateModel(RenameFolderModel model)
+        { }
+    }
+}

--- a/Rubberduck.Core/UI/Command/Refactorings/Notifiers/MoveContainingFolderRefactoringFailedNotifier.cs
+++ b/Rubberduck.Core/UI/Command/Refactorings/Notifiers/MoveContainingFolderRefactoringFailedNotifier.cs
@@ -26,10 +26,6 @@ namespace Rubberduck.UI.Command.Refactorings.Notifiers
                         DeclarationType.Module);
                 case NoTargetFolderException noTargetFolder:
                     return Resources.RubberduckUI.RefactoringFailure_NoTargetFolder;
-                case AffectedModuleIsStaleException affectedModuleIsStale:
-                    return string.Format(
-                        Resources.RubberduckUI.RefactoringFailure_AffectedModuleIsStale,
-                        affectedModuleIsStale.StaleModule.ToString());
                 default:
                     return base.Message(exception);
             }

--- a/Rubberduck.Core/UI/Command/Refactorings/Notifiers/MoveToFolderRefactoringFailedNotifier.cs
+++ b/Rubberduck.Core/UI/Command/Refactorings/Notifiers/MoveToFolderRefactoringFailedNotifier.cs
@@ -26,10 +26,6 @@ namespace Rubberduck.UI.Command.Refactorings.Notifiers
                         DeclarationType.Module);
                 case NoTargetFolderException noTargetFolder:
                     return Resources.RubberduckUI.RefactoringFailure_NoTargetFolder;
-                case AffectedModuleIsStaleException affectedModuleIsStale:
-                    return string.Format(
-                        Resources.RubberduckUI.RefactoringFailure_AffectedModuleIsStale,
-                        affectedModuleIsStale.StaleModule.ToString());
                 default:
                     return base.Message(exception);
             }

--- a/Rubberduck.Core/UI/Command/Refactorings/Notifiers/RefactoringFailureNotifierBase.cs
+++ b/Rubberduck.Core/UI/Command/Refactorings/Notifiers/RefactoringFailureNotifierBase.cs
@@ -44,6 +44,10 @@ namespace Rubberduck.UI.Command.Refactorings.Notifiers
                 case SuspendParserFailureException suspendParserFailure:
                     Logger.Warn(suspendParserFailure);
                     return Resources.RubberduckUI.RefactoringFailure_SuspendParserFailure;
+                case AffectedModuleIsStaleException affectedModuleIsStale:
+                    return string.Format(
+                        Resources.RubberduckUI.RefactoringFailure_AffectedModuleIsStale,
+                        affectedModuleIsStale.StaleModule.ToString());
                 default:
                     Logger.Error(exception);
                     return string.Empty;

--- a/Rubberduck.Core/UI/Command/Refactorings/Notifiers/RenameFolderFailedNotifier.cs
+++ b/Rubberduck.Core/UI/Command/Refactorings/Notifiers/RenameFolderFailedNotifier.cs
@@ -1,0 +1,13 @@
+﻿using Rubberduck.Interaction;
+
+namespace Rubberduck.UI.Command.Refactorings.Notifiers
+{
+    public class RenameFolderFailedNotifier : RefactoringFailureNotifierBase
+    {
+        public RenameFolderFailedNotifier(IMessageBox messageBox) 
+            : base(messageBox)
+        {}
+
+        protected override string Caption => Resources.RubberduckUI.RenameDialog_Caption;
+    }
+}

--- a/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderPresenter.cs
+++ b/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderPresenter.cs
@@ -1,0 +1,14 @@
+﻿using Rubberduck.Refactorings.RenameFolder;
+using Rubberduck.Resources;
+
+namespace Rubberduck.UI.Refactorings.RenameFolder
+{
+    public class RenameFolderPresenter : RefactoringPresenterBase<RenameFolderModel>, IRenameFolderPresenter
+    {
+        private static readonly DialogData DialogData = DialogData.Create(RubberduckUI.RenameDialog_Caption, 164, 684);
+
+        public RenameFolderPresenter(RenameFolderModel model, IRefactoringDialogFactory dialogFactory) :
+            base(DialogData, model, dialogFactory)
+        { }
+    }
+}

--- a/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml
+++ b/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml
@@ -1,0 +1,78 @@
+﻿<UserControl x:Class="Rubberduck.UI.Refactorings.RenameFolder.RenameFolderView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../../Controls/ToolBar.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="50" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="40" />
+        </Grid.RowDefinitions>
+        <StackPanel Background="{StaticResource BackgroundLightBrush}">
+            <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=RenameDialog_TitleText_Folder}" FontWeight="Bold" />
+            <TextBlock Text="{Binding Instructions}" Margin="5,0" />
+        </StackPanel>
+        <Grid Grid.Row="1" Margin="5,10,10,5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=RenameDialog_FolderLabel}"
+                       VerticalAlignment="Top"
+                       Margin="0,0,5,0" />
+            <TextBox Name="RenameFolderTextBox"
+                     Grid.Column="1"
+                     Style="{StaticResource TextBoxErrorStyle}"
+                     Text="{Binding NewFolderName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     Height="22"
+                     VerticalAlignment="Top"
+                     VerticalContentAlignment="Center"
+                     HorizontalAlignment="Stretch" />
+        </Grid>
+        <StackPanel Grid.Row="2"
+                    Margin="5,10,10,5"
+                    Orientation="Horizontal">
+            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=FullNewFolderLabel}"
+                       VerticalAlignment="Top"
+                       Margin="0,0,5,0" />
+            <TextBlock Text="{Binding FullNewFolderName}"
+                       VerticalAlignment="Top"/>
+        </StackPanel>
+        <Grid Grid.Row="3" Background="{x:Static SystemColors.ControlDarkBrush}" Grid.IsSharedSizeScope="True">
+            <Grid HorizontalAlignment="Right"
+                  Margin="5,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition SharedSizeGroup="SettingsButtons" />
+                    <ColumnDefinition SharedSizeGroup="SettingsButtons" />
+                </Grid.ColumnDefinitions>
+                <Button Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=OK}"
+                        Grid.Column="0"
+                        Height="20"
+                        Margin="5,0"
+                        Padding="10,0"
+                        IsEnabled="{Binding IsValidFolder}"
+                        IsDefault="True"
+                        Command="{Binding OkButtonCommand}" />
+                <Button Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=CancelButtonText}"
+                        Grid.Column="1"
+                        Height="20"
+                        Margin="5,0"
+                        Padding="10,0"
+                        IsCancel="True"
+                        Command="{Binding CancelButtonCommand}">
+                </Button>
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml
+++ b/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml
@@ -29,21 +29,21 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=RenameDialog_FolderLabel}"
-                       VerticalAlignment="Top"
+                       VerticalAlignment="Center"
                        Margin="0,0,5,0" />
             <TextBox Name="RenameFolderTextBox"
                      Grid.Column="1"
                      Style="{StaticResource TextBoxErrorStyle}"
                      Text="{Binding NewFolderName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      Height="22"
-                     VerticalAlignment="Top"
+                     VerticalAlignment="Center"
                      VerticalContentAlignment="Center"
                      HorizontalAlignment="Stretch" />
         </Grid>
         <StackPanel Grid.Row="2"
                     Margin="5,10,10,5"
                     Orientation="Horizontal">
-            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=FullNewFolderLabel}"
+            <TextBlock Text="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=RenameDialog_FullNewFolderLabel}"
                        VerticalAlignment="Top"
                        Margin="0,0,5,0" />
             <TextBlock Text="{Binding FullNewFolderName}"

--- a/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml.cs
+++ b/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System.Windows;
+using Rubberduck.Refactorings;
+
+namespace Rubberduck.UI.Refactorings.RenameFolder
+{
+    public partial class RenameFolderView : IRefactoringView<RenameFolderView>
+    {
+        public RenameFolderView()
+        {
+            InitializeComponent();
+
+            Loaded += AfterLoadHandler;
+        }
+
+        private void AfterLoadHandler(object sender, RoutedEventArgs e)
+        {
+            RenameFolderTextBox.Focus();
+            RenameFolderTextBox.SelectAll();
+            Loaded -= AfterLoadHandler;
+        }
+    }
+}

--- a/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml.cs
+++ b/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderView.xaml.cs
@@ -1,9 +1,10 @@
 ﻿using System.Windows;
 using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.RenameFolder;
 
 namespace Rubberduck.UI.Refactorings.RenameFolder
 {
-    public partial class RenameFolderView : IRefactoringView<RenameFolderView>
+    public partial class RenameFolderView : IRefactoringView<RenameFolderModel>
     {
         public RenameFolderView()
         {

--- a/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderViewModel.cs
+++ b/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderViewModel.cs
@@ -1,0 +1,131 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rubberduck.Interaction;
+using Rubberduck.JunkDrawer.Extensions;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings.RenameFolder;
+using Rubberduck.Resources;
+
+namespace Rubberduck.UI.Refactorings.RenameFolder
+{
+    public class RenameFolderViewModel : RefactoringViewModelBase<RenameFolderModel>
+    {
+        private readonly IDeclarationFinderProvider _declarationFinderProvider;
+        private readonly IMessageBox _messageBox;
+
+        public RenameFolderViewModel(RenameFolderModel model, IMessageBox messageBox, IDeclarationFinderProvider declarationFinderProvider)
+            : base(model)
+        {
+            _declarationFinderProvider = declarationFinderProvider;
+            _messageBox = messageBox;
+        }
+
+        public string Instructions
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(Model?.OriginalFolder))
+                {
+                    return string.Empty;
+                }
+
+                var folderToRename = Model.OriginalFolder;
+
+                return string.Format(
+                    RubberduckUI.RenameDialog_InstructionsLabelText,
+                    folderToRename, 
+                    RubberduckUI.RenameDialog_Folder);
+            }
+        }
+
+        public string NewFolderName
+        {
+            get => Model.NewSubFolder;
+            set
+            {
+                Model.NewSubFolder = value;
+                ValidateFolder();
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsValidFolder));
+                OnPropertyChanged(nameof(FullNewFolderName));
+            }
+        }
+
+        public string FullNewFolderName => Model.OriginalFolder.Contains(FolderExtensions.FolderDelimiter)
+            ? $"{Model.OriginalFolder.ParentFolder()}{FolderExtensions.FolderDelimiter}{NewFolderName}"
+            : NewFolderName;
+
+        private void ValidateFolder()
+        {
+            var errors = new List<string>();
+
+            if (string.IsNullOrEmpty(NewFolderName))
+            {
+                //We generally already rename a subfolder, here.
+                errors.Add(RubberduckUI.MoveFolders_EmptySubfolderName);
+            }
+            else
+            {
+                if (NewFolderName.Any(char.IsControl))
+                {
+                    errors.Add(RubberduckUI.MoveFolders_ControlCharacter);
+                }
+
+                if (NewFolderName.Split(FolderExtensions.FolderDelimiter).Any(string.IsNullOrEmpty))
+                {
+                    errors.Add(RubberduckUI.MoveFolders_EmptySubfolderName);
+                }
+            }
+
+            if (errors.Any())
+            {
+                SetErrors(nameof(NewFolderName), errors);
+            }
+            else
+            {
+                ClearErrors();
+            }
+        }
+
+        public bool IsValidFolder => Model?.ModulesToMove != null
+                                     && Model.ModulesToMove.Any()
+                                     && !HasErrors;
+
+        protected override void DialogOk()
+        {
+            if (Model?.ModulesToMove == null
+                || !Model.ModulesToMove.Any()
+                || !Model.SubFolderToRename.Equals(Model.NewSubFolder)
+                    && FolderAlreadyExists(FullNewFolderName)
+                    && !UserConfirmsToProceedWithFolderMerge(FullNewFolderName, Model.SubFolderToRename, NewFolderName))
+            {
+                base.DialogCancel();
+            }
+            else
+            {
+                base.DialogOk();
+            }
+        }
+
+        private bool FolderAlreadyExists(string fullFolderName)
+        {
+            return _declarationFinderProvider.DeclarationFinder
+                .UserDeclarations(DeclarationType.Module)
+                .OfType<ModuleDeclaration>()
+                .Select(module => module.CustomFolder)
+                .Any(folder => folder.Equals(fullFolderName) 
+                               || folder.IsSubFolderOf(fullFolderName));
+        }
+
+        private bool UserConfirmsToProceedWithFolderMerge(string fullTargetFolder, string partToRename, string newFolderPart)
+        {
+            var message = string.Format(
+                RubberduckUI.RenameDialog_FolderAlreadyExists,
+                fullTargetFolder,
+                partToRename,
+                newFolderPart);
+            return _messageBox?.ConfirmYesNo(message, RubberduckUI.RenameDialog_Caption) ?? false;
+        }
+    }
+}

--- a/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderViewModel.cs
+++ b/Rubberduck.Core/UI/Refactorings/RenameFolder/RenameFolderViewModel.cs
@@ -34,8 +34,8 @@ namespace Rubberduck.UI.Refactorings.RenameFolder
 
                 return string.Format(
                     RubberduckUI.RenameDialog_InstructionsLabelText,
-                    folderToRename, 
-                    RubberduckUI.RenameDialog_Folder);
+                    RubberduckUI.RenameDialog_Folder,
+                    folderToRename);
             }
         }
 

--- a/Rubberduck.Refactorings/ChangeFolder/ChangeFolderModel.cs
+++ b/Rubberduck.Refactorings/ChangeFolder/ChangeFolderModel.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Rubberduck.Parsing.Symbols;
+
+namespace Rubberduck.Refactorings.ChangeFolder
+{
+    public class ChangeFolderModel : IRefactoringModel
+    {
+        public string OriginalFolder { get; }
+        public ICollection<ModuleDeclaration> ModulesToMove { get; }
+        public string NewFolder { get; set; }
+
+        public ChangeFolderModel(string originalFolder, ICollection<ModuleDeclaration> modulesToMove, string newFolder)
+        {
+            OriginalFolder = originalFolder;
+            ModulesToMove = modulesToMove;
+            NewFolder = newFolder;
+        }
+    }
+}

--- a/Rubberduck.Refactorings/ChangeFolder/ChangeFolderRefactoringAction.cs
+++ b/Rubberduck.Refactorings/ChangeFolder/ChangeFolderRefactoringAction.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using Rubberduck.JunkDrawer.Extensions;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Refactorings.MoveToFolder;
+
+namespace Rubberduck.Refactorings.ChangeFolder
+{
+    public class ChangeFolderRefactoringAction : CodeOnlyRefactoringActionBase<ChangeFolderModel>
+    {
+        private readonly ICodeOnlyRefactoringAction<MoveToFolderModel> _moveToFolder;
+
+        public ChangeFolderRefactoringAction(
+            IRewritingManager rewritingManager,
+            MoveToFolderRefactoringAction moveToFolder)
+            : base(rewritingManager)
+        {
+            _moveToFolder = moveToFolder;
+        }
+
+        public override void Refactor(ChangeFolderModel model, IRewriteSession rewriteSession)
+        {
+            var originalFolder = model.OriginalFolder;
+
+            foreach (var module in model.ModulesToMove.Distinct())
+            {
+                var currentFolder = module.CustomFolder;
+
+                if (!currentFolder.StartsWith(originalFolder))
+                {
+                    continue;
+                }
+                
+                var newFolder = currentFolder.Equals(originalFolder)
+                    ? model.NewFolder
+                    : $"{model.NewFolder}{FolderExtensions.FolderDelimiter}{currentFolder.SubFolderPathRelativeTo(model.OriginalFolder)}";
+
+                var moduleModel = new MoveToFolderModel(module, newFolder);
+                _moveToFolder.Refactor(moduleModel, rewriteSession);
+            }
+        }
+    }
+}

--- a/Rubberduck.Refactorings/MoveFolder/MoveFolderModel.cs
+++ b/Rubberduck.Refactorings/MoveFolder/MoveFolderModel.cs
@@ -5,14 +5,14 @@ namespace Rubberduck.Refactorings.MoveFolder
 {
     public class MoveFolderModel : IRefactoringModel
     {
-        public string SourceFolder { get; }
-        public ICollection<ModuleDeclaration> ContainedModules { get; }
+        public string FolderToMove { get; }
+        public ICollection<ModuleDeclaration> ModulesToMove { get; }
         public string TargetFolder { get; set; }
 
-        public MoveFolderModel(string sourceFolder, ICollection<ModuleDeclaration> containedModules, string targetFolder)
+        public MoveFolderModel(string folderToMove, ICollection<ModuleDeclaration> modulesToMove, string targetFolder)
         {
-            SourceFolder = sourceFolder;
-            ContainedModules = containedModules;
+            FolderToMove = folderToMove;
+            ModulesToMove = modulesToMove;
             TargetFolder = targetFolder;
         }
     }

--- a/Rubberduck.Refactorings/MoveFolder/MoveFolderRefactoringAction.cs
+++ b/Rubberduck.Refactorings/MoveFolder/MoveFolderRefactoringAction.cs
@@ -1,34 +1,26 @@
-﻿using System.Linq;
-using Rubberduck.JunkDrawer.Extensions;
+﻿using Rubberduck.JunkDrawer.Extensions;
 using Rubberduck.Parsing.Rewriter;
-using Rubberduck.Refactorings.MoveToFolder;
+using Rubberduck.Refactorings.ChangeFolder;
 
 namespace Rubberduck.Refactorings.MoveFolder
 {
     public class MoveFolderRefactoringAction : CodeOnlyRefactoringActionBase<MoveFolderModel>
     {
-        private readonly ICodeOnlyRefactoringAction<MoveToFolderModel> _moveToFolder;
+        private readonly ICodeOnlyRefactoringAction<ChangeFolderModel> _changeFolder;
 
         public MoveFolderRefactoringAction(
             IRewritingManager rewritingManager,
-            MoveToFolderRefactoringAction moveToFolder)
+            ChangeFolderRefactoringAction changeFolder)
             : base(rewritingManager)
         {
-            _moveToFolder = moveToFolder;
+            _changeFolder = changeFolder;
         }
 
         public override void Refactor(MoveFolderModel model, IRewriteSession rewriteSession)
         {
-            var sourceFolderParent = model.SourceFolder.ParentFolder();
-
-            foreach (var module in model.ContainedModules.Distinct())
-            {
-                var currentFolder = module.CustomFolder;
-                var subPath = currentFolder.SubFolderPathRelativeTo(sourceFolderParent);
-                var newFolder = $"{model.TargetFolder}{FolderExtensions.FolderDelimiter}{subPath}";
-                var moduleModel = new MoveToFolderModel(module, newFolder);
-                _moveToFolder.Refactor(moduleModel, rewriteSession);
-            }
+            var sourceFolderParent = model.FolderToMove.ParentFolder();
+            var changeFolderModel = new ChangeFolderModel(sourceFolderParent, model.ModulesToMove, model.TargetFolder);
+            _changeFolder.Refactor(changeFolderModel, rewriteSession);
         }
     }
 }

--- a/Rubberduck.Refactorings/RenameFolder/IRenameFolderPresenter.cs
+++ b/Rubberduck.Refactorings/RenameFolder/IRenameFolderPresenter.cs
@@ -1,0 +1,5 @@
+﻿namespace Rubberduck.Refactorings.RenameFolder
+{
+    public interface IRenameFolderPresenter : IRefactoringPresenter<RenameFolderModel>
+    { }
+}

--- a/Rubberduck.Refactorings/RenameFolder/RenameFolderModel.cs
+++ b/Rubberduck.Refactorings/RenameFolder/RenameFolderModel.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Rubberduck.JunkDrawer.Extensions;
+using Rubberduck.Parsing.Symbols;
+
+namespace Rubberduck.Refactorings.RenameFolder
+{
+    public class RenameFolderModel : IRefactoringModel
+    {
+        public string OriginalFolder { get; }
+        public ICollection<ModuleDeclaration> ModulesToMove { get; }
+        public string NewSubFolder { get; set; }
+
+        public RenameFolderModel(string originalFolder, ICollection<ModuleDeclaration> modulesToMove, string newSubFolder)
+        {
+            OriginalFolder = originalFolder;
+            ModulesToMove = modulesToMove;
+            NewSubFolder = newSubFolder;
+        }
+
+        public string SubFolderToRename => OriginalFolder.SubFolderName();
+    }
+}

--- a/Rubberduck.Refactorings/RenameFolder/RenameFolderRefactoringAction.cs
+++ b/Rubberduck.Refactorings/RenameFolder/RenameFolderRefactoringAction.cs
@@ -1,0 +1,30 @@
+﻿using Rubberduck.JunkDrawer.Extensions;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Refactorings.ChangeFolder;
+
+namespace Rubberduck.Refactorings.RenameFolder
+{
+    public class RenameFolderRefactoringAction : CodeOnlyRefactoringActionBase<RenameFolderModel>
+    {
+        private readonly ICodeOnlyRefactoringAction<ChangeFolderModel> _changeFolder;
+
+        public RenameFolderRefactoringAction(
+            IRewritingManager rewritingManager,
+            ChangeFolderRefactoringAction changeFolder)
+            : base(rewritingManager)
+        {
+            _changeFolder = changeFolder;
+        }
+
+        public override void Refactor(RenameFolderModel model, IRewriteSession rewriteSession)
+        {
+            var sourceFolderParent = model.OriginalFolder.ParentFolder();
+            var targetFolder = string.IsNullOrEmpty(sourceFolderParent)
+                ? model.NewSubFolder
+                : $"{sourceFolderParent}{FolderExtensions.FolderDelimiter}{model.NewSubFolder}";
+
+            var changeFolderModel = new ChangeFolderModel(model.OriginalFolder, model.ModulesToMove, targetFolder);
+            _changeFolder.Refactor(changeFolderModel, rewriteSession);
+        }
+    }
+}

--- a/Rubberduck.Resources/RubberduckUI.Designer.cs
+++ b/Rubberduck.Resources/RubberduckUI.Designer.cs
@@ -2973,7 +2973,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is defined neither in the component component it is used nor in a standard module. .
+        ///   Looks up a localized string similar to &apos;{0}&apos; is defined neither in the component component it is used nor in a standard module..
         /// </summary>
         public static string MoveCloserToUsageFailure_TargetIsInOtherNonStandardModule {
             get {
@@ -4375,6 +4375,43 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to folder.
+        /// </summary>
+        public static string RenameDialog_Folder {
+            get {
+                return ResourceManager.GetString("RenameDialog_Folder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The folder &apos;{0}&apos; already exists. Renaming &apos;{1}&apos; to &apos;{2}&apos; will lead to a merge with the existing folder.
+        ///Do you want to proceed?.
+        /// </summary>
+        public static string RenameDialog_FolderAlreadyExists {
+            get {
+                return ResourceManager.GetString("RenameDialog_FolderAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folder:.
+        /// </summary>
+        public static string RenameDialog_FolderLabel {
+            get {
+                return ResourceManager.GetString("RenameDialog_FolderLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Full new folder:.
+        /// </summary>
+        public static string RenameDialog_FullNewFolderLabel {
+            get {
+                return ResourceManager.GetString("RenameDialog_FullNewFolderLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please specify new name for {0} &apos;{1}&apos;..
         /// </summary>
         public static string RenameDialog_InstructionsLabelText {
@@ -4407,6 +4444,15 @@ namespace Rubberduck.Resources {
         public static string RenameDialog_TitleText {
             get {
                 return ResourceManager.GetString("RenameDialog_TitleText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename folder.
+        /// </summary>
+        public static string RenameDialog_TitleText_Folder {
+            get {
+                return ResourceManager.GetString("RenameDialog_TitleText_Folder", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/RubberduckUI.de.resx
+++ b/Rubberduck.Resources/RubberduckUI.de.resx
@@ -1706,4 +1706,20 @@ Wollen Sie fortfahren?</value>
   <data name="MoveFolders_EmptySubfolderName" xml:space="preserve">
     <value>Die Namen individueller Unterordner dürfen nicht leer sein.</value>
   </data>
+  <data name="RenameDialog_Folder" xml:space="preserve">
+    <value>Ordner</value>
+  </data>
+  <data name="RenameDialog_FolderAlreadyExists" xml:space="preserve">
+    <value>Der Ordner '{0}' existiert bereits. '{1}' in '{2}. umzubenennen wird die Ordner verschmelzen.
+Wollen Sie fortfahren?</value>
+  </data>
+  <data name="RenameDialog_FolderLabel" xml:space="preserve">
+    <value>Ordner:</value>
+  </data>
+  <data name="RenameDialog_FullNewFolderLabel" xml:space="preserve">
+    <value>Kompletter Ordnername:</value>
+  </data>
+  <data name="RenameDialog_TitleText_Folder" xml:space="preserve">
+    <value>Ordner umbenennen</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.resx
+++ b/Rubberduck.Resources/RubberduckUI.resx
@@ -1496,7 +1496,7 @@ NOTE: Restart is required for the setting to take effect.</value>
     <comment>{0}: Variable Name</comment>
   </data>
   <data name="MoveCloserToUsageFailure_TargetIsInOtherNonStandardModule" xml:space="preserve">
-    <value>'{0}' is defined neither in the component component it is used nor in a standard module. </value>
+    <value>'{0}' is defined neither in the component component it is used nor in a standard module.</value>
     <comment>{0}: Variable Name</comment>
   </data>
   <data name="MoveCloserToUsageFailure_TargetIsNonPrivateInNonStandardModule" xml:space="preserve">
@@ -1922,5 +1922,22 @@ Do you want to proceed?</value>
   </data>
   <data name="MoveFolders_EmptySubfolderName" xml:space="preserve">
     <value>The names of individual subfolders cannot be empty.</value>
+  </data>
+  <data name="RenameDialog_Folder" xml:space="preserve">
+    <value>folder</value>
+  </data>
+  <data name="RenameDialog_FolderAlreadyExists" xml:space="preserve">
+    <value>The folder '{0}' already exists. Renaming '{1}' to '{2}' will lead to a merge with the existing folder.
+Do you want to proceed?</value>
+    <comment>{0} new full folder name; {1} folder part to rename; {2} new folder part name</comment>
+  </data>
+  <data name="RenameDialog_FolderLabel" xml:space="preserve">
+    <value>Folder:</value>
+  </data>
+  <data name="RenameDialog_FullNewFolderLabel" xml:space="preserve">
+    <value>Full new folder:</value>
+  </data>
+  <data name="RenameDialog_TitleText_Folder" xml:space="preserve">
+    <value>Rename folder</value>
   </data>
 </root>

--- a/RubberduckTests/Commands/RefactorCommands/CodePaneMoveContainingFolderCommandTests.cs
+++ b/RubberduckTests/Commands/RefactorCommands/CodePaneMoveContainingFolderCommandTests.cs
@@ -6,6 +6,7 @@ using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.UIContext;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.ChangeFolder;
 using Rubberduck.Refactorings.MoveFolder;
 using Rubberduck.Refactorings.MoveToFolder;
 using Rubberduck.UI.Command;
@@ -40,7 +41,8 @@ namespace RubberduckTests.Commands.RefactorCommands
 
             var annotationUpdater = new AnnotationUpdater();
             var moveToFolderAction = new MoveToFolderRefactoringAction(rewritingManager, annotationUpdater);
-            var moveFolderAction = new MoveFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            var changeFolderAction = new ChangeFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            var moveFolderAction = new MoveFolderRefactoringAction(rewritingManager, changeFolderAction);
             var moveMultipleFoldersAction = new MoveMultipleFoldersRefactoringAction(rewritingManager, moveFolderAction);
 
             var selectedDeclarationProvider = new SelectedDeclarationProvider(selectionService, state);

--- a/RubberduckTests/Refactoring/ChangeFolder/ChangeFolderRefactoringActionTests.cs
+++ b/RubberduckTests/Refactoring/ChangeFolder/ChangeFolderRefactoringActionTests.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.ChangeFolder;
+using Rubberduck.Refactorings.MoveToFolder;
+using Rubberduck.VBEditor.SafeComWrappers;
+
+namespace RubberduckTests.Refactoring.ChangeFolder
+{
+    [TestFixture]
+    public class ChangeFolderRefactoringActionTests : RefactoringActionTestBase<ChangeFolderModel>
+    {
+        [Test]
+        [Category("Refactorings")]
+        public void ChangeFolderRefactoringAction_TopLevelFolder()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = @"
+'@Folder ""MyNewFolder.MySubFolder""
+Public Sub Foo()
+End Sub
+";
+            Func<RubberduckParserState, ChangeFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new ChangeFolderModel("MyOldFolder", new List<ModuleDeclaration> { module }, "MyNewFolder.MySubFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void ChangeFolderRefactoringAction_SubFolder()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder.MyOldSubFolder.SubSub"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = @"
+'@Folder ""MyNewFolder""
+Public Sub Foo()
+End Sub
+";
+            Func<RubberduckParserState, ChangeFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new ChangeFolderModel("MyOldFolder.MyOldSubFolder.SubSub", new List<ModuleDeclaration> { module }, "MyNewFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void ChangeFolderRefactoringAction_PreservesSubFolderStructure()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder.MyOldSubFolder.SubSub.Sub"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = @"
+'@Folder ""MyNewFolder.MySubFolder.SubSub.Sub""
+Public Sub Foo()
+End Sub
+";
+            Func<RubberduckParserState, ChangeFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new ChangeFolderModel("MyOldFolder.MyOldSubFolder", new List<ModuleDeclaration> { module }, "MyNewFolder.MySubFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void ChangeFolderRefactoringAction_NotInFolder_DoesNothing()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder.MyOldSubFolder.SubSub.Sub"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = code;
+
+            Func<RubberduckParserState, ChangeFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new ChangeFolderModel("NotMyOldFolder.MyOldSubFolder", new List<ModuleDeclaration> { module }, "MyNewFolder.MySubFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void ChangeFolderRefactoringAction_ChangesExactlyTheSpecifiedModules()
+        {
+            const string code1 = @"
+'@Folder(""MyOldFolder.MyOldSubfolder.SubSub"")
+Public Sub Foo()
+End Sub
+";
+            const string code2 = @"
+'@Folder(""MyOldFolder.MyOldSubfolder"")
+Public Sub Foo()
+End Sub
+";
+            const string code3 = @"
+'@Folder(""MyOtherFolder.MyOldSubfolder"")
+Public Sub Foo()
+End Sub
+";
+            const string code4 = @"
+'@Folder(""MyOtherFolder.MyOtherSubfolder"")
+Public Sub Foo()
+End Sub
+";
+            const string code5 = @"
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode1 = @"
+'@Folder ""MyNewFolder.SubSub""
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode2 = @"
+'@Folder ""MyNewFolder""
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode3 = code3;
+            const string expectedCode4 = code4;
+            const string expectedCode5 = code5;
+            Func<RubberduckParserState, ChangeFolderModel> modelBuilder = (state) =>
+            {
+                var modules = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Module)
+                    .OfType<ModuleDeclaration>()
+                    .ToList();
+
+                var module1 = modules.Single(module => module.IdentifierName.Equals("SubSubFolderModule"));
+                var module2 = modules.Single(module => module.IdentifierName.Equals("SubFolderModuleIncluded"));
+                const string originalFolder = "MyOldFolder.MyOldSubfolder";
+                
+                return new ChangeFolderModel(originalFolder, new List<ModuleDeclaration>{module1, module2}, "MyNewFolder");
+            };
+
+            var refactoredCode = RefactoredCode(
+                    modelBuilder,
+                ("SubSubFolderModule", code1, ComponentType.StandardModule),
+                    ("SubFolderModuleIncluded", code2, ComponentType.ClassModule),
+                    ("SubFolderModuleNotIncluded", code3, ComponentType.ClassModule),
+                    ("UnaffectedSubFolderModule", code4, ComponentType.StandardModule),
+                    ("NoFolderModule", code5, ComponentType.StandardModule));
+
+            Assert.AreEqual(expectedCode1, refactoredCode["SubSubFolderModule"]);
+            Assert.AreEqual(expectedCode2, refactoredCode["SubFolderModuleIncluded"]);
+            Assert.AreEqual(expectedCode3, refactoredCode["SubFolderModuleNotIncluded"]);
+            Assert.AreEqual(expectedCode4, refactoredCode["UnaffectedSubFolderModule"]);
+            Assert.AreEqual(expectedCode5, refactoredCode["NoFolderModule"]);
+        }
+
+        protected override IRefactoringAction<ChangeFolderModel> TestBaseRefactoring(RubberduckParserState state, IRewritingManager rewritingManager)
+        {
+            var annotationUpdater = new AnnotationUpdater();
+            var moveToFolderAction = new MoveToFolderRefactoringAction(rewritingManager, annotationUpdater);
+            return new ChangeFolderRefactoringAction(rewritingManager, moveToFolderAction);
+        }
+    }
+}

--- a/RubberduckTests/Refactoring/MoveFolders/MoveContainingFolderRefactoringTests.cs
+++ b/RubberduckTests/Refactoring/MoveFolders/MoveContainingFolderRefactoringTests.cs
@@ -7,6 +7,7 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.UIContext;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.ChangeFolder;
 using Rubberduck.Refactorings.MoveFolder;
 using Rubberduck.Refactorings.MoveToFolder;
 using Rubberduck.VBEditor.SafeComWrappers;
@@ -369,7 +370,8 @@ End Sub
         {
             var annotationUpdater = new AnnotationUpdater();
             var moveToFolderAction = new MoveToFolderRefactoringAction(rewritingManager, annotationUpdater);
-            var moveFolderAction = new MoveFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            var changeFolderAction = new ChangeFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            var moveFolderAction = new MoveFolderRefactoringAction(rewritingManager, changeFolderAction);
             var moveMultipleFoldersAction = new MoveMultipleFoldersRefactoringAction(rewritingManager, moveFolderAction);
 
             var selectedDeclarationProvider = new SelectedDeclarationProvider(selectionService, state);

--- a/RubberduckTests/Refactoring/MoveFolders/MoveFolderRefactoringActionTests.cs
+++ b/RubberduckTests/Refactoring/MoveFolders/MoveFolderRefactoringActionTests.cs
@@ -6,6 +6,7 @@ using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.ChangeFolder;
 using Rubberduck.Refactorings.MoveFolder;
 using Rubberduck.Refactorings.MoveToFolder;
 using Rubberduck.VBEditor.SafeComWrappers;
@@ -198,7 +199,8 @@ End Sub
         {
             var annotationUpdater = new AnnotationUpdater();
             var moveToFolderAction = new MoveToFolderRefactoringAction(rewritingManager, annotationUpdater);
-            return new MoveFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            var changeFolderAction = new ChangeFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            return new MoveFolderRefactoringAction(rewritingManager, changeFolderAction);
         }
     }
 }

--- a/RubberduckTests/Refactoring/MoveFolders/MoveMultipleFoldersViewModelTests.cs
+++ b/RubberduckTests/Refactoring/MoveFolders/MoveMultipleFoldersViewModelTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using Castle.Core.Smtp;
 using Moq;
 using NUnit.Framework;
 using Rubberduck.Interaction;

--- a/RubberduckTests/Refactoring/MoveFolders/MoveMultipleToFolderRefactoringActionTests.cs
+++ b/RubberduckTests/Refactoring/MoveFolders/MoveMultipleToFolderRefactoringActionTests.cs
@@ -7,6 +7,7 @@ using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.ChangeFolder;
 using Rubberduck.Refactorings.MoveFolder;
 using Rubberduck.Refactorings.MoveToFolder;
 using Rubberduck.VBEditor.SafeComWrappers;
@@ -106,7 +107,8 @@ End Sub
         {
             var annotationUpdater = new AnnotationUpdater();
             var moveToFolderAction = new MoveToFolderRefactoringAction(rewritingManager, annotationUpdater);
-            var moveFolderAction = new MoveFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            var changeFolderAction = new ChangeFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            var moveFolderAction = new MoveFolderRefactoringAction(rewritingManager, changeFolderAction);
             return new MoveMultipleFoldersRefactoringAction(rewritingManager, moveFolderAction);
         }
     }

--- a/RubberduckTests/Refactoring/MoveToFolder/MoveMultipleToFolderViewModelTests.cs
+++ b/RubberduckTests/Refactoring/MoveToFolder/MoveMultipleToFolderViewModelTests.cs
@@ -155,6 +155,5 @@ namespace RubberduckTests.Refactoring.MoveToFolder
                 .Build()
                 .Object;
         }
-
     }
 }

--- a/RubberduckTests/Refactoring/RenameFolder/RenameFolderRefactoringActionTests.cs
+++ b/RubberduckTests/Refactoring/RenameFolder/RenameFolderRefactoringActionTests.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.ChangeFolder;
+using Rubberduck.Refactorings.MoveToFolder;
+using Rubberduck.Refactorings.RenameFolder;
+using Rubberduck.VBEditor.SafeComWrappers;
+
+namespace RubberduckTests.Refactoring.RenameFolder
+{
+    [TestFixture]
+    public class RenameFolderRefactoringActionTests : RefactoringActionTestBase<RenameFolderModel>
+    {
+        [Test]
+        [Category("Refactorings")]
+        public void RenameFolderRefactoringAction_TopLevelFolder()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = @"
+'@Folder ""MyNewFolder.MySubFolder""
+Public Sub Foo()
+End Sub
+";
+            Func<RubberduckParserState, RenameFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new RenameFolderModel("MyOldFolder", new List<ModuleDeclaration> { module }, "MyNewFolder.MySubFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void RenameFolderRefactoringAction_SubFolder()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder.MyOldSubFolder.SubSub"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = @"
+'@Folder ""MyOldFolder.MyOldSubFolder.MyNewFolder""
+Public Sub Foo()
+End Sub
+";
+            Func<RubberduckParserState, RenameFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new RenameFolderModel("MyOldFolder.MyOldSubFolder.SubSub", new List<ModuleDeclaration> { module }, "MyNewFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void RenameFolderRefactoringAction_PreservesSubFolderStructure()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder.MyOldSubFolder.SubSub.Sub"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = @"
+'@Folder ""MyOldFolder.MyNewFolder.MySubFolder.SubSub.Sub""
+Public Sub Foo()
+End Sub
+";
+            Func<RubberduckParserState, RenameFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new RenameFolderModel("MyOldFolder.MyOldSubFolder", new List<ModuleDeclaration> { module }, "MyNewFolder.MySubFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void RenameFolderRefactoringAction_NotInFolder_DoesNothing()
+        {
+            const string code = @"
+'@Folder(""MyOldFolder.MyOldSubFolder.SubSub.Sub"")
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode = code;
+
+            Func<RubberduckParserState, RenameFolderModel> modelBuilder = (state) =>
+            {
+                var module = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.ProceduralModule)
+                    .Single() as ModuleDeclaration;
+                return new RenameFolderModel("NotMyOldFolder.MyOldSubFolder", new List<ModuleDeclaration> { module }, "MyNewFolder.MySubFolder");
+            };
+
+            var refactoredCode = RefactoredCode(code, modelBuilder);
+
+            Assert.AreEqual(expectedCode, refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void RenameFolderRefactoringAction_ChangesExactlyTheSpecifiedModules()
+        {
+            const string code1 = @"
+'@Folder(""MyOldFolder.MyOldSubfolder.SubSub"")
+Public Sub Foo()
+End Sub
+";
+            const string code2 = @"
+'@Folder(""MyOldFolder.MyOldSubfolder"")
+Public Sub Foo()
+End Sub
+";
+            const string code3 = @"
+'@Folder(""MyOtherFolder.MyOldSubfolder"")
+Public Sub Foo()
+End Sub
+";
+            const string code4 = @"
+'@Folder(""MyOtherFolder.MyOtherSubfolder"")
+Public Sub Foo()
+End Sub
+";
+            const string code5 = @"
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode1 = @"
+'@Folder ""MyOldFolder.MyNewFolder.SubSub""
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode2 = @"
+'@Folder ""MyOldFolder.MyNewFolder""
+Public Sub Foo()
+End Sub
+";
+            const string expectedCode3 = code3;
+            const string expectedCode4 = code4;
+            const string expectedCode5 = code5;
+            Func<RubberduckParserState, RenameFolderModel> modelBuilder = (state) =>
+            {
+                var modules = state.DeclarationFinder
+                    .UserDeclarations(DeclarationType.Module)
+                    .OfType<ModuleDeclaration>()
+                    .ToList();
+
+                var module1 = modules.Single(module => module.IdentifierName.Equals("SubSubFolderModule"));
+                var module2 = modules.Single(module => module.IdentifierName.Equals("SubFolderModuleIncluded"));
+                const string originalFolder = "MyOldFolder.MyOldSubfolder";
+
+                return new RenameFolderModel(originalFolder, new List<ModuleDeclaration> { module1, module2 }, "MyNewFolder");
+            };
+
+            var refactoredCode = RefactoredCode(
+                    modelBuilder,
+                ("SubSubFolderModule", code1, ComponentType.StandardModule),
+                    ("SubFolderModuleIncluded", code2, ComponentType.ClassModule),
+                    ("SubFolderModuleNotIncluded", code3, ComponentType.ClassModule),
+                    ("UnaffectedSubFolderModule", code4, ComponentType.StandardModule),
+                    ("NoFolderModule", code5, ComponentType.StandardModule));
+
+            Assert.AreEqual(expectedCode1, refactoredCode["SubSubFolderModule"]);
+            Assert.AreEqual(expectedCode2, refactoredCode["SubFolderModuleIncluded"]);
+            Assert.AreEqual(expectedCode3, refactoredCode["SubFolderModuleNotIncluded"]);
+            Assert.AreEqual(expectedCode4, refactoredCode["UnaffectedSubFolderModule"]);
+            Assert.AreEqual(expectedCode5, refactoredCode["NoFolderModule"]);
+        }
+
+        protected override IRefactoringAction<RenameFolderModel> TestBaseRefactoring(RubberduckParserState state, IRewritingManager rewritingManager)
+        {
+            var annotationUpdater = new AnnotationUpdater();
+            var moveToFolderAction = new MoveToFolderRefactoringAction(rewritingManager, annotationUpdater);
+            var changeFolderAction = new ChangeFolderRefactoringAction(rewritingManager, moveToFolderAction);
+            return new RenameFolderRefactoringAction(rewritingManager, changeFolderAction);
+        }
+    }
+}

--- a/RubberduckTests/Refactoring/RenameFolder/RenameFolderViewModelTests.cs
+++ b/RubberduckTests/Refactoring/RenameFolder/RenameFolderViewModelTests.cs
@@ -1,0 +1,229 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NUnit.Framework;
+using Rubberduck.Interaction;
+using Rubberduck.JunkDrawer.Extensions;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.Refactorings;
+using Rubberduck.Refactorings.MoveFolder;
+using Rubberduck.Refactorings.MoveToFolder;
+using Rubberduck.Refactorings.RenameFolder;
+using Rubberduck.UI.Refactorings.MoveFolder;
+using Rubberduck.UI.Refactorings.MoveToFolder;
+using Rubberduck.UI.Refactorings.RenameFolder;
+using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Refactoring.RenameFolder
+{
+    [TestFixture]
+    public class RenameFolderViewModelTests
+    {
+        [Test]
+        [Category("Refactorings")]
+        public void InitialNewFolderNameIsNewSubFolderNameFromModel()
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo", state.DeclarationFinder);
+
+                var initialNewSubfolderName = model.NewSubFolder;
+                var messageBox = MessageBoxMock(new List<bool>()).Object;
+                var viewModel = TestViewModel(model, state, messageBox);
+
+                Assert.AreEqual(initialNewSubfolderName, viewModel.NewFolderName);
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void UpdatingNewFolderUpdatesModel()
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo", state.DeclarationFinder);
+                var messageBox = MessageBoxMock(new List<bool>()).Object;
+                var viewModel = TestViewModel(model, state, messageBox);
+
+                const string newSubFolder = "Test.Test.Test";
+                viewModel.NewFolderName = newSubFolder;
+
+                Assert.AreEqual(newSubFolder, model.NewSubFolder);
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [TestCase(null)]
+        [TestCase("")]
+        public void EmptyTargetFolder_Error(string emptyFolderName)
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo", state.DeclarationFinder);
+                var messageBox = MessageBoxMock(new List<bool>()).Object;
+                var viewModel = TestViewModel(model, state, messageBox);
+
+                viewModel.NewFolderName = emptyFolderName;
+
+                Assert.IsTrue(viewModel.HasErrors);
+                Assert.IsFalse(viewModel.IsValidFolder);
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [TestCase("raeraf afrwefe \n fefaef")]
+        [TestCase("raeraf afrwefe \r fefaef")]
+        [TestCase("raeraf afrwefe \u0000 fefaef")]
+        public void TargetFolderWithControlCharacter_Error(string folderName)
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo", state.DeclarationFinder);
+                var messageBox = MessageBoxMock(new List<bool>()).Object;
+                var viewModel = TestViewModel(model, state, messageBox);
+
+                viewModel.NewFolderName = folderName;
+
+                Assert.IsTrue(viewModel.HasErrors);
+                Assert.IsFalse(viewModel.IsValidFolder);
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [TestCase(".SomeFolder.SomeOtherFolder")]
+        [TestCase("SomeFolder..SomeOtherFolder")]
+        [TestCase("SomeFolder.SomeOtherFolder.")]
+        public void TargetFolderWithEmptyIndividualFolder_Error(string folderName)
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo", state.DeclarationFinder);
+                var messageBox = MessageBoxMock(new List<bool>()).Object;
+                var viewModel = TestViewModel(model, state, messageBox);
+
+                viewModel.NewFolderName = folderName;
+
+                Assert.IsTrue(viewModel.HasErrors);
+                Assert.IsFalse(viewModel.IsValidFolder);
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void NonEmptyTargetFolderWithoutControlCharacter_NoError()
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo", state.DeclarationFinder);
+                var messageBox = MessageBoxMock(new List<bool>()).Object;
+                var viewModel = TestViewModel(model, state, messageBox);
+
+                viewModel.NewFolderName = ";oehaha .adaiafa.a@#$^%&#@$&%%$%^$.ad3.1010101.  ## . @.{ ]. rqrq";
+
+                Assert.IsFalse(viewModel.HasErrors);
+                Assert.IsTrue(viewModel.IsValidFolder);
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        public void FolderAlreadyExists_AsksForConfirmation()
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo.Barr", state.DeclarationFinder);
+                var messageBoxMock = MessageBoxMock(new List<bool>());
+                var viewModel = TestViewModel(model, state, messageBoxMock.Object);
+
+                viewModel.NewFolderName = "Barz";
+
+                viewModel.OkButtonCommand.Execute(null);
+
+                messageBoxMock.Verify(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), true), Times.Once);
+            }
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [TestCase(true, RefactoringDialogResult.Execute)]
+        [TestCase(false, RefactoringDialogResult.Cancel)]
+        public void FolderAlreadyExists_ResultBasedOnConfirmation(bool confirms, RefactoringDialogResult expectedResult)
+        {
+            using (var state = MockParser.CreateAndParse(TestVbe()))
+            {
+                var model = TestModel("FooBar.Foo.Barr", state.DeclarationFinder);
+                var messageBoxMock = MessageBoxMock(new List<bool>{ confirms });
+                var viewModel = TestViewModel(model, state, messageBoxMock.Object);
+
+                viewModel.NewFolderName = "Barz";
+
+                var executionResults = new List<RefactoringDialogResult>();
+                void DialogEventCloseHandler(object sender, RefactoringDialogResult result) => executionResults.Add(result);
+
+                viewModel.OnWindowClosed += DialogEventCloseHandler;
+                viewModel.OkButtonCommand.Execute(null);
+                viewModel.OnWindowClosed -= DialogEventCloseHandler;
+
+                var actualResult = executionResults.Single();
+
+                Assert.AreEqual(expectedResult, actualResult);
+            }
+        }
+
+        private Mock<IMessageBox> MessageBoxMock(IList<bool> confirmsRequest)
+        {
+            var requestCounter = 0;
+            var messageBox = new Mock<IMessageBox>();
+            messageBox.Setup(m => m.ConfirmYesNo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns<string, string, bool>((message, caption, suggestion) => requestCounter < confirmsRequest.Count
+                                                                                 && confirmsRequest[requestCounter++]);
+            return messageBox;
+        }
+
+        private RenameFolderViewModel TestViewModel(RenameFolderModel model, IDeclarationFinderProvider declarationFinderProvider, IMessageBox messageBox)
+        {
+            return new RenameFolderViewModel(model, messageBox, declarationFinderProvider);
+        }
+
+        private RenameFolderModel TestModel(string sourceFolder, DeclarationFinder finder)
+        {
+            var modulesToMove = finder.UserDeclarations(DeclarationType.Module)
+                .OfType<ModuleDeclaration>()
+                .Where(module => module.CustomFolder.Equals(sourceFolder)
+                                 || module.CustomFolder.IsSubFolderOf(sourceFolder))
+                .ToList();
+
+            var initialTarget = sourceFolder.SubFolderName();
+
+            return new RenameFolderModel(sourceFolder, modulesToMove, initialTarget);
+        }
+
+        private IVBE TestVbe()
+        {
+            const string targetFolderComponentCode = @"
+'@Folder ""Test.Foo.Bar.Test.Baz""";
+
+            const string component1Code = @"
+'@Folder ""FooBar.Foo.Barr.Foo.Test""";
+
+            const string component2Code = @"
+'@Folder ""FooBar.Foo.Barz.Test.Foo""";
+
+            return new MockVbeBuilder()
+                .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
+                .AddComponent("TargetFolderComponent", ComponentType.ClassModule, targetFolderComponentCode)
+                .AddComponent("Component1", ComponentType.ClassModule, component1Code)
+                .AddComponent("Component2", ComponentType.ClassModule, component2Code)
+                .AddProjectToVbeBuilder()
+                .Build()
+                .Object;
+        }
+    }
+}


### PR DESCRIPTION
Closes #3745

This PR introduces the `RenameFolderRefactoringAction`, which allows to rename the final subfolder part of a given folder. It then replaces this part and retains both the parent folder and the subfolder structure---you can introduce intermediate folders, though. This is used to add a new `RenameFolderCommand` for the CE, which is now integrated into the `RenameCommand` to allow folder renames in the CE.

![RenameFolder](https://user-images.githubusercontent.com/22868956/83967929-c11abc80-a8c5-11ea-9e74-43a945e37258.gif)
Note that the capture has been made before fixing the order of _folder_ and the folder name in the arguments to the instruction text. That is the right way around, now.

To better split the functionality, a `ChangeFolderRefactoringAction` has been extracted from `MoveFolderRefactoringAction`, which allows to exchange the full folder while leaving the subfolder structure intact. This is used both in `MoveFolderRefactoringAction` and `RenameFolderRefactoringAction`.

This PR is still a draft because it is based on PR #5497. Once that PR is merged, I will rebase this one and remove the draft status. Then, it will be more clear in the diff what is actually new in this PR.