### PR TITLE
Add delay to search box input

### DIFF
--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -385,7 +385,7 @@
                 Padding="2">
             <controls:SearchBox x:Name="SearchBox"
                       Background="{x:Static SystemColors.WindowBrush}"
-                      Text="{Binding Search, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                      Text="{Binding Search, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=400}"
                       Hint="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI,
                           Key=CodeExplorer_SearchPlaceholder}"
                       Grid.Column="0"

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -136,7 +136,7 @@
                 <Label Content="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=GroupingGrid_Filter}" VerticalContentAlignment="Center" />
 
                 <controls:SearchBox Width="100"
-                                    Text="{Binding InspectionDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    Text="{Binding InspectionDescriptionFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=400}" />
 
                 <Label Content="{Resx ResxName=Rubberduck.Resources.Inspections.InspectionsUI ,Key=CodeInspection_SeverityFilter}" />
 

--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
@@ -208,7 +208,7 @@
 
                 <Label Content="{Resx Key=TestExplorer_Filter, ResxName=Rubberduck.Resources.UnitTesting.TestExplorer}" />
                 <controls:SearchBox Width="100"
-                                    Text="{Binding TestNameFilter, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" />
+                                    Text="{Binding TestNameFilter, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged, Delay=400}" />
 
                 <Label Content="{Resx Key=TestExplorer_Outcome, ResxName=Rubberduck.Resources.UnitTesting.TestExplorer}" />
                 <ToggleButton Style="{StaticResource ToolBarToggleStyle}"


### PR DESCRIPTION
This adds a delay of 400ms to the search boxes in the test explorer, the inspection results window and the CE. This means that a somewhat below average typer with a typing speed of 150cpm will just not trigger a UI refresh while typing.

In particular in the CE, the delay is considerably shorter than the refresh time for the filter change.