### PR TITLE
Use live grouping and live filtering in TestExplorer

### DIFF
--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerViewModel.cs
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerViewModel.cs
@@ -82,14 +82,17 @@ namespace Rubberduck.UI.UnitTesting
             AnnotationUpdater = annotationUpdater;
 
             Model = model;
-            Model.TestCompleted += HandleTestCompletion;
 
             if (CollectionViewSource.GetDefaultView(Model.Tests) is ListCollectionView tests)
             {
                 tests.SortDescriptions.Add(new SortDescription("QualifiedName.QualifiedModuleName.Name", ListSortDirection.Ascending));
                 tests.SortDescriptions.Add(new SortDescription("QualifiedName.MemberName", ListSortDirection.Ascending));
+                tests.IsLiveFiltering = true;
+                tests.IsLiveGrouping = true;
                 Tests = tests;
             }
+
+            
 
             OnPropertyChanged(nameof(Tests));
             TestGrouping = TestExplorerGrouping.Outcome;
@@ -228,16 +231,6 @@ namespace Rubberduck.UI.UnitTesting
             var passesOutcomeFilter = (OutcomeFilter & convertedOutcome) == convertedOutcome;
 
             return passesNameFilter && passesOutcomeFilter;
-        }
-
-        private void HandleTestCompletion(object sender, TestCompletedEventArgs e)
-        {
-            if (TestGrouping != TestExplorerGrouping.Outcome)
-            {
-                return;
-            }
-
-            Tests.Refresh();
         }
 
         public IRewritingManager RewritingManager { get; }
@@ -605,7 +598,6 @@ namespace Rubberduck.UI.UnitTesting
 
         public void Dispose()
         {
-            Model.TestCompleted -= HandleTestCompletion;
             Model.Dispose();
         }
     }


### PR DESCRIPTION
This uses live grouping and live filtering in the test explorer, which is the built-in functionality to allow updates of the grouping based on property changes. This is faster than refreshing the entire collection view each time and also does not have the negative side effects of changing the selected items and expended states all the time.

As such, it will help with #5052, but the main issue there seems to a different one.