### PR TITLE
Suppress only horizontal scroll in inspection results window and test explorer

### DIFF
--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -201,6 +201,7 @@
                                            SelectionUnit="FullRow"
                                            ItemsSource="{Binding Results, NotifyOnSourceUpdated=True}"
                                            VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                                           RequestBringIntoView="InspectionResultsGrid_RequestBringIntoView"
                                            ScrollViewer.CanContentScroll="True" 
                                            ScrollViewer.VerticalScrollBarVisibility="Auto"
                                            ScrollViewer.HorizontalScrollBarVisibility="Disabled">

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml.cs
@@ -1,10 +1,14 @@
-﻿namespace Rubberduck.UI.Inspections
+﻿using System.Windows;
+
+namespace Rubberduck.UI.Inspections
 {
     /// <summary>
     /// Interaction logic for InspectionResultsControl.xaml
     /// </summary>
     public partial class InspectionResultsControl
     {
+        private const int HorizontalRectangleAdjustment = 2000;
+
         private InspectionResultsViewModel ViewModel => DataContext as InspectionResultsViewModel;
 
         public InspectionResultsControl()
@@ -12,9 +16,25 @@
             InitializeComponent();
         }
 
-        private void InspectionResultsGrid_RequestBringIntoView(object sender, System.Windows.RequestBringIntoViewEventArgs e)
+        //Based on https://stackoverflow.com/a/42238409/5536802 by Jason Williams and the comment to it by Nick Desjardins.
+        private bool _requestingModifiedBringIntoView;
+        private void InspectionResultsGrid_RequestBringIntoView(object sender, RequestBringIntoViewEventArgs e)
         {
+            if (_requestingModifiedBringIntoView
+                || !(e?.OriginalSource is FrameworkElement source))
+            {
+                return;
+            }
+
             e.Handled = true;
+
+            //Prevents adjustment of the adjusted event triggered below.
+            _requestingModifiedBringIntoView = true;
+
+            var newRectangle = new Rect(-HorizontalRectangleAdjustment, 0, source.ActualWidth + HorizontalRectangleAdjustment, source.ActualHeight);
+            source.BringIntoView(newRectangle);
+
+            _requestingModifiedBringIntoView = false;
         }
     }
 }

--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
@@ -334,6 +334,7 @@
 	                                       ShowGroupingItemCount="True"
 	                                       InitialExpandedState="True"
 	                                       VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                                           RequestBringIntoView="TestGrid_RequestBringIntoView"
 	                                       ScrollViewer.CanContentScroll="False" 
 	                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
 	                                       ScrollViewer.HorizontalScrollBarVisibility="Disabled">

--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml.cs
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml.cs
@@ -1,18 +1,38 @@
-﻿namespace Rubberduck.UI.UnitTesting
+﻿using System.Windows;
+
+namespace Rubberduck.UI.UnitTesting
 {
     /// <summary>
     /// Interaction logic for TestExplorerControl.xaml
     /// </summary>
     public partial class TestExplorerControl
     {
+        private const int HorizontalRectangleAdjustment = 2000;
+
         public TestExplorerControl()
         {
             InitializeComponent();
         }
 
-        private void TestGrid_RequestBringIntoView(object sender, System.Windows.RequestBringIntoViewEventArgs e)
+        //Based on https://stackoverflow.com/a/42238409/5536802 by Jason Williams and the comment to it by Nick Desjardins.
+        private bool _requestingModifiedBringIntoView;
+        private void TestGrid_RequestBringIntoView(object sender, RequestBringIntoViewEventArgs e)
         {
+            if (_requestingModifiedBringIntoView
+                || !(e?.OriginalSource is FrameworkElement source))
+            {
+                return;
+            }
+
             e.Handled = true;
+
+            //Prevents adjustment of the adjusted event triggered below.
+            _requestingModifiedBringIntoView = true;
+
+            var newRectangle = new Rect(-HorizontalRectangleAdjustment, 0, source.ActualWidth + HorizontalRectangleAdjustment, source.ActualHeight);
+            source.BringIntoView(newRectangle);
+
+            _requestingModifiedBringIntoView = false;
         }
     }
 }


### PR DESCRIPTION
Closes #5527

To achieve this, a new request from the original source is performed with a rectangle extending to the left into negative space. As a result, vertical scrolling is preserved, but horizontal scrolling suppressed.

Testing with the project I could reproduce the freeze with before deactivating the general bring into view suppression, I do not get a freeze again. So, I hope this way of suppressing the horizontal scroll is safe. 