### PR TITLE
Disable FunctionReturnValueDiscardedInspection for built-in functions

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueDiscardedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueDiscardedInspection.cs
@@ -53,11 +53,12 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         protected override bool IsResultReference(IdentifierReference reference, DeclarationFinder finder)
         {
             return reference?.Declaration != null
-                && !reference.IsAssignment
-                && !reference.IsArrayAccess
-                && !reference.IsInnerRecursiveDefaultMemberAccess
-                && reference.Declaration.DeclarationType == DeclarationType.Function
-                && IsCalledAsProcedure(reference.Context);
+                   && reference.Declaration.IsUserDefined
+                   && !reference.IsAssignment
+                   && !reference.IsArrayAccess
+                   && !reference.IsInnerRecursiveDefaultMemberAccess
+                   && reference.Declaration.DeclarationType == DeclarationType.Function
+                   && IsCalledAsProcedure(reference.Context);
         }
 
         private static bool IsCalledAsProcedure(ParserRuleContext context)

--- a/RubberduckTests/Inspections/FunctionReturnValueDiscardedInspectionTests.cs
+++ b/RubberduckTests/Inspections/FunctionReturnValueDiscardedInspectionTests.cs
@@ -4,6 +4,7 @@ using Rubberduck.CodeAnalysis.Inspections;
 using Rubberduck.CodeAnalysis.Inspections.Concrete;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
 
 namespace RubberduckTests.Inspections
 {
@@ -308,8 +309,20 @@ Public Sub Dummy()
     MsgBox ""Test""
     Workbooks.Add
 End Sub
+
+Public Sub Baz()
+    Err.Raise -1, ""Foo"", ""Bar""
+End Sub
 ";
-            Assert.AreEqual(0, InspectionResultsForStandardModule(code).Count());
+            var vbe = new MockVbeBuilder()
+                .ProjectBuilder("TestProject", ProjectProtection.Unprotected)
+                .AddComponent("TestModule", ComponentType.StandardModule, code)
+                .AddReference(ReferenceLibrary.VBA)
+                .AddReference(ReferenceLibrary.Excel)
+                .AddProjectToVbeBuilder()
+                .Build()
+                .Object;
+            Assert.AreEqual(0, InspectionResults(vbe).Count());
         }
 
         [Test]


### PR DESCRIPTION
Closes #5480

This has always been intended, but the corresponding test setup was bad. The reason to ignore results for built-in functions is that there are lots of built-in functions used for their side-effects or those of the members of the return value, e.g. `MsgBox` and `Err`.