### PR TITLE
German translations

### DIFF
--- a/Rubberduck.Core/UI/Styles/DefaultStyle.xaml
+++ b/Rubberduck.Core/UI/Styles/DefaultStyle.xaml
@@ -146,6 +146,10 @@
         </Style.Triggers>
     </Style>
 
+    <Style TargetType="{x:Type CheckBox}">
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
     <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
     <converters:BoolToHiddenVisibilityConverter x:Key="BoolToHiddenVisibility" />
     <settingsConverters:SelectedItemToBooleanConverter x:Key="HasSelectedItems"/>

--- a/Rubberduck.RegexAssistant/i18n/AssistantResources.de.resx
+++ b/Rubberduck.RegexAssistant/i18n/AssistantResources.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -193,7 +193,7 @@
     <value>Erkennt die exakte Sequenz</value>
   </data>
   <data name="ExpressionDescription_ErrorExpression" xml:space="preserve">
-    <value>Konnte '{0}' nicht als Literal erkennen. Bitte überprüfen Sie die Eingabe</value>
+    <value>'{0}' konnte nicht als Literal erkennen werden. Bitte überprüfen Sie die Eingabe.</value>
   </data>
   <data name="PatternDescription_AnchorEnd" xml:space="preserve">
     <value>$ stellt sicher, dass alle Zeichen im String verwendet wurden</value>

--- a/Rubberduck.Resources/About/AboutUI.de.resx
+++ b/Rubberduck.Resources/About/AboutUI.de.resx
@@ -140,7 +140,7 @@ WPF Lokalisierungsunterstützung von Grant Frisken</value>
   <data name="AboutWindow_GeneralThanks" xml:space="preserve">
     <value>Allen, die zu unserem GitHub Repositoty beigetragen haben
 Allen Sternguckern, Likern &amp; Followern, für das warme Kribbeln
-… und jedem der dies leist.</value>
+… und jedem der dies liest.</value>
   </data>
   <data name="AboutWindow_BlogsHeader" xml:space="preserve">
     <value>Blogs:</value>

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.Designer.cs
@@ -111,7 +111,7 @@ namespace Rubberduck.Resources.CodeExplorer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add.
+        ///   Looks up a localized string similar to Add....
         /// </summary>
         public static string CodeExplorer_Add {
             get {

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.de.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.de.resx
@@ -317,7 +317,7 @@ Fortfahren?</value>
     <value>Komponenten aus Dateien aktualisieren...</value>
   </data>
   <data name="ReplaceFromFiles" xml:space="preserve">
-    <value>Projektinhalt durch Dateiinhalt ersetzen... </value>
+    <value>Projektinhalt durch Dateiinhalt ersetzen...</value>
   </data>
   <data name="CodeExplorer_ExtractInterfaceText" xml:space="preserve">
     <value>Interface extrahieren...</value>

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.resx
@@ -317,7 +317,7 @@
     <value>Group by Type</value>
   </data>
   <data name="CodeExplorer_Add" xml:space="preserve">
-    <value>Add</value>
+    <value>Add...</value>
   </data>
   <data name="ExportBeforeRemove_Caption" xml:space="preserve">
     <value>Confirm Export</value>

--- a/Rubberduck.Resources/Inspections/QuickFixes.de.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.de.resx
@@ -136,7 +136,7 @@
     <value>Als explizit 'Variant' deklarieren</value>
   </data>
   <data name="MakeSingleLineParameterQuickFix" xml:space="preserve">
-    <value>Variable in einer Zeile schreiben </value>
+    <value>Variable in einer Zeile schreiben</value>
   </data>
   <data name="ObsoleteGlobalInspectionQuickFix" xml:space="preserve">
     <value>'Global' durch 'Public' ersetzen</value>
@@ -220,7 +220,7 @@
     <value>Leeren 'If'-Block entfernen</value>
   </data>
   <data name="ImplicitByRefModifierQuickFix" xml:space="preserve">
-    <value>Parameter explizit als Referenz übergeben.</value>
+    <value>Parameter explizit als Referenz übergeben</value>
   </data>
   <data name="ReplaceObsoleteErrorStatementQuickFix" xml:space="preserve">
     <value>'Error' durch 'Err.Raise' ersetzen</value>
@@ -280,7 +280,7 @@
     <value>Attributannotation hinzufügen</value>
   </data>
   <data name="ApplyQuickFixesFailedMessage" xml:space="preserve">
-    <value>Die Ausführen des Quickfixes ist fehlgeschlagen. </value>
+    <value>Die Ausführen des Quickfixes ist fehlgeschlagen.</value>
   </data>
   <data name="StaleModuleFailureReason" xml:space="preserve">
     <value>Ein betroffenes Module wurde seit dem letzten Parse modifiziert.</value>

--- a/Rubberduck.Resources/Menus/RubberduckMenus.de.resx
+++ b/Rubberduck.Resources/Menus/RubberduckMenus.de.resx
@@ -157,7 +157,7 @@
     <value>To&amp;Do Liste</value>
   </data>
   <data name="ToolsMenu_ExportProject" xml:space="preserve">
-    <value>Aktives Projekt exportieren</value>
+    <value>Aktives Projekt exportieren...</value>
   </data>
   <data name="RubberduckMenu_Refresh" xml:space="preserve">
     <value>Aktualisieren</value>

--- a/Rubberduck.Resources/Refactorings/Refactorings.de.resx
+++ b/Rubberduck.Resources/Refactorings/Refactorings.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ImplementInterface_TODO" xml:space="preserve">
+    <value>'TODO Schnittstellenmitglied implementieren</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/RegexAssistant/RegexAssistantUI.de.resx
+++ b/Rubberduck.Resources/RegexAssistant/RegexAssistantUI.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -193,7 +193,7 @@
     <value>Erkennt die exakte Sequenz</value>
   </data>
   <data name="ExpressionDescription_ErrorExpression" xml:space="preserve">
-    <value>Konnte '{0}' nicht als Literal erkennen. Bitte überprüfen Sie die Eingabe</value>
+    <value>'{0}' konnte nicht als Literal erkennen werden. Bitte überprüfen Sie die Eingabe.</value>
   </data>
   <data name="PatternDescription_AnchorEnd" xml:space="preserve">
     <value>$ stellt sicher, dass alle Zeichen im String verwendet wurden</value>

--- a/Rubberduck.Resources/RubberduckUI.Designer.cs
+++ b/Rubberduck.Resources/RubberduckUI.Designer.cs
@@ -759,7 +759,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to These identifiers will be ignored by the &apos;Use meaningful names&apos; inspection.
+        ///   Looks up a localized string similar to These identifiers will be ignored by the &apos;Use meaningful names&apos; inspection..
         /// </summary>
         public static string CodeInspectionSettings_WhitelistedIdentifiersDescription {
             get {
@@ -822,7 +822,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to compile for parsing.
+        ///   Looks up a localized string similar to Unable to compile for parsing..
         /// </summary>
         public static string Command_Reparse_CannotCompile_Caption {
             get {
@@ -1437,7 +1437,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to encapsulate {0}. Redim({0}) statement(s) exist in other modules.
+        ///   Looks up a localized string similar to Unable to encapsulate &apos;{0}&apos;. Redim({0}) statement(s) exist in other modules..
         /// </summary>
         public static string EncapsulateField_ArrayHasExternalRedimFormat {
             get {
@@ -1473,7 +1473,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select one or more fields to encapsulate.  Accept the default values or edit property names.
+        ///   Looks up a localized string similar to Select one or more fields to encapsulate.  Accept the default values or edit property names..
         /// </summary>
         public static string EncapsulateField_InstructionText {
             get {
@@ -1828,7 +1828,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Check if a newer version is available at startup.
+        ///   Looks up a localized string similar to Check if a newer version is available at startup..
         /// </summary>
         public static string GeneralSettings_CheckVersion {
             get {
@@ -2019,7 +2019,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tell me if a newer pre-release build is available.
+        ///   Looks up a localized string similar to Tell me if a newer pre-release build is available..
         /// </summary>
         public static string GeneralSettings_IncludePreRelease {
             get {
@@ -2745,7 +2745,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not begin with a letter.
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not start with a letter..
         /// </summary>
         public static string InvalidNameCriteria_DoesNotStartWithLetterFormat {
             get {
@@ -2754,7 +2754,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; exceeds the maximum allowed string length.
+        ///   Looks up a localized string similar to &apos;{0}&apos; exceeds the maximum allowed string length..
         /// </summary>
         public static string InvalidNameCriteria_ExceedsMaximumLengthFormat {
             get {
@@ -2772,7 +2772,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to VBA Identifiers cannot be null or zero-length.
+        ///   Looks up a localized string similar to VBA Identifiers cannot be null or zero-length..
         /// </summary>
         public static string InvalidNameCriteria_IsNullOrEmpty {
             get {
@@ -2929,7 +2929,7 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Member Attribute Recovery Failure .
+        ///   Looks up a localized string similar to Member Attribute Recovery Failure.
         /// </summary>
         public static string MemberAttributeRecoveryFailureCaption {
             get {

--- a/Rubberduck.Resources/RubberduckUI.de.resx
+++ b/Rubberduck.Resources/RubberduckUI.de.resx
@@ -374,7 +374,7 @@ Warnung: Alle eigenen Einstellungen gehen dabei verloren. Die Originaldatei wird
     <value>Rubberduck - Parameter entfernen</value>
   </data>
   <data name="RemoveParamsDialog_InstructionsLabelText" xml:space="preserve">
-    <value>Wählen Sie einen Parameter und benutzen Sie die Schaltflächen oder doppelklicken Sie um ihn zu bewegen oder zu löschen</value>
+    <value>Wählen Sie einen Parameter und benutzen Sie die Schaltflächen oder doppelklicken Sie um ihn zu bewegen oder zu löschen.</value>
   </data>
   <data name="Restore" xml:space="preserve">
     <value>Wiederherstellen</value>
@@ -489,7 +489,7 @@ Wollen Sie trotzdem fortfahren?</value>
   </data>
   <data name="CodeInspections_NumberOfIssuesFound_Plural" xml:space="preserve">
     <value>Rubberduck Code Untersuchung - {0} 
-{1} Probleme gefunden</value>
+{1} Probleme gefunden.</value>
   </data>
   <data name="Language_DE" xml:space="preserve">
     <value>Deutsch</value>
@@ -558,10 +558,10 @@ Wollen Sie trotzdem fortfahren?</value>
     <value>Mitglieder</value>
   </data>
   <data name="ExtractInterface_InstructionLabel" xml:space="preserve">
-    <value>Bitte spezifizieren Sie den Interface-Namen und die Mitglieder</value>
+    <value>Bitte spezifizieren Sie den Interface-Namen und die Mitglieder.</value>
   </data>
   <data name="PromoteVariable_InvalidSelection" xml:space="preserve">
-    <value>Die Auswahl ist keine Variable</value>
+    <value>Die Auswahl ist keine Variable.</value>
   </data>
   <data name="EncapsulateField_Caption" xml:space="preserve">
     <value>Rubberduck - Gekapseltes Feld</value>
@@ -594,7 +594,7 @@ Wollen Sie trotzdem fortfahren?</value>
     <value>Rubberduck - Näher an die Nutzung führen</value>
   </data>
   <data name="EncapsulateField_InstructionText" xml:space="preserve">
-    <value>Spezifizierung des Eigenschaftsnamen, Parameterverfügbarkeit und 'Setter type' notwendig.</value>
+    <value>Bitte wählen Sie ein oder mehrere Felder, die gekapselt werden sollen. Die Eigenschaftsnamen könne vor dem bestätigen geändert werden.</value>
   </data>
   <data name="MoveCloserToUsageFailure_InvalidSelection" xml:space="preserve">
     <value>Ungültige Auswahl.</value>
@@ -753,7 +753,7 @@ Wollen Sie trotzdem fortfahren?</value>
     <value>Fertig analysiert</value>
   </data>
   <data name="ParserState_Parsing" xml:space="preserve">
-    <value>Parsing …</value>
+    <value>Parsing…</value>
   </data>
   <data name="ParserState_Pending" xml:space="preserve">
     <value>Wartend</value>
@@ -816,7 +816,7 @@ Wollen Sie trotzdem fortfahren?</value>
     <value>Parserfehler</value>
   </data>
   <data name="GeneralSettings_MinimumLogLevelLabel" xml:space="preserve">
-    <value>Minimale Logging-Empfindlichkeit</value>
+    <value>Minimale Logging-Empfindlichkeit:</value>
   </data>
   <data name="GeneralSettings_DebugLogLevel" xml:space="preserve">
     <value>Debugging</value>
@@ -1031,7 +1031,7 @@ Dieses Fenster wird angezeigt, da Aktualisierungsprüfungen aktiviert sind. Dies
     <value>Quellcode aus Datei importieren</value>
   </data>
   <data name="EmptyUIRefreshMessage_Title" xml:space="preserve">
-    <value>Rubberduck sieht noch nichts</value>
+    <value>Rubberduck sieht noch nichts.</value>
   </data>
   <data name="GeneralSettings_ExperimentalFeaturesWarning" xml:space="preserve">
     <value>Auf eigene Verantwortung und Gefahr aktivieren. Aktivierung und / oder Verwendung von Funktionalitäten in dieser Sektion kann zu unvorhergesehenen Fehlern und unwiederbringlichem Datenverlust führen.</value>
@@ -1114,10 +1114,10 @@ Dieses Fenster wird angezeigt, da Aktualisierungsprüfungen aktiviert sind. Dies
     <value>Aktives Projekt exportieren</value>
   </data>
   <data name="GeneralSettings_HotkeyRestrictionLabel" xml:space="preserve">
-    <value>Tastenkürzel sollten Alt und/oder Strg verwenden</value>
+    <value>Tastenkürzel sollten Alt und/oder Strg verwenden.</value>
   </data>
   <data name="GeneralSettings_HotkeyRestrictionToolTip" xml:space="preserve">
-    <value>Die aktuellen Tastenkürzeleinstellungen könnten ungewollte Nebeneffekte erzeugen</value>
+    <value>Die aktuellen Tastenkürzeleinstellungen könnten ungewollte Nebeneffekte haben.</value>
   </data>
   <data name="GeneralSettings_ModifierWarning" xml:space="preserve">
     <value>Warnung</value>
@@ -1245,7 +1245,7 @@ ACHTUNG: Ein Neustart ist nötig, damit die Änderungen wirksam werden.</value>
     <value>Referenzen hinzufügen/entfernen - {0}</value>
   </data>
   <data name="References_Caption" xml:space="preserve">
-    <value>Referenzen hinzufügen/entfernen</value>
+    <value>Referenzen hinzufügen/entfernen...</value>
   </data>
   <data name="References_BrowseFilterVisio" xml:space="preserve">
     <value>Alle Visio-Dateien ({0})|{0}</value>
@@ -1311,7 +1311,7 @@ ACHTUNG: Ein Neustart ist nötig, damit die Änderungen wirksam werden.</value>
     <value>Publisher-Dateien ({0}|{0}</value>
   </data>
   <data name="ReferenceSettings_RecentTracked" xml:space="preserve">
-    <value>Zuletzt verfolgte Referenzen</value>
+    <value>Zuletzt verfolgte Referenzen:</value>
   </data>
   <data name="References_Recent" xml:space="preserve">
     <value>Zuletzt verwendet</value>
@@ -1332,7 +1332,7 @@ ACHTUNG: Ein Neustart ist nötig, damit die Änderungen wirksam werden.</value>
     <value>Wiederherstellen der Elementattribute fehlgeschlagen</value>
   </data>
   <data name="MemberAttributeRecoveryMembersNotFoundMessage" xml:space="preserve">
-    <value>Die Elementattribute für die folgenden Elemente konnten nicht wiederhergestellt werden, da sie nicht mehr aufgefunden wurden: {0} </value>
+    <value>Die Elementattribute für die folgenden Elemente konnten nicht wiederhergestellt werden, da sie nicht mehr aufgefunden wurden: {0}</value>
   </data>
   <data name="AllReferences_NoneFoundReference" xml:space="preserve">
     <value>Es wurden keine Verwendungen der Projektreferenz '{0}' gefunden.</value>
@@ -1490,7 +1490,7 @@ ACHTUNG: Ein Neustart ist nötig, damit die Änderungen wirksam werden.</value>
 Import abgebrochen.</value>
   </data>
   <data name="ReplaceProjectContentsFromFilesCommand_DialogCaption" xml:space="preserve">
-    <value>Projektinhalt durch Inhalt von Dateien ersetzen </value>
+    <value>Projektinhalt durch Inhalt von Dateien ersetzen</value>
   </data>
   <data name="ReplaceProjectContentsFromFilesCommand_ConfirmationMessage" xml:space="preserve">
     <value>Soll der Inhalt von Project '{0}' wirklich gelöscht und durch den Inhalt der ausgewählten Dateien ersetzt werden?</value>
@@ -1572,7 +1572,7 @@ Import abgebrochen.</value>
     <value>Es war nicht möglich den Parser zum Ausführen des Refactorings temporär zu deaktivieren.</value>
   </data>
   <data name="MoveToFolderDialog_Caption" xml:space="preserve">
-    <value>Rubberduck - In Ordner verschieben </value>
+    <value>Rubberduck - In Ordner verschieben</value>
   </data>
   <data name="MoveToFolderDialog_InstructionsLabelText" xml:space="preserve">
     <value>Bitte geben Sie einen neuen Ordner für {0} '{1}' im Ordner '{2}' an.</value>
@@ -1727,5 +1727,43 @@ Wollen Sie fortfahren?</value>
   </data>
   <data name="AnnotateDeclarationDialog_AdjustAttributeLabel" xml:space="preserve">
     <value>Attribut hinzufügen / anpassen</value>
+  </data>
+  <data name="EncapsulateField_ArrayHasExternalRedimFormat" xml:space="preserve">
+    <value>Das Kapseln von '{0}' ist nicht möglich. Es existieren ReDim({0})-Anweisungen in anderen Modulen.</value>
+  </data>
+  <data name="EncapsulateField_ParameterName" xml:space="preserve">
+    <value>Parametername:</value>
+  </data>
+  <data name="EncapsulateField_PreviewMarker" xml:space="preserve">
+    <value>'&lt;===== Eigenschafts- und Deklarationsänderungen oberhalb dieser Zeile =====&gt;</value>
+  </data>
+  <data name="EncapsulateField_PrivateUDTPropertyText" xml:space="preserve">
+    <value>Erstellt eine Eigenschaft für jedes UDT-Mitglied</value>
+  </data>
+  <data name="EncapsulateField_ReadOnlyCheckBoxContent" xml:space="preserve">
+    <value>Schreibgeschützt</value>
+  </data>
+  <data name="EncapsulateField_WrapFieldsInPrivateType" xml:space="preserve">
+    <value>Felder in einem privaten Typ kapseln</value>
+  </data>
+  <data name="ExtractInterface_Private" xml:space="preserve">
+    <value>Privat</value>
+  </data>
+  <data name="ExtractInterface_Public" xml:space="preserve">
+    <value>Öffentlich</value>
+  </data>
+  <data name="ExtractInterface_PublicInstancingMandatedByPublicClass" xml:space="preserve">
+    <value>Die implementierende Klasse ist öffentlich, was es notwendig macht, dass die Schnittstelle ebenfalls öffentlich ist.
+Falls Sie eine 'private' Schnittstelle benötigen, machen Sie bitte die implementierende Klasse ebenfalls privat.
+Eine private Klasse kann eine private Schnittstelle implementieren.</value>
+  </data>
+  <data name="EncapsulateField_NameConflictDetected" xml:space="preserve">
+    <value>Namenskonflikt</value>
+  </data>
+  <data name="EncapsulateField_SetterType" xml:space="preserve">
+    <value>Typ des Schreibzugriffs:</value>
+  </data>
+  <data name="ExtractInterface_InstancingGroupBox" xml:space="preserve">
+    <value>Sichtbarkeit</value>
   </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.resx
+++ b/Rubberduck.Resources/RubberduckUI.resx
@@ -572,7 +572,7 @@ Do you want to proceed with this rename?</value>
     <value>Rubberduck - Encapsulate Field</value>
   </data>
   <data name="EncapsulateField_InstructionText" xml:space="preserve">
-    <value>Select one or more fields to encapsulate.  Accept the default values or edit property names</value>
+    <value>Select one or more fields to encapsulate.  Accept the default values or edit property names.</value>
   </data>
   <data name="EncapsulateField_Preview" xml:space="preserve">
     <value>Preview:</value>
@@ -941,7 +941,7 @@ Do you want to proceed with this rename?</value>
     <value>Whitelisted Identifiers</value>
   </data>
   <data name="CodeInspectionSettings_WhitelistedIdentifiersDescription" xml:space="preserve">
-    <value>These identifiers will be ignored by the 'Use meaningful names' inspection</value>
+    <value>These identifiers will be ignored by the 'Use meaningful names' inspection.</value>
   </data>
   <data name="CommandDescription_RefactorEncapsulateFieldCommand" xml:space="preserve">
     <value>Refactor / Encapsulate Field</value>
@@ -1055,7 +1055,7 @@ This dialog is showing because version checks are enabled. You can turn off this
     <comment>{0}=local; {1}=latest; {2}=buildtype (release/pre-release)</comment>
   </data>
   <data name="GeneralSettings_CheckVersion" xml:space="preserve">
-    <value>Check if a newer version is available at startup</value>
+    <value>Check if a newer version is available at startup.</value>
   </data>
   <data name="AssignedByValDialog_NewNameAlreadyUsedFormat" xml:space="preserve">
     <value>'{0}' is already accessible to this scope.</value>
@@ -1158,7 +1158,7 @@ This dialog is showing because version checks are enabled. You can turn off this
     <value>The following project(s) cannot be compiled, which will most likely result in parser errors. Continue anyway? {0}</value>
   </data>
   <data name="Command_Reparse_CannotCompile_Caption" xml:space="preserve">
-    <value>Unable to compile for parsing</value>
+    <value>Unable to compile for parsing.</value>
   </data>
   <data name="GeneralSettings_CompileBeforeParse" xml:space="preserve">
     <value>Compile code before parsing</value>
@@ -1470,7 +1470,7 @@ NOTE: Restart is required for the setting to take effect.</value>
     <value>Failed to recover member attributes.</value>
   </data>
   <data name="MemberAttributeRecoveryFailureCaption" xml:space="preserve">
-    <value>Member Attribute Recovery Failure </value>
+    <value>Member Attribute Recovery Failure</value>
   </data>
   <data name="MemberAttributeRecoveryMembersNotFoundMessage" xml:space="preserve">
     <value>Member attributes for the following modules could not be recovered because they could no longer be found. {0}</value>
@@ -1621,11 +1621,11 @@ NOTE: Restart is required for the setting to take effect.</value>
     <value>Unknown</value>
   </data>
   <data name="InvalidNameCriteria_DoesNotStartWithLetterFormat" xml:space="preserve">
-    <value>'{0}' does not begin with a letter</value>
+    <value>'{0}' does not start with a letter.</value>
     <comment>{0} = code element name</comment>
   </data>
   <data name="InvalidNameCriteria_ExceedsMaximumLengthFormat" xml:space="preserve">
-    <value>'{0}' exceeds the maximum allowed string length</value>
+    <value>'{0}' exceeds the maximum allowed string length.</value>
     <comment>{0} = code element name</comment>
   </data>
   <data name="InvalidNameCriteria_InvalidCharactersFormat" xml:space="preserve">
@@ -1633,7 +1633,7 @@ NOTE: Restart is required for the setting to take effect.</value>
     <comment>{0} = code element name</comment>
   </data>
   <data name="InvalidNameCriteria_IsNullOrEmpty" xml:space="preserve">
-    <value>VBA Identifiers cannot be null or zero-length</value>
+    <value>VBA Identifiers cannot be null or zero-length.</value>
   </data>
   <data name="InvalidNameCriteria_IsReservedKeywordFormat" xml:space="preserve">
     <value>'{0}' is a reserved keyword.</value>
@@ -1658,7 +1658,7 @@ NOTE: Restart is required for the setting to take effect.</value>
     <value>Unable to suspend the Parser to perform the refactoring operation.</value>
   </data>
   <data name="GeneralSettings_IncludePreRelease" xml:space="preserve">
-    <value>Tell me if a newer pre-release build is available</value>
+    <value>Tell me if a newer pre-release build is available.</value>
   </data>
   <data name="VersionCheck_BuildType_PreRelease" xml:space="preserve">
     <value>pre-release</value>
@@ -1755,7 +1755,7 @@ Import aborted.</value>
     <value>VB Form</value>
   </data>
   <data name="EncapsulateField_ArrayHasExternalRedimFormat" xml:space="preserve">
-    <value>Unable to encapsulate {0}. Redim({0}) statement(s) exist in other modules</value>
+    <value>Unable to encapsulate '{0}'. Redim({0}) statement(s) exist in other modules.</value>
     <comment>{0} = selected field IdentifierName</comment>
   </data>
   <data name="EncapsulateField_DefaultObjectStateUDTFieldName" xml:space="preserve">

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
@@ -88,7 +88,7 @@ namespace Rubberduck.Resources.Settings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Concatenate &apos;vbNewLine&apos; on Ctrl+Enter.
+        ///   Looks up a localized string similar to Concatenate &apos;vbNewLine&apos; on Ctrl+Enter..
         /// </summary>
         public static string ConcatVbNewLine {
             get {

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.resx
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.resx
@@ -133,7 +133,7 @@
     <value>Block Completion</value>
   </data>
   <data name="ConcatVbNewLine" xml:space="preserve">
-    <value>Concatenate 'vbNewLine' on Ctrl+Enter</value>
+    <value>Concatenate 'vbNewLine' on Ctrl+Enter.</value>
   </data>
   <data name="EnableAutocompleteLabel" xml:space="preserve">
     <value>Enable autocompletion features</value>

--- a/Rubberduck.Resources/UnitTesting/TestExplorer.Designer.cs
+++ b/Rubberduck.Resources/UnitTesting/TestExplorer.Designer.cs
@@ -700,7 +700,7 @@ namespace Rubberduck.Resources.UnitTesting {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to this method runs before every test in the module.
+        ///   Looks up a localized string similar to This method runs before every test in the module..
         /// </summary>
         public static string UnitTest_NewModule_RunBeforeTest {
             get {

--- a/Rubberduck.Resources/UnitTesting/TestExplorer.de.resx
+++ b/Rubberduck.Resources/UnitTesting/TestExplorer.de.resx
@@ -324,4 +324,16 @@
   <data name="TestExplorer_TestToggle_Unignore" xml:space="preserve">
     <value>Test nicht mehr ignorieren</value>
   </data>
+  <data name="TestExplorer_ContextMenuIgnoreSelectedTests" xml:space="preserve">
+    <value>Selektierte Tests ignorieren</value>
+  </data>
+  <data name="TestExplorer_ContextMenuIgnoreGroup" xml:space="preserve">
+    <value>Alle Tests in der Gruppe ignorieren</value>
+  </data>
+  <data name="TestExplorer_ContextMenuUnignoreSelectedTests" xml:space="preserve">
+    <value>Ignorieren der selektierten Tests aufheben</value>
+  </data>
+  <data name="TestExplorer_ContextMenuUnignoreGroup" xml:space="preserve">
+    <value>Ignorieren aller Tests in der Gruppe aufheben</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/UnitTesting/TestExplorer.resx
+++ b/Rubberduck.Resources/UnitTesting/TestExplorer.resx
@@ -200,7 +200,7 @@
     <comment>Comment text.</comment>
   </data>
   <data name="UnitTest_NewModule_RunBeforeTest" xml:space="preserve">
-    <value>this method runs before every test in the module</value>
+    <value>This method runs before every test in the module.</value>
     <comment>Comment text.</comment>
   </data>
   <data name="UnitTest_NewModule_RunAfterTest" xml:space="preserve">


### PR DESCRIPTION
These are the German translations for the currently untranslated resources, apart from those for which a translation does not make a lot of sense.

In addition, the endings of several resources have been aligned.

Finally, I have added a default style for `CheckBoxe`s that centers the content vertically since I have observed on my system that the default seems to be _top_ alignment, which shifts the labels to the top relative to the box itself. 