### PR TITLE
Link to inspection details pages

### DIFF
--- a/Rubberduck.Core/UI/About/AboutControlViewModel.cs
+++ b/Rubberduck.Core/UI/About/AboutControlViewModel.cs
@@ -13,10 +13,12 @@ namespace Rubberduck.UI.About
     public class AboutControlViewModel
     {
         private readonly IVersionCheck _version;
+        private readonly IWebNavigator _web;
 
-        public AboutControlViewModel(IVersionCheck version)
+        public AboutControlViewModel(IVersionCheck version, IWebNavigator web)
         {
             _version = version;
+            _web = web;
 
             UriCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteUri);
             ViewLogCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteViewLog);
@@ -42,10 +44,7 @@ namespace Rubberduck.UI.About
 
         public CommandBase ViewLogCommand { get; }
 
-        private void ExecuteUri(object parameter)
-        {
-            Process.Start(new ProcessStartInfo(((Uri)parameter).AbsoluteUri));
-        }
+        private void ExecuteUri(object parameter) => _web.Navigate(((Uri)parameter));
 
         private void ExecuteViewLog(object parameter)
         {

--- a/Rubberduck.Core/UI/About/AboutDialog.cs
+++ b/Rubberduck.Core/UI/About/AboutDialog.cs
@@ -5,9 +5,9 @@ namespace Rubberduck.UI.About
 {
     public partial class AboutDialog : Form
     {
-        public AboutDialog(IVersionCheck versionCheck) : this()
+        public AboutDialog(IVersionCheck versionCheck, IWebNavigator web) : this()
         {
-            ViewModel = new AboutControlViewModel(versionCheck);
+            ViewModel = new AboutControlViewModel(versionCheck, web);
         }
 
         public AboutDialog()

--- a/Rubberduck.Core/UI/Command/AboutCommand.cs
+++ b/Rubberduck.Core/UI/Command/AboutCommand.cs
@@ -10,16 +10,18 @@ namespace Rubberduck.UI.Command
     [ComVisible(false)]
     public class AboutCommand : CommandBase
     {
-        public AboutCommand(IVersionCheck versionService)
+        public AboutCommand(IVersionCheck versionService, IWebNavigator web)
         {
             _versionService = versionService;
+            _web = web;
         }
 
         private readonly IVersionCheck _versionService;
+        private readonly IWebNavigator _web;
 
         protected override void OnExecute(object parameter)
         {
-            using (var window = new AboutDialog(_versionService))
+            using (var window = new AboutDialog(_versionService, _web))
             {
                 window.ShowDialog();
             }

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsControl.xaml
@@ -278,6 +278,11 @@
                         Visibility="{Binding CanDisableInspection, Converter={StaticResource BoolToVisibility}}"
                         Command="{Binding DisableInspectionCommand}"
                         Content="{Resx ResxName=Rubberduck.Resources.Inspections.InspectionsUI, Key=DisableThisInspection}" />
+
+                    <controls:LinkButton Margin="4"
+                        Command="{Binding OpenInspectionDetailsPageCommand}"
+                        Content="{Binding InspectionDetailsUrl}" />
+
                 </StackPanel>
             </ScrollViewer>
         </Border>

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -144,6 +144,8 @@ namespace Rubberduck.UI.Inspections
             OpenInspectionSettings = new DelegateCommand(LogManager.GetCurrentClassLogger(), OpenSettings);
             CollapseAllCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteCollapseAll);
             ExpandAllCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteExpandAll);
+            
+            OpenInspectionDetailsPageCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), ExecuteOpenInspectionDetailsPageCommand);
 
             QuickFixCommands = new List<(ICommand command, string key, Func<IQuickFix, bool> visibility)>
             {
@@ -195,6 +197,8 @@ namespace Rubberduck.UI.Inspections
             get => _selectedItem;
             set
             {
+                SelectedInspection = null;
+                CanQuickFix = false;
                 if (value == _selectedItem)
                 {
                     return;
@@ -203,8 +207,6 @@ namespace Rubberduck.UI.Inspections
                 _selectedItem = value; 
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(QuickFixes));
-                SelectedInspection = null;
-                CanQuickFix = false;
 
                 if (_selectedItem is IInspectionResult inspectionResult)
                 {
@@ -225,6 +227,7 @@ namespace Rubberduck.UI.Inspections
             {
                 _selectedInspection = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(InspectionDetailsUrl));
             }
         }
 
@@ -354,6 +357,7 @@ namespace Rubberduck.UI.Inspections
         public CommandBase OpenInspectionSettings { get; }
         public CommandBase CollapseAllCommand { get; }
         public CommandBase ExpandAllCommand { get; }
+        public CommandBase OpenInspectionDetailsPageCommand { get; }
 
         private void ExecuteCollapseAll(object parameter)
         {
@@ -766,6 +770,12 @@ namespace Rubberduck.UI.Inspections
                 OnPropertyChanged();
             }
         }
+
+        public string InspectionDetailsUrl => _selectedInspection == null 
+            ? "https://rubberduckvba.com/inspections"
+            : $"https://rubberduckvba.com/inspections/details/{_selectedInspection.AnnotationName}";
+
+        private void ExecuteOpenInspectionDetailsPageCommand(object parameter) => Process.Start(new ProcessStartInfo(InspectionDetailsUrl));
 
         private static readonly List<(string Name, hAlignment alignment)> ResultColumns = new List<(string Name, hAlignment alignment)>
         {

--- a/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsViewModel.cs
@@ -89,6 +89,7 @@ namespace Rubberduck.UI.Inspections
 
     public sealed class InspectionResultsViewModel : ViewModelBase, INavigateSelection, IComparer<IInspectionResult>, IComparer, IDisposable
     {
+        private readonly IWebNavigator _web;
         private readonly RubberduckParserState _state;
         private readonly IInspector _inspector;
         private readonly IQuickFixProvider _quickFixProvider;
@@ -106,10 +107,12 @@ namespace Rubberduck.UI.Inspections
             INavigateCommand navigateCommand, 
             ReparseCommand reparseCommand,
             IClipboardWriter clipboard,
+            IWebNavigator web,
             IConfigurationService<Configuration> configService,
             ISettingsFormFactory settingsFormFactory,
             IUiDispatcher uiDispatcher)
         {
+            _web = web;
             _state = state;
             _inspector = inspector;
             _quickFixProvider = quickFixProvider;
@@ -771,11 +774,13 @@ namespace Rubberduck.UI.Inspections
             }
         }
 
-        public string InspectionDetailsUrl => _selectedInspection == null 
-            ? "https://rubberduckvba.com/inspections"
-            : $"https://rubberduckvba.com/inspections/details/{_selectedInspection.AnnotationName}";
+        private static readonly Uri _inspectionsHomeUrl = new Uri("https://rubberduckvba.com/inspections");
 
-        private void ExecuteOpenInspectionDetailsPageCommand(object parameter) => Process.Start(new ProcessStartInfo(InspectionDetailsUrl));
+        public Uri InspectionDetailsUrl => _selectedInspection == null 
+            ? _inspectionsHomeUrl 
+            : new Uri($"https://rubberduckvba.com/inspections/details/{_selectedInspection.AnnotationName}");
+
+        private void ExecuteOpenInspectionDetailsPageCommand(object parameter) => _web.Navigate(InspectionDetailsUrl);
 
         private static readonly List<(string Name, hAlignment alignment)> ResultColumns = new List<(string Name, hAlignment alignment)>
         {

--- a/Rubberduck.Core/UI/WebNavigator.cs
+++ b/Rubberduck.Core/UI/WebNavigator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Rubberduck.UI
+{
+    public interface IWebNavigator
+    {
+        /// <summary>
+        /// Opens the specified URI in the default browser.
+        /// </summary>
+        void Navigate(Uri uri);
+    }
+
+    public class WebNavigator : IWebNavigator
+    {
+        public void Navigate(Uri uri)
+        {
+            Process.Start(new ProcessStartInfo(uri.AbsoluteUri));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a simple button linking to the /inspections website page that opens the details page for the selected inspection.

From that page, the user can view the otherwise inaccessible-from-within-RD xmldoc content for the selected inspection, navigate to the xmldoc content for the available quickfixes, and submit a pull request to add new examples or fix typos in the documentation.

This PR also consolidates the web-browser commands ("about" dialog also spawns a process like this) into a simple `IWebNavigator` interface, so that the "go to some url" wheel doesn't need reinventing every time.