### PR TITLE
Remove com project flag

### DIFF
--- a/Rubberduck.Parsing/VBA/ParseCoordinator.cs
+++ b/Rubberduck.Parsing/VBA/ParseCoordinator.cs
@@ -340,9 +340,6 @@ namespace Rubberduck.Parsing.VBA
             token.ThrowIfCancellationRequested();
         }
 
-        //TODO: Remove the conditional compilation after loading from typelibs actually works.
-        //TODO: Improve the handling to avoid host crashing. See https://github.com/rubberduck-vba/Rubberduck/issues/5217
-        [Conditional("LOAD_USER_COM_PROJECTS")]
         private void ProcessUserComProjects(ref CancellationToken token, ref IReadOnlyCollection<QualifiedModuleName> toParse, ref HashSet<QualifiedModuleName> toReresolveReferences, ref IReadOnlyCollection<string> newProjectIds)
         {
             RefreshUserComProjects(toParse, newProjectIds);

--- a/Rubberduck.VBEEditor/ComManagement/TypeLibs/Utility/VarDescExtensions.cs
+++ b/Rubberduck.VBEEditor/ComManagement/TypeLibs/Utility/VarDescExtensions.cs
@@ -32,7 +32,7 @@ namespace Rubberduck.VBEditor.ComManagement.TypeLibs.Utility
 
             return (varDesc.memid & _ourConstantsDispatchMemberIDRangeBitmaskCheck) >= _ourConstantsDispatchMemberIDRangeStart
                 && varDesc.varkind == VARKIND.VAR_STATIC 
-                && varDesc.desc.lpvarValue != IntPtr.Zero;
+                && varDesc.desc.oInst != 0;
         }
     }
 }


### PR DESCRIPTION
This enables the parsing of user's VBA project by removing the conditional flag, meaning it will be now be on for every parse. By itself not much will have changed, but we want to get this in pre-releases to ensure there are no issues with using TypeLib APIs that we did not anticipate. 

Also, the check for constants in VBA projects was incorrect. The plan was to check `oInst = 0`, not `lpVarValue != IntPtr.Zero`. That has been corrected.