### PR TITLE
Fix PermissiveAssertClass

### DIFF
--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/PermissiveAssertClass.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/PermissiveAssertClass.cs
@@ -31,15 +31,14 @@ namespace Rubberduck.UnitTesting
         /// </remarks>
         public override void AreEqual(object expected, object actual, string message = "")
         {
-            // vbNullString is marshalled as null. assume value semantics:
-            expected = expected ?? string.Empty;
-            actual = actual ?? string.Empty;
-
-            if (!PermissiveComparer.Equals(expected, actual))
+            if (PermissiveComparer.Equals(expected, actual))
+            {
+                AssertHandler.OnAssertSucceeded();
+            }
+            else
             {
                 AssertHandler.OnAssertFailed(message);
             }
-            AssertHandler.OnAssertSucceeded();
         }
 
         public override void AreNotEqual(object expected, object actual, string message = "")

--- a/Rubberduck.UnitTesting/ComClientHelpers/PermissiveObjectComparer.cs
+++ b/Rubberduck.UnitTesting/ComClientHelpers/PermissiveObjectComparer.cs
@@ -14,19 +14,7 @@ namespace Rubberduck.UnitTesting.ComClientHelpers
         /// <returns>VBA equity</returns>
         public new bool Equals(object x, object y)
         {
-            if (x == null)
-            {
-                return y == null;
-            }
-
-            if (y == null)
-            {
-                return false;
-            }
-            
-            var converted = VariantConverter.ChangeType(y, x.GetType());
-
-            return x.Equals(converted);
+            return VariantComparer.Compare(x, y) == VariantComparisonResults.VARCMP_EQ;
         }
 
         /// <summary>

--- a/Rubberduck.VBEEditor/Variants/VariantComparer.cs
+++ b/Rubberduck.VBEEditor/Variants/VariantComparer.cs
@@ -1,0 +1,31 @@
+﻿using System.Globalization;
+
+namespace Rubberduck.VBEditor.Variants
+{
+    public static class VariantComparer
+    {
+        public static VariantComparisonResults Compare(object x, object y)
+        {
+            return Compare(x, y, VariantComparisonFlags.NORM_IGNORECASE);
+        }
+
+        public static VariantComparisonResults Compare(object x, object y, VariantComparisonFlags flags)
+        {
+            return Compare(x, y, CultureInfo.InvariantCulture.LCID, flags);
+        }
+
+        public static VariantComparisonResults Compare(object x, object y, int lcid, VariantComparisonFlags flags)
+        {
+            object dy;
+            try
+            {
+                dy = VariantConverter.ChangeType(y, x.GetType());
+            }
+            catch
+            {
+                dy = y;
+            }
+            return (VariantComparisonResults)VariantNativeMethods.VarCmp(ref x, ref dy, lcid, (uint)flags);
+        }
+    }
+}

--- a/Rubberduck.VBEEditor/Variants/VariantConverter.cs
+++ b/Rubberduck.VBEEditor/Variants/VariantConverter.cs
@@ -4,56 +4,6 @@ using System.Runtime.InteropServices;
 
 namespace Rubberduck.VBEditor.Variants
 {
-    public enum VARENUM
-    {
-        VT_EMPTY = 0x0000,
-        VT_NULL = 0x0001,
-        VT_I2 = 0x0002,
-        VT_I4 = 0x0003,
-        VT_R4 = 0x0004,
-        VT_R8 = 0x0005,
-        VT_CY = 0x0006,
-        VT_DATE = 0x0007,
-        VT_BSTR = 0x0008,
-        VT_DISPATCH = 0x0009,
-        VT_ERROR = 0x000A,
-        VT_BOOL = 0x000B,
-        VT_VARIANT = 0x000C,
-        VT_UNKNOWN = 0x000D,
-        VT_DECIMAL = 0x000E,
-        VT_I1 = 0x0010,
-        VT_UI1 = 0x0011,
-        VT_UI2 = 0x0012,
-        VT_UI4 = 0x0013,
-        VT_I8 = 0x0014,
-        VT_UI8 = 0x0015,
-        VT_INT = 0x0016,
-        VT_UINT = 0x0017,
-        VT_VOID = 0x0018,
-        VT_HRESULT = 0x0019,
-        VT_PTR = 0x001A,
-        VT_SAFEARRAY = 0x001B,
-        VT_CARRAY = 0x001C,
-        VT_USERDEFINED = 0x001D,
-        VT_LPSTR = 0x001E,
-        VT_LPWSTR = 0x001F,
-        VT_RECORD = 0x0024,
-        VT_INT_PTR = 0x0025,
-        VT_UINT_PTR = 0x0026,
-        VT_ARRAY = 0x2000,
-        VT_BYREF = 0x4000
-    }
-
-    [Flags]
-    public enum VariantConversionFlags : ushort
-    {
-        NO_FLAGS = 0x00,
-        VARIANT_NOVALUEPROP = 0x01,     //Prevents the function from attempting to coerce an object to a fundamental type by getting the Value property. Applications should set this flag only if necessary, because it makes their behavior inconsistent with other applications.
-        VARIANT_ALPHABOOL = 0x02,       //Converts a VT_BOOL value to a string containing either "True" or "False".
-        VARIANT_NOUSEROVERRIDE = 0x04,  //For conversions to or from VT_BSTR, passes LOCALE_NOUSEROVERRIDE to the core coercion routines.
-        VARIANT_LOCALBOOL = 0x08        //For conversions from VT_BOOL to VT_BSTR and back, uses the language specified by the locale in use on the local computer. 
-    }
-
     /// <summary>
     /// Handles variant conversions, enabling us to have same implicit conversion behaviors within
     /// .NET as we can observe it from VBA/VB6.
@@ -67,40 +17,18 @@ namespace Rubberduck.VBEditor.Variants
     /// </remarks>
     public static class VariantConverter
     {
-        private const string dllName = "oleaut32.dll";
-
-        // HRESULT VariantChangeType(
-        //   VARIANTARG       *pvargDest,
-        //   const VARIANTARG *pvarSrc,
-        //   USHORT           wFlags,
-        //   VARTYPE          vt
-        // );
-        [DllImport(dllName, EntryPoint = "VariantChangeType", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = true)]
-        private static extern int VariantChangeType(ref object pvargDest, ref object pvarSrc, VariantConversionFlags wFlags, VARENUM vt);
-
-        // HRESULT VariantChangeTypeEx(
-        //   VARIANTARG        *pvargDest,
-        //   const VARIANTARG  *pvarSrc,
-        //   LCID              lcid,
-        //   USHORT            wFlags,
-        //   VARTYPE           vt
-        // );
-        [DllImport(dllName, EntryPoint = "VariantChangeTypeEx", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = true)]
-        private static extern int VariantChangeTypeEx(ref object pvargDest, ref object pvarSrc, int lcid, VariantConversionFlags wFlags, VARENUM vt);
-
         public static object ChangeType(object value, VARENUM vt)
         {
             return ChangeType(value, vt, null);
         }
 
-        private static bool HRESULT_FAILED(int hr) => hr < 0;
         public static object ChangeType(object value, VARENUM vt, CultureInfo cultureInfo)
         {
             object result = null;
             var hr = cultureInfo == null
-                ? VariantChangeType(ref result, ref value, VariantConversionFlags.NO_FLAGS, vt)
-                : VariantChangeTypeEx(ref result, ref value, cultureInfo.LCID, VariantConversionFlags.NO_FLAGS, vt);
-            if (HRESULT_FAILED(hr))
+                ? VariantNativeMethods.VariantChangeType(ref result, ref value, VariantConversionFlags.NO_FLAGS, vt)
+                : VariantNativeMethods.VariantChangeTypeEx(ref result, ref value, cultureInfo.LCID, VariantConversionFlags.NO_FLAGS, vt);
+            if (HResult.Failed(hr))
             {
                 throw Marshal.GetExceptionForHR(hr);
             }

--- a/Rubberduck.VBEEditor/Variants/VariantNativeMethods.cs
+++ b/Rubberduck.VBEEditor/Variants/VariantNativeMethods.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Rubberduck.VBEditor.Variants
+{
+    public enum VARENUM
+    {
+        VT_EMPTY = 0x0000,
+        VT_NULL = 0x0001,
+        VT_I2 = 0x0002,
+        VT_I4 = 0x0003,
+        VT_R4 = 0x0004,
+        VT_R8 = 0x0005,
+        VT_CY = 0x0006,
+        VT_DATE = 0x0007,
+        VT_BSTR = 0x0008,
+        VT_DISPATCH = 0x0009,
+        VT_ERROR = 0x000A,
+        VT_BOOL = 0x000B,
+        VT_VARIANT = 0x000C,
+        VT_UNKNOWN = 0x000D,
+        VT_DECIMAL = 0x000E,
+        VT_I1 = 0x0010,
+        VT_UI1 = 0x0011,
+        VT_UI2 = 0x0012,
+        VT_UI4 = 0x0013,
+        VT_I8 = 0x0014,
+        VT_UI8 = 0x0015,
+        VT_INT = 0x0016,
+        VT_UINT = 0x0017,
+        VT_VOID = 0x0018,
+        VT_HRESULT = 0x0019,
+        VT_PTR = 0x001A,
+        VT_SAFEARRAY = 0x001B,
+        VT_CARRAY = 0x001C,
+        VT_USERDEFINED = 0x001D,
+        VT_LPSTR = 0x001E,
+        VT_LPWSTR = 0x001F,
+        VT_RECORD = 0x0024,
+        VT_INT_PTR = 0x0025,
+        VT_UINT_PTR = 0x0026,
+        VT_ARRAY = 0x2000,
+        VT_BYREF = 0x4000
+    }
+
+    [Flags]
+    public enum VariantConversionFlags : ushort
+    {
+        NO_FLAGS = 0x00,
+        VARIANT_NOVALUEPROP = 0x01,     //Prevents the function from attempting to coerce an object to a fundamental type by getting the Value property. Applications should set this flag only if necessary, because it makes their behavior inconsistent with other applications.
+        VARIANT_ALPHABOOL = 0x02,       //Converts a VT_BOOL value to a string containing either "True" or "False".
+        VARIANT_NOUSEROVERRIDE = 0x04,  //For conversions to or from VT_BSTR, passes LOCALE_NOUSEROVERRIDE to the core coercion routines.
+        VARIANT_LOCALBOOL = 0x08        //For conversions from VT_BOOL to VT_BSTR and back, uses the language specified by the locale in use on the local computer. 
+    }
+
+    [Flags]
+    public enum VariantComparisonFlags : ulong
+    {
+        NO_FLAGS = 0x00,
+        NORM_IGNORECASE = 0x00000001,       //Ignore case.
+        NORM_IGNORENONSPACE = 0x00000002,   //Ignore nonspace characters.
+        NORM_IGNORESYMBOLS = 0x00000004,    //Ignore symbols.
+        NORM_IGNOREWIDTH = 0x00000008,      //Ignore string width.
+        NORM_IGNOREKANATYPE = 0x00000040,   //Ignore Kana type.
+        NORM_IGNOREKASHIDA = 0x00040000     //Ignore Arabic kashida characters. 
+    }
+
+    public enum VariantComparisonResults : int
+    {
+        VARCMP_LT = 0,      //pvarLeft is less than pvarRight.
+        VARCMP_EQ = 1,      //The parameters are equal.
+        VARCMP_GT = 2,      //pvarLeft is greater than pvarRight.
+        VARCMP_NULL = 3     //Either expression is NULL.
+    }
+
+    public static class HResult
+    {
+        internal static bool Succeeded(int hr) => hr >= 0;
+        internal static bool Failed(int hr) => hr < 0;
+    }
+
+    internal static class VariantNativeMethods
+    {
+        private const string dllName = "oleaut32.dll";
+
+        // HRESULT VariantChangeType(
+        //   VARIANTARG       *pvargDest,
+        //   const VARIANTARG *pvarSrc,
+        //   USHORT           wFlags,
+        //   VARTYPE          vt
+        // );
+        [DllImport(dllName, EntryPoint = "VariantChangeType", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = true)]
+        internal static extern int VariantChangeType(ref object pvargDest, ref object pvarSrc, VariantConversionFlags wFlags, VARENUM vt);
+
+        // HRESULT VariantChangeTypeEx(
+        //   VARIANTARG        *pvargDest,
+        //   const VARIANTARG  *pvarSrc,
+        //   LCID              lcid,
+        //   USHORT            wFlags,
+        //   VARTYPE           vt
+        // );
+        [DllImport(dllName, EntryPoint = "VariantChangeTypeEx", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = true)]
+        internal static extern int VariantChangeTypeEx(ref object pvargDest, ref object pvarSrc, int lcid, VariantConversionFlags wFlags, VARENUM vt);
+
+        // HRESULT VarCmp(
+        //   LPVARIANT pvarLeft,
+        //   LPVARIANT pvarRight,
+        //   LCID lcid,
+        //   ULONG dwFlags
+        // );
+        [DllImport(dllName, EntryPoint = "VarCmp", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = true)]
+        internal static extern int VarCmp(ref object pvarLeft, ref object pvarRight, int lcid, ulong dwFlags);
+    }
+}

--- a/RubberduckTests/UnitTesting/AssertTests.cs
+++ b/RubberduckTests/UnitTesting/AssertTests.cs
@@ -4,11 +4,6 @@ using Rubberduck.UnitTesting;
 
 namespace RubberduckTests.UnitTesting
 {
-    //NOTE: The tests for reference equity are ignored pending some way of figuring out how to test the correct behavior.
-    //These methods have to check to see if the parameters are COM objects (see https://github.com/rubberduck-vba/Rubberduck/issues/2848)
-    //to make the result match the VBA interpretations of reference and value types.  Similarly, the SequenceEqual and NotSequenceEqual
-    //methods remain untested because they make several of the same Type tests that are AFAIK impossible to mock.
-
     [TestFixture]
     public class AssertTests
     {
@@ -25,6 +20,11 @@ namespace RubberduckTests.UnitTesting
         {
             _args = null;
             AssertHandler.OnAssertCompleted -= AssertHandler_OnAssertCompleted;
+        }
+
+        private void AssertHandler_OnAssertCompleted(object sender, AssertCompletedEventArgs e)
+        {
+            _args = e;
         }
 
         [Category("Unit Testing")]
@@ -276,11 +276,6 @@ namespace RubberduckTests.UnitTesting
             assert.Inconclusive();
 
             Assert.AreEqual(TestOutcome.Inconclusive, _args.Outcome);
-        }
-
-        private void AssertHandler_OnAssertCompleted(object sender, AssertCompletedEventArgs e)
-        {
-            _args = e;
         }
 
         [Category("Unit Testing")]

--- a/RubberduckTests/UnitTesting/PermissiveAssertTests.cs
+++ b/RubberduckTests/UnitTesting/PermissiveAssertTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using NUnit.Framework;
+using Rubberduck.UnitTesting;
+
+namespace RubberduckTests.UnitTesting
+{
+    [TestFixture]
+    [NonParallelizable]
+    [Category("PermissiveAsserts")]
+    public class PermissiveAssertTests
+    {
+        private AssertCompletedEventArgs _args;
+
+        [SetUp]
+        public void Initialize()
+        {
+            AssertHandler.OnAssertCompleted += AssertHandler_OnAssertCompleted;
+        }
+
+        private void AssertHandler_OnAssertCompleted(object sender, AssertCompletedEventArgs e)
+        {
+            _args = e;
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _args = null;
+            AssertHandler.OnAssertCompleted -= AssertHandler_OnAssertCompleted;
+        }
+
+        // Note: nulls are basically equivalent to an empty variant. Therefore,
+        // comparisons to a initialized variable should be as if it was the 
+        // default value of the given type (e.g. 0 for numeric data types, empty
+        // string for string data type and so on). To compare a value against a 
+        // VBA's Null, we must use DBNull instead.
+
+        [Test]
+        [TestCase(true, -1)]
+        [TestCase(true, "-1")]
+        [TestCase(true, "true")]
+        [TestCase(0, "0E1")]
+        [TestCase(0e1, "0")]
+        [TestCase("", null)]
+        [TestCase(0, null)]
+        [TestCase(null, 0)]
+        [TestCase(null, "")]
+        [TestCase("123", 123)]
+        [TestCase(456, "456")]
+        [TestCase("abc", "abc")]
+        [TestCase("abc", "ABC")]
+        public void PermissiveAreEqual(object left, object right)
+        {
+            var assert = new PermissiveAssertClass();
+            assert.AreEqual(left, right);
+
+            Assert.AreEqual(TestOutcome.Succeeded, _args.Outcome);
+        }
+
+        [Test]
+        [TestCase(true, 1)]
+        [TestCase(true, 0)]
+        [TestCase(true, "0")]
+        [TestCase(true, "false")]
+        [TestCase(123, "abc")]
+        [TestCase("abc","def")]
+        [TestCase("ABC", "def")]
+        public void PermissiveAreNotEqual(object left, object right)
+        {
+            var assert = new PermissiveAssertClass();
+            assert.AreNotEqual(left, right);
+
+            Assert.AreEqual(TestOutcome.Succeeded, _args.Outcome);
+        }
+
+        [Test]
+        public void PermissiveAreEqualStrings()
+        {
+            PermissiveAreEqual(string.Empty, "");
+        }
+
+        [Test]
+        [TestCase("", false)]
+        [TestCase("", true)]
+        [TestCase(0, false)]
+        [TestCase(0, true)]
+        public void PermissiveAreNotEqualToNull(object x, bool invert)
+        {
+            if (invert)
+            {
+                PermissiveAreNotEqual(DBNull.Value, x);
+            }
+            else
+            {
+                PermissiveAreNotEqual(x, DBNull.Value);
+            }
+        }
+
+        [Test]
+        [TestCase("", false)]
+        [TestCase("", true)]
+        [TestCase(0, false)]
+        [TestCase(0, true)]
+        public void PermissiveAreNotEqualToMissing(object x, bool invert)
+        {
+            if (invert)
+            {
+                PermissiveAreNotEqual(Missing.Value, x);
+            }
+            else
+            {
+                PermissiveAreNotEqual(x, Missing.Value);
+            }
+        }
+
+        [Test]
+        [TestCase("0", "0", true)]
+        [TestCase("1", "1", true)]
+        [TestCase("1", "0", false)]
+        [TestCase("1.1", "1.1", true)]
+        [TestCase("1.1", "2.2", false)]
+        public void PermissiveCompareDecimal(string x, string y, bool shouldEqual)
+        {
+            var dx = decimal.Parse(x, CultureInfo.InvariantCulture);
+            var dy = decimal.Parse(y, CultureInfo.InvariantCulture);
+
+            if (shouldEqual)
+            {
+                PermissiveAreEqual(dx, dy);
+            }
+            else
+            {
+                PermissiveAreNotEqual(dx, dy);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The PermissiveAssert class is broken. This PR makes it acts using the same semantics as used by VBA by using the [`VarCmp` function](https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-varcmp) to do the comparison. In testing, I found it was necessary to also change the type to handle some comparisons like `True = "True"`. This also refactors the `Variants` namespace a little bit.