### PR TITLE
Add MisleadingByRefParameterInspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitByRefModifierInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitByRefModifierInspection.cs
@@ -67,7 +67,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                     && !finder.FindEventHandlers().Contains(enclosingMethod);
         }
 
-        private bool IsPropertyMutatorRHSParameter(ModuleBodyElementDeclaration enclosingMethod, ParameterDeclaration implicitByRefParameter)
+        private static bool IsPropertyMutatorRHSParameter(ModuleBodyElementDeclaration enclosingMethod, ParameterDeclaration implicitByRefParameter)
         {
             return (enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertyLet)
                     || enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertySet)) 

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitByRefModifierInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitByRefModifierInspection.cs
@@ -3,6 +3,7 @@ using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.Resources.Inspections;
+using System.Linq;
 
 namespace Rubberduck.CodeAnalysis.Inspections.Concrete
 {
@@ -10,8 +11,11 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
     /// Highlights implicit ByRef modifiers in user code.
     /// </summary>
     /// <why>
-    /// In modern VB (VB.NET), the implicit modifier is ByVal, as it is in most other programming languages.
-    /// Making the ByRef modifiers explicit can help surface potentially unexpected language defaults.
+    /// VBA parameters are implicitly ByRef, which differs from modern VB (VB.NET) and most other programming languages which are implicitly ByVal.
+    /// So, explicitly identifing VBA parameter mechanisms (the ByRef and ByVal modifiers) can help surface potentially unexpected language results.
+    /// The inspection does not flag an implicit parameter mechanism for the last parameter of Property mutators (Let or Set).
+    /// VBA applies a ByVal parameter mechanism to the last parameter in the absence (or presence!) of a modifier. 
+    /// Exception: UserDefinedType parameters must always be passed as ByRef.
     /// </why>
     /// <example hasResult="true">
     /// <module name="MyModule" type="Standard Module">
@@ -31,6 +35,16 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
     /// ]]>
     /// </module>
     /// </example>
+    /// <example hasResult="false">
+    /// <module name="MyModule" type="Standard Module">
+    /// <![CDATA[
+    /// Private theLength As Long
+    /// Public Property Let Length(newLength As Long)
+    ///     theLength = newLength
+    /// End Sub
+    /// ]]>
+    /// </module>
+    /// </example>
     internal sealed class ImplicitByRefModifierInspection : DeclarationInspectionBase
     {
         public ImplicitByRefModifierInspection(IDeclarationFinderProvider declarationFinderProvider)
@@ -41,21 +55,23 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         {
             if (!(declaration is ParameterDeclaration parameter)
                 || !parameter.IsImplicitByRef
-                || parameter.IsParamArray)
+                || parameter.IsParamArray
+                //Exclude parameters of Declare statements
+                || !(parameter.ParentDeclaration is ModuleBodyElementDeclaration enclosingMethod))
             {
                 return false;
             }
 
-            var parentDeclaration = parameter.ParentDeclaration;
+            return !IsPropertyMutatorRHSParameter(enclosingMethod, parameter)
+                    && !enclosingMethod.IsInterfaceImplementation
+                    && !finder.FindEventHandlers().Contains(enclosingMethod);
+        }
 
-            if (parentDeclaration is ModuleBodyElementDeclaration enclosingMethod)
-            {
-                return !enclosingMethod.IsInterfaceImplementation
-                       && !finder.FindEventHandlers().Contains(enclosingMethod);
-            }
-
-            return parentDeclaration.DeclarationType != DeclarationType.LibraryFunction
-                   && parentDeclaration.DeclarationType != DeclarationType.LibraryProcedure;
+        private bool IsPropertyMutatorRHSParameter(ModuleBodyElementDeclaration enclosingMethod, ParameterDeclaration implicitByRefParameter)
+        {
+            return (enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertyLet)
+                    || enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertySet)) 
+                && enclosingMethod.Parameters.Last().Equals(implicitByRefParameter);
         }
 
         protected override string ResultDescription(Declaration declaration)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MisleadingByRefParameterInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MisleadingByRefParameterInspection.cs
@@ -49,24 +49,20 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
 
         protected override bool IsResultDeclaration(Declaration declaration, DeclarationFinder finder)
         {
-            if ((declaration is ParameterDeclaration parameter)  
+            return declaration is ParameterDeclaration parameter
+                && !(parameter.AsTypeDeclaration?.DeclarationType.HasFlag(DeclarationType.UserDefinedType) ?? false)
                 && parameter.ParentDeclaration is ModuleBodyElementDeclaration enclosingMethod
                 && (enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertyLet)
                     || enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertySet))
                 && enclosingMethod.Parameters.Last() == parameter
-                && !(parameter.AsTypeDeclaration?.DeclarationType.HasFlag(DeclarationType.UserDefinedType) ?? false))
-            {
-                return parameter.IsByRef && !parameter.IsImplicitByRef;
-            }
-
-            return false;
+                && parameter.IsByRef && !parameter.IsImplicitByRef;
         }
 
         protected override string ResultDescription(Declaration declaration)
         {
             return string.Format(
                 InspectionResults.MisleadingByRefParameterInspection,
-                declaration.IdentifierName);
+                declaration.IdentifierName, declaration.ParentDeclaration.QualifiedName.MemberName);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MisleadingByRefParameterInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MisleadingByRefParameterInspection.cs
@@ -1,0 +1,72 @@
+﻿using Rubberduck.CodeAnalysis.Inspections.Abstract;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.Resources.Inspections;
+using System.Linq;
+
+namespace Rubberduck.CodeAnalysis.Inspections.Concrete
+{
+    /// <summary>
+    /// Flags the value-parameter of a property mutators that are declared with an explict ByRef modifier.
+    /// </summary>
+    /// <why>
+    /// Regardless of the presence or absence of an explicit ByRef or ByVal modifier, the value-parameter
+    /// of a property mutator is always treated as though it had an explicit ByVal modifier.
+    /// Exception: UserDefinedType parameters are always passed by reference.
+    /// </why>
+    /// <example hasResult="true">
+    /// <module name="MyModule" type="Standard Module">
+    /// <![CDATA[
+    /// Private fizzField As Long
+    /// Public Property Get Fizz() As Long
+    ///     Fizz = fizzFiled
+    /// End Property
+    /// Public Property Let Fizz(ByRef arg As Long)
+    ///     fizzFiled = arg
+    /// End Property
+    /// ]]>
+    /// </module>
+    /// </example>
+    /// <example hasResult="false">
+    /// <module name="MyModule" type="Standard Module">
+    /// <![CDATA[
+    /// Private fizzField As Long
+    /// Public Property Get Fizz() As Long
+    ///     Fizz = fizzFiled
+    /// End Property
+    /// Public Property Let Fizz(arg As Long)
+    ///     fizzFiled = arg
+    /// End Property
+    /// ]]>
+    /// </module>
+    /// </example>
+    internal sealed class MisleadingByRefParameterInspection : DeclarationInspectionBase
+    {
+        public MisleadingByRefParameterInspection(IDeclarationFinderProvider declarationFinderProvider)
+            : base(declarationFinderProvider, DeclarationType.Parameter)
+        { }
+
+        protected override bool IsResultDeclaration(Declaration declaration, DeclarationFinder finder)
+        {
+            if ((declaration is ParameterDeclaration parameter)  
+                && parameter.ParentDeclaration is ModuleBodyElementDeclaration enclosingMethod
+                && (enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertyLet)
+                    || enclosingMethod.DeclarationType.HasFlag(DeclarationType.PropertySet))
+                && enclosingMethod.Parameters.Last() == parameter
+                && !(parameter.AsTypeDeclaration?.DeclarationType.HasFlag(DeclarationType.UserDefinedType) ?? false))
+            {
+                return parameter.IsByRef && !parameter.IsImplicitByRef;
+            }
+
+            return false;
+        }
+
+        protected override string ResultDescription(Declaration declaration)
+        {
+            return string.Format(
+                InspectionResults.MisleadingByRefParameterInspection,
+                declaration.IdentifierName);
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/PassParameterByValueQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/PassParameterByValueQuickFix.cs
@@ -38,7 +38,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
         private readonly IDeclarationFinderProvider _declarationFinderProvider;
 
         public PassParameterByValueQuickFix(IDeclarationFinderProvider declarationFinderProvider)
-            : base(typeof(ParameterCanBeByValInspection))
+            : base(typeof(ParameterCanBeByValInspection), typeof(MisleadingByRefParameterInspection))
         {
             _declarationFinderProvider = declarationFinderProvider;
         }

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -502,7 +502,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The last parameter (the &apos;Value&apos; parameter) of property mutators are always passed by value.  This is true regardless of the presence or absence of a ByVal modifier.  Exception: UserDefinedType parameters must always be passed by reference in all cases..
+        ///   Looks up a localized string similar to The last parameter (the &apos;Value&apos; parameter) of property mutators are always passed ByVal. This is true regardless of the presence or absence of a ByRef or ByVal modifier. Exception: A UserDefinedType must always be passed ByRef even when it is the last parameter of a property mutator..
         /// </summary>
         public static string MisleadingByRefParameterInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Inspections {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InspectionInfo {
@@ -498,6 +498,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The last parameter (the &apos;Value&apos; parameter) of property mutators are always passed by value.  This is true regardless of the presence or absence of a ByVal modifier.  Exception: UserDefinedType parameters must always be passed by reference in all cases..
+        /// </summary>
+        public static string MisleadingByRefParameterInspection {
+            get {
+                return ResourceManager.GetString("MisleadingByRefParameterInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -443,6 +443,6 @@ If the parameter can be null, ignore this inspection result; passing a null valu
     <value>An annotation has more arguments than allowed; superfluous arguments are ignored.</value>
   </data>
   <data name="MisleadingByRefParameterInspection" xml:space="preserve">
-    <value>The last parameter (the 'Value' parameter) of property mutators are always passed by value.  This is true regardless of the presence or absence of a ByVal modifier.  Exception: UserDefinedType parameters must always be passed by reference in all cases.</value>
+    <value>The last parameter (the 'Value' parameter) of property mutators are always passed ByVal. This is true regardless of the presence or absence of a ByRef or ByVal modifier. Exception: A UserDefinedType must always be passed ByRef even when it is the last parameter of a property mutator.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -442,4 +442,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="SuperfluousAnnotationArgumentInspection" xml:space="preserve">
     <value>An annotation has more arguments than allowed; superfluous arguments are ignored.</value>
   </data>
+  <data name="MisleadingByRefParameterInspection" xml:space="preserve">
+    <value>The last parameter (the 'Value' parameter) of property mutators are always passed by value.  This is true regardless of the presence or absence of a ByVal modifier.  Exception: UserDefinedType parameters must always be passed by reference in all cases.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -502,7 +502,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ByRef is a misleading modifier because the parameter will be passed ByVal..
+        ///   Looks up a localized string similar to Misleading ByRef parameter modifier.
         /// </summary>
         public static string MisleadingByRefParameterInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Inspections {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InspectionNames {
@@ -498,6 +498,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ByRef is a misleading modifier because the parameter will be passed ByVal..
+        /// </summary>
+        public static string MisleadingByRefParameterInspection {
+            get {
+                return ResourceManager.GetString("MisleadingByRefParameterInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -443,6 +443,6 @@
     <value>Superfluous annotation arguments</value>
   </data>
   <data name="MisleadingByRefParameterInspection" xml:space="preserve">
-    <value>ByRef is a misleading modifier because the parameter will be passed ByVal.</value>
+    <value>Misleading ByRef parameter modifier</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -362,19 +362,15 @@
   </data>
   <data name="KeywordsUsedAsMemberInspection" xml:space="preserve">
     <value>Keyword used as member name</value>
-    
   </data>
   <data name="LineContinuationBetweenKeywordsInspection" xml:space="preserve">
     <value>Line continuation between keywords</value>
-    
   </data>
   <data name="NonBreakingSpaceIdentifierInspection" xml:space="preserve">
     <value>Identifier containing a non-breaking space</value>
-    
   </data>
   <data name="NegativeLineNumberInspection" xml:space="preserve">
     <value>Negative line number</value>
-    
   </data>
   <data name="OnErrorGoToMinusOneInspection" xml:space="preserve">
     <value>OnErrorGoto -1</value>
@@ -445,5 +441,8 @@
   </data>
   <data name="SuperfluousAnnotationArgumentInspection" xml:space="preserve">
     <value>Superfluous annotation arguments</value>
+  </data>
+  <data name="MisleadingByRefParameterInspection" xml:space="preserve">
+    <value>ByRef is a misleading modifier because the parameter will be passed ByVal.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -520,7 +520,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Misleading ByRef modifier used for Parameter &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Misleading ByRef modifier used for parameter &apos;{0}&apos; ({1})..
         /// </summary>
         public static string MisleadingByRefParameterInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Inspections {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class InspectionResults {
@@ -516,6 +516,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string MemberNotOnInterfaceInspection {
             get {
                 return ResourceManager.GetString("MemberNotOnInterfaceInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Misleading ByRef modifier used for Parameter &apos;{0}&apos;..
+        /// </summary>
+        public static string MisleadingByRefParameterInspection {
+            get {
+                return ResourceManager.GetString("MisleadingByRefParameterInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -513,4 +513,8 @@ In memoriam, 1972-2018</value>
     <value>The annotation '{0}' was expected to have less arguments.</value>
     <comment>{0} annotation name</comment>
   </data>
+  <data name="MisleadingByRefParameterInspection" xml:space="preserve">
+    <value>Misleading ByRef modifier used for Parameter '{0}'.</value>
+    <comment>{0} Parameter name</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -514,7 +514,7 @@ In memoriam, 1972-2018</value>
     <comment>{0} annotation name</comment>
   </data>
   <data name="MisleadingByRefParameterInspection" xml:space="preserve">
-    <value>Misleading ByRef modifier used for Parameter '{0}'.</value>
-    <comment>{0} Parameter name</comment>
+    <value>Misleading ByRef modifier used for parameter '{0}' ({1}).</value>
+    <comment>{0} Parameter, {1} Member</comment>
   </data>
 </root>

--- a/RubberduckTests/Inspections/MisleadingByRefParameterInspectionTests.cs
+++ b/RubberduckTests/Inspections/MisleadingByRefParameterInspectionTests.cs
@@ -1,0 +1,72 @@
+﻿using NUnit.Framework;
+using Rubberduck.CodeAnalysis.Inspections;
+using Rubberduck.CodeAnalysis.Inspections.Concrete;
+using Rubberduck.Parsing.VBA;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class MisleadingByRefParameterInspectionTests : InspectionTestsBase
+    {
+        [TestCase("Property Let Fizz(ByRef arg1 As Integer)\r\nEnd Property", 1)]
+        [TestCase("Property Let Fizz(arg1 As Integer)\r\nEnd Property", 0)]
+        [TestCase("Property Let Fizz(ByVal arg1 As Integer)\r\nEnd Property", 0)]
+        [TestCase("Property Set Fizz(ByRef arg1 As Object)\r\nEnd Property", 1)]
+        [TestCase("Property Set Fizz(arg1 As Object)\r\nEnd Property", 0)]
+        [TestCase("Property Set Fizz(ByVal arg1 As Object)\r\nEnd Property", 0)]
+        [Category("QuickFixes")]
+        [Category(nameof(MisleadingByRefParameterInspection))]
+        public void AllParamMechanisms(string inputCode, int expectedCount)
+        {
+            Assert.AreEqual(expectedCount, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [TestCase("arg")]
+        [TestCase("ByRef arg")]
+        [Category("QuickFixes")]
+        [Category(nameof(MisleadingByRefParameterInspection))]
+        public void UserDefinedTypeEdgeCase(string parameterMechanismAndParam)
+        {
+            var inputCode =
+$@"
+Option Explicit
+
+Public Type TestType
+    FirstValue As Long
+End Type
+
+Private this As TestType
+
+Public Property Get UserDefinedType() As TestType
+    UserDefinedType = this
+End Property
+
+Public Property Let UserDefinedType({parameterMechanismAndParam} As TestType)
+    this = arg
+End Property
+";
+
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        [Category(nameof(MisleadingByRefParameterInspection))]
+        public void InspectionName()
+        {
+            var inspection = new MisleadingByRefParameterInspection(null);
+
+            Assert.AreEqual(nameof(MisleadingByRefParameterInspection), inspection.Name);
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new MisleadingByRefParameterInspection(state);
+        }
+    }
+}

--- a/RubberduckTests/QuickFixes/PassParameterByValueQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/PassParameterByValueQuickFixTests.cs
@@ -296,6 +296,28 @@ End Sub";
             Assert.AreEqual(expectedCode, actualCode);
         }
 
+        [Test]
+        [Category("QuickFixes")]
+        [Category(nameof(MisleadingByRefParameterInspection))]
+        public void CorrectsMisleadingByRefPropertyMutatorParameter()
+        {
+            const string inputCode =
+@"
+Option Explicit
+
+Private fizzField As Long
+
+Public Property Get Fizz() As Long
+    Fizz = fizzField
+End Property
+
+Public Property Let Fizz(ByRef arg As Long)
+    fizzField = arg
+End Property
+";
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MisleadingByRefParameterInspection(state));
+            StringAssert.Contains("Public Property Let Fizz(ByVal arg As Long)", actualCode);
+        }
 
         protected override IQuickFix QuickFix(RubberduckParserState state)
         {


### PR DESCRIPTION
Closes #3486 
Closes #5374 

Recruits `PassParameterByValueQuickFix` to correct explicit `ByRef` declarations.

Additionally updates `ImplicitByRefParameterInspection` to ignore implicit `ByRef` modifiers for the value-parameter of property mutators per #3486 comment.