### PR TITLE
Fix neg line number detected in legitimate go to neg one

### DIFF
--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
@@ -646,8 +646,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
 
         private void AddLineNumberLabelDeclaration(VBAParser.LineNumberLabelContext context)
         {
-            var statementText = context.numberLiteral().GetText();
-            var statementSelection = context.numberLiteral().GetSelection();
+            var statementText = context.GetText().Trim();
+            var statementSelection = context.GetSelection();
 
             AddDeclaration(
                 CreateDeclaration(

--- a/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
+++ b/RubberduckTests/Inspections/ThunderCode/ThunderCodeInspectionTests.cs
@@ -225,6 +225,39 @@ GoTo -5
 1
 -5:
 End Sub")]
+        [TestCase(1, @"Public Sub Gogo()
+On Error GoTo 1
+1
+-1:
+End Sub")]
+        [TestCase(2, @"Public Sub Gogo()
+On Error GoTo -1
+1
+-1:
+End Sub")]
+        [TestCase(2, @"Public Sub Gogo()
+On Error GoTo -1
+1:
+-1
+End Sub")]
+        [TestCase(0, @"Public Sub Gogo()
+On Error GoTo -1
+1
+End Sub")]
+        [TestCase(1, @"Public Sub Gogo()
+On Error GoTo -2
+1
+End Sub")]
+        [TestCase(2, @"Public Sub Gogo()
+On Error GoTo -5
+1
+-5:
+End Sub")]
+        [TestCase(2, @"Public Sub Gogo()
+On Error GoTo -5
+1:
+-5
+End Sub")]
         public void NegativeLineNumberLabel_ReturnResults(int expectedCount, string inputCode)
         {
             var func = new Func<RubberduckParserState, IInspection>(state =>


### PR DESCRIPTION
Closes #5544

There will no longer be a result for the negative line number inspection for `On Error GoTo -1`, unless the `-1` actually refers to an existing line label.

This also fixes a bug in the declaration resolver because of which we lost the minus sign for all negative line numbers.