### PR TITLE
Fix missing default member result for optional parentheses on properties

### DIFF
--- a/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/IndexDefaultBinding.cs
@@ -356,8 +356,11 @@ namespace Rubberduck.Parsing.Binding
         private static bool ArgumentListIsCompatible(ICollection<ParameterDeclaration> parameters, ArgumentList argumentList)
         {
             return (parameters.Count >= (argumentList?.Arguments.Count ?? 0) 
-                        || parameters.Any(parameter => parameter.IsParamArray))
-                    && parameters.Count(parameter => !parameter.IsOptional && !parameter.IsParamArray) <= (argumentList?.Arguments.Count ?? 0);
+                            || parameters.Any(parameter => parameter.IsParamArray))
+                        && parameters.Count(parameter => !parameter.IsOptional && !parameter.IsParamArray) <= (argumentList?.Arguments.Count ?? 0)
+                   || parameters.Count == 0 
+                        && argumentList?.Arguments.Count == 1
+                        && argumentList.Arguments.Single().ArgumentType == ArgumentListArgumentType.Missing;
         }
 
         private IBoundExpression ResolveRecursiveDefaultMember(Declaration defaultMember, ExpressionClassification defaultMemberClassification, ArgumentList argumentList, ParserRuleContext expression, Declaration parent, int defaultMemberResolutionRecursionDepth, RecursiveDefaultMemberAccessExpression containedExpression)

--- a/RubberduckTests/Inspections/DefaultMemberRequiredInspectionTests.cs
+++ b/RubberduckTests/Inspections/DefaultMemberRequiredInspectionTests.cs
@@ -332,6 +332,31 @@ End Function
 
         [Category("Inspections")]
         [Test]
+        public void OptionalParenthesesAfterVariantReturningProperty_NoResult()
+        {
+            var classCode = @"
+Public Property Get Foo() As Variant
+End Property
+";
+
+            var moduleCode = @"
+Private Function Bar() As String 
+    Dim cls As new Class1
+    Bar = cls.Foo()
+End Function
+";
+
+            var vbe = MockVbeBuilder.BuildFromModules(
+                ("Class1", classCode, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule));
+
+            var inspectionResults = InspectionResults(vbe.Object);
+            
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Category("Inspections")]
+        [Test]
         public void FailedIndexExpressionOnFunctionWithParameters_NoResult()
         {
             var classCode = @"


### PR DESCRIPTION
Closes #5581

The problem was that the empty argument list gets parsed as an argument list with a single missing argument and the `IndexDefaultBinding` did not account for it. Since the missing argument is actually a valid way to parse the empty argument list and the parser cannot know whether there is an optional parameter or not, I chose to catch this in the `IndexDefaultBinding`.