### PR TITLE
Modify EncapsulateFieldRefactoring to generate Identifiers without underscores

### DIFF
--- a/Rubberduck.Refactorings/EncapsulateField/ConflictDetection/EncapsulateFieldConflictFinder.cs
+++ b/Rubberduck.Refactorings/EncapsulateField/ConflictDetection/EncapsulateFieldConflictFinder.cs
@@ -224,6 +224,7 @@ namespace Rubberduck.Refactorings.EncapsulateField
         {
             return HasInternalPropertyAndBackingFieldConflict(candidate)
                 || HasConflictsWithOtherEncapsulationPropertyIdentifiers(candidate, identifierToCompare)
+                || HasConflictsWithOtherEncapsulationBackingIdentifiers(candidate, identifierToCompare)
                 || HasConflictsWithUnmodifiedPropertyAndFieldIdentifiers(candidate, identifierToCompare)
                 || HasConflictWithLocalDeclarationIdentifiers(candidate, identifierToCompare);
         }
@@ -233,10 +234,19 @@ namespace Rubberduck.Refactorings.EncapsulateField
                 && candidate.EncapsulateFlag
                 && candidate.PropertyIdentifier.IsEquivalentVBAIdentifierTo(candidate.BackingIdentifier);
 
-        private bool HasConflictsWithOtherEncapsulationPropertyIdentifiers(IEncapsulateFieldCandidate candidate, string identifierToCompare) 
+        private bool HasConflictsWithOtherEncapsulationPropertyIdentifiers(IEncapsulateFieldCandidate candidate, string identifierToCompare)
             => _allCandidates.Where(c => c.TargetID != candidate.TargetID
                 && c.EncapsulateFlag
                 && c.PropertyIdentifier.IsEquivalentVBAIdentifierTo(identifierToCompare)).Any();
+
+        private bool HasConflictsWithOtherEncapsulationBackingIdentifiers(IEncapsulateFieldCandidate candidate, string identifierToCompare)
+        {
+            return candidate is IEncapsulateFieldAsUDTMemberCandidate || candidate is IUserDefinedTypeMemberCandidate
+                ? false
+                : _allCandidates.Where(c => c.TargetID != candidate.TargetID
+                    && c.EncapsulateFlag
+                    && c.BackingIdentifier.IsEquivalentVBAIdentifierTo(identifierToCompare)).Any();
+        }
 
         private bool HasConflictsWithUnmodifiedPropertyAndFieldIdentifiers(IEncapsulateFieldCandidate candidate, string identifierToCompare)
         {

--- a/Rubberduck.Refactorings/EncapsulateField/Extensions/StringExtensions.cs
+++ b/Rubberduck.Refactorings/EncapsulateField/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Rubberduck.Refactorings.EncapsulateField.Extensions
 {
@@ -9,20 +10,13 @@ namespace Rubberduck.Refactorings.EncapsulateField.Extensions
 
         public static string IncrementEncapsulationIdentifier(this string identifier)
         {
-            var fragments = identifier.Split('_');
-            if (fragments.Length == 1)
+            var numeric = string.Concat(identifier.Reverse().TakeWhile(c => char.IsDigit(c)).Reverse());
+            if (!int.TryParse(numeric, out var currentNum))
             {
-                return $"{identifier}_1";
+                currentNum = 0;
             }
-
-            var lastFragment = fragments[fragments.Length - 1];
-            if (long.TryParse(lastFragment, out var number))
-            {
-                fragments[fragments.Length - 1] = (number + 1).ToString();
-
-                return string.Join("_", fragments);
-            }
-            return $"{identifier}_1"; ;
+            var identifierSansNumericSuffix = identifier.Substring(0, identifier.Length - numeric.Length);
+            return $"{identifierSansNumericSuffix}{++currentNum}";
         }
     }
 }

--- a/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateArrayFieldTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateArrayFieldTests.cs
@@ -148,8 +148,8 @@ End Sub
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             StringAssert.Contains("Public Property Get MyArray() As Variant", actualCode);
             StringAssert.DoesNotContain("Public Property Let MyArray(", actualCode);
-            StringAssert.Contains("Redim myArray_1(size)", actualCode);
-            StringAssert.Contains("myArray_1(idx) = idx", actualCode);
+            StringAssert.Contains("Redim myArray1(size)", actualCode);
+            StringAssert.Contains("myArray1(idx) = idx", actualCode);
         }
 
         [Test]

--- a/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateFieldTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateFieldTests.cs
@@ -328,9 +328,9 @@ End Enum
 
             var presenterAction = Support.UserAcceptsDefaults();
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
-            StringAssert.Contains("Private numberType_1 As NumberTypes", actualCode);
+            StringAssert.Contains("Private numberType1 As NumberTypes", actualCode);
             StringAssert.Contains("Public Property Get NumberType() As NumberTypes", actualCode);
-            StringAssert.Contains("NumberType = numberType_1", actualCode);
+            StringAssert.Contains("NumberType = numberType1", actualCode);
         }
 
         //5.3.1 The declared type of a function declaration may not be a private enum name.
@@ -357,9 +357,9 @@ Private numberT|ype As NumberTypes{declarationList ?? string.Empty}
             var presenterAction = Support.UserAcceptsDefaults();
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             var expectedPropertyType = enumTypeAccessibility == "Public" ? "NumberTypes" : "Long";
-            StringAssert.Contains("Private numberType_1 As NumberTypes", actualCode);
+            StringAssert.Contains("Private numberType1 As NumberTypes", actualCode);
             StringAssert.Contains($"Public Property Get NumberType() As {expectedPropertyType}", actualCode);
-            StringAssert.Contains("NumberType = numberType_1", actualCode);
+            StringAssert.Contains("NumberType = numberType1", actualCode);
         }
 
         [Test]
@@ -373,12 +373,12 @@ Private numberT|ype As NumberTypes{declarationList ?? string.Empty}
             var presenterAction = Support.SetParametersForSingleTarget("fizz");
 
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
-            StringAssert.Contains("Private fizz_1 As Integer, fuzz As Integer,", actualCode);
+            StringAssert.Contains("Private fizz1 As Integer, fuzz As Integer,", actualCode);
             StringAssert.Contains("Public Property Get Fizz() As Integer", actualCode);
             StringAssert.Contains("Public Property Let Fizz(", actualCode);
             StringAssert.Contains($"(ByVal {Support.RHSIdentifier} As Integer)", actualCode);
-            StringAssert.Contains("Fizz = fizz_1", actualCode);
-            StringAssert.Contains($"fizz_1 = {Support.RHSIdentifier}", actualCode);
+            StringAssert.Contains("Fizz = fizz1", actualCode);
+            StringAssert.Contains($"fizz1 = {Support.RHSIdentifier}", actualCode);
             StringAssert.Contains("End Property", actualCode);
         }
 
@@ -396,8 +396,8 @@ Private numberT|ype As NumberTypes{declarationList ?? string.Empty}
             StringAssert.Contains("Public Property Get Fizz() As Integer", actualCode);
             StringAssert.Contains("Public Property Let Fizz(", actualCode);
             StringAssert.Contains($"(ByVal {Support.RHSIdentifier} As Integer)", actualCode);
-            StringAssert.Contains("Fizz = fizz_1", actualCode);
-            StringAssert.Contains($"fizz_1 = {Support.RHSIdentifier}", actualCode);
+            StringAssert.Contains("Fizz = fizz1", actualCode);
+            StringAssert.Contains($"fizz1 = {Support.RHSIdentifier}", actualCode);
             StringAssert.Contains("End Property", actualCode);
         }
 

--- a/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateFieldUseBackingFieldRefactoringActionTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateFieldUseBackingFieldRefactoringActionTests.cs
@@ -49,7 +49,7 @@ namespace RubberduckTests.Refactoring.EncapsulateField.EncapsulateFieldUseBackin
 
             var backingField = propertyIdentifier != null
                 ? target
-                : $"{target}_1";
+                : $"{target}1";
 
             StringAssert.Contains($"Public Property Get {resultPropertyIdentifier}()", refactoredCode);
             StringAssert.Contains($"{resultPropertyIdentifier} = {backingField}", refactoredCode);

--- a/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateUDTFieldTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingField/EncapsulateUDTFieldTests.cs
@@ -88,12 +88,12 @@ Public that As TBar";
                 StringAssert.Contains($"Property Get Second", actualCode);
 
                 StringAssert.Contains($"Private {expectedThat.TargetFieldName} As TBar", actualCode);
-                StringAssert.Contains($"First_1 = {expectedThat.TargetFieldName}.First", actualCode);
-                StringAssert.Contains($"Second_1 = {expectedThat.TargetFieldName}.Second", actualCode);
+                StringAssert.Contains($"First1 = {expectedThat.TargetFieldName}.First", actualCode);
+                StringAssert.Contains($"Second1 = {expectedThat.TargetFieldName}.Second", actualCode);
                 StringAssert.Contains($"{expectedThat.TargetFieldName}.First = {Support.RHSIdentifier}", actualCode);
                 StringAssert.Contains($"{expectedThat.TargetFieldName}.Second = {Support.RHSIdentifier}", actualCode);
-                StringAssert.Contains($"Property Get First_1", actualCode);
-                StringAssert.Contains($"Property Get Second_1", actualCode);
+                StringAssert.Contains($"Property Get First1", actualCode);
+                StringAssert.Contains($"Property Get Second1", actualCode);
 
                 StringAssert.Contains($"Private {expectedThis.TargetFieldName} As TBar", actualCode);
                 StringAssert.Contains($"Private {expectedThat.TargetFieldName} As TBar", actualCode);
@@ -749,7 +749,7 @@ End Function";
 
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
 
-            StringAssert.Contains("Public Property Let First_1", actualCode);
+            StringAssert.Contains("Public Property Let First1", actualCode);
             StringAssert.Contains("Public Property Let Second", actualCode);
         }
 
@@ -809,8 +809,8 @@ Private my|Bar As TBar
 
             StringAssert.Contains("Public Property Let Foo(", actualCode);
             StringAssert.Contains("Public Property Let Bar(", actualCode);
-            StringAssert.Contains("Public Property Let Foo_1(", actualCode);
-            StringAssert.Contains("Public Property Let Bar_1(", actualCode);
+            StringAssert.Contains("Public Property Let Foo1(", actualCode);
+            StringAssert.Contains("Public Property Let Bar1(", actualCode);
             StringAssert.Contains($"myBar.FooBar.Foo = {Support.RHSIdentifier}", actualCode);
             StringAssert.Contains($"myBar.ReBar.Foo = {Support.RHSIdentifier}", actualCode);
         }

--- a/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingUDTMember/EncapsulateUsingStateUDTTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldUseBackingUDTMember/EncapsulateUsingStateUDTTests.cs
@@ -58,7 +58,7 @@ Private this As Long";
             var presenterAction = Support.UserAcceptsDefaults(convertFieldToUDTMember: true);
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             StringAssert.Contains("Private this As Long", actualCode);
-            StringAssert.Contains($"Private this_1 As {Support.StateUDTDefaultTypeName}", actualCode);
+            StringAssert.Contains($"Private this1 As {Support.StateUDTDefaultTypeName}", actualCode);
         }
 
         [Test]
@@ -377,7 +377,7 @@ End Property
         [Category("Encapsulate Field")]
         public void UserDefinedTypeDefaultNameHasConflict()
         {
-            var expectedIdentifier = "TTestModule1_1";
+            var expectedIdentifier = "TTestModule2";
             var inputCode =
 $@"
 

--- a/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldValidatorTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateField/EncapsulateFieldValidatorTests.cs
@@ -75,11 +75,11 @@ End Property
             var presenterAction = Support.SetParameters(userInput);
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             StringAssert.Contains("Public Property Get Variable() As Integer", actualCode);
-            StringAssert.Contains("Variable = variable_1", actualCode);
+            StringAssert.Contains("Variable = variable3", actualCode);
             StringAssert.Contains("Public Property Get Variable1() As Long", actualCode);
-            StringAssert.Contains("Variable1 = variable1_1", actualCode);
+            StringAssert.Contains("Variable1 = variable4", actualCode);
             StringAssert.Contains("Public Property Get Variable2() As Integer", actualCode);
-            StringAssert.Contains("Variable2 = variable2_1", actualCode);
+            StringAssert.Contains("Variable2 = variable5", actualCode);
             StringAssert.DoesNotContain("Public Property Get Variable3() As Integer", actualCode);
         }
 
@@ -117,11 +117,11 @@ $@"Public fizz As String
             Private fizzle As String
 
             'fizz1 is the initial default name for encapsulating 'fizz'            
-            Public Property Get Fizz_1() As String
-                Fizz_1 = fizzle
+            Public Property Get Fizz1() As String
+                Fizz1 = fizzle
             End Property
 
-            Public Property Let Fizz_1(ByVal value As String)
+            Public Property Let Fizz1(ByVal value As String)
                 fizzle = value
             End Property
             ";
@@ -256,7 +256,7 @@ Public wholeNumber As String
 Public Enum NumberTypes 
      Whole = -1 
      Integral = 0 
-     Rational_1 = 1 
+     Rational1 = 1 
 End Enum
 
 Private rati|onal As NumberTypes
@@ -265,7 +265,7 @@ Private rati|onal As NumberTypes
             var presenterAction = Support.UserAcceptsDefaults();
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             StringAssert.Contains("Public Property Get Rational() As NumberTypes", actualCode);
-            StringAssert.Contains("Rational = rational_2", actualCode);
+            StringAssert.Contains("Rational = rational2", actualCode);
         }
 
         [Test]
@@ -287,7 +287,7 @@ Private whe|els As Integer
             var presenterAction = Support.UserAcceptsDefaults();
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             StringAssert.Contains("Public Property Get Wheels()", actualCode);
-            StringAssert.Contains("Wheels = wheels_1", actualCode);
+            StringAssert.Contains("Wheels = wheels1", actualCode);
         }
 
         [Test]
@@ -329,8 +329,8 @@ End Function
             var presenterAction = Support.UserAcceptsDefaults();
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             StringAssert.Contains("Test", actualCode);
-            StringAssert.Contains("test_1", actualCode);
-            StringAssert.DoesNotContain("Test_1", actualCode);
+            StringAssert.Contains("test1", actualCode);
+            StringAssert.DoesNotContain("Test1", actualCode);
         }
 
         [TestCase("Dim test As String", "arg")] //Local variable
@@ -369,17 +369,17 @@ End Function
             var inputCode =
 $@"
 Private tes|t As String
-Private test_1 As String
+Private test1 As String
 
 Public Sub Foo(arg As String)
-    test = arg & test_1
+    test = arg & test1
 End Sub
 ";
             var presenterAction = Support.UserAcceptsDefaults();
             var actualCode = Support.RefactoredCode(inputCode.ToCodeString(), presenterAction);
             StringAssert.Contains("Test", actualCode);
-            StringAssert.Contains("Private test_2 As String", actualCode);
-            StringAssert.DoesNotContain("test_1 = arg & test_1", actualCode);
+            StringAssert.Contains("Private test2 As String", actualCode);
+            StringAssert.DoesNotContain("test1 = arg & test1", actualCode);
         }
 
         [TestCase(MockVbeBuilder.TestModuleName)]
@@ -472,7 +472,7 @@ Public mF|oo As Long
             var actualModuleCode = Support.RefactoredCode(presenterAction, 
                 (moduleOneName, inputCode.ToCodeString(), ComponentType.StandardModule));
 
-            StringAssert.Contains($"Private Type TModuleOne_1", actualModuleCode[moduleOneName]);
+            StringAssert.Contains($"Private Type TModuleOne1", actualModuleCode[moduleOneName]);
         }
 
         [Test]
@@ -682,7 +682,7 @@ Private {fieldUT} As Double
 
                 model.ConflictFinder.AssignNoConflictIdentifiers(objectStateUDT);
 
-                StringAssert.AreEqualIgnoringCase("this_1", objectStateUDT.IdentifierName);
+                StringAssert.AreEqualIgnoringCase("this1", objectStateUDT.IdentifierName);
             }
         }
 

--- a/RubberduckTests/Refactoring/EncapsulateField/EncapsulationIdentifiersTests.cs
+++ b/RubberduckTests/Refactoring/EncapsulateField/EncapsulationIdentifiersTests.cs
@@ -45,24 +45,24 @@ $@"Public fizz As String
             var inputCode = "Public fizz As String";
 
             var encapsulatedField = Support.RetrieveEncapsulateFieldCandidate(inputCode, "fizz");
-            StringAssert.AreEqualIgnoringCase("fizz_1", encapsulatedField.BackingIdentifier);
+            StringAssert.AreEqualIgnoringCase("fizz1", encapsulatedField.BackingIdentifier);
 
             encapsulatedField.PropertyIdentifier = "Test";
             StringAssert.AreEqualIgnoringCase("fizz", encapsulatedField.BackingIdentifier);
 
             encapsulatedField.PropertyIdentifier = "Fizz";
-            StringAssert.AreEqualIgnoringCase("fizz_1", encapsulatedField.BackingIdentifier);
+            StringAssert.AreEqualIgnoringCase("fizz1", encapsulatedField.BackingIdentifier);
 
             encapsulatedField.PropertyIdentifier = "Fiz";
             StringAssert.AreEqualIgnoringCase("fizz", encapsulatedField.BackingIdentifier);
 
             encapsulatedField.PropertyIdentifier = "Fizz";
-            StringAssert.AreEqualIgnoringCase("fizz_1", encapsulatedField.BackingIdentifier);
+            StringAssert.AreEqualIgnoringCase("fizz1", encapsulatedField.BackingIdentifier);
         }
 
         [TestCase("strValue", "Value", "strValue")]
         [TestCase("m_Text", "Text", "m_Text")]
-        [TestCase("notAHungarianName", "NotAHungarianName", "notAHungarianName_1")]
+        [TestCase("notAHungarianName", "NotAHungarianName", "notAHungarianName1")]
         [Category("Refactorings")]
         [Category("Encapsulate Field")]
         public void AccountsForHungarianNamesAndMemberPrefix(string inputName, string expectedPropertyName, string expectedFieldName)


### PR DESCRIPTION
Closes #5425 

The PR changes the `EncapsulateFieldRefactoring` declaration identifier modification scheme to increment identifiers without using an underscore.

The `EncapsulateFieldRefactoring` currently appends "_1" and the increments the value as necessary to resolve conflicting property and backing field names.  Introducing the underscore generated members that could not be subsequently used as an interface member (without renaming to eliminate the underscore).   

Equally important: The expected effect of changing the incrementing scheme was several failing tests.  However, one test did not pass by simply removing the underscores from the expected results.  The modified test surfaced a `EncapsulateFieldConflictFinder` bug that is also fixed in this PR.