### PR TITLE
Fix bug in supertype name derivation

### DIFF
--- a/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/ReferenceResolveRunnerBase.cs
@@ -223,7 +223,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             //Since we do not have a declaration for the hidden interface, we have to go one more step up the hierarchy.
             var additionalInterfaces = relevantInterfaces
                 .Where(i => i.Name.Equals("_" + comModule.Name))
-                .SelectMany(i => i.InheritedInterfaces);
+                .SelectMany(i => i.InheritedInterfaces)
+                .ToList();
 
             relevantInterfaces.AddRange(additionalInterfaces);
 


### PR DESCRIPTION
Closes #5624

Materialize additional supertype interfaces before adding them to the collection they are based on.

I should have tested this on Access, but apparently didn't. On Excel, the problem does not surface since this interface construction is specific to Access.