### PR TITLE
Cache directory path on code export

### DIFF
--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -419,7 +419,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         public CodeExplorerMoveToFolderDragAndDropCommand MoveToFolderDragAndDropCommand { get; set; }
 
         public string CachedExportPath { get; internal set; }
-        public (CodeExplorerViewModel, ICodeExplorerNode) ExportCommandParameter => (this, SelectedItem);
+        public CodeExplorerViewModel ExportCommandsParameter => this;
 
         public ICodeExplorerNode FindVisibleNodeForDeclaration(Declaration declaration)
         {

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -418,6 +418,9 @@ namespace Rubberduck.Navigation.CodeExplorer
 
         public CodeExplorerMoveToFolderDragAndDropCommand MoveToFolderDragAndDropCommand { get; set; }
 
+        public string CachedExportPath { get; internal set; }
+        public (CodeExplorerViewModel, ICodeExplorerNode) ExportCommandParameter => (this, SelectedItem);
+
         public ICodeExplorerNode FindVisibleNodeForDeclaration(Declaration declaration)
         {
             if (declaration == null)

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerViewModel.cs
@@ -418,7 +418,7 @@ namespace Rubberduck.Navigation.CodeExplorer
 
         public CodeExplorerMoveToFolderDragAndDropCommand MoveToFolderDragAndDropCommand { get; set; }
 
-    public ICodeExplorerNode FindVisibleNodeForDeclaration(Declaration declaration)
+        public ICodeExplorerNode FindVisibleNodeForDeclaration(Declaration declaration)
         {
             if (declaration == null)
             {

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -506,11 +506,11 @@
                     </MenuItem>
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_Export}"
                               Command="{Binding ExportCommand}"
-                              CommandParameter="{Binding ExportCommandParameter, Mode=OneWay}"
+                              CommandParameter="{Binding ExportCommandsParameter, Mode=OneWay}"
                               Visibility="{Binding ExportVisibility}" />
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_ExportAll}"
                               Command="{Binding ExportAllCommand}"
-                              CommandParameter="{Binding ExportCommandParameter, Mode=OneWay}" 
+                              CommandParameter="{Binding ExportCommandsParameter, Mode=OneWay}" 
                               Visibility="{Binding ExportAllVisibility}" />
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_Remove}"
                               Command="{Binding RemoveCommand}"

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -506,11 +506,11 @@
                     </MenuItem>
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_Export}"
                               Command="{Binding ExportCommand}"
-                              CommandParameter="{Binding SelectedItem, Mode=OneWay}"
+                              CommandParameter="{Binding ExportCommandParameter, Mode=OneWay}"
                               Visibility="{Binding ExportVisibility}" />
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_ExportAll}"
                               Command="{Binding ExportAllCommand}"
-                              CommandParameter="{Binding SelectedItem, Mode=OneWay}" 
+                              CommandParameter="{Binding ExportCommandParameter, Mode=OneWay}" 
                               Visibility="{Binding ExportAllVisibility}" />
                     <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_Remove}"
                               Command="{Binding RemoveCommand}"

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
@@ -79,6 +79,8 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             PromptFileNameAndExport(node.Declaration.QualifiedName.QualifiedModuleName);
         }
 
+        private string cachedExportPath = null;
+
         public bool PromptFileNameAndExport(QualifiedModuleName qualifiedModule)
         {
             if (!_exportableFileExtensions.TryGetValue(qualifiedModule.ComponentType, out var extension))
@@ -89,6 +91,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             using (var dialog = _dialogFactory.CreateSaveFileDialog())
             {
                 dialog.OverwritePrompt = true;
+                dialog.InitialDirectory = cachedExportPath ?? string.Empty;
                 dialog.FileName = qualifiedModule.ComponentName + extension;
 
                 var result = dialog.ShowDialog();
@@ -97,11 +100,11 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                     return false;
                 }
 
+                cachedExportPath = System.IO.Path.GetDirectoryName(dialog.FileName);
                 var component = ProjectsProvider.Component(qualifiedModule);
                 try
                 {
-                    var path = System.IO.Path.GetDirectoryName(dialog.FileName);
-                    component.ExportAsSourceFile(path, false, true); // skipped optional parameters interfere with mock setup
+                    component.ExportAsSourceFile(cachedExportPath, false, true); // skipped optional parameters interfere with mock setup
                 }
                 catch (Exception ex)
                 {

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
@@ -72,15 +72,15 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                     return true;
                 }
 
-                if (obj is ValueTuple<CodeExplorerViewModel, ICodeExplorerNode> tuple)
+                if (obj is CodeExplorerViewModel viewModel)
                 {
-                    if (tuple.Item1.SelectedItem is CodeExplorerCustomFolderViewModel)
+                    if (viewModel.SelectedItem is CodeExplorerCustomFolderViewModel)
                     {
                         compType = ComponentType.Undefined;
                         return false;
                     }
 
-                    if (tuple.Item1.SelectedItem is CodeExplorerComponentViewModel componentViewModel)
+                    if (viewModel.SelectedItem is CodeExplorerComponentViewModel componentViewModel)
                     {
                         compType = componentViewModel.Declaration.QualifiedName.QualifiedModuleName.ComponentType;
                         return true;
@@ -97,8 +97,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         protected override void OnExecute(object parameter)
         {
-            var tuple = (ValueTuple<CodeExplorerViewModel, ICodeExplorerNode>)parameter;
-            var viewModel = tuple.Item1;
+            var viewModel = (CodeExplorerViewModel)parameter;
 
             if (!(viewModel.SelectedItem is CodeExplorerComponentViewModel componentViewModel) ||
                 componentViewModel.Declaration == null)

--- a/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
+++ b/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
@@ -101,15 +101,12 @@ namespace Rubberduck.UI.Command.ComCommands
             }
         }
 
+        private string cachedExportPath = null;
         private void Export(IVBProject project)
         {
             var desc = string.Format(RubberduckUI.ExportAllCommand_SaveAsDialog_Title, project.Name);
 
-            // If .GetDirectoryName is passed an empty string for a RootFolder, 
-            // it defaults to the Documents library (Win 7+) or equivalent.
-            var path = string.IsNullOrWhiteSpace(project.FileName)
-                ? string.Empty
-                : Path.GetDirectoryName(project.FileName);
+            var path = ExportPath();
 
             using (var _folderBrowser = _factory.CreateFolderBrowser(desc, true, path))
             {
@@ -117,8 +114,23 @@ namespace Rubberduck.UI.Command.ComCommands
 
                 if (result == DialogResult.OK)
                 {
-                    project.ExportSourceFiles(_folderBrowser.SelectedPath);
+                    cachedExportPath = _folderBrowser.SelectedPath;
+                    project.ExportSourceFiles(cachedExportPath);
                 }
+            }
+
+            string ExportPath()
+            {
+                if (!string.IsNullOrWhiteSpace(cachedExportPath))
+                {
+                    return cachedExportPath;
+                }
+
+                // If .GetDirectoryName is passed an empty string for a RootFolder, 
+                // it defaults to the Documents library (Win 7+) or equivalent.
+                return string.IsNullOrWhiteSpace(project.FileName)
+                    ? string.Empty
+                    : Path.GetDirectoryName(project.FileName);
             }
         }
     }

--- a/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
+++ b/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
@@ -76,12 +76,12 @@ namespace Rubberduck.UI.Command.ComCommands
 
         protected override void OnExecute(object parameter)
         {
-            dynamic node; //unsure if this the correct usage
+            dynamic node; // used to get passing tests and feedback on PR.
             CodeExplorerViewModel viewModel = null;
-            if (parameter is ValueTuple<CodeExplorerViewModel, ICodeExplorerNode> tuple)
+            if (parameter is CodeExplorerViewModel)
             {
-                viewModel = tuple.Item1;
-                node = tuple.Item2;
+                viewModel = (CodeExplorerViewModel)parameter;
+                node = viewModel.SelectedItem;
             }
             else
             {

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -450,7 +450,8 @@ namespace RubberduckTests.CodeExplorer
             {
                 ImplementExportAllCommand();
             }
-            ViewModel.ExportAllCommand.Execute(ViewModel.SelectedItem);
+            (CodeExplorerViewModel ViewModel, ICodeExplorerNode SelectedItem) parameter = (ViewModel, ViewModel.SelectedItem);
+            ViewModel.ExportAllCommand.Execute(parameter);
         }
 
         public MockedCodeExplorer ImplementExportAllCommand()
@@ -465,7 +466,8 @@ namespace RubberduckTests.CodeExplorer
             {
                 ImplementExportCommand();
             }
-            ViewModel.ExportCommand.Execute(ViewModel.SelectedItem);
+            (CodeExplorerViewModel ViewModel, ICodeExplorerNode SelectedItem) parameter = (ViewModel, ViewModel.SelectedItem);
+            ViewModel.ExportCommand.Execute(parameter);
         }
 
         public MockedCodeExplorer ImplementExportCommand()

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -450,8 +450,8 @@ namespace RubberduckTests.CodeExplorer
             {
                 ImplementExportAllCommand();
             }
-            (CodeExplorerViewModel ViewModel, ICodeExplorerNode SelectedItem) parameter = (ViewModel, ViewModel.SelectedItem);
-            ViewModel.ExportAllCommand.Execute(parameter);
+            
+            ViewModel.ExportAllCommand.Execute(ViewModel);
         }
 
         public MockedCodeExplorer ImplementExportAllCommand()
@@ -466,8 +466,8 @@ namespace RubberduckTests.CodeExplorer
             {
                 ImplementExportCommand();
             }
-            (CodeExplorerViewModel ViewModel, ICodeExplorerNode SelectedItem) parameter = (ViewModel, ViewModel.SelectedItem);
-            ViewModel.ExportCommand.Execute(parameter);
+            
+            ViewModel.ExportCommand.Execute(ViewModel);
         }
 
         public MockedCodeExplorer ImplementExportCommand()

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -34,7 +34,6 @@ using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SourceCodeHandling;
 using Rubberduck.VBEditor.Utility;
 using RubberduckTests.Settings;
-using Rubberduck.Refactorings;
 
 namespace RubberduckTests.CodeExplorer
 {

--- a/RubberduckTests/Commands/ExportAllCommandTests.cs
+++ b/RubberduckTests/Commands/ExportAllCommandTests.cs
@@ -97,10 +97,10 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project = projectMock.Build();
             project.SetupGet(m => m.IsSaved).Returns(true);
@@ -130,10 +130,10 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project = projectMock.Build();
             project.SetupGet(m => m.IsSaved).Returns(true);
@@ -164,16 +164,16 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project1 = projectMock1.Build();
             var project2 = projectMock2.Build();
@@ -211,16 +211,16 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project1 = projectMock1.Build();
             var project2 = projectMock2.Build();
@@ -257,10 +257,10 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project = projectMock.Build();
             project.SetupGet(m => m.IsSaved).Returns(true);
@@ -290,10 +290,10 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project = projectMock.Build();
             project.SetupGet(m => m.IsSaved).Returns(true);
@@ -324,16 +324,16 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project1 = projectMock1.Build();
             var project2 = projectMock2.Build();
@@ -371,16 +371,16 @@ namespace RubberduckTests.Commands
             var builder = new MockVbeBuilder();
 
             var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
+                .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                .AddComponent("Document1", ComponentType.Document, string.Empty)
+                .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
 
             var project1 = projectMock1.Build();
             var project2 = projectMock2.Build();

--- a/RubberduckTests/Commands/ExportAllCommandTests.cs
+++ b/RubberduckTests/Commands/ExportAllCommandTests.cs
@@ -316,7 +316,6 @@ namespace RubberduckTests.Commands
             project.Verify(m => m.ExportSourceFiles(_path), Times.Never);
         }
 
-
         [Category("Commands")]
         [Test]
         public void ExportAllCommand_Execute_PassedNull_MultipleProjects_BrowserCanceled_ExpectNoExecution()

--- a/RubberduckTests/Mocks/MockProjectBuilder.cs
+++ b/RubberduckTests/Mocks/MockProjectBuilder.cs
@@ -231,8 +231,7 @@ namespace RubberduckTests.Mocks
                     {".frm", ComponentType.UserForm}
                 };
 
-                ComponentType type;
-                types.TryGetValue(extension, out type);
+                types.TryGetValue(extension, out ComponentType type);
 
                 _componentsMock.Add(CreateComponentMock(Path.GetFileNameWithoutExtension(s), type, string.Empty, new Selection(), null, out var codeModule));
                 _codeModuleMocks.Add(codeModule);


### PR DESCRIPTION
Close #5584.

Added a property to store the export location on the ViewModel. The commands now receive a reference to the ViewModel as I saw no other way for them to share the reference.