### PR TITLE
Potentially fix the AV when running Rubberduck with Access

### DIFF
--- a/Rubberduck.Parsing/ComReflection/XmlComProjectSerializer.cs
+++ b/Rubberduck.Parsing/ComReflection/XmlComProjectSerializer.cs
@@ -17,19 +17,22 @@ namespace Rubberduck.Parsing.ComReflection
         public readonly string DefaultSerializationPath;
         private readonly IFileSystem _fileSystem;
 
+        private XmlComProjectSerializer(IFileSystem fileSystem, string defaultPath, string path)
+        {
+            _fileSystem = fileSystem;
+            DefaultSerializationPath = defaultPath;
+            Target = path ?? DefaultSerializationPath;
+        }
+
         public XmlComProjectSerializer(
             IPersistencePathProvider pathProvider,
             IFileSystem fileSystem)
-        {
-            DefaultSerializationPath = pathProvider.DataFolderPath("Declarations");
-            _fileSystem = fileSystem;
-        }
+            : this(fileSystem, pathProvider.DataFolderPath("Declarations"), null)
+        { }
 
-        public XmlComProjectSerializer(IFileSystem filesystem, string path = null)
-        {
-            Target = path ?? DefaultSerializationPath;
-            _fileSystem = filesystem;
-        }
+        public XmlComProjectSerializer(IFileSystem fileSystem, string path)
+            : this(fileSystem, path, path)
+        { }
 
         private static readonly XmlReaderSettings ReaderSettings = new XmlReaderSettings
         {

--- a/RubberduckBaseProject.csproj
+++ b/RubberduckBaseProject.csproj
@@ -59,7 +59,18 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug'">
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <!-- Valid Constants used in the solution: 
+      LOG_COM_RELEASE     // Records COM objects released when a safe COM wrapper has been disposed
+      PRETTY_XML          // Includes whitespace and formatting to serialized XML files for XmlComProjectSerializer
+      REF_COUNT           // Tracks the reported reference counts when acquiring/disposing COM objects
+      THRISTY_DUCK        // Outputs the message content from the message pump in VBENativeServices / SubclassingWindow
+      THRISTY_DUCK_EVT    // Outptus the events raised from the message pump in VBENativeServices / SubclassingWindow
+      TRACE_COM_SAFE      // Tracks the COM wrappers added & removed to the ComSafe and also allow serializing the contents of ComSafe
+      TRACE_TYPEAPI       // Tracks the methods called on the wrapped ITypeLib & ITypeInfo
+      TRACE_COM_POINTERS  // Tracks the ComPointer access & disposal
+      TRACE_MARSHAL       // Tracks the calls made through the RdMarshal class (useful for tracking all Marshal methods)
+    -->
+    <DefineConstants>DEBUG;TRACE;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release'">


### PR DESCRIPTION
There is an access violation when one tries to parse too soon or at wrong time which then leaks the pointer and causes Access to becomes unstable and thus can crash when exiting normally. This helps fixes and also 2 minor changes for developer's convenience. 
