### PR TITLE
Fix ignore module quick fix and ReDim array types

### DIFF
--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/IgnoreInModuleQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/IgnoreInModuleQuickFix.cs
@@ -60,7 +60,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
 
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
-            var module = result.Target.QualifiedModuleName;
+            var module = result.QualifiedSelection.QualifiedName;
             var moduleDeclaration = _state.DeclarationFinder.Members(module, DeclarationType.Module)
                 .FirstOrDefault();
 

--- a/RubberduckTests/Inspections/VariableTypeNotDeclaredInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableTypeNotDeclaredInspectionTests.cs
@@ -119,6 +119,32 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
+        [TestCase("Variant")]
+        [TestCase("Long")]
+        public void VariableTypeNotDeclared_TypedArray_Dim_DoesNotReturnResult(string variableType)
+        {
+            var inputCode =
+                $@"Sub Foo()
+    Dim bar(0 To 1) As {variableType}
+End Sub";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Variant")]
+        [TestCase("Long")]
+        public void VariableTypeNotDeclared_TypedArray_ReDim_DoesNotReturnResult(string variableType)
+        {
+            var inputCode =
+                $@"Sub Foo()
+    ReDim bar(0 To 1) As {variableType}
+End Sub";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void InspectionName()
         {
             var inspection = new VariableTypeNotDeclaredInspection(null);


### PR DESCRIPTION
Closes #5690
Closes #5686

This PR fixes two issues previously not covered in tests and not encountered regularly in real code.

1. The `IgnoreModuleQuickFix` added the annotation in the target's module instead of the one the inspection result was in. This only ever makes a difference for identifier reference results for which the referenced declaration is in another module. In the referenced issue, this meant that we tries to change the code behind of a built-in module, which failed silently.
2. We ignored the type defined on a `ReDim` statement when it declares a variable, leading to the false-positive in the issue above and generally preventing the correct resolution of member accesses to array members.

The fix for 1. is straightforward; use the module on the qualified selection instead of that on the target.

The fix for 2. I added is not really clean. I have basically copied the logic to get the `AsTypeContext`, `TypeHint` and `AsTypeName` from the `DeclarationSymbolslistener` and the type resolution logic from the `TypeAnnotationPass`. This made it necessary to explicitly new up the components injected into the `TypeAnnotationPass` every time. Although this is not really a clean solution, I would like to postpone the cleanup to a future PR, in which the entire part dealing with undeclared variables gets extracted out of the `DeclarationFinder`.