### PR TITLE
Make DescriptionString work with VB_VarDescription attributes.

### DIFF
--- a/Rubberduck.Parsing/Symbols/Declaration.cs
+++ b/Rubberduck.Parsing/Symbols/Declaration.cs
@@ -289,7 +289,10 @@ namespace Rubberduck.Parsing.Symbols
             {
                 string literalDescription;
 
-                var memberAttribute = Attributes.SingleOrDefault(a => a.Name == Attributes.MemberAttributeName("VB_Description", IdentifierName));
+                var memberAttribute = Attributes.SingleOrDefault(a => 
+                    a.Name == Attributes.MemberAttributeName("VB_Description", IdentifierName) || 
+                    a.Name == Attributes.MemberAttributeName("VB_VarDescription", IdentifierName));
+
                 if (memberAttribute != null)
                 {
                     literalDescription = memberAttribute.Values.SingleOrDefault() ?? string.Empty;


### PR DESCRIPTION
`VB_VarDescription` attributes are not being taken into account when evaluating `Declaration.Description`. This PR fixes that, making variable descriptions appear in both the Code Explorer's bottom panel and the RD commandbar.