### PR TITLE
Fix context menus

### DIFF
--- a/Rubberduck.Core/AppMenu.cs
+++ b/Rubberduck.Core/AppMenu.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using NLog;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.VBA;
@@ -43,8 +44,14 @@ namespace Rubberduck
             {
                 _stateBar.Initialize();
             }
+            catch (COMException exception)
+            {
+                _logger.Error(exception);
+                throw; // NOTE: this exception should bubble up to _Extension.Startup() and cleanly fail the add-in's initialization.
+            }
             catch (Exception exception)
             {
+                // we don't want to abort init just because some CanExecute method threw a NRE
                 _logger.Error(exception);
             }
         }
@@ -57,8 +64,14 @@ namespace Rubberduck
                 {
                     menu.Initialize();
                 }
+                catch (COMException exception)
+                {
+                    _logger.Error(exception);
+                    throw; // NOTE: this exception should bubble up to _Extension.Startup() and cleanly fail the add-in's initialization.
+                }
                 catch (Exception exception)
                 {
+                    // we don't want to abort init just because some CanExecute method threw a NRE
                     _logger.Error(exception);
                 }
             }
@@ -83,8 +96,9 @@ namespace Rubberduck
                 {
                     menu.EvaluateCanExecute(state);
                 }
-                catch(Exception exception)
+                catch (Exception exception)
                 {
+                    // swallow exception to evaluate the other commands
                     _logger.Error(exception);
                 }
             }

--- a/Rubberduck.Core/AppMenu.cs
+++ b/Rubberduck.Core/AppMenu.cs
@@ -33,10 +33,34 @@ namespace Rubberduck
 
         public void Initialize()
         {
-            _stateBar.Initialize();
+            InitializeRubberduckCommandBar();
+            InitializeRubberduckMenus();
+        }
+
+        private void InitializeRubberduckCommandBar()
+        {
+            try
+            {
+                _stateBar.Initialize();
+            }
+            catch (Exception exception)
+            {
+                _logger.Error(exception);
+            }
+        }
+
+        private void InitializeRubberduckMenus()
+        { 
             foreach (var menu in _menus)
             {
-                menu.Initialize();
+                try
+                {
+                    menu.Initialize();
+                }
+                catch (Exception exception)
+                {
+                    _logger.Error(exception);
+                }
             }
             EvaluateCanExecute(_parser.State);
         }
@@ -55,18 +79,48 @@ namespace Rubberduck
         {
             foreach (var menu in _menus)
             {
-                menu.EvaluateCanExecute(state);
+                try
+                {
+                    menu.EvaluateCanExecute(state);
+                }
+                catch(Exception exception)
+                {
+                    _logger.Error(exception);
+                }
             }
         }
 
         public void Localize()
         {
-            _stateBar.Localize();
-            _stateBar.SetStatusLabelCaption(_parser.State.Status);
+            LocalizeRubberduckCommandBar();
+            LocalizeRubberduckMenus();
+        }
 
+        private void LocalizeRubberduckCommandBar()
+        {
+            try
+            {
+                _stateBar.Localize();
+                _stateBar.SetStatusLabelCaption(_parser.State.Status);
+            }
+            catch (Exception exception)
+            {
+                _logger.Error(exception);
+            }
+        }
+
+        private void LocalizeRubberduckMenus()
+        {
             foreach (var menu in _menus)
             {
-                menu.Localize();
+                try
+                {
+                    menu.Localize();
+                }
+                catch (Exception exception)
+                {
+                    _logger.Error(exception);
+                }
             }
         }
 
@@ -95,13 +149,20 @@ namespace Rubberduck
         {
             foreach (var menu in _menus.Where(menu => menu.Item != null))
             {
-                _logger.Debug($"Starting removal of top-level menu {menu.GetType()}.");
-                menu.RemoveMenu();
-                //We do this here and not in the menu items because we only want to dispose of/release the parents of the top level parent menus.
-                //The parents further down get disposed of/released as part of the remove chain.
-                _logger.Trace($"Removing parent menu of top-level menu {menu.GetType()}.");
-                menu.Parent.Dispose();
-                menu.Parent = null;
+                try
+                {
+                    _logger.Debug($"Starting removal of top-level menu {menu.GetType()}.");
+                    menu.RemoveMenu();
+                    //We do this here and not in the menu items because we only want to dispose of/release the parents of the top level parent menus.
+                    //The parents further down get disposed of/released as part of the remove chain.
+                    _logger.Trace($"Removing parent menu of top-level menu {menu.GetType()}.");
+                    menu.Parent.Dispose();
+                    menu.Parent = null;
+                }
+                catch (Exception exception)
+                {
+                    _logger.Error(exception);
+                }
             }
         }
     }

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AnnotateDeclarationCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AnnotateDeclarationCommand.cs
@@ -97,9 +97,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         public bool CanExecuteForNode(ICodeExplorerNode node)
         {
-            if (!ApplicableNodes.Contains(node.GetType())
-                || !(node is CodeExplorerItemViewModel)
-                || node.Declaration == null)
+            if (node?.Declaration == null
+                || !ApplicableNodes.Contains(node.GetType())
+                || !(node is CodeExplorerItemViewModel))
             {
                 return false;
             }

--- a/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
+++ b/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
@@ -174,6 +174,7 @@ namespace Rubberduck.Root
             RegisterRubberduckMenu(container);
             RegisterCodePaneContextMenu(container);
             RegisterFormDesignerContextMenu(container);
+            RegisterFormDesignerControlContextMenu(container);
             RegisterProjectExplorerContextMenu(container);
 
             RegisterWindowsHooks(container);
@@ -592,6 +593,21 @@ namespace Rubberduck.Root
             var beforeIndex = FindRubberduckMenuInsertionIndex(parent, location.BeforeControlId);
             var menuItemTypes = FormDesignerContextMenuItems();
             RegisterMenu<FormDesignerContextParentMenu>(container, parent, beforeIndex, menuItemTypes);
+        }
+
+        private void RegisterFormDesignerControlContextMenu(IWindsorContainer container)
+        {
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.FormDesignerControlContextMenu, out var location))
+            {
+                return;
+            }
+
+            var parent = location.ParentId != default
+                ? MainCommandBarControls(location.ParentId)
+                : MainCommandBarControls(location.ParentName);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(parent, location.BeforeControlId);
+            var menuItemTypes = FormDesignerContextMenuItems();
+            RegisterMenu<FormDesignerControlContextParentMenu>(container, parent, beforeIndex, menuItemTypes);
         }
 
         private Type[] FormDesignerContextMenuItems()

--- a/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
+++ b/Rubberduck.Main/Root/RubberduckIoCInstaller.cs
@@ -174,7 +174,6 @@ namespace Rubberduck.Root
             RegisterRubberduckMenu(container);
             RegisterCodePaneContextMenu(container);
             RegisterFormDesignerContextMenu(container);
-            RegisterFormDesignerControlContextMenu(container);
             RegisterProjectExplorerContextMenu(container);
 
             RegisterWindowsHooks(container);
@@ -524,6 +523,19 @@ namespace Rubberduck.Root
             return controls.Count;
         }
 
+        private ICommandBarControls MainCommandBarControls(string commandBarName)
+        {
+            ICommandBarControls controls;
+            using (var commandBars = _vbe.CommandBars)
+            {
+                using (var menuBar = commandBars[commandBarName])
+                {
+                    controls = menuBar.Controls;
+                }
+            }
+            return controls;
+        }
+
         private ICommandBarControls MainCommandBarControls(int commandBarIndex)
         {
             ICommandBarControls controls;
@@ -539,15 +551,17 @@ namespace Rubberduck.Root
 
         private void RegisterCodePaneContextMenu(IWindsorContainer container)
         {
-            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.CodeWindow, out var location))
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.CodePaneContextMenu, out var location))
             {
                 return;
             }
 
-            var controls = MainCommandBarControls(location.ParentId);
-            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
+            var parent = location.ParentId != default
+                ? MainCommandBarControls(location.ParentId)
+                : MainCommandBarControls(location.ParentName);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(parent, location.BeforeControlId);
             var menuItemTypes = CodePaneContextMenuItems();
-            RegisterMenu<CodePaneContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
+            RegisterMenu<CodePaneContextParentMenu>(container, parent, beforeIndex, menuItemTypes);
         }
 
         private Type[] CodePaneContextMenuItems()
@@ -567,15 +581,17 @@ namespace Rubberduck.Root
 
         private void RegisterFormDesignerContextMenu(IWindsorContainer container)
         {
-            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.MsForm, out var location))
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.FormDesignerContextMenu, out var location))
             {
                 return;
             }
 
-            var controls = MainCommandBarControls(location.ParentId);
-            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
+            var parent = location.ParentId != default
+                ? MainCommandBarControls(location.ParentId)
+                : MainCommandBarControls(location.ParentName);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(parent, location.BeforeControlId);
             var menuItemTypes = FormDesignerContextMenuItems();
-            RegisterMenu<FormDesignerContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
+            RegisterMenu<FormDesignerContextParentMenu>(container, parent, beforeIndex, menuItemTypes);
         }
 
         private Type[] FormDesignerContextMenuItems()
@@ -587,30 +603,19 @@ namespace Rubberduck.Root
             };
         }
 
-        private void RegisterFormDesignerControlContextMenu(IWindsorContainer container)
-        {
-            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.MsFormControl, out var location))
-            {
-                return;
-            }
-
-            var controls = MainCommandBarControls(location.ParentId);
-            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
-            var menuItemTypes = FormDesignerContextMenuItems();
-            RegisterMenu<FormDesignerControlContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
-        }
-
         private void RegisterProjectExplorerContextMenu(IWindsorContainer container)
         {
-            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.ProjectExplorer, out var location))
+            if (!_addin.CommandBarLocations.TryGetValue(CommandBarSite.ProjectExplorerContextMenu, out var location))
             {
                 return;
             }
 
-            var controls = MainCommandBarControls(location.ParentId);
-            var beforeIndex = FindRubberduckMenuInsertionIndex(controls, location.BeforeControlId);
+            var parent = location.ParentId != default
+                ? MainCommandBarControls(location.ParentId)
+                : MainCommandBarControls(location.ParentName);
+            var beforeIndex = FindRubberduckMenuInsertionIndex(parent, location.BeforeControlId);
             var menuItemTypes = ProjectWindowContextMenuItems();
-            RegisterMenu<ProjectWindowContextParentMenu>(container, controls, beforeIndex, menuItemTypes);
+            RegisterMenu<ProjectWindowContextParentMenu>(container, parent, beforeIndex, menuItemTypes);
         }
 
         private Type[] ProjectWindowContextMenuItems()

--- a/Rubberduck.VBEEditor/CommandBarLocation.cs
+++ b/Rubberduck.VBEEditor/CommandBarLocation.cs
@@ -2,12 +2,19 @@
 {
     public class CommandBarLocation
     {
+        public CommandBarLocation(string parentName, int beforeControlId)
+        {
+            ParentName = parentName;
+            BeforeControlId = beforeControlId;
+        }
+
         public CommandBarLocation(int parentId, int beforeControlId)
         {
             ParentId = parentId;
             BeforeControlId = beforeControlId;
         }
 
+        public string ParentName { get; }
         public int ParentId { get; }
         public int BeforeControlId { get; }
     }

--- a/Rubberduck.VBEEditor/CommandBarSite.cs
+++ b/Rubberduck.VBEEditor/CommandBarSite.cs
@@ -3,9 +3,8 @@
     public enum CommandBarSite
     {
         MenuBar,
-        CodeWindow,
-        ProjectExplorer,
-        MsForm,
-        MsFormControl
+        CodePaneContextMenu,
+        ProjectExplorerContextMenu,
+        FormDesignerContextMenu,
     }
 }

--- a/Rubberduck.VBEEditor/CommandBarSite.cs
+++ b/Rubberduck.VBEEditor/CommandBarSite.cs
@@ -6,5 +6,6 @@
         CodePaneContextMenu,
         ProjectExplorerContextMenu,
         FormDesignerContextMenu,
+        FormDesignerControlContextMenu,
     }
 }

--- a/Rubberduck.VBEEditor/VbeCommandBarMenuNames.cs
+++ b/Rubberduck.VBEEditor/VbeCommandBarMenuNames.cs
@@ -1,0 +1,16 @@
+﻿namespace Rubberduck.VBEditor
+{
+    public class VbeCommandBarMenuNames
+    {
+        public static readonly string MenuBar = "Menu Bar";
+        public static readonly string CodePaneContext = "Code Window";
+        public static readonly string CodePaneBreakContext = "Code Window (Break)";
+        public static readonly string ProjectExplorerContext = "Project Window";
+        public static readonly string ProjectExplorerBreakContext = "Project Window (Break)";
+        public static readonly string FormDesignerContext = "MSForms";
+        public static readonly string FormDesignerControlContext = "MSForms Control";
+        public static readonly string FormDesignerControlGroupContext = "MSForms Control Group";
+        public static readonly string ObjectBrowserContext = "Object Browser";
+        public static readonly string PropertiesContext = "Property Browser";
+    }
+}

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
@@ -28,10 +28,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             CommandBarLocations = new ReadOnlyDictionary<CommandBarSite, CommandBarLocation>(new Dictionary<CommandBarSite, CommandBarLocation>
             {
                 {CommandBarSite.MenuBar, new CommandBarLocation(MenuBar, WindowMenu)},
-                {CommandBarSite.CodeWindow, new CommandBarLocation(CodeWindow, ListProperties)},
-                {CommandBarSite.ProjectExplorer, new CommandBarLocation(ProjectExplorer, ProjectProperties)},
+                {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(CodeWindow, ListProperties)},
+                {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(ProjectExplorer, ProjectProperties)},
                 // {CommandBarSite.MsForm, new CommandBarLocation(MsForm, UpdateUserControls)}, // FIXME - quick hack for #4280
-                {CommandBarSite.MsFormControl, new CommandBarLocation(MsFormControl, ViewCode)}
+                {CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(MsFormControl, ViewCode)}
             });
         }
 

--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
@@ -8,12 +8,8 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 {
     public class AddIn : SafeComWrapper<VB.AddIn>, IAddIn
     {
-
+        // this one is an index, not an ID:
         private const int MenuBar = 1;
-        private const int CodeWindow = 15;
-        private const int ProjectExplorer = 22;
-        private const int MsForm = 20;
-        private const int MsFormControl = 21;
 
         private const int WindowMenu = 30009;
         private const int ListProperties = 2529;
@@ -28,10 +24,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
             CommandBarLocations = new ReadOnlyDictionary<CommandBarSite, CommandBarLocation>(new Dictionary<CommandBarSite, CommandBarLocation>
             {
                 {CommandBarSite.MenuBar, new CommandBarLocation(MenuBar, WindowMenu)},
-                {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(CodeWindow, ListProperties)},
-                {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(ProjectExplorer, ProjectProperties)},
-                // {CommandBarSite.MsForm, new CommandBarLocation(MsForm, UpdateUserControls)}, // FIXME - quick hack for #4280
-                {CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(MsFormControl, ViewCode)}
+                {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.CodePaneContext, ListProperties)},
+                {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.ProjectExplorerContext, ProjectProperties)},
+                //{CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.FormDesignerContext, ViewCode)}, // FIXME - see #4280
+                {CommandBarSite.FormDesignerControlContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.FormDesignerControlContext, ViewCode)},
             });
         }
 

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/AddIn.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/AddIn.cs
@@ -6,28 +6,10 @@ using VB = Microsoft.Vbe.Interop;
 // ReSharper disable once CheckNamespace - Special dispensation due to conflicting file vs namespace priorities
 namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 {
-    public class VbeCommandBarMenuNames
-    {
-        public static readonly string MenuBar = "Menu Bar";
-        public static readonly string CodePaneContext = "Code Window";
-        public static readonly string CodePaneBreakContext = "Code Window (Break)";
-        public static readonly string ProjectExplorerContext = "Project Window";
-        public static readonly string ProjectExplorerBreakContext = "Project Window (Break)";
-        public static readonly string FormDesignerContext = "MSForms";
-        public static readonly string FormDesignerControlContext = "MSForms Control";
-        public static readonly string FormDesignerControlGroupContext = "MSForms Control Group";
-        public static readonly string ObjectBrowserContext = "Object Browser";
-        public static readonly string PropertiesContext = "Property Browser";
-    }
-
     public class AddIn : SafeComWrapper<VB.AddIn>, IAddIn
     {
-        // these are indexes, not IDs; they can (and do) change between versions.
-        private const int MenuBar = 1; // assuming this one sticks...
-        //private const int CodeWindow = 9;
-        //private const int ProjectExplorer = 14;
-        //private const int MsForm = 17;
-        //private const int MsFormControl = 18;
+        // this one is an index, not an ID:
+        private const int MenuBar = 1;
 
         private const int WindowMenu = 30009;
         private const int ListProperties = 2529;

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/AddIn.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/AddIn.cs
@@ -6,13 +6,28 @@ using VB = Microsoft.Vbe.Interop;
 // ReSharper disable once CheckNamespace - Special dispensation due to conflicting file vs namespace priorities
 namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 {
+    public class VbeCommandBarMenuNames
+    {
+        public static readonly string MenuBar = "Menu Bar";
+        public static readonly string CodePaneContext = "Code Window";
+        public static readonly string CodePaneBreakContext = "Code Window (Break)";
+        public static readonly string ProjectExplorerContext = "Project Window";
+        public static readonly string ProjectExplorerBreakContext = "Project Window (Break)";
+        public static readonly string FormDesignerContext = "MSForms";
+        public static readonly string FormDesignerControlContext = "MSForms Control";
+        public static readonly string FormDesignerControlGroupContext = "MSForms Control Group";
+        public static readonly string ObjectBrowserContext = "Object Browser";
+        public static readonly string PropertiesContext = "Property Browser";
+    }
+
     public class AddIn : SafeComWrapper<VB.AddIn>, IAddIn
     {
-        private const int MenuBar = 1;
-        private const int CodeWindow = 9;
-        private const int ProjectExplorer = 14;
-        private const int MsForm = 17;
-        private const int MsFormControl = 18;
+        // these are indexes, not IDs; they can (and do) change between versions.
+        private const int MenuBar = 1; // assuming this one sticks...
+        //private const int CodeWindow = 9;
+        //private const int ProjectExplorer = 14;
+        //private const int MsForm = 17;
+        //private const int MsFormControl = 18;
 
         private const int WindowMenu = 30009;
         private const int ListProperties = 2529;
@@ -25,12 +40,10 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             CommandBarLocations = new ReadOnlyDictionary<CommandBarSite, CommandBarLocation>(new Dictionary<CommandBarSite, CommandBarLocation>
             {
                 {CommandBarSite.MenuBar, new CommandBarLocation(MenuBar, WindowMenu)},
-                {CommandBarSite.CodeWindow, new CommandBarLocation(CodeWindow, ListProperties)},
-                {CommandBarSite.ProjectExplorer, new CommandBarLocation(ProjectExplorer, ProjectProperties)},
-                {CommandBarSite.MsForm, new CommandBarLocation(MsForm, ViewCode)},
-                {CommandBarSite.MsFormControl, new CommandBarLocation(MsFormControl, ViewCode)}
+                {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.CodePaneContext, ListProperties)},
+                {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.ProjectExplorerContext, ProjectProperties)},
+                {CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.FormDesignerContext, ViewCode)},
             });
-
         }
 
 

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/AddIn.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/AddIn.cs
@@ -43,6 +43,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.CodePaneContext, ListProperties)},
                 {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.ProjectExplorerContext, ProjectProperties)},
                 {CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.FormDesignerContext, ViewCode)},
+                {CommandBarSite.FormDesignerControlContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.FormDesignerControlContext, ViewCode)},
             });
         }
 

--- a/RubberduckTests/Mocks/MockAddinBuilder.cs
+++ b/RubberduckTests/Mocks/MockAddinBuilder.cs
@@ -25,7 +25,7 @@ namespace RubberduckTests.Mocks
                 {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(2, 2)},
                 {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(3, 3)},
                 {CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(4, 4)},
-                {CommandBarSite.MsFormControl, new CommandBarLocation(5, 5)}
+                {CommandBarSite.FormDesignerControlContextMenu, new CommandBarLocation(5, 5)}
             }));
 
             return addIn;

--- a/RubberduckTests/Mocks/MockAddinBuilder.cs
+++ b/RubberduckTests/Mocks/MockAddinBuilder.cs
@@ -22,9 +22,9 @@ namespace RubberduckTests.Mocks
             addIn.Setup(a => a.CommandBarLocations).Returns(new ReadOnlyDictionary<CommandBarSite, CommandBarLocation>(new Dictionary<CommandBarSite, CommandBarLocation>
             {
                 {CommandBarSite.MenuBar, new CommandBarLocation(1, 1)},
-                {CommandBarSite.CodeWindow, new CommandBarLocation(2, 2)},
-                {CommandBarSite.ProjectExplorer, new CommandBarLocation(3, 3)},
-                {CommandBarSite.MsForm, new CommandBarLocation(4, 4)},
+                {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(2, 2)},
+                {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(3, 3)},
+                {CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(4, 4)},
                 {CommandBarSite.MsFormControl, new CommandBarLocation(5, 5)}
             }));
 


### PR DESCRIPTION
Code pane context menu was being inserted as a child of the `CommandBar` at index 9, and other parent menus were also being inserted as a child of a `CommandBar` object at a specific index. This PR changes the indexing to fetch parent commandbars by their `Name`, which seems more reliable.