### PR TITLE
Enable Rename command for sub-member nodes

### DIFF
--- a/Rubberduck.Core/UI/CodeExplorer/Commands/AddTemplateCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/AddTemplateCommand.cs
@@ -74,9 +74,9 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         private bool EvaluateCanExecute(ICodeExplorerNode node)
         {
-            if (!ApplicableNodes.Contains(node.GetType())
-                || !(node is CodeExplorerItemViewModel)
-                || node.Declaration == null)
+            if (node?.Declaration == null 
+                || !ApplicableNodes.Contains(node.GetType())
+                || !(node is CodeExplorerItemViewModel))
             {
                 return false;
             }

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/RenameCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/RenameCommand.cs
@@ -18,6 +18,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
             typeof(CodeExplorerProjectViewModel),
             typeof(CodeExplorerComponentViewModel),
             typeof(CodeExplorerMemberViewModel),
+            typeof(CodeExplorerSubMemberViewModel),
             typeof(CodeExplorerCustomFolderViewModel)
         };
 


### PR DESCRIPTION
This PR enables the CE "Rename" command for sub-member nodes (i.e. UDT and Enum members).