### PR TITLE
Stop reporting undeclared variables as "unused"

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UseMeaningfulNameInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UseMeaningfulNameInspection.cs
@@ -89,7 +89,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
             return declaration.DeclarationType.HasFlag(DeclarationType.Module)
                    || declaration.DeclarationType.HasFlag(DeclarationType.Project)
                    || declaration.DeclarationType.HasFlag(DeclarationType.Control)
-                   ? new List<string> {"IgnoreOnceQuickFix"}
+                   ? new List<string> {nameof(QuickFixes.Concrete.IgnoreOnceQuickFix)}
                    : new List<string>();
         }
     }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotUsedInspection.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Antlr4.Runtime;
 using Rubberduck.CodeAnalysis.Inspections.Abstract;
@@ -50,11 +51,18 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
             : base(declarationFinderProvider, DeclarationType.Variable)
         {}
 
+        protected override ICollection<string> DisabledQuickFixes(Declaration declaration)
+        {
+            return declaration.IsUndeclared 
+                ? new List<string> { nameof(QuickFixes.Concrete.RemoveUnusedDeclarationQuickFix) } 
+                : new List<string>();
+        }
+
         protected override bool IsResultDeclaration(Declaration declaration, DeclarationFinder finder)
         {
-            return !declaration.IsWithEvents
-                   && declaration.References
-                       .All(reference => reference.IsAssignment)
+            // exclude undeclared, see #5439
+            return !declaration.IsWithEvents && !declaration.IsUndeclared
+                   && declaration.References.All(reference => reference.IsAssignment)
                    && !declaration.References.Any(IsForLoopAssignment);
         }
 

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotUsedInspection.cs
@@ -51,13 +51,6 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
             : base(declarationFinderProvider, DeclarationType.Variable)
         {}
 
-        protected override ICollection<string> DisabledQuickFixes(Declaration declaration)
-        {
-            return declaration.IsUndeclared 
-                ? new List<string> { nameof(QuickFixes.Concrete.RemoveUnusedDeclarationQuickFix) } 
-                : new List<string>();
-        }
-
         protected override bool IsResultDeclaration(Declaration declaration, DeclarationFinder finder)
         {
             // exclude undeclared, see #5439

--- a/RubberduckTests/Inspections/VariableNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableNotUsedInspectionTests.cs
@@ -157,6 +157,26 @@ End Sub";
             Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
         }
 
+        [Test]
+        [Category("Inspections")]
+        public void UndeclaredVariableNotUsed_RemoveUnusedDeclarationQuickFixDisabled()
+        {
+            var expected = nameof(Rubberduck.CodeAnalysis.QuickFixes.Concrete.RemoveUnusedDeclarationQuickFix);
+
+            // "Dim undeclared As Object" was previously removed; see #5439
+            const string inputCode =
+@"Public Sub Foo()
+    Set undeclared = Nothing
+End Sub";
+            var results = InspectionResultsForStandardModule(inputCode);
+            if (!results.Any())
+            {
+                Assert.Inconclusive("Input code yielded no inspection results.");
+            }
+
+            Assert.That(() => results.All(result => result.DisabledQuickFixes.Contains(expected)));
+        }
+
         protected override IInspection InspectionUnderTest(RubberduckParserState state)
         {
             return new VariableNotUsedInspection(state);

--- a/RubberduckTests/Inspections/VariableNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableNotUsedInspectionTests.cs
@@ -159,22 +159,15 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void UndeclaredVariableNotUsed_RemoveUnusedDeclarationQuickFixDisabled()
+        public void UndeclaredVariableNotUsed_NoResults()
         {
-            var expected = nameof(Rubberduck.CodeAnalysis.QuickFixes.Concrete.RemoveUnusedDeclarationQuickFix);
-
             // "Dim undeclared As Object" was previously removed; see #5439
             const string inputCode =
 @"Public Sub Foo()
     Set undeclared = Nothing
 End Sub";
             var results = InspectionResultsForStandardModule(inputCode);
-            if (!results.Any())
-            {
-                Assert.Inconclusive("Input code yielded no inspection results.");
-            }
-
-            Assert.That(() => results.All(result => result.DisabledQuickFixes.Contains(expected)));
+            Assert.AreEqual(0, results.Count());
         }
 
         protected override IInspection InspectionUnderTest(RubberduckParserState state)


### PR DESCRIPTION
This PR stops `VariableNotUsedInspection` issuing results for undeclared variables, fixing #5439. Assuming it's enabled, the undeclared variable should still get red-flagged by `UndeclaredVariableInspection`.