### PR TITLE
UnitTests: Fix AddTestMethod commands to generate compilable code

### DIFF
--- a/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestMethodBase.cs
+++ b/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestMethodBase.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Rubberduck.Parsing.Annotations.Concrete;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.UI.Command.ComCommands;
+using Rubberduck.UnitTesting;
+using Rubberduck.UnitTesting.CodeGeneration;
+using Rubberduck.VBEditor.Events;
+using Rubberduck.VBEditor.Extensions;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.UI.UnitTesting.ComCommands
+{
+    public class AddTestMethodBase : ComCommandBase
+    {
+        private readonly IVBE _vbe;
+        private readonly RubberduckParserState _state;
+        private readonly IRewritingManager _rewritingManager;
+        private readonly ITestCodeGenerator _testCodeGenerator;
+
+        public AddTestMethodBase(
+            IVBE vbe,
+            RubberduckParserState state,
+            IRewritingManager rewritingManager,
+            ITestCodeGenerator codeGenerator,
+            IVbeEvents vbeEvents)
+            : base(vbeEvents)
+        {
+            _vbe = vbe;
+            _state = state;
+            _testCodeGenerator = codeGenerator;
+            _rewritingManager = rewritingManager;
+
+            MethodGenerator = _testCodeGenerator.GetNewTestMethodCode;
+
+            AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
+        }
+
+        protected Func<IVBComponent, string> MethodGenerator { set; get; }
+
+        private bool SpecialEvaluateCanExecute(object parameter)
+        {
+            if (_state.Status != ParserState.Ready)
+            {
+                return false;
+            }
+
+            using (var activePane = _vbe.ActiveCodePane)
+            {
+                if (activePane?.IsWrappingNullReference ?? true)
+                {
+                    return false;
+                }
+            }
+
+            var testModules = _state.AllUserDeclarations.Where(d =>
+                        d.DeclarationType == DeclarationType.ProceduralModule &&
+                        d.Annotations.Any(pta => pta.Annotation is TestModuleAnnotation));
+
+            try
+            {
+                // the code modules consistently match correctly, but the components don't
+                using (var activeCodePane = _vbe.ActiveCodePane)
+                {
+                    using (var activePaneCodeModule = activeCodePane.CodeModule)
+                    {
+                        return testModules.Any(a => _state.ProjectsProvider.Component(a.QualifiedModuleName).HasEqualCodeModule(activePaneCodeModule));
+                    }
+                }
+            }
+            catch (COMException)
+            {
+                return false;
+            }
+        }
+        protected override void OnExecute(object parameter)
+        {
+            (Declaration targetModule, string testMethodCode) = GetTargetModuleAndTestMethodCode(_vbe, _state, MethodGenerator);
+
+            if (targetModule != null)
+            {
+                var rewriteSession = _rewritingManager.CheckOutCodePaneSession();
+                var rewriter = rewriteSession.CheckOutModuleRewriter(targetModule.QualifiedModuleName);
+                rewriter.InsertAfter(rewriter.TokenStream.Size, $"{Environment.NewLine}{Environment.NewLine}{testMethodCode}");
+
+                rewriteSession.TryRewrite();
+
+                _state.OnParseRequested(this);
+            }
+        }
+
+        private static  (Declaration targetModule, string testMethodContent) GetTargetModuleAndTestMethodCode(IVBE vbe, RubberduckParserState state, Func<IVBComponent, string> methodGenerator)
+        {
+            (Declaration, string) defaultResult = (null, string.Empty);
+
+            using (var pane = vbe.ActiveCodePane)
+            {
+                if (pane?.IsWrappingNullReference ?? true)
+                {
+                    return defaultResult;
+                }
+
+                using (var module = pane.CodeModule)
+                {
+                    var declaration = state.GetTestModules()
+                        .FirstOrDefault(f => state.ProjectsProvider.Component(f.QualifiedModuleName).HasEqualCodeModule(module));
+
+                    if (declaration == null)
+                    {
+                        return defaultResult;
+                    }
+
+                    var testMethodCode = string.Empty;
+                    using (var component = module.Parent)
+                    {
+                        testMethodCode = methodGenerator(component);
+                        return (declaration, testMethodCode);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestMethodCommand.cs
+++ b/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestMethodCommand.cs
@@ -1,13 +1,8 @@
-using System.Linq;
 using System.Runtime.InteropServices;
-using Rubberduck.Parsing.Annotations.Concrete;
-using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.VBA;
-using Rubberduck.UI.Command.ComCommands;
-using Rubberduck.UnitTesting;
 using Rubberduck.UnitTesting.CodeGeneration;
 using Rubberduck.VBEditor.Events;
-using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.UnitTesting.ComCommands
@@ -16,88 +11,17 @@ namespace Rubberduck.UI.UnitTesting.ComCommands
     /// A command that adds a new test method stub to the active code pane.
     /// </summary>
     [ComVisible(false)]
-    public class AddTestMethodCommand : ComCommandBase
+    public class AddTestMethodCommand : AddTestMethodBase
     {
-        private readonly IVBE _vbe;
-        private readonly RubberduckParserState _state;
-        private readonly ITestCodeGenerator _codeGenerator;
-
         public AddTestMethodCommand(
             IVBE vbe, 
             RubberduckParserState state, 
+            IRewritingManager rewritingManager,
             ITestCodeGenerator codeGenerator, 
-            IVbeEvents vbeEvents) 
-            : base(vbeEvents)
+            IVbeEvents vbeEvents)
+            : base(vbe, state, rewritingManager, codeGenerator, vbeEvents)
         {
-            _vbe = vbe;
-            _state = state;
-            _codeGenerator = codeGenerator;
-
-            AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
-        }
-
-        private bool SpecialEvaluateCanExecute(object parameter)
-        {
-            if (_state.Status != ParserState.Ready)
-            {
-                return false;
-            }
-
-            using (var activePane = _vbe.ActiveCodePane)
-            {
-                if (activePane?.IsWrappingNullReference ?? true)
-                {
-                    return false;
-                }
-            }
-
-            var testModules = _state.AllUserDeclarations.Where(d =>
-                        d.DeclarationType == DeclarationType.ProceduralModule &&
-                        d.Annotations.Any(pta => pta.Annotation is TestModuleAnnotation));
-
-            try
-            {
-                // the code modules consistently match correctly, but the components don't
-                using( var activeCodePane = _vbe.ActiveCodePane)
-                {
-                    using( var activePaneCodeModule = activeCodePane.CodeModule)
-                    {
-                        return testModules.Any(a => _state.ProjectsProvider.Component(a.QualifiedModuleName).HasEqualCodeModule(activePaneCodeModule));
-                    }
-                }
-            }
-            catch (COMException)
-            {
-                return false;
-            }
-        }
-
-        protected override void OnExecute(object parameter)
-        {
-            using (var pane = _vbe.ActiveCodePane)
-            {
-                if (pane?.IsWrappingNullReference ?? true)
-                {
-                    return;
-                }
-
-                using (var module = pane.CodeModule)
-                {
-                    var declaration = _state.GetTestModules()
-                        .FirstOrDefault(f => _state.ProjectsProvider.Component(f.QualifiedModuleName).HasEqualCodeModule(module));
-
-                    if (declaration == null)
-                    {
-                        return;
-                    }
-
-                    using (var component = module.Parent)
-                    {
-                        module.InsertLines(module.CountOfLines, _codeGenerator.GetNewTestMethodCode(component));
-                    }
-                }
-            }
-            _state.OnParseRequested(this);
+            MethodGenerator = codeGenerator.GetNewTestMethodCode;
         }
     }
 }

--- a/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestMethodExpectedErrorCommand.cs
+++ b/Rubberduck.Core/UI/UnitTesting/ComCommands/AddTestMethodExpectedErrorCommand.cs
@@ -1,13 +1,8 @@
-using System.Linq;
 using System.Runtime.InteropServices;
-using Rubberduck.Parsing.Annotations.Concrete;
-using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.VBA;
-using Rubberduck.UI.Command.ComCommands;
-using Rubberduck.UnitTesting;
 using Rubberduck.UnitTesting.CodeGeneration;
 using Rubberduck.VBEditor.Events;
-using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.UI.UnitTesting.ComCommands
@@ -16,86 +11,17 @@ namespace Rubberduck.UI.UnitTesting.ComCommands
     /// A command that adds a new test method stub to the active code pane.
     /// </summary>
     [ComVisible(false)]
-    public class AddTestMethodExpectedErrorCommand : ComCommandBase
+    public class AddTestMethodExpectedErrorCommand : AddTestMethodBase
     {
-        private readonly IVBE _vbe;
-        private readonly RubberduckParserState _state;
-        private readonly ITestCodeGenerator _codeGenerator;
-
         public AddTestMethodExpectedErrorCommand(
-            IVBE vbe, 
-            RubberduckParserState state, 
-            ITestCodeGenerator codeGenerator, 
-            IVbeEvents vbeEvents) 
-            : base(vbeEvents)
+            IVBE vbe,
+            RubberduckParserState state,
+            IRewritingManager rewritingManager,
+            ITestCodeGenerator codeGenerator,
+            IVbeEvents vbeEvents)
+            : base(vbe, state, rewritingManager, codeGenerator, vbeEvents)
         {
-            _vbe = vbe;
-            _state = state;
-            _codeGenerator = codeGenerator;
-
-            AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
-        }
-
-        private bool SpecialEvaluateCanExecute(object parameter)
-        {
-            using (var pane = _vbe.ActiveCodePane)
-            {
-                if (_state.Status != ParserState.Ready || pane is null || pane.IsWrappingNullReference)
-                {
-                    return false;
-                }
-            }
-            var testModules = _state.AllUserDeclarations.Where(d =>
-                            d.DeclarationType == DeclarationType.ProceduralModule &&
-                            d.Annotations.Any(pta => pta.Annotation is TestModuleAnnotation));
-
-            try
-            {
-                // the code modules consistently match correctly, but the components don't
-                using (var component = _vbe.SelectedVBComponent)
-                {
-                    using(var selectedModule = component.CodeModule)
-                    {
-                        return testModules.Any(a => _state.ProjectsProvider.Component(a.QualifiedModuleName).HasEqualCodeModule(selectedModule));
-                    }
-                }
-            }
-            catch (COMException)
-            {
-                return false;
-            }      
-        }
-
-        protected override void OnExecute(object parameter)
-        {
-            using (var pane = _vbe.ActiveCodePane)
-            {
-                if (pane?.IsWrappingNullReference ?? true)
-                {
-                    return;
-                }
-
-                using (var activeModule = pane.CodeModule)
-                {
-                    var declaration = _state.GetTestModules().FirstOrDefault(f =>
-                    {
-                        var component = _state.ProjectsProvider.Component(f.QualifiedName.QualifiedModuleName);
-                        using (var thisModule = component.CodeModule)
-                        {
-                            return thisModule.Equals(activeModule);
-                        }
-                    });
-
-                    if (declaration != null)
-                    {
-                        using (var component = activeModule.Parent)
-                        {
-                            activeModule.InsertLines(activeModule.CountOfLines, _codeGenerator.GetNewTestMethodCodeErrorExpected(component));
-                        }
-                    }
-                }
-            }
-            _state.OnParseRequested(this);
+            MethodGenerator = codeGenerator.GetNewTestMethodCodeErrorExpected;
         }
     }
 }


### PR DESCRIPTION
Closes #4169

This PR addresses the uncompilable code generated when adding a UnitTest TestMethod.

The fundamental issue involved was an incorrect insertion point for the generated code.  

1. Noticed that the commands did not use the `RewritingManager`.  So, they now do.
2. The two 'Add Test' command classes (`AddTestMethodCommand` and `AddTestMethodExpectedErrorCommand`) had identical code except for a single function call.  So, the PR introduces a base class to make these commands more DRY and consistent.
3. There were a number of `'TODO` comments in the tests regarding temporal coupling.  These were addressed as well.

This is my first PR within the UnitTest area.   I'm hoping, no basic design/architecture 'rules' have not been violated by my changes.  The commands did not use the `RewritingManager` so is it possible that this area may be a little behind in other areas?  I started wondering if calling upon a `RefactoringAction` would now be a preferred approach for generating/adding unit test code and modules.