### PR TITLE
Address or suppress warnings and messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+﻿[*.cs]
+
+# CS1584: XML comment has syntactically incorrect cref attribute
+dotnet_diagnostic.CS1584.severity = none
+
+# CS1041: expected identifier, invalid keyword
+dotnet_diagnostic.CS1041.severity = none
+
+# CS1658: Warning is overriding an error
+dotnet_diagnostic.CS1658.severity = none
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = none

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
@@ -35,6 +35,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
     ///     value = otherVar * value
     /// End Sub
     /// ]]>
+    /// </module>
+    /// </example>
     /// <example hasResult="true">
     /// <module name="Module1" type="Standard Module">
     /// <![CDATA[
@@ -205,7 +207,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
 
         private static bool IsPotentiallyUsedAssignment<T>(T jumpContext, IdentifierReference resultCandidate, Dictionary<string, int> labelIdLineNumberPairs) where T : ParserRuleContext
         {
-            int? executionBranchLine = null;
+            int? executionBranchLine;
 
             switch (jumpContext)
             {
@@ -220,9 +222,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                     break;
             }
 
-            return executionBranchLine.HasValue
-                ?   AssignmentIsUsedPriorToExitStmts(resultCandidate, executionBranchLine.Value)
-                :   false;
+            return executionBranchLine.HasValue && AssignmentIsUsedPriorToExitStmts(resultCandidate, executionBranchLine.Value);
         }
 
         private static bool AssignmentIsUsedPriorToExitStmts(IdentifierReference resultCandidate, int executionBranchLine)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/InvalidAnnotationInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/InvalidAnnotationInspection.cs
@@ -222,7 +222,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         {
             return GetUnboundAnnotations(annotations, userDeclarations, identifierReferences)
                 .Where(pta => !pta.Annotation.Target.HasFlag(AnnotationTarget.General) || pta.AnnotatedLine == null)
-                .Concat(AttributeAnnotationsOnDeclarationsNotAllowingAttributes(annotations, userDeclarations, identifierReferences))
+                .Concat(AttributeAnnotationsOnDeclarationsNotAllowingAttributes(userDeclarations))
                 .ToList();
         }
 
@@ -241,10 +241,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 .Where(pta => pta.Annotation.GetType() != typeof(NotRecognizedAnnotation) && !boundAnnotationsSelections.Contains(pta.QualifiedSelection));
         }
 
-        private IEnumerable<IParseTreeAnnotation> AttributeAnnotationsOnDeclarationsNotAllowingAttributes(
-            IEnumerable<IParseTreeAnnotation> annotations,
-            IEnumerable<Declaration> userDeclarations,
-            IEnumerable<IdentifierReference> identifierReferences)
+        private IEnumerable<IParseTreeAnnotation> AttributeAnnotationsOnDeclarationsNotAllowingAttributes(IEnumerable<Declaration> userDeclarations)
         {
             return userDeclarations
                 .Where(declaration => declaration.AttributesPassContext == null

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/SheetAccessedUsingStringInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/SheetAccessedUsingStringInspection.cs
@@ -129,8 +129,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         private string CodeNameOfVBComponentMatchingSheetName(string projectId, string sheetName)
         {
             var components = _projectsProvider.Components(projectId);
-
-            foreach (var (module, component) in components)
+            foreach (var (_, component) in components)
             {
                 if (component.Type != ComponentType.Document)
                 {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/FilterLimits.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/FilterLimits.cs
@@ -36,9 +36,9 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
 
         public static bool operator !=(Limit<T> LHS, Limit<T> RHS) => !(LHS == RHS);
 
-        public static bool operator >(Limit<T> LHS, T RHS) => LHS.HasValue ? LHS.Value.CompareTo(RHS) > 0 : false;
+        public static bool operator >(Limit<T> LHS, T RHS) => LHS.HasValue && LHS.Value.CompareTo(RHS) > 0;
 
-        public static bool operator <(Limit<T> LHS, T RHS) => LHS.HasValue? LHS.Value.CompareTo(RHS) < 0 : false;
+        public static bool operator <(Limit<T> LHS, T RHS) => LHS.HasValue && LHS.Value.CompareTo(RHS) < 0;
 
         public static bool operator >=(Limit<T> LHS, Limit<T> RHS) => LHS == RHS || LHS > RHS;
 
@@ -106,7 +106,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
 
         public bool SetMinimum(T min)
         {
-            var setNewValue = false;
+            bool setNewValue;
             if (_min.HasValue)
             {
                 setNewValue = min.CompareTo(_min.Value) > 0;
@@ -123,7 +123,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
 
         public bool SetMaximum(T max)
         {
-            var setNewValue = false;
+            bool setNewValue;
             if (_max.HasValue)
             {
                 setNewValue = max.CompareTo(_max.Value) < 0;
@@ -195,6 +195,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
             return true;
         }
 
+        public override int GetHashCode() => VBEditor.HashCode.Compute(Minimum, Maximum);
+
         public override string ToString()
         {
             var minString = string.Empty;
@@ -202,13 +204,13 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
             if (_min.HasValue)
             {
                 minString = MinimumExtent.HasValue && _min == MinimumExtent
-                    ? $"Min(typeMin)" : $"Min({_min.ToString()})";
+                    ? $"Min(typeMin)" : $"Min({_min})";
             }
 
             if (_max.HasValue)
             {
                 maxString = MaximumExtent.HasValue && _max == MaximumExtent
-                    ? $"Max(typeMax)" : $"Max({_max.ToString()})";
+                    ? $"Max(typeMax)" : $"Max({_max})";
             }
             return $"{minString}{maxString}";
         }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ExpandBangNotationQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ExpandBangNotationQuickFix.cs
@@ -132,8 +132,8 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
         public override bool CanFixInProject => true;
         public override bool CanFixAll => true;
 
-        private string NonIdentifierCharacters = "[](){}\r\n\t.,'\"\\ |!@#$%^&*-+:=; ";
-        private string AdditionalNonFirstIdentifierCharacters = "0123456789_";
+        private readonly string NonIdentifierCharacters = "[](){}\r\n\t.,'\"\\ |!@#$%^&*-+:=; ";
+        private readonly string AdditionalNonFirstIdentifierCharacters = "0123456789_";
 
         private static readonly Dictionary<string, string> DefaultMemberOverrides = new Dictionary<string, string>
         {

--- a/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerMemberViewModel.cs
+++ b/Rubberduck.Core/Navigation/CodeExplorer/CodeExplorerMemberViewModel.cs
@@ -51,7 +51,7 @@ namespace Rubberduck.Navigation.CodeExplorer
         }
 
         public override bool IsObsolete =>
-            Declaration.Annotations.Any(annotation => annotation is ObsoleteAnnotation);
+            Declaration.Annotations.Any(pta => pta.Annotation is ObsoleteAnnotation);
 
         public static readonly DeclarationType[] SubMemberTypes =
         {

--- a/Rubberduck.Core/Refactorings/ExtractMethod/ExtractMethodModel.cs
+++ b/Rubberduck.Core/Refactorings/ExtractMethod/ExtractMethodModel.cs
@@ -60,14 +60,15 @@ namespace Rubberduck.Refactorings.ExtractMethod
 
     public class ExtractMethodModel : IExtractMethodModel
     {
-        private List<Declaration> _extractDeclarations;
-        private IExtractMethodParameterClassification _paramClassify;
-        private IExtractedMethod _extractedMethod;
+        private readonly List<Declaration> _extractDeclarations = new List<Declaration>();
+        private readonly IExtractMethodParameterClassification _paramClassify;
+        private readonly IExtractedMethod _extractedMethod;
 
         public ExtractMethodModel(IExtractedMethod extractedMethod, IExtractMethodParameterClassification paramClassify)
         {
             _extractedMethod = extractedMethod;
             _paramClassify = paramClassify;
+            _sourceMember = null;
         }
 
         public void extract(IEnumerable<Declaration> declarations, QualifiedSelection selection, string selectedCode)
@@ -101,7 +102,7 @@ namespace Rubberduck.Refactorings.ExtractMethod
             }
             _declarationsToMove = _paramClassify.DeclarationsToMove.ToList();
 
-            _rowsToRemove = splitSelection(selection.Selection, _declarationsToMove).ToList();
+            _rowsToRemove = SplitSelection(selection.Selection, _declarationsToMove).ToList();
 
             var methodCallPositionStartLine = selectionStartLine - _declarationsToMove.Count(d => d.Selection.StartLine < selectionStartLine);
             _positionForMethodCall = new Selection(methodCallPositionStartLine, 1, methodCallPositionStartLine, 1);
@@ -136,7 +137,7 @@ namespace Rubberduck.Refactorings.ExtractMethod
             return declaration;
         }
 
-        public IEnumerable<Selection> splitSelection(Selection selection, IEnumerable<Declaration> declarations)
+        public IEnumerable<Selection> SplitSelection(Selection selection, IEnumerable<Declaration> declarations)
         {
             var tupleList = new List<Tuple<int, int>>();
             var declarationRows = declarations
@@ -152,7 +153,7 @@ namespace Rubberduck.Refactorings.ExtractMethod
             return returnList;
         }
 
-        private Declaration _sourceMember;
+        private readonly Declaration _sourceMember;
         public Declaration SourceMember { get { return _sourceMember; } }
 
         private QualifiedSelection _selection;
@@ -161,15 +162,15 @@ namespace Rubberduck.Refactorings.ExtractMethod
         private string _selectedCode;
         public string SelectedCode { get { return _selectedCode; } }
 
-        private List<Declaration> _locals;
+        private readonly List<Declaration> _locals = new List<Declaration>();
         public IEnumerable<Declaration> Locals { get { return _locals; } }
 
-        private IEnumerable<ExtractedParameter> _input;
+        private readonly IEnumerable<ExtractedParameter> _input = new List<ExtractedParameter>();
         public IEnumerable<ExtractedParameter> Inputs { get { return _input; } }
-        private IEnumerable<ExtractedParameter> _output;
+        private readonly IEnumerable<ExtractedParameter> _output = new List<ExtractedParameter>();
         public IEnumerable<ExtractedParameter> Outputs { get { return _output; } }
 
-        private List<Declaration> _declarationsToMove;
+        private List<Declaration> _declarationsToMove = new List<Declaration>();
         public IEnumerable<Declaration> DeclarationsToMove { get { return _declarationsToMove; } }
 
         public IExtractedMethod Method { get { return _extractedMethod; } }
@@ -181,7 +182,8 @@ namespace Rubberduck.Refactorings.ExtractMethod
 
         private Selection _positionForNewMethod;
         public Selection PositionForNewMethod { get { return _positionForNewMethod; } }
-        IList<Selection> _rowsToRemove;
+        
+        private IList<Selection> _rowsToRemove;
         public IEnumerable<Selection> RowsToRemove
         {
             // we need to split selectionToRemove around any declarations that

--- a/Rubberduck.Core/UI/Command/RunSelectedTestModuleCommand.cs
+++ b/Rubberduck.Core/UI/Command/RunSelectedTestModuleCommand.cs
@@ -23,7 +23,7 @@ namespace Rubberduck.UI.Command
         {
             return (parameter ?? FindModuleFromSelection()) is Declaration candidate &&
                    candidate.DeclarationType == DeclarationType.ProceduralModule &&
-                   candidate.Annotations.Any(annotation => annotation is TestModuleAnnotation) &&
+                   candidate.Annotations.Any(pta => pta.Annotation is TestModuleAnnotation) &&
                    _engine.CanRun &&
                    _engine.Tests.Any(test => test.Declaration.QualifiedModuleName.Equals(candidate.QualifiedModuleName));
         }
@@ -32,7 +32,7 @@ namespace Rubberduck.UI.Command
         {
             if (!((parameter ?? FindModuleFromSelection()) is Declaration candidate) ||
                 candidate.DeclarationType != DeclarationType.ProceduralModule ||
-                !candidate.Annotations.Any(annotation => annotation is TestModuleAnnotation) ||
+                !candidate.Annotations.Any(pta => pta.Annotation is TestModuleAnnotation) ||
                 !_engine.CanRun)
             {
                 return;

--- a/Rubberduck.Core/UI/Refactorings/ExtractMethodDialog.cs
+++ b/Rubberduck.Core/UI/Refactorings/ExtractMethodDialog.cs
@@ -15,6 +15,7 @@ namespace Rubberduck.UI.Refactorings
     {
         public ExtractMethodDialog()
         {
+            _returnValue = null;
             _parameters = new BindingList<ExtractedParameter>();
 
             InitializeComponent();
@@ -152,7 +153,7 @@ namespace Rubberduck.UI.Refactorings
         private BindingList<ExtractedParameter> _parameters;
         public IEnumerable<ExtractedParameter> Parameters
         {
-            get { return _parameters.Where(p => p.Name != _returnValue.Name); }
+            get { return _parameters.Where(p => p.Name != _returnValue?.Name); }
             set
             {
                 _parameters = new BindingList<ExtractedParameter>(value.ToList());
@@ -168,11 +169,11 @@ namespace Rubberduck.UI.Refactorings
             set
             {
                 _returnValues = new BindingList<ExtractedParameter>(value.ToList());
-                var items = _returnValues.ToArray();
+                //var items = _returnValues.ToArray();
             }
         }
 
-        private ExtractedParameter _returnValue;
+        private readonly ExtractedParameter _returnValue;
 
         public IEnumerable<ExtractedParameter> Inputs { get; set; }
         public IEnumerable<ExtractedParameter> Outputs { get; set; }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
@@ -61,7 +61,7 @@ namespace Rubberduck.UnitTesting
             var returnInfo =
                 ReturnValues.Where(r => r.Invocation == (any ? FakesProvider.AllInvocations : (int) InvocationCount) &&
                                    r.Argument != null &&
-                                   r.Argument == string.Empty).ToList();
+                                   string.IsNullOrWhiteSpace(r.Argument.ToString())).ToList();
 
             if (returnInfo.Count <= 0)
             {

--- a/Rubberduck.Parsing/Annotations/Concrete/MemberAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/MemberAttributeAnnotation.cs
@@ -59,7 +59,7 @@ namespace Rubberduck.Parsing.Annotations.Concrete
         public override IReadOnlyList<ComponentType> IncompatibleComponentTypes => _incompatibleComponentTypes;
             
 
-        private static AnnotationArgumentType[] _argumentTypes = new[]
+        private static readonly AnnotationArgumentType[] _argumentTypes = new[]
         {
             AnnotationArgumentType.Attribute,
             AnnotationArgumentType.Text | AnnotationArgumentType.Number | AnnotationArgumentType.Boolean

--- a/Rubberduck.Parsing/Annotations/Concrete/ModuleAttributeAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/ModuleAttributeAnnotation.cs
@@ -54,7 +54,7 @@ namespace Rubberduck.Parsing.Annotations.Concrete
         private readonly IReadOnlyList<ComponentType> _incompatibleComponentTypes;
         public override IReadOnlyList<ComponentType> IncompatibleComponentTypes => _incompatibleComponentTypes;
 
-        private static AnnotationArgumentType[] _argumentTypes = new[]
+        private static readonly AnnotationArgumentType[] _argumentTypes = new[]
         {
             AnnotationArgumentType.Attribute,
             AnnotationArgumentType.Text | AnnotationArgumentType.Number | AnnotationArgumentType.Boolean

--- a/Rubberduck.Parsing/ComReflection/ComProject.cs
+++ b/Rubberduck.Parsing/ComReflection/ComProject.cs
@@ -34,30 +34,32 @@ namespace Rubberduck.Parsing.ComReflection
 
         // YGNI...
         // ReSharper disable once NotAccessedField.Local
+#pragma warning disable IDE0052 // Remove unread private members
         private readonly TypeLibTypeFlags _flags;
+#pragma warning restore IDE0052 // Remove unread private members
 
         [DataMember(IsRequired = true)]
-        private List<ComAlias> _aliases = new List<ComAlias>();
+        private readonly List<ComAlias> _aliases = new List<ComAlias>();
         public IEnumerable<ComAlias> Aliases => _aliases;
 
         [DataMember(IsRequired = true)]
-        private List<ComInterface> _interfaces = new List<ComInterface>();
+        private readonly List<ComInterface> _interfaces = new List<ComInterface>();
         public IEnumerable<ComInterface> Interfaces => _interfaces;
 
         [DataMember(IsRequired = true)]
-        private List<ComEnumeration> _enumerations = new List<ComEnumeration>();
+        private readonly List<ComEnumeration> _enumerations = new List<ComEnumeration>();
         public IEnumerable<ComEnumeration> Enumerations => _enumerations;
 
         [DataMember(IsRequired = true)]
-        private List<ComCoClass> _classes = new List<ComCoClass>();
+        private readonly List<ComCoClass> _classes = new List<ComCoClass>();
         public IEnumerable<ComCoClass> CoClasses => _classes;
 
         [DataMember(IsRequired = true)]
-        private List<ComModule> _modules = new List<ComModule>();
+        private readonly List<ComModule> _modules = new List<ComModule>();
         public IEnumerable<ComModule> Modules => _modules;
 
         [DataMember(IsRequired = true)]
-        private List<ComStruct> _structs = new List<ComStruct>();
+        private readonly List<ComStruct> _structs = new List<ComStruct>();
         public IEnumerable<ComStruct> Structs => _structs;
 
         //Note - Enums and Types should enumerate *last*. That will prevent a duplicate module in the unlikely(?)

--- a/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -36,6 +36,9 @@
     </Antlr4>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Rubberduck.InternalApi\Rubberduck.InternalApi.csproj" />
     <ProjectReference Include="..\Rubberduck.SettingsProvider\Rubberduck.SettingsProvider.csproj" />
     <ProjectReference Include="..\Rubberduck.VBEEditor\Rubberduck.VBEditor.csproj" />

--- a/Rubberduck.Parsing/UIContext/IUiDispatcher.cs
+++ b/Rubberduck.Parsing/UIContext/IUiDispatcher.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Rubberduck.VBEditor.Utility;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,7 +20,7 @@ namespace Rubberduck.Parsing.UIContext
         /// on the UI thread's dispatcher and executed asynchronously.
         /// <para>For additional operations on the UI thread, you can get a
         /// reference to the UI thread's context thanks to the property
-        /// <see cref="UiContext" /></para>.
+        /// <see cref="UiContextProvider" /></para>.
         /// </summary>
         /// <param name="action">The action that will be executed on the UI
         /// thread</param>

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -119,30 +119,10 @@ namespace Rubberduck.Parsing.VBA
         [SuppressMessage("ReSharper", "JoinNullCheckWithUsage")]
         public RubberduckParserState(IVBE vbe, IProjectsRepository projectRepository, IDeclarationFinderFactory declarationFinderFactory, IVbeEvents vbeEvents)
         {
-            if (vbe == null)
-            {
-                throw new ArgumentNullException(nameof(vbe));
-            }
-
-            if (projectRepository == null)
-            {
-                throw new ArgumentException(nameof(projectRepository));
-            }
-
-            if (declarationFinderFactory == null)
-            {
-                throw new ArgumentNullException(nameof(declarationFinderFactory)); 
-            }
-
-            if (vbeEvents == null)
-            {
-                throw new ArgumentNullException(nameof(vbeEvents));
-            }
-
-            _vbe = vbe;
-            _projectRepository = projectRepository;
-            _declarationFinderFactory = declarationFinderFactory;
-            _vbeEvents = vbeEvents;
+            _vbe = vbe ?? throw new ArgumentNullException(nameof(vbe));
+            _projectRepository = projectRepository ?? throw new ArgumentException(nameof(projectRepository));
+            _declarationFinderFactory = declarationFinderFactory ?? throw new ArgumentNullException(nameof(declarationFinderFactory));
+            _vbeEvents = vbeEvents ?? throw new ArgumentNullException(nameof(vbeEvents));
             
             var values = Enum.GetValues(typeof(ParserState));
             foreach (var value in values)
@@ -167,10 +147,7 @@ namespace Rubberduck.Parsing.VBA
             _declarationFinderFactory.Release(oldDeclarationFinder);
         }
 
-        public void RefreshDeclarationFinder()
-        {
-            RefreshFinder(_hostApp);
-        }
+        public void RefreshDeclarationFinder() => RefreshFinder(_hostApp);
 
         #region Event Handling
 
@@ -324,15 +301,12 @@ namespace Rubberduck.Parsing.VBA
         /// were projects with duplicate ID's to clear the old
         /// declarations referencing the project by the old ID.
         /// </summary>
-        public void RefreshProjects()
-        {
-            _projectRepository.Refresh();
-        }
+        public void RefreshProjects() => _projectRepository.Refresh();
+        
 
         private void RefreshProject(string projectId)
         {
             _projectRepository.Refresh(projectId);
-
             ClearStateCache(projectId);
         }
 
@@ -456,10 +430,8 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        private IVBProject GetProject(string projectId)
-        {
-            return _projectRepository.Project(projectId);
-        }
+        private IVBProject GetProject(string projectId) => _projectRepository.Project(projectId);
+        
 
         public void EvaluateParserState(CancellationToken token)
         {
@@ -657,10 +629,9 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        public void SetModuleComments(QualifiedModuleName module, IEnumerable<CommentNode> comments)
-        {
+        public void SetModuleComments(QualifiedModuleName module, IEnumerable<CommentNode> comments) =>
             _moduleStates[module].SetComments(new List<CommentNode>(comments));
-        }
+        
 
         public IReadOnlyCollection<CommentNode> GetModuleComments(QualifiedModuleName module)
         {
@@ -723,10 +694,8 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        private bool ThereAreDeclarations()
-        {
-            return _moduleStates.Values.Any(state => state.Declarations != null && state.Declarations.Any());
-        }
+        private bool ThereAreDeclarations() => _moduleStates.Values.Any(state => state.Declarations != null && state.Declarations.Any());
+        
 
         /// <summary>
         /// Gets a copy of the failed resolution stores directly from the module states. (Used for refreshing the DeclarationFinder.)
@@ -954,7 +923,7 @@ namespace Rubberduck.Parsing.VBA
         }
 
         /// <summary>
-        /// Removes the specified <see cref="declaration"/> from the collection.
+        /// Removes the specified <see cref="Declaration"/> from the collection.
         /// </summary>
         /// <param name="declaration"></param>
         /// <returns>Returns true when successful.</returns>

--- a/Rubberduck.Refactorings/Common/ParseTreeValue/ComparableDateValue.cs
+++ b/Rubberduck.Refactorings/Common/ParseTreeValue/ComparableDateValue.cs
@@ -97,7 +97,7 @@ namespace Rubberduck.Refactoring.ParseTreeValue
             {
                 return false;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //even though a SyntaxErrorException/InputMismatchException is thrown, 
                 //this catch-all block seems to be needed(?)

--- a/Rubberduck.VBEEditor/ComManagement/TypeLibs/Abstract/ITypeInfoFunction.cs
+++ b/Rubberduck.VBEEditor/ComManagement/TypeLibs/Abstract/ITypeInfoFunction.cs
@@ -21,6 +21,6 @@ namespace Rubberduck.VBEditor.ComManagement.TypeLibs.Abstract
         string Name { get; }
         int ParamCount { get; }
         PROCKIND ProcKind { get; }
-        void Dispose();
+        //void Dispose();
     }
 }

--- a/Rubberduck.VBEEditor/ComManagement/TypeLibs/Abstract/ITypeInfoVariable.cs
+++ b/Rubberduck.VBEEditor/ComManagement/TypeLibs/Abstract/ITypeInfoVariable.cs
@@ -8,6 +8,6 @@ namespace Rubberduck.VBEditor.ComManagement.TypeLibs.Abstract
         string Name { get; }
         int MemberID { get; }
         VARFLAGS MemberFlags { get; }
-        void Dispose();
+        //void Dispose();
     }
 }

--- a/Rubberduck.VBEEditor/ComManagement/TypeLibs/Abstract/ITypeInfoWrapper.cs
+++ b/Rubberduck.VBEEditor/ComManagement/TypeLibs/Abstract/ITypeInfoWrapper.cs
@@ -23,7 +23,7 @@ namespace Rubberduck.VBEditor.ComManagement.TypeLibs.Abstract
         System.Runtime.InteropServices.ComTypes.TYPEFLAGS Flags { get; }
         string ContainerName { get; }
         ITypeInfoVBEExtensions VBEExtensions { get; }
-        void Dispose();
+        //void Dispose();
         int GetSafeRefTypeInfo(int hRef, out ITypeInfoWrapper outTI);
         IntPtr GetCOMReferencePtr();
         int GetContainingTypeLib(IntPtr ppTLB, IntPtr pIndex);
@@ -37,14 +37,14 @@ namespace Rubberduck.VBEditor.ComManagement.TypeLibs.Abstract
         int GetIDsOfNames(IntPtr rgszNames, int cNames, IntPtr pMemId);
         int Invoke(IntPtr pvInstance, int memid, short wFlags, IntPtr pDispParams, IntPtr pVarResult, IntPtr pExcepInfo, IntPtr puArgErr);
         int GetDocumentation(int memid, IntPtr strName, IntPtr strDocString, IntPtr dwHelpContext, IntPtr strHelpFile);
-        int GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, IntPtr pBstrDllName, IntPtr pBstrName, IntPtr pwOrdinal);
+        new int GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, IntPtr pBstrDllName, IntPtr pBstrName, IntPtr pwOrdinal);
         int GetRefTypeInfo(int hRef, IntPtr ppTI);
         int AddressOfMember(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, IntPtr ppv);
         int CreateInstance(IntPtr pUnkOuter, ref Guid riid, IntPtr ppvObj);
         int GetMops(int memid, IntPtr pBstrMops);
-        void ReleaseTypeAttr(IntPtr pTypeAttr);
-        void ReleaseFuncDesc(IntPtr pFuncDesc);
-        void ReleaseVarDesc(IntPtr pVarDesc);
+        new void ReleaseTypeAttr(IntPtr pTypeAttr);
+        new void ReleaseFuncDesc(IntPtr pFuncDesc);
+        new void ReleaseVarDesc(IntPtr pVarDesc);
         ITypeInfoFunctionCollection Funcs { get; }
         ITypeInfoVariablesCollection Vars { get; }
         ITypeInfoImplementedInterfacesCollection ImplementedInterfaces { get; }

--- a/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApiAccessor.cs
+++ b/Rubberduck.VBEEditor/VbeRuntime/VbeNativeApiAccessor.cs
@@ -10,14 +10,7 @@ namespace Rubberduck.VBEditor.VbeRuntime
     public class VbeNativeApiAccessor : IVbeNativeApi
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
-        private static readonly DllVersion Version;
-        private IVbeNativeApi _runtime;
-        
-        static VbeNativeApiAccessor()
-        {
-            Version = DllVersion.Unknown;
-        }
+        private IVbeNativeApi _runtime;        
         
         private static readonly List<(string Name, Type ApiType, DllVersion Version)> VbeApis =new List<(string Dll, Type ApiType, DllVersion Version)>
         {

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/Application/ExcelApp.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/Application/ExcelApp.cs
@@ -6,12 +6,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 {
     public class ExcelApp : HostApplicationBase<Microsoft.Office.Interop.Excel.Application>
     {
-        private IEnumerable<(ComponentType componentType, string moduleName, string procedureName)>
-            _autoMacroIdentifiers;
-
-        public ExcelApp(IVBE vbe) : base(vbe, "Excel", true)
-        {
-        }
+        public ExcelApp(IVBE vbe) : base(vbe, "Excel", true) { }
 
         public override IEnumerable<HostAutoMacro> AutoMacroIdentifiers => new HostAutoMacro[]
         {

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBE.cs
@@ -207,7 +207,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
             {"SLDWORKS.EXE", typeof(SolidWorksApp)},
         };
 
-        private static IHostApplication _host;
+        private static IHostApplication _host = null;
 
         /// <summary> Returns the type of Office Application that is hosting the VBE. </summary>
         public IHostApplication HostApplication()
@@ -222,21 +222,21 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
 
             if (HostAppMap.ContainsKey(host))
             {
-                return (IHostApplication)Activator.CreateInstance(HostAppMap[host], this);
+                _host = (IHostApplication)Activator.CreateInstance(HostAppMap[host], this);
+                return _host;
             }
 
             //Guessing the above will work like 99.9999% of the time for supported applications.
             using (var project = ActiveVBProject)
             {
+                IHostApplication result = null;
                 if (project.IsWrappingNullReference)
                 {
                     const int ctlViewHost = 106;
-
                     using (var commandBars = CommandBars)
                     {
                         var hostAppControl = commandBars.FindControl(ControlType.Button, ctlViewHost);
                         {
-                            IHostApplication result;
                             if (hostAppControl.IsWrappingNullReference)
                             {
                                 result = null;
@@ -286,6 +286,11 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                         }
                     }
                 }
+                if (result != null)
+                {
+                    _host = result;
+                    return result;
+                }
 
                 var references = project.References;
                 {
@@ -294,33 +299,48 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                         switch (reference.Name)
                         {
                             case "Excel":
-                                return new ExcelApp(this);
+                                result = new ExcelApp(this);
+                                break;
                             case "Access":
-                                return new AccessApp(this);
+                                result = new AccessApp(this);
+                                break;
                             case "Word":
-                                return new WordApp(this);
+                                result = new WordApp(this);
+                                break;
                             case "PowerPoint":
-                                return new PowerPointApp(this);
+                                result = new PowerPointApp(this);
+                                break;
                             case "Outlook":
-                                return new OutlookApp(this);
+                                result = new OutlookApp(this);
+                                break;
                             case "MSProject":
-                                return new ProjectApp(this);
+                                result = new ProjectApp(this);
+                                break;
                             case "Publisher":
-                                return new PublisherApp(this);
+                                result = new PublisherApp(this);
+                                break;
                             case "Visio":
-                                return new VisioApp(this);
+                                result = new VisioApp(this);
+                                break;
                             case "AutoCAD":
-                                return new AutoCADApp(this);
+                                result = new AutoCADApp(this);
+                                break;
                             case "CorelDRAW":
-                                return new CorelDRAWApp(this);
+                                result = new CorelDRAWApp(this);
+                                break;
                             case "SolidWorks":
-                                return new SolidWorksApp(this);
+                                result = new SolidWorksApp(this);
+                                break;
+                            default:
+                                result = null;
+                                break;
                         }
                     }
                 }
-            }
 
-            return null;
+                _host = result;
+                return result;
+            }
         }
 
         /// <summary> Returns the topmost MDI child window. </summary>

--- a/Rubberduck.sln
+++ b/Rubberduck.sln
@@ -10,6 +10,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rubberduck.Parsing", "Rubbe
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{07952BD8-646C-4494-965C-E80F3CDE3485}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
 		libs\Autodesk.AutoCAD.Interop.Common.dll = libs\Autodesk.AutoCAD.Interop.Common.dll
 		libs\Autodesk.AutoCAD.Interop.dll = libs\Autodesk.AutoCAD.Interop.dll

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -34,7 +34,6 @@ using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SourceCodeHandling;
 using Rubberduck.VBEditor.Utility;
 using RubberduckTests.Settings;
-using Rubberduck.Refactorings;
 using System.IO.Abstractions;
 
 namespace RubberduckTests.CodeExplorer
@@ -120,11 +119,11 @@ namespace RubberduckTests.CodeExplorer
                 var item = componentTypes[index];
                 if (item == ComponentType.UserForm)
                 {
-                    project.MockUserFormBuilder($"{item.ToString()}{index}", code is null ? string.Empty : code[index]).AddFormToProjectBuilder();
+                    project.MockUserFormBuilder($"{item}{index}", code is null ? string.Empty : code[index]).AddFormToProjectBuilder();
                 }
                 else
                 {
-                    project.AddComponent($"{item.ToString()}{index}", item, code is null ? string.Empty : code[index]);
+                    project.AddComponent($"{item}{index}", item, code is null ? string.Empty : code[index]);
                 }
             }
 

--- a/RubberduckTests/Inspections/UseMeaningfulNameInspectionTests.cs
+++ b/RubberduckTests/Inspections/UseMeaningfulNameInspectionTests.cs
@@ -159,7 +159,7 @@ End Sub";
             return settings;
         }
 
-        private IEnumerable<IInspectionResult> InspectionResultsForModules(params (string name, string content, ComponentType componentType)[] modules)
+        private new IEnumerable<IInspectionResult> InspectionResultsForModules(params (string name, string content, ComponentType componentType)[] modules)
         {
             var vbe = MockVbeBuilder.BuildFromModules("TestProject", modules, Enumerable.Empty<ReferenceLibrary>());
             return InspectionResults(vbe.Object);

--- a/RubberduckTests/Mocks/MockVbeBuilder.cs
+++ b/RubberduckTests/Mocks/MockVbeBuilder.cs
@@ -34,7 +34,6 @@ namespace RubberduckTests.Mocks
     /// <summary>
     /// Builds a mock <see cref="IVBE"/>.
     /// </summary>
-    [SuppressMessage("Microsoft.Design", "CA1001")] //CA1001 is complaining about RubberduckTests.Mocks.Windows, which doesn't need to be disposed in this context.
     public class MockVbeBuilder
     {
         public const string TestProjectName = "TestProject1";

--- a/RubberduckTests/ParserState/ParserStateTests.cs
+++ b/RubberduckTests/ParserState/ParserStateTests.cs
@@ -14,7 +14,7 @@ namespace RubberduckTests.ParserStateTests
     [TestFixture]
     public class ParserStateTests
     {
-        private static IEnumerable<ParserState> AllowedRunStates = new [] {ParserState.Ready};
+        private static readonly IEnumerable<ParserState> AllowedRunStates = new [] {ParserState.Ready};
 
         [SetUp]
         public void SetUp()
@@ -158,7 +158,6 @@ namespace RubberduckTests.ParserStateTests
         public void Test_RPS_SuspendParser_IncompatibleState()
         {
             var result = SuspensionOutcome.Pending;
-            var wasRun = false;
             var wasSuspended = false;
 
             var vbe = MockVbeBuilder.BuildFromSingleModule("", ComponentType.StandardModule, out var _);

--- a/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodModelTests.cs
+++ b/RubberduckTests/Refactoring/ExtractMethod/ExtractMethodModelTests.cs
@@ -16,7 +16,7 @@ namespace RubberduckTests.Refactoring.ExtractMethod
     {
 
         #region variableInternalAndOnlyUsedInternally
-        string internalVariable = @"
+        private readonly string internalVariable = @"
 Option explicit
 Public Sub CodeWithDeclaration()
     Dim x as long
@@ -39,33 +39,24 @@ End Sub
                                                '21:
 
 ";
-        string selectedCode = @"
+        private readonly string selectedCode = @"
 y = x + 1 
 x = 2
 Debug.Print y";
-
-        string outputCode = @"
-Public Sub NewVal( byval x as long, byval y as long)
-    DebugPrint ""something""
-    y = x + 1
-    x = 2
-    DebugPrint y
-End Sub";
         #endregion
 
-        List<IExtractMethodRule> emRules = new List<IExtractMethodRule>(){
-            new ExtractMethodRuleInSelection(),
-            new ExtractMethodRuleIsAssignedInSelection(),
-            new ExtractMethodRuleUsedBefore(),
-            new ExtractMethodRuleUsedAfter(),
-            new ExtractMethodRuleExternalReference()};
+        //private readonly List<IExtractMethodRule> emRules = new List<IExtractMethodRule>(){
+        //    new ExtractMethodRuleInSelection(),
+        //    new ExtractMethodRuleIsAssignedInSelection(),
+        //    new ExtractMethodRuleUsedBefore(),
+        //    new ExtractMethodRuleUsedAfter(),
+        //    new ExtractMethodRuleExternalReference()};
 
         [Test]
         [Category("ExtractMethodModelTests")]
-        public void shouldClassifyDeclarations()
+        public void ShouldClassifyDeclarations()
         {
-            QualifiedModuleName qualifiedModuleName;
-            using (var state = MockParser.ParseString(internalVariable, out qualifiedModuleName))
+            using (var state = MockParser.ParseString(internalVariable, out QualifiedModuleName qualifiedModuleName))
             {
                 var declarations = state.AllDeclarations;
 
@@ -88,9 +79,7 @@ End Sub";
         [TestFixture]
         public class WhenExtractingFromASelection : ExtractedMethodTests
         {
-
-            #region hard coded data
-            string inputCode = @"
+            private readonly string inputCode = @"
 Option explicit
 Public Sub CodeWithDeclaration()
     Dim x as long
@@ -112,35 +101,25 @@ End Sub
 
 
 ";
-            string selectedCode = @"
+            private readonly string selectedCode = @"
 y = x + 1 
 x = 2
 Debug.Print y";
-
-            string outputCode = @"
-Public Sub NewVal( byval x as long)
-    Dim y as long
-    y = x + 1
-    x = 2
-    DebugPrint y
-End Sub";
-            #endregion
 
             [TestFixture]
             public class WhenTheSelectionIsNotWithinAMethod : WhenExtractingFromASelection
             {
                 [Test]
                 [Category("ExtractMethodModelTests")]
-                public void shouldThrowAnException()
+                public void ShouldThrowAnException()
                 {
-                    QualifiedModuleName qualifiedModuleName;
-                    using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                    using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                     {
                         var declarations = state.AllDeclarations;
 
                         var selection = new Selection(21, 1, 22, 17);
                         QualifiedSelection? qSelection = new QualifiedSelection(qualifiedModuleName, selection);
-                        
+
                         var extractedMethod = new Mock<IExtractedMethod>();
                         var paramClassify = new Mock<IExtractMethodParameterClassification>();
                         var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
@@ -154,10 +133,9 @@ End Sub";
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void shouldProvideAListOfDimsNoLongerNeededInTheContainingMethod()
+            public void ShouldProvideAListOfDimsNoLongerNeededInTheContainingMethod()
             {
-                QualifiedModuleName qualifiedModuleName;
-                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                 {
                     var declarations = state.AllDeclarations;
 
@@ -180,10 +158,9 @@ End Sub";
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void shouldProvideTheSelectionOfLinesOfToRemove()
+            public void ShouldProvideTheSelectionOfLinesOfToRemove()
             {
-                QualifiedModuleName qualifiedModuleName;
-                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                 {
                     var declarations = state.AllDeclarations;
 
@@ -218,10 +195,9 @@ End Sub";
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void shouldProvideTheExtractMethodCaller()
+            public void ShouldProvideTheExtractMethodCaller()
             {
-                QualifiedModuleName qualifiedModuleName;
-                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                 {
                     var declarations = state.AllDeclarations;
 
@@ -244,10 +220,9 @@ End Sub";
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void shouldProvideThePositionForTheMethodCall()
+            public void ShouldProvideThePositionForTheMethodCall()
             {
-                QualifiedModuleName qualifiedModuleName;
-                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                 {
                     var declarations = state.AllDeclarations;
 
@@ -269,10 +244,9 @@ End Sub";
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void shouldProvideThePositionForTheNewMethod()
+            public void ShouldProvideThePositionForTheNewMethod()
             {
-                QualifiedModuleName qualifiedModuleName;
-                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                 {
                     var declarations = state.AllDeclarations;
 
@@ -304,7 +278,7 @@ End Sub";
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void shouldExcludeVariableInSignature()
+            public void ShouldExcludeVariableInSignature()
             {
 
                 #region inputCode
@@ -335,10 +309,10 @@ End Sub
 y = x + 1 
 x = 2
 Debug.Print y";
+
                 #endregion
 
-                QualifiedModuleName qualifiedModuleName;
-                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                 {
                     var declarations = state.AllDeclarations;
 
@@ -370,7 +344,7 @@ Debug.Print y";
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void shouldSplitTheCodeAroundTheDefinition()
+            public void ShouldSplitTheCodeAroundTheDefinition()
             {
 
                 #region inputCode
@@ -397,12 +371,6 @@ End Sub
 
 ";
 
-                var selectedCode = @"
-    DebugPrint x                      '8
-    y = x + 1
-    Dim z as long                     '10
-    z = x
-    DebugPrint z                      '12";
                 #endregion
 
                 #region whatItShouldLookLike
@@ -417,8 +385,7 @@ end sub
 */
                 #endregion
 
-                QualifiedModuleName qualifiedModuleName;
-                using (var state = MockParser.ParseString(inputCode, out qualifiedModuleName))
+                using (var state = MockParser.ParseString(inputCode, out QualifiedModuleName qualifiedModuleName))
                 {
                     var declarations = state.AllDeclarations;
                     var selection = new Selection(8, 1, 12, 50);
@@ -428,7 +395,7 @@ end sub
                     var yDecl = declarations.Where(decl => decl.IdentifierName.Equals("z"));
                     var SUT = new ExtractMethodModel(extractedMethod.Object, paramClassify.Object);
                     //Act
-                    var actual = SUT.splitSelection(selection, declarations);
+                    var actual = SUT.SplitSelection(selection, declarations);
                     //Assert
                     var selection1 = new Selection(8, 1, 9, 1);
                     var selection2 = new Selection(11, 1, 12, 1);
@@ -448,7 +415,7 @@ end sub
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void testSelection()
+            public void TestSelection()
             {
                 IEnumerable<int> list = new List<int> { 2, 3, 4, 6, 8, 9, 10, 12, 13, 15 };
                 var grouped = list.GroupByMissing(x => (x + 1), (x, y) => new Selection(x, 1, y, 1), (x, y) => y - x);
@@ -456,7 +423,7 @@ end sub
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void isUnordered()
+            public void IsUnordered()
             {
                 IEnumerable<int> list = new List<int> { 2, 3, 4, 6, 7, 9, 8, 12, 13, 15 };
 
@@ -466,7 +433,7 @@ end sub
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void emptyList()
+            public void EmptyList()
             {
                 IEnumerable<int> list = new List<int> { };
                 var grouped = list.GroupByMissing(x => (x + 1), (x, y) => Tuple.Create(x, y), (x, y) => y - x).ToList();
@@ -475,7 +442,7 @@ end sub
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void listOfSingleItem()
+            public void ListOfSingleItem()
             {
                 IEnumerable<int> list = new List<int> { 2 };
                 var grouped = list.GroupByMissing(x => (x + 1), (x, y) => Tuple.Create(x, y), (x, y) => y - x).ToList();
@@ -490,7 +457,7 @@ end sub
 
             [Test]
             [Category("ExtractMethodModelTests")]
-            public void testingUsefulList()
+            public void TestingUsefulList()
             {
                 IEnumerable<int> list = new List<int> { 2, 3, 4, 6, 8, 9, 10, 12, 13, 15 };
                 var grouped = list.GroupByMissing(x => (x + 1), (x, y) => Tuple.Create(x, y), (x, y) => y - x).ToList();

--- a/RubberduckTests/Rewriter/RewriteSessionTestBase.cs
+++ b/RubberduckTests/Rewriter/RewriteSessionTestBase.cs
@@ -54,10 +54,8 @@ namespace RubberduckTests.Rewriter
         [Category("Rewriter")]
         public void StatusChangesToInvalidStateStaleParseTreeIfADirtyRewriterGetsCheckedOut()
         {
-            var isCalled = false;
             var rewriteSession = RewriteSession(session =>
             {
-                isCalled = true;
                 return true;
             }, out _, rewritersAreDirty: true);
             var module = new QualifiedModuleName("TestProject", string.Empty, "TestModule");


### PR DESCRIPTION
Unhandled:
- ANTLR warnings about VBALexer.g4 (1)
- ANTLR warnings about VBAParser.g4 (3)
- ANTLR warnings about VBAConditionalCompilation.g4 (4)
- TX001311 warning about cross-compiling and bitness (1)
- InspectionXmlDocAnalyzer is failing with an `InvalidOperationException` and an obscure message "TypedConstant is an array. Use Values property." - no idea where it's coming from... (1)
- MissingExampleElement: ThunderCode inspections don't have examples, by design (7)

Total: 17 warnings, 0 messages.

I think the implicit tokens in VBAConditionalCompilation.g4 can be fixed, examples _could_ be added to the ThunderCode inspections, and I'm not sure about the rest.