### PR TITLE
Completes the resolution of document module supertypes

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/ImplicitSheetReferenceInspectionBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/ImplicitSheetReferenceInspectionBase.cs
@@ -26,6 +26,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Abstract
                 .Select(className => finder.FindClassModule(className, excel, true))
                 .OfType<ModuleDeclaration>();
 
+
             return globalModules
                 .SelectMany(moduleClass => moduleClass.Members)
                 .Where(declaration => TargetMemberNames.Contains(declaration.IdentifierName)
@@ -35,7 +36,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Abstract
 
         private static readonly string[] GlobalObjectClassNames =
         {
-            "Global", "_Global"
+            "Global", "_Global", 
+            "Worksheet", "_Worksheet"
         };
 
         private static readonly string[] TargetMemberNames =

--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/ImplicitWorkbookReferenceInspectionBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/ImplicitWorkbookReferenceInspectionBase.cs
@@ -24,9 +24,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Abstract
 
         protected override IEnumerable<Declaration> ObjectionableDeclarations(DeclarationFinder finder)
         {
-            var excel = finder.Projects
-                .SingleOrDefault(project => project.IdentifierName == "Excel" && !project.IsUserDefined);
-            if (excel == null)
+            if (!finder.TryFindProjectDeclaration("Excel", out var excel))
             {
                 return Enumerable.Empty<Declaration>();
             }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/AssignmentNotUsedInspection.cs
@@ -131,20 +131,19 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                                                             .Contains(refNode));
 
                 var assignmentsPrecedingReference = assignmentExprNodesWithReference.Any()
-                    ? assignmentExprNodes.TakeWhile(n => n != assignmentExprNodesWithReference.Last())
-                                                .Last()
-                                                .Nodes(new[] { typeof(AssignmentNode) })
+                    ? assignmentExprNodes.TakeWhile(n => n != assignmentExprNodesWithReference.LastOrDefault())
+                                                ?.LastOrDefault()
+                                                ?.Nodes(new[] { typeof(AssignmentNode) })
                     : allAssignmentsAndReferences.TakeWhile(n => n != refNode)
                         .OfType<AssignmentNode>();
 
-                if (assignmentsPrecedingReference.Any())
+                if (assignmentsPrecedingReference?.Any() ?? false)
                 {
-                    usedAssignments.Add(assignmentsPrecedingReference.Last() as AssignmentNode);
+                    usedAssignments.Add(assignmentsPrecedingReference.LastOrDefault() as AssignmentNode);
                 }
             }
 
-            return allAssignmentsAndReferences.OfType<AssignmentNode>()
-                                                .Except(usedAssignments);
+            return allAssignmentsAndReferences.OfType<AssignmentNode>().Except(usedAssignments);
         }
 
         private static bool IsDescendentOfNeverFlagNode(AssignmentNode assignment)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/SheetAccessedUsingStringInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/SheetAccessedUsingStringInspection.cs
@@ -61,19 +61,19 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
 
         private static readonly string[] InterestingMembers =
         {
-            "Worksheets", "Sheets"
+            "Worksheets", // gets a Sheets object containing Worksheet objects.
+            "Sheets", // gets a Sheets object containing all sheets (not just Worksheet sheets) in the qualifying workbook.
         };
 
         private static readonly string[] InterestingClasses =
         {
-            "Workbook"
+            "Workbook", // unqualified member call
+            "_Workbook", // qualified member call
         };
 
         protected override IEnumerable<Declaration> ObjectionableDeclarations(DeclarationFinder finder)
         {
-            var excel = finder.Projects
-                .SingleOrDefault(project => project.IdentifierName == "Excel" && !project.IsUserDefined);
-            if (excel == null)
+            if (!finder.TryFindProjectDeclaration("Excel", out var excel))
             {
                 return Enumerable.Empty<Declaration>();
             }

--- a/Rubberduck.Parsing/Binding/Bindings/SimpleNameDefaultBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/SimpleNameDefaultBinding.cs
@@ -187,7 +187,7 @@ namespace Rubberduck.Parsing.Binding
             var defaultInstanceVariableClass = _declarationFinder.FindDefaultInstanceVariableClassEnclosingProject(_project, _module, _name);
             if (defaultInstanceVariableClass != null)
             {
-                return new SimpleNameExpression(defaultInstanceVariableClass, ExpressionClassification.Type, _context);
+                return new SimpleNameExpression(defaultInstanceVariableClass, ExpressionClassification.Variable, _context);
             }
             return null;
         }

--- a/Rubberduck.Parsing/Symbols/VariableDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/VariableDeclaration.cs
@@ -23,7 +23,8 @@ namespace Rubberduck.Parsing.Symbols
             bool isArray,
             VBAParser.AsTypeClauseContext asTypeContext,
             IEnumerable<IParseTreeAnnotation> annotations = null,
-            Attributes attributes = null)
+            Attributes attributes = null, 
+            bool isUserDefined = true)
             : base(
                 qualifiedName,
                 parentDeclaration,
@@ -39,7 +40,7 @@ namespace Rubberduck.Parsing.Symbols
                 selection,
                 isArray,
                 asTypeContext,
-                true,
+                isUserDefined,
                 annotations,
                 attributes)
         {

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -357,6 +357,17 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         public IEnumerable<Declaration> Classes => _classes.Value;
         public IEnumerable<Declaration> Projects => _projects.Value;
 
+        /// <summary>
+        /// Gets the <see cref="ProjectDeclaration"/> object for specified referenced project/library.
+        /// </summary>
+        /// <param name="name">The identifier name of the project declaration to find.</param>
+        /// <param name="result">The <see cref="ProjectDeclaration"/> result, if found; null otherwise.</param>
+        public bool TryFindProjectDeclaration(string name, out Declaration result)
+        {
+            result = _projects.Value.SingleOrDefault(project => project.IdentifierName.Equals(name, StringComparison.InvariantCultureIgnoreCase) && !project.IsUserDefined);
+            return result != null;
+        }
+
         public IEnumerable<Declaration> UserDeclarations(DeclarationType type)
         {
             return _userDeclarationsByType.TryGetValue(type, out var result)

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -333,7 +333,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         {
             var withEventsDeclarations = FindWithEventFields(eventDeclaration);
             return withEventsDeclarations
-                .Select(withEventsField => FindHandlersForWithEventsField(withEventsField).Single(handler => 
+                .Select(withEventsField => FindHandlersForWithEventsField(withEventsField).SingleOrDefault(handler => 
                     handler.IdentifierName.Equals($"{withEventsField.IdentifierName}_{eventDeclaration.IdentifierName}", StringComparison.InvariantCultureIgnoreCase)));
         }
 
@@ -362,9 +362,10 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         /// </summary>
         /// <param name="name">The identifier name of the project declaration to find.</param>
         /// <param name="result">The <see cref="ProjectDeclaration"/> result, if found; null otherwise.</param>
-        public bool TryFindProjectDeclaration(string name, out Declaration result)
+        /// <param name="includeUserDefined">True to include user-defined projects in the search; false by default.</param>
+        public bool TryFindProjectDeclaration(string name, out Declaration result, bool includeUserDefined = false)
         {
-            result = _projects.Value.SingleOrDefault(project => project.IdentifierName.Equals(name, StringComparison.InvariantCultureIgnoreCase) && !project.IsUserDefined);
+            result = _projects.Value.FirstOrDefault(project => project.IdentifierName.Equals(name, StringComparison.InvariantCultureIgnoreCase) && project.IsUserDefined == includeUserDefined);
             return result != null;
         }
 

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
@@ -147,14 +147,6 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                 var membersAllowingAttributes = _state.GetMembersAllowingAttributes(module);
 
                 var moduleDeclaration = NewModuleDeclaration(module, tree, annotationsOnWhiteSpaceLines, attributes, projectDeclaration);
-                if (moduleDeclaration is DocumentModuleDeclaration documentModule)
-                {
-                    var varAttributes = new Attributes();
-                    //varAttributes.AddMemberDescriptionAttribute(documentModule.IdentifierName, "An object variable VBA creates automatically to refer to a specific document module.");
-                    var variableDeclaration = new VariableDeclaration(documentModule.QualifiedName, documentModule, documentModule, 
-                        documentModule.IdentifierName, null, true, false, Accessibility.Public, null, null, Selection.Empty, false, null, attributes:varAttributes, isUserDefined:false);
-                    _state.AddDeclaration(variableDeclaration);
-                }
                 _state.AddDeclaration(moduleDeclaration);
 
                 var controlDeclarations = DeclarationsFromControls(moduleDeclaration);

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
@@ -147,6 +147,14 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                 var membersAllowingAttributes = _state.GetMembersAllowingAttributes(module);
 
                 var moduleDeclaration = NewModuleDeclaration(module, tree, annotationsOnWhiteSpaceLines, attributes, projectDeclaration);
+                if (moduleDeclaration is DocumentModuleDeclaration documentModule)
+                {
+                    var varAttributes = new Attributes();
+                    //varAttributes.AddMemberDescriptionAttribute(documentModule.IdentifierName, "An object variable VBA creates automatically to refer to a specific document module.");
+                    var variableDeclaration = new VariableDeclaration(documentModule.QualifiedName, documentModule, documentModule, 
+                        documentModule.IdentifierName, null, true, false, Accessibility.Public, null, null, Selection.Empty, false, null, attributes:varAttributes, isUserDefined:false);
+                    _state.AddDeclaration(variableDeclaration);
+                }
                 _state.AddDeclaration(moduleDeclaration);
 
                 var controlDeclarations = DeclarationsFromControls(moduleDeclaration);

--- a/Rubberduck.Resources/RubberduckUI.Designer.cs
+++ b/Rubberduck.Resources/RubberduckUI.Designer.cs
@@ -1211,6 +1211,15 @@ namespace Rubberduck.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to document.
+        /// </summary>
+        public static string DeclarationType_Document {
+            get {
+                return ResourceManager.GetString("DeclarationType_Document", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to enum.
         /// </summary>
         public static string DeclarationType_Enumeration {

--- a/Rubberduck.Resources/RubberduckUI.resx
+++ b/Rubberduck.Resources/RubberduckUI.resx
@@ -1892,4 +1892,7 @@ Do you want to proceed?</value>
   <data name="IndenterSettings_GroupRelatedProperties" xml:space="preserve">
     <value>Remove vertical space between related property members</value>
   </data>
+  <data name="DeclarationType_Document" xml:space="preserve">
+    <value>document</value>
+  </data>
 </root>

--- a/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
+++ b/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
@@ -527,7 +527,7 @@ End Sub";
                 .AddProjectToVbeBuilder()
                 .Build();
 
-            var (expected, actual) = DeclarationsFromParse(vbe.Object, DeclarationType.Parameter, "Link", "EXCEL.EXE;Excel.Worksheet.Paste");
+            var (expected, actual) = DeclarationsFromParse(vbe.Object, DeclarationType.Parameter, "Link", "EXCEL.EXE;Excel._Worksheet.Paste");
 
             Assert.AreEqual(expected, actual);
         }


### PR DESCRIPTION
This PR completes the work done on supertype resolution.

An unqualified `Cells` member call resolves to `Excel._Global.Cells` same as before in, say, `ThisWorkbook`:

![_Global.Cells](https://user-images.githubusercontent.com/5751684/113661739-a72c4080-9674-11eb-979e-ba4fd9cd573e.png)

But now in `Sheet1` the same identical code is now resolving to `Excel._Worksheet.Cells`:

![_Worksheet.Cells](https://user-images.githubusercontent.com/5751684/113661875-f07c9000-9674-11eb-84f4-ed6e9d0dd48c.png)

The *implicit ActiveSheet* and *implicit containing sheet* reference inspections still work as intended after including the `_Worksheet` superclass in the class names array.

Interestingly it's the `Worksheet` type that comes up on qualified instance member calls:

![_Worksheet members of a document module resolve to Worksheet members when qualified](https://user-images.githubusercontent.com/5751684/113816169-6a2e7f80-9742-11eb-83d5-9ecf489b15f5.png)

As a result, `Sheet1.Cells` resolves to a member of `Excel.Worksheet`, as it should:

![Sheet1.Cells property](https://user-images.githubusercontent.com/5751684/113816246-8cc09880-9742-11eb-8d22-6ee319335265.png)

