### PR TITLE
fixes the EntryPointAnnotation broken xmldoc example

### DIFF
--- a/Rubberduck.Parsing/Annotations/Concrete/EntryPointAnnotation.cs
+++ b/Rubberduck.Parsing/Annotations/Concrete/EntryPointAnnotation.cs
@@ -16,7 +16,6 @@ namespace Rubberduck.Parsing.Annotations.Concrete
     /// </remarks>
     /// <example>
     /// <module name="Module1" type="Standard Module">
-    /// </module>
     /// <![CDATA[
     /// Option Explicit
     /// Option Private Module
@@ -31,6 +30,7 @@ namespace Rubberduck.Parsing.Annotations.Concrete
     ///     '...
     /// End Sub
     /// ]]>
+    /// </module>
     /// </example>
     public sealed class EntryPointAnnotation : AnnotationBase
     {


### PR DESCRIPTION
ContentUpdater app is unable to parse the example code because the code is outside of the `<module>` tag.