### PR TITLE
Hotfix for ImplicitActiveSheetReference inspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Abstract/ImplicitSheetReferenceInspectionBase.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Abstract/ImplicitSheetReferenceInspectionBase.cs
@@ -34,13 +34,13 @@ namespace Rubberduck.CodeAnalysis.Inspections.Abstract
                                       && declaration.AsTypeName == "Range");
         }
 
-        private static readonly string[] GlobalObjectClassNames =
+        protected virtual string[] GlobalObjectClassNames => new[]
         {
             "Global", "_Global", 
             "Worksheet", "_Worksheet"
         };
 
-        private static readonly string[] TargetMemberNames =
+        protected virtual string[] TargetMemberNames => new[]
         {
             "Cells", "Range", "Columns", "Rows"
         };

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitActiveSheetReferenceInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ImplicitActiveSheetReferenceInspection.cs
@@ -47,10 +47,13 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
             : base(declarationFinderProvider)
         {}
 
+        protected override string[] GlobalObjectClassNames => new[] { "Global", "_Global", };
+
         protected override bool IsResultReference(IdentifierReference reference, DeclarationFinder finder)
         {
-            return !(Declaration.GetModuleParent(reference.ParentNonScoping) is DocumentModuleDeclaration document)
+            var result = !(Declaration.GetModuleParent(reference.ParentNonScoping) is DocumentModuleDeclaration document)
                 || !document.SupertypeNames.Contains("Worksheet");
+            return result;
         }
 
         protected override string ResultDescription(IdentifierReference reference)

--- a/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
+++ b/RubberduckTests/Inspections/ImplicitActiveSheetReferenceInspectionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
@@ -13,6 +14,12 @@ namespace RubberduckTests.Inspections
     [TestFixture]
     public class ImplicitActiveSheetReferenceInspectionTests : InspectionTestsBase
     {
+        private static readonly IDictionary<string, IEnumerable<string>> DefaultDocumentModuleSupertypeNames = new Dictionary<string, IEnumerable<string>>
+        {
+            ["ThisWorkbook"] = new[] { "Workbook", "_Workbook" },
+            ["Sheet1"] = new[] { "Worksheet", "_Worksheet" }
+        };
+
         [Test]
         [Category("Inspections")]
         public void ImplicitActiveSheetReference_ReportsRange()
@@ -23,8 +30,13 @@ namespace RubberduckTests.Inspections
     arr1 = Range(""A1:B2"")
 End Sub
 ";
-            var modules = new(string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
+            var modules = new(string, string, ComponentType)[] 
+            {
+                ("ThisWorkbook", string.Empty, ComponentType.Document),
+                ("Sheet1", string.Empty, ComponentType.Document),
+                ("Class1", inputCode, ComponentType.ClassModule)
+            };
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
         }
 
         [Test]
@@ -37,8 +49,13 @@ End Sub
     arr1 = Cells(1,2)
 End Sub
 ";
-            var modules = new (string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
+            var modules = new (string, string, ComponentType)[]
+            {
+                ("ThisWorkbook", string.Empty, ComponentType.Document),
+                ("Sheet1", string.Empty, ComponentType.Document),
+                ("Class1", inputCode, ComponentType.ClassModule)
+            };
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
         }
 
         [Test]
@@ -51,8 +68,13 @@ End Sub
     arr1 = Columns(3)
 End Sub
 ";
-            var modules = new (string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
+            var modules = new (string, string, ComponentType)[]
+            {
+                ("ThisWorkbook", string.Empty, ComponentType.Document),
+                ("Sheet1", string.Empty, ComponentType.Document),
+                ("Class1", inputCode, ComponentType.ClassModule)
+            };
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
         }
 
         [Test]
@@ -65,8 +87,13 @@ End Sub
     arr1 = Rows(3)
 End Sub
 ";
-            var modules = new (string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
+            var modules = new (string, string, ComponentType)[]
+            {
+                ("ThisWorkbook", string.Empty, ComponentType.Document),
+                ("Sheet1", string.Empty, ComponentType.Document),
+                ("Class1", inputCode, ComponentType.ClassModule)
+            };
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
         }
 
         [Test]
@@ -79,21 +106,13 @@ End Sub
     arr1 = Cells(1,2)
 End Sub
 ";
-            var module = ("Sheet1", inputCode, ComponentType.Document);
-            var vbe = MockVbeBuilder.BuildFromModules(module, ReferenceLibrary.Excel).Object;
-
-            using (var state = MockParser.CreateAndParse(vbe))
+            var modules = new (string, string, ComponentType)[]
             {
-                var documentModule = state.DeclarationFinder.UserDeclarations(DeclarationType.Document)
-                    .OfType<DocumentModuleDeclaration>()
-                    .Single();
-                documentModule.AddSupertypeName("Worksheet");
-
-                var inspection = InspectionUnderTest(state);
-                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
-
-                Assert.AreEqual(0, inspectionResults.Count());
-            }
+                ("ThisWorkbook", string.Empty, ComponentType.Document),
+                ("Sheet1", inputCode, ComponentType.Document),
+                ("Class1", string.Empty, ComponentType.ClassModule)
+            };
+            Assert.AreEqual(0, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
         }
 
         [Test]
@@ -106,21 +125,33 @@ End Sub
     arr1 = Cells(1,2)
 End Sub
 ";
-            var module = ("Sheet1", inputCode, ComponentType.Document);
-            var vbe = MockVbeBuilder.BuildFromModules(module, ReferenceLibrary.Excel).Object;
-
-            using (var state = MockParser.CreateAndParse(vbe))
+            var modules = new (string, string, ComponentType)[]
             {
-                var documentModule = state.DeclarationFinder.UserDeclarations(DeclarationType.Document)
-                    .OfType<DocumentModuleDeclaration>()
-                    .Single();
-                documentModule.AddSupertypeName("Workbook");
+                ("ThisWorkbook", inputCode, ComponentType.Document),
+                ("Sheet1", string.Empty, ComponentType.Document),
+                ("Class1", string.Empty, ComponentType.ClassModule)
+            };
+            Assert.AreEqual(1, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
+        }
 
-                var inspection = InspectionUnderTest(state);
-                var inspectionResults = inspection.GetInspectionResults(CancellationToken.None);
-
-                Assert.AreEqual(1, inspectionResults.Count());
-            }
+        [Test]
+        [Category("Inspections")]
+        public void ImplicitActiveSheetReference_NoResultForWorksheetVariable()
+        {
+            const string inputCode =
+                @"Sub foo()
+    Dim sh As Worksheet
+    Set sh = Sheet1
+    Debug.Print sh.Cells(1, 1)
+End Sub
+";
+            var modules = new (string, string, ComponentType)[]
+            {
+                ("ThisWorkbook", string.Empty, ComponentType.Document),
+                ("Sheet1", string.Empty, ComponentType.Document),
+                ("Module1", inputCode, ComponentType.StandardModule)
+            };
+            Assert.AreEqual(0, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
         }
 
         [Test]
@@ -135,9 +166,14 @@ End Sub
     arr1 = Range(""A1:B2"")
 End Sub
 ";
+            var modules = new (string, string, ComponentType)[]
+            {
+                ("ThisWorkbook", string.Empty, ComponentType.Document),
+                ("Sheet1", string.Empty, ComponentType.Document),
+                ("Class1", inputCode, ComponentType.ClassModule)
+            };
 
-            var modules = new(string, string, ComponentType)[] { ("Class1", inputCode, ComponentType.ClassModule) };
-            Assert.AreEqual(0, InspectionResultsForModules(modules, ReferenceLibrary.Excel).Count());
+            Assert.AreEqual(0, InspectionResultsForModules(modules, ReferenceLibrary.Excel, DefaultDocumentModuleSupertypeNames).Count());
         }
 
         [Test]

--- a/RubberduckTests/Inspections/InspectionTestsBase.cs
+++ b/RubberduckTests/Inspections/InspectionTestsBase.cs
@@ -38,13 +38,13 @@ namespace RubberduckTests.Inspections
         public IEnumerable<IInspectionResult> InspectionResultsForModules((string name, string content, ComponentType componentType) module, params ReferenceLibrary[] libraries)
             => InspectionResultsForModules(new (string, string, ComponentType)[] { module }, libraries);
 
-        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, ReferenceLibrary library)
-            => InspectionResultsForModules(modules, new ReferenceLibrary[] { library });
+        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, ReferenceLibrary library, IDictionary<string, IEnumerable<string>> documentModuleSupertypeNames = null)
+            => InspectionResultsForModules(modules, new ReferenceLibrary[] { library }, documentModuleSupertypeNames);
 
-        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<ReferenceLibrary> libraries)
+        public IEnumerable<IInspectionResult> InspectionResultsForModules(IEnumerable<(string name, string content, ComponentType componentType)> modules, IEnumerable<ReferenceLibrary> libraries, IDictionary<string, IEnumerable<string>> documentModuleSupertypeNames = null)
         {
             var vbe = MockVbeBuilder.BuildFromModules(modules, libraries).Object;
-            return InspectionResults(vbe);
+            return InspectionResults(vbe, documentModuleSupertypeNames);
         }
 
         public IEnumerable<IInspectionResult> InspectionResults(IVBE vbe, IDictionary<string, IEnumerable<string>> documentModuleSupertypeNames = null)


### PR DESCRIPTION
This patch makes the ImplicitActiveSheetReference inspection tests to now correctly set the document module supertypes in the test code, and adds a test that confirms the fix for the referenced issue.