### PR TITLE
Make SelectedDeclarationProvider argument-aware

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/NonReturningFunctionInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/NonReturningFunctionInspection.cs
@@ -71,7 +71,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 return false;
             }
 
-            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, enclosingProcedure);
+            var argument = argExpression.GetAncestor<VBAParser.ArgumentContext>();
+            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argument, enclosingProcedure);
 
             // note: not recursive, by design.
             return parameter != null

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterCanBeByValInspection.cs
@@ -142,7 +142,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 return false;
             }
 
-            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, module);
+            var argument = argExpression.GetAncestor<VBAParser.ArgumentContext>();
+            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argument, module);
 
             if (parameter == null)
             {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterNotUsedInspection.cs
@@ -114,7 +114,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
 
         private static bool ParameterAtIndexIsNotUsed(IParameterizedDeclaration declaration, int parameterIndex)
         {
-            var parameter = declaration.Parameters.ElementAtOrDefault(parameterIndex);
+            var parameter = declaration?.Parameters.ElementAtOrDefault(parameterIndex);
             return parameter != null
                    && !parameter.References.Any();
         }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ProcedureCanBeWrittenAsFunctionInspection.cs
@@ -88,7 +88,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 return false;
             }
 
-            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, reference.QualifiedModuleName);
+            var argument = argExpression.GetAncestor<VBAParser.ArgumentContext>();
+            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argument, reference.QualifiedModuleName);
 
             if (parameter == null)
             {

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnassignedVariableUsageInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnassignedVariableUsageInspection.cs
@@ -155,7 +155,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 return false;
             }
 
-            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, enclosingProcedure);
+            var argument = argExpression.GetAncestor<VBAParser.ArgumentContext>();
+            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argument, enclosingProcedure);
 
             // note: not recursive, by design.
             return parameter != null

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
@@ -69,7 +69,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 return false;
             }
 
-            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argExpression, enclosingProcedure);
+            var argument = argExpression.GetAncestor<VBAParser.ArgumentContext>();
+            var parameter = finder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argument, enclosingProcedure);
 
             // note: not recursive, by design.
             return parameter != null

--- a/Rubberduck.Core/AppMenu.cs
+++ b/Rubberduck.Core/AppMenu.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using NLog;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.VBA;
@@ -75,26 +77,26 @@ namespace Rubberduck
                     _logger.Error(exception);
                 }
             }
-            EvaluateCanExecute(_parser.State);
+            EvaluateCanExecuteAsync(_parser.State, CancellationToken.None).Wait();
         }
 
-        public void OnSelectedDeclarationChange(object sender, DeclarationChangedEventArgs e)
+        public async void OnSelectedDeclarationChange(object sender, DeclarationChangedEventArgs e)
         {
-            EvaluateCanExecute(_parser.State);
+            await EvaluateCanExecuteAsync(_parser.State, CancellationToken.None);
         }
 
-        private void OnParserStateChanged(object sender, EventArgs e)
+        private async void OnParserStateChanged(object sender, EventArgs e)
         {            
-            EvaluateCanExecute(_parser.State);
+            await EvaluateCanExecuteAsync(_parser.State, CancellationToken.None);
         }
 
-        public void EvaluateCanExecute(RubberduckParserState state)
+        public async Task EvaluateCanExecuteAsync(RubberduckParserState state, CancellationToken token)
         {
             foreach (var menu in _menus)
             {
                 try
                 {
-                    menu.EvaluateCanExecute(state);
+                    await menu.EvaluateCanExecuteAsync(state, token);
                 }
                 catch (Exception exception)
                 {

--- a/Rubberduck.Core/Refactorings/ExtractMethod/ExtractedParameter.cs
+++ b/Rubberduck.Core/Refactorings/ExtractMethod/ExtractedParameter.cs
@@ -1,5 +1,6 @@
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Resources;
+using Tokens = Rubberduck.Resources.Tokens;
 
 namespace Rubberduck.Refactorings.ExtractMethod
 {

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerFindAllReferencesCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerFindAllReferencesCommand.cs
@@ -19,11 +19,11 @@ namespace Rubberduck.UI.CodeExplorer.Commands
         };
 
         private readonly RubberduckParserState _state;
-        private readonly FindAllReferencesService _finder;
+        private readonly FindAllReferencesAction _finder;
 
         public CodeExplorerFindAllReferencesCommand(
             RubberduckParserState state, 
-            FindAllReferencesService finder, 
+            FindAllReferencesAction finder, 
             IVbeEvents vbeEvents) 
             : base(vbeEvents)
         {

--- a/Rubberduck.Core/UI/Command/ComCommands/FindAllReferencesCommand.cs
+++ b/Rubberduck.Core/UI/Command/ComCommands/FindAllReferencesCommand.cs
@@ -18,7 +18,7 @@ namespace Rubberduck.UI.Command.ComCommands
         private readonly IDeclarationFinderProvider _declarationFinderProvider;
         private readonly ISelectedDeclarationProvider _selectedDeclarationProvider;
         private readonly IVBE _vbe;
-        private readonly FindAllReferencesService _finder;
+        private readonly FindAllReferencesAction _service;
 
         public FindAllReferencesCommand(
             IParserStatusProvider parserStatusProvider,
@@ -26,7 +26,7 @@ namespace Rubberduck.UI.Command.ComCommands
             ISelectedDeclarationProvider selectedDeclarationProvider,
             IVBE vbe, 
             ISearchResultsWindowViewModel viewModel, 
-            FindAllReferencesService finder, 
+            FindAllReferencesAction finder, 
             IVbeEvents vbeEvents)
             : base(vbeEvents)
         {
@@ -34,7 +34,7 @@ namespace Rubberduck.UI.Command.ComCommands
             _declarationFinderProvider = declarationFinderProvider;
             _selectedDeclarationProvider = selectedDeclarationProvider;
             _vbe = vbe;
-            _finder = finder;
+            _service = finder;
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
@@ -77,7 +77,7 @@ namespace Rubberduck.UI.Command.ComCommands
                 return;
             }
 
-            _finder.FindAllReferences(declaration);
+            _service.FindAllReferences(declaration);
         }
 
         private Declaration FindTarget(object parameter)

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
@@ -125,9 +125,9 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                 return RubberduckUI.ContextMultipleControlsSelection;
             }
 
-            var friendlyTypeName = declaration.AsTypeName.Equals("IDispatch", System.StringComparison.InvariantCultureIgnoreCase)
+            var friendlyTypeName = "IDispatch".Equals(declaration.AsTypeName, System.StringComparison.InvariantCultureIgnoreCase)
                 ? "Object"
-                : declaration.AsTypeName;
+                : declaration.AsTypeName ?? string.Empty;
 
             var typeName = declaration.IsArray
                 ? $"{friendlyTypeName}()"

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
@@ -125,9 +125,13 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                 return RubberduckUI.ContextMultipleControlsSelection;
             }
 
-            var typeName = declaration.IsArray
-                ? $"{declaration.AsTypeName}()"
+            var friendlyTypeName = declaration.AsTypeName.Equals("IDispatch", System.StringComparison.InvariantCultureIgnoreCase)
+                ? "Object"
                 : declaration.AsTypeName;
+
+            var typeName = declaration.IsArray
+                ? $"{friendlyTypeName}()"
+                : friendlyTypeName;
 
             switch (declaration)
             {

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/IContextFormatter.cs
@@ -1,8 +1,10 @@
+using System.Threading;
 using Path = System.IO.Path;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.Resources;
 using Rubberduck.VBEditor;
+using System.Threading.Tasks;
 
 namespace Rubberduck.UI.Command.MenuItems.CommandBars
 {
@@ -11,16 +13,16 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
         /// <summary>
         /// Determines the formatting of the contextual selection caption when a codepane is active.
         /// </summary>
-        string Format(ICodePane activeCodePane, Declaration declaration);
+        Task<string> FormatAsync(ICodePane activeCodePane, Declaration declaration, CancellationToken token);
         /// <summary>
         /// Determines the formatting of the contextual selection caption when a codepane is not active.
         /// </summary>
-        string Format(Declaration declaration, bool multipleControls);
+        Task<string> FormatAsync(Declaration declaration, bool multipleControls, CancellationToken token);
     }
 
     public class ContextFormatter : IContextFormatter
     {
-        public string Format(ICodePane activeCodePane, Declaration declaration)
+        public async Task<string> FormatAsync(ICodePane activeCodePane, Declaration declaration, CancellationToken token)
         {
             if (activeCodePane == null)
             {
@@ -35,93 +37,105 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
             var selection = qualifiedSelection.Value;
             var codePaneSelectionText = selection.Selection.ToString();
-            var contextSelectionText = FormatDeclaration(declaration);
+            var contextSelectionText = await FormatDeclarationAsync(declaration, token);
 
             return $"{codePaneSelectionText} | {contextSelectionText}";
         }
 
-        public string Format(Declaration declaration, bool multipleControls)
+        public async Task<string> FormatAsync(Declaration declaration, bool multipleControls, CancellationToken token)
         {
             if (declaration == null)
             {
                 return string.Empty;
             }
-
+            
+            token.ThrowIfCancellationRequested();
             // designer, there is no code pane selection
-            return FormatDeclaration(declaration, multipleControls);
+            return await FormatDeclarationAsync(declaration, token, multipleControls);
         }
 
-        private string FormatDeclaration(Declaration declaration, bool multipleControls = false)
+        private async Task<string> FormatDeclarationAsync(Declaration declaration, CancellationToken token, bool multipleControls = false)
         {
+            token.ThrowIfCancellationRequested();
             var moduleName = declaration.QualifiedName.QualifiedModuleName;
             var declarationType = RubberduckUI.ResourceManager.GetString("DeclarationType_" + declaration.DeclarationType, Settings.Settings.Culture);
 
             var typeName = TypeName(declaration, multipleControls, declarationType);
-            var formattedDeclaration = FormattedDeclaration(declaration, typeName, moduleName, declarationType);
+            var formattedDeclaration = await FormattedDeclarationAsync(declaration, typeName, moduleName, declarationType, token);
             return formattedDeclaration.Trim();
         }
 
-        private static string FormattedDeclaration(
+        private async Task<string> FormattedDeclarationAsync(
             Declaration declaration, 
             string typeName,
             QualifiedModuleName moduleName, 
-            string declarationType)
+            string declarationType, 
+            CancellationToken token)
         {
-            if (declaration.ParentDeclaration != null)
+            return await Task.Run(() =>
             {
-                if (declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Member))
+
+                token.ThrowIfCancellationRequested();
+                if (declaration.ParentDeclaration != null)
                 {
-                    // locals, parameters
-                    return $"{declaration.ParentDeclaration.QualifiedName}:{declaration.IdentifierName} {typeName}";
+                    if (declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Member))
+                    {
+                        // locals, parameters
+                        return $"{declaration.ParentDeclaration.QualifiedName}:{declaration.IdentifierName} {typeName}";
+                    }
+
+                    if (declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Module))
+                    {
+                        // fields
+                        var withEvents = declaration.IsWithEvents ? $"({Tokens.WithEvents}) " : string.Empty;
+                        return $"{withEvents}{moduleName}.{declaration.IdentifierName} {typeName}";
+                    }
                 }
 
-                if (declaration.ParentDeclaration.DeclarationType.HasFlag(DeclarationType.Module))
+                token.ThrowIfCancellationRequested();
+                if (declaration.DeclarationType.HasFlag(DeclarationType.Member))
                 {
-                    // fields
-                    var withEvents = declaration.IsWithEvents ? $"({Tokens.WithEvents}) " : string.Empty;
-                    return $"{withEvents}{moduleName}.{declaration.IdentifierName} {typeName}";
-                }
-            } 
+                    var formattedDeclaration = $"{declaration.QualifiedName}";
+                    if (declaration.DeclarationType == DeclarationType.Function
+                        || declaration.DeclarationType == DeclarationType.PropertyGet)
+                    {
+                        formattedDeclaration += $" {typeName}";
+                    }
 
-            if (declaration.DeclarationType.HasFlag(DeclarationType.Member))
-            {
-                var formattedDeclaration = $"{declaration.QualifiedName}";
-                if (declaration.DeclarationType == DeclarationType.Function
-                    || declaration.DeclarationType == DeclarationType.PropertyGet)
-                {
-                    formattedDeclaration += $" {typeName}";
+                    return formattedDeclaration;
                 }
 
-                return formattedDeclaration;
-            }
-            
-            if (declaration.DeclarationType.HasFlag(DeclarationType.Module))
-            {
-                return $"{moduleName} ({declarationType})";
-            }
-            
-            switch (declaration.DeclarationType)
-            {
-                case DeclarationType.Project:
-                case DeclarationType.BracketedExpression:
-                    var filename = Path.GetFileName(declaration.QualifiedName.QualifiedModuleName.ProjectPath);
-                    return $"{filename}{(string.IsNullOrEmpty(filename) ? string.Empty : ";")}{declaration.IdentifierName} ({declarationType})";
-                case DeclarationType.Enumeration:
-                case DeclarationType.UserDefinedType:
-                    return !declaration.IsUserDefined
-                        // built-in enums & UDTs don't have a module
-                        ? $"{Path.GetFileName(moduleName.ProjectPath)};{declaration.IdentifierName}"
-                        : moduleName.ToString();
-                case DeclarationType.EnumerationMember:
-                case DeclarationType.UserDefinedTypeMember:
-                    return declaration.IsUserDefined
-                        ? $"{moduleName}.{declaration.ParentDeclaration.IdentifierName}.{declaration.IdentifierName} {typeName}"
-                        : $"{Path.GetFileName(moduleName.ProjectPath)};{declaration.ParentDeclaration.IdentifierName}.{declaration.IdentifierName} {typeName}";
-                case DeclarationType.ComAlias:
-                    return $"{Path.GetFileName(moduleName.ProjectPath)};{declaration.IdentifierName} (alias:{declaration.AsTypeName})";
-            }
+                if (declaration.DeclarationType.HasFlag(DeclarationType.Module))
+                {
+                    return $"{moduleName} ({declarationType})";
+                }
 
-            return string.Empty;
+                token.ThrowIfCancellationRequested();
+                switch (declaration.DeclarationType)
+                {
+                    case DeclarationType.Project:
+                    case DeclarationType.BracketedExpression:
+                        var filename = Path.GetFileName(declaration.QualifiedName.QualifiedModuleName.ProjectPath);
+                        return
+                            $"{filename}{(string.IsNullOrEmpty(filename) ? string.Empty : ";")}{declaration.IdentifierName} ({declarationType})";
+                    case DeclarationType.Enumeration:
+                    case DeclarationType.UserDefinedType:
+                        return !declaration.IsUserDefined
+                            // built-in enums & UDTs don't have a module
+                            ? $"{Path.GetFileName(moduleName.ProjectPath)};{declaration.IdentifierName}"
+                            : moduleName.ToString();
+                    case DeclarationType.EnumerationMember:
+                    case DeclarationType.UserDefinedTypeMember:
+                        return declaration.IsUserDefined
+                            ? $"{moduleName}.{declaration.ParentDeclaration.IdentifierName}.{declaration.IdentifierName} {typeName}"
+                            : $"{Path.GetFileName(moduleName.ProjectPath)};{declaration.ParentDeclaration.IdentifierName}.{declaration.IdentifierName} {typeName}";
+                    case DeclarationType.ComAlias:
+                        return
+                            $"{Path.GetFileName(moduleName.ProjectPath)};{declaration.IdentifierName} (alias:{declaration.AsTypeName})";
+                }
+
+                return string.Empty;
+            }, token);
         }
 
         private static string TypeName(Declaration declaration, bool multipleControls, string declarationType)

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -64,7 +64,10 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                 caption = e.FallbackCaption;
             }
 
-            var refCount = e.Declaration?.References.Count() ?? 0;
+            var refCount = (e.Declaration?.References.Count() ?? 0)
+                + ((e.Declaration is ParameterDeclaration parameter)
+                    ? parameter.ArgumentReferences.Count()
+                    : 0);
             var description = e.Declaration?.DescriptionString ?? string.Empty;
             //& renders the next character as if it was an accelerator.
             SetContextSelectionCaption(caption?.Replace("&", "&&"), refCount, description);

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Rubberduck.Resources;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.UIContext;
@@ -35,13 +37,14 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
         {
             base.Initialize();
             SetStatusLabelCaption(ParserState.Pending);
-            EvaluateCanExecute(_state);
+            EvaluateCanExecuteAsync(_state, CancellationToken.None);
         }
 
         private Declaration _lastDeclaration;
         private ParserState _lastStatus = ParserState.None;
-        private void EvaluateCanExecute(RubberduckParserState state, Declaration selected)
+        private async Task EvaluateCanExecuteAsync(RubberduckParserState state, Declaration selected, CancellationToken token)
         {
+            token.ThrowIfCancellationRequested();
             var currentStatus = _state.Status;
             if (_lastStatus == currentStatus && 
                 (selected == null || selected.Equals(_lastDeclaration)) &&
@@ -52,29 +55,77 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
             _lastStatus = currentStatus;
             _lastDeclaration = selected;
-            base.EvaluateCanExecute(state);
+            await base.EvaluateCanExecuteAsync(state, token);
         }
 
-        private void OnSelectionChange(object sender, DeclarationChangedEventArgs e)
+        private readonly ConcurrentDictionary<string, CancellationTokenSource> _tokenSources = new ConcurrentDictionary<string, CancellationTokenSource>();
+
+        private async void OnSelectionChange(object sender, DeclarationChangedEventArgs e)
         {
-            var caption = _formatter.Format(e.Declaration, e.MultipleControlsSelected);
-            if (string.IsNullOrEmpty(caption))
+            try
             {
-                //Fallback caption for selections in the Project window.                               
-                caption = e.FallbackCaption;
-            }
+                try
+                {
+                    if (_tokenSources.TryRemove(nameof(OnSelectionChange), out var existing))
+                    {
+                        existing.Cancel();
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    Logger.Trace($"CancellationTokenSource was already disposed for {nameof(OnSelectionChange)}.");
+                }
 
-            var refCount = (e.Declaration?.References.Count() ?? 0)
-                + ((e.Declaration is ParameterDeclaration parameter)
-                    ? parameter.ArgumentReferences.Count()
-                    : 0);
-            var description = e.Declaration?.DescriptionString ?? string.Empty;
-            //& renders the next character as if it was an accelerator.
-            SetContextSelectionCaption(caption?.Replace("&", "&&"), refCount, description);
-            EvaluateCanExecute(_state, e.Declaration);
+                var source = _tokenSources.GetOrAdd(nameof(OnSelectionChange), k => new CancellationTokenSource());
+                var token = source.Token;
+
+                await Task.Run(async () =>
+                    {
+                        var caption = await _formatter.FormatAsync(e.Declaration, e.MultipleControlsSelected, token);
+                        token.ThrowIfCancellationRequested();
+
+                        var argRefCount = e.Declaration is ParameterDeclaration parameter ? parameter.ArgumentReferences.Count() : 0;
+                        var refCount = e.Declaration?.References.Count() ?? 0 + argRefCount;
+                        var description = e.Declaration?.DescriptionString ?? string.Empty;
+                        token.ThrowIfCancellationRequested();
+
+                        //& renders the next character as if it was an accelerator.
+                        SetContextSelectionCaption(caption?.Replace("&", "&&"), refCount, description);
+                        token.ThrowIfCancellationRequested();
+
+                        await EvaluateCanExecuteAsync(_state, e.Declaration, token);
+
+                    }, token)
+                    .ContinueWith(t =>
+                    {
+                        try
+                        {
+                            if (!t.IsCanceled)
+                            {
+                                source.Dispose();
+                            }
+                        }
+                        catch (Exception exception)
+                        {
+                            Logger.Trace($"CancellationTokenSource.Dispose() threw an exception for {nameof(OnSelectionChange)}: {exception}");
+                        }
+                    }, token);
+            }
+            catch(ObjectDisposedException)
+            {
+                Logger.Trace($"CancellationTokenSource was already disposed for {nameof(OnSelectionChange)}.");
+            }
+            catch (OperationCanceledException exception)
+            {
+                Logger.Info(exception);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception);
+            }
         }
 
-        
+
         private void OnParserStatusMessageUpdate(object sender, RubberduckStatusMessageEventArgs e)
         {
             var message = e.Message;
@@ -87,11 +138,56 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             SetStatusLabelCaption(message, _state.ModuleExceptions.Count);            
         }
 
-        private void OnParserStateChanged(object sender, EventArgs e)
+        private async void OnParserStateChanged(object sender, EventArgs e)
         {
-            _lastStatus = _state.Status;
-            EvaluateCanExecute(_state);    
-            SetStatusLabelCaption(_state.Status, _state.ModuleExceptions.Count);                 
+            try
+            {
+                _lastStatus = _state.Status;
+                try
+                {
+                    if (_tokenSources.TryRemove(nameof(OnParserStateChanged), out var existing))
+                    {
+                        existing.Cancel();
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    Logger.Trace($"CancellationTokenSource was already disposed for {nameof(OnParserStateChanged)}.");
+                }
+
+                var source = _tokenSources.GetOrAdd(nameof(OnParserStateChanged), k => new CancellationTokenSource());
+                var token = source.Token;
+
+                await EvaluateCanExecuteAsync(_state, token)
+                    .ContinueWith(t =>
+                    {
+                        try
+                        {
+                            if (!t.IsCanceled)
+                            {
+                                source.Dispose();
+                            }
+                        }
+                        catch (Exception exception)
+                        {
+                            Logger.Trace($"CancellationTokenSource.Dispose() threw an exception for {nameof(OnParserStateChanged)}: {exception}");
+                        }
+                    }, token);
+
+                SetStatusLabelCaption(_state.Status, _state.ModuleExceptions.Count);
+            }
+            catch (ObjectDisposedException)
+            {
+                Logger.Trace($"CancellationTokenSource was already disposed for {nameof(OnParserStateChanged)}.");
+            }
+            catch (OperationCanceledException exception)
+            {
+                Logger.Info(exception);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception);
+            }
         }
 
         public void SetStatusLabelCaption(ParserState state, int? errorCount = null)
@@ -102,16 +198,12 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
         private void SetStatusLabelCaption(string caption, int? errorCount = null)
         {
-            var reparseCommandButton =
-                FindChildByTag(typeof(ReparseCommandMenuItem).FullName) as ReparseCommandMenuItem;
-            if (reparseCommandButton == null)
+            if (!(FindChildByTag(typeof(ReparseCommandMenuItem).FullName) is ReparseCommandMenuItem reparseCommandButton))
             {
                 return;
             }
 
-            var showErrorsCommandButton =
-                FindChildByTag(typeof(ShowParserErrorsCommandMenuItem).FullName) as ShowParserErrorsCommandMenuItem;
-            if (showErrorsCommandButton == null)
+            if (!(FindChildByTag(typeof(ShowParserErrorsCommandMenuItem).FullName) is ShowParserErrorsCommandMenuItem showErrorsCommandButton))
             {
                 return;
             }
@@ -122,7 +214,7 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                 {
                     reparseCommandButton.SetCaption(caption);
                     reparseCommandButton.SetToolTip(string.Format(RubberduckUI.ReparseToolTipText, caption));
-                    if (errorCount.HasValue && errorCount.Value > 0)
+                    if (errorCount > 0)
                     {
                         showErrorsCommandButton.SetToolTip(
                             string.Format(RubberduckUI.ParserErrorToolTipText, errorCount.Value));
@@ -171,6 +263,18 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
             if (_isDisposed || !disposing)
             {
                 return;
+            }
+
+            foreach (var source in _tokenSources)
+            {
+                try
+                {
+                    source.Value.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    Logger.Trace($"Disposing CancellationTokenSource for {nameof(OnParserStateChanged)} threw an exception: {exception}");
+                }
             }
 
             _selectionService.SelectionChanged -= OnSelectionChange;

--- a/Rubberduck.Core/UI/Command/MenuItems/IAppMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/IAppMenu.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Rubberduck.Parsing.VBA;
 
 namespace Rubberduck.UI.Command.MenuItems
@@ -6,6 +8,6 @@ namespace Rubberduck.UI.Command.MenuItems
     {
         void Localize();
         void Initialize();
-        void EvaluateCanExecute(RubberduckParserState state);
+        Task EvaluateCanExecuteAsync(RubberduckParserState state, CancellationToken token);
     }
 }

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/AnnotateParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/AnnotateParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class AnnotateParentMenu : ParentMenuItemBase
     {
-        public AnnotateParentMenu(IEnumerable<IMenuItem> items)
-            : base("AnnotateMenu", items)
+        public AnnotateParentMenu(IEnumerable<IMenuItem> items, IUiDispatcher dispatcher)
+            : base(dispatcher, "AnnotateMenu", items)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/CodePaneContextParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/CodePaneContextParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class CodePaneContextParentMenu : ParentMenuItemBase
     {
-        public CodePaneContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex)
-            : base("RubberduckMenu", items, beforeIndex)
+        public CodePaneContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex, IUiDispatcher dispatcher)
+            : base(dispatcher,"RubberduckMenu", items, beforeIndex)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/CodePaneRefactoringsParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/CodePaneRefactoringsParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class CodePaneRefactoringsParentMenu : ParentMenuItemBase
     {
-        public CodePaneRefactoringsParentMenu(IEnumerable<IMenuItem> items)
-            : base("RubberduckMenu_CodePaneRefactor", items)
+        public CodePaneRefactoringsParentMenu(IEnumerable<IMenuItem> items, IUiDispatcher dispatcher)
+            : base(dispatcher, "RubberduckMenu_CodePaneRefactor", items)
         { }
 
         //This display order is different from the main menu; it is the sole reason this class is separate from the main menu one.

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/FormDesignerContextParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/FormDesignerContextParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class FormDesignerContextParentMenu : ParentMenuItemBase
     {
-        public FormDesignerContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex)
-            : base("RubberduckMenu", items, beforeIndex)
+        public FormDesignerContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex, IUiDispatcher dispatcher)
+            : base(dispatcher,"RubberduckMenu", items, beforeIndex)
         {
         }
 
@@ -14,8 +15,8 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 
     public class FormDesignerControlContextParentMenu : ParentMenuItemBase
     {
-        public FormDesignerControlContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex)
-            : base("RubberduckMenu", items, beforeIndex)
+        public FormDesignerControlContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex, IUiDispatcher dispatcher)
+            : base(dispatcher,"RubberduckMenu", items, beforeIndex)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/NavigateParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/NavigateParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class NavigateParentMenu : ParentMenuItemBase
     {
-        public NavigateParentMenu(IEnumerable<IMenuItem> items) 
-            : base("RubberduckMenu_Navigate", items)
+        public NavigateParentMenu(IEnumerable<IMenuItem> items, IUiDispatcher dispatcher) 
+            : base(dispatcher,"RubberduckMenu_Navigate", items)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/ProjectWindowContextParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/ProjectWindowContextParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class ProjectWindowContextParentMenu : ParentMenuItemBase
     {
-        public ProjectWindowContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex)
-            : base("RubberduckMenu", items, beforeIndex)
+        public ProjectWindowContextParentMenu(IEnumerable<IMenuItem> items, int beforeIndex, IUiDispatcher dispatcher)
+            : base(dispatcher,"RubberduckMenu", items, beforeIndex)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/RefactoringsParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/RefactoringsParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class RefactoringsParentMenu : ParentMenuItemBase
     {
-        public RefactoringsParentMenu(IEnumerable<IMenuItem> items)
-            : base("RubberduckMenu_Refactor", items)
+        public RefactoringsParentMenu(IEnumerable<IMenuItem> items, IUiDispatcher dispatcher)
+            : base(dispatcher,"RubberduckMenu_Refactor", items)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/RubberduckParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/RubberduckParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class RubberduckParentMenu : ParentMenuItemBase
     {
-        public RubberduckParentMenu(IEnumerable<IMenuItem> items, int beforeIndex) 
-            : base("RubberduckMenu", items, beforeIndex)
+        public RubberduckParentMenu(IEnumerable<IMenuItem> items, int beforeIndex, IUiDispatcher dispatcher) 
+            : base(dispatcher, "RubberduckMenu", items, beforeIndex)
         {
         }
     }

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/SmartIndenterParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/SmartIndenterParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class SmartIndenterParentMenu : ParentMenuItemBase
     {
-        public SmartIndenterParentMenu(IEnumerable<IMenuItem> items)
-            : base("SmartIndenterMenu", items)
+        public SmartIndenterParentMenu(IEnumerable<IMenuItem> items, IUiDispatcher dispatcher)
+            : base(dispatcher, "SmartIndenterMenu", items)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/ToolsParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/ToolsParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class ToolsParentMenu : ParentMenuItemBase
     {
-        public ToolsParentMenu(IEnumerable<IMenuItem> items)
-            : base("ToolsMenu", items)
+        public ToolsParentMenu(IEnumerable<IMenuItem> items, IUiDispatcher dispatcher)
+            : base(dispatcher, "ToolsMenu", items)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/UnitTestingParentMenu.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/UnitTestingParentMenu.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using Rubberduck.Parsing.UIContext;
 
 namespace Rubberduck.UI.Command.MenuItems.ParentMenus
 {
     public class UnitTestingParentMenu : ParentMenuItemBase
     {
-        public UnitTestingParentMenu(IEnumerable<IMenuItem> items) 
-            : base("RubberduckMenu_UnitTests", items)
+        public UnitTestingParentMenu(IEnumerable<IMenuItem> items, IUiDispatcher dispatcher) 
+            : base(dispatcher, "RubberduckMenu_UnitTests", items)
         {
         }
 

--- a/Rubberduck.Core/UI/Command/RunSelectedTestModuleCommand.cs
+++ b/Rubberduck.Core/UI/Command/RunSelectedTestModuleCommand.cs
@@ -23,7 +23,7 @@ namespace Rubberduck.UI.Command
         {
             return (parameter ?? FindModuleFromSelection()) is Declaration candidate &&
                    candidate.DeclarationType == DeclarationType.ProceduralModule &&
-                   candidate.Annotations.Any(annotation => annotation is TestModuleAnnotation) &&
+                   candidate.Annotations.Any(annotation => annotation.Annotation is TestModuleAnnotation) &&
                    _engine.CanRun &&
                    _engine.Tests.Any(test => test.Declaration.QualifiedModuleName.Equals(candidate.QualifiedModuleName));
         }
@@ -32,7 +32,7 @@ namespace Rubberduck.UI.Command
         {
             if (!((parameter ?? FindModuleFromSelection()) is Declaration candidate) ||
                 candidate.DeclarationType != DeclarationType.ProceduralModule ||
-                !candidate.Annotations.Any(annotation => annotation is TestModuleAnnotation) ||
+                !candidate.Annotations.Any(annotation => annotation.Annotation is TestModuleAnnotation) ||
                 !_engine.CanRun)
             {
                 return;

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
@@ -25,7 +25,7 @@
             <ColumnDefinition Width="32" />
         </Grid.ColumnDefinitions>
 
-        <ComboBox x:Name="searchComboBox"
+        <ComboBox x:Name="SearchComboBox"
                   IsEditable="True"
                   ItemsSource="{Binding MatchResults}"
                   SelectedItem="{Binding SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
@@ -46,7 +46,7 @@ namespace Rubberduck.UI.FindSymbol
 
         private void FindSymbolControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
         {
-            searchComboBox.Focus();
+            SearchComboBox.Focus();
         }
     }
 }

--- a/Rubberduck.Core/UI/Refactorings/ExtractMethodDialog.cs
+++ b/Rubberduck.Core/UI/Refactorings/ExtractMethodDialog.cs
@@ -195,13 +195,9 @@ namespace Rubberduck.UI.Refactorings
 
         private void ValidateName()
         {
-            var tokenValues = typeof(Tokens).GetFields()
-                .Where(item => !item.GetCustomAttributes<NotReservedAttribute>().Any())
-                .Select(item => item.GetValue(null)).Cast<string>().Select(item => item);
-
             OkButton.Enabled = MethodName != OldMethodName
                                && char.IsLetter(MethodName.FirstOrDefault())
-                               && !tokenValues.Contains(MethodName, StringComparer.InvariantCultureIgnoreCase)
+                               && !Tokens.IllegalIdentifierNames.Contains(MethodName, StringComparer.InvariantCultureIgnoreCase)
                                && !MethodName.Any(c => !char.IsLetterOrDigit(c) && c != '_');
 
             InvalidNameValidationIcon.Visible = !OkButton.Enabled;

--- a/Rubberduck.Core/UI/Refactorings/ExtractMethodDialog.cs
+++ b/Rubberduck.Core/UI/Refactorings/ExtractMethodDialog.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Reflection;
 using System.Windows.Forms;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Refactorings.ExtractMethod;
 using Rubberduck.Resources;
+using Tokens = Rubberduck.Resources.Tokens;
 
 namespace Rubberduck.UI.Refactorings
 {
@@ -193,7 +195,9 @@ namespace Rubberduck.UI.Refactorings
 
         private void ValidateName()
         {
-            var tokenValues = typeof(Tokens).GetFields().Select(item => item.GetValue(null)).Cast<string>().Select(item => item);
+            var tokenValues = typeof(Tokens).GetFields()
+                .Where(item => !item.GetCustomAttributes<NotReservedAttribute>().Any())
+                .Select(item => item.GetValue(null)).Cast<string>().Select(item => item);
 
             OkButton.Enabled = MethodName != OldMethodName
                                && char.IsLetter(MethodName.FirstOrDefault())

--- a/Rubberduck.Core/UI/SelectionChangeService.cs
+++ b/Rubberduck.Core/UI/SelectionChangeService.cs
@@ -40,6 +40,7 @@ namespace Rubberduck.UI
         {
             Task.Run(() =>
             {
+                
                 var selectedDeclaration = _selectedDeclarationProvider.SelectedDeclaration();
                 var eventArgs = new DeclarationChangedEventArgs(_vbe, selectedDeclaration);
                 DispatchSelectedDeclaration(eventArgs);

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -655,7 +655,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                 }
                 parameter = parameters
                     .Select((param, index) => (param, index))
-                    .Single(item => item.index == indexedArg.index).param;
+                    .SingleOrDefault(item => item.index == indexedArg.index).param;
             }
 
             return parameter;

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -640,14 +640,13 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             {
                 // argument is positional: work out its index
                 var argumentList = argumentExpression.GetAncestor<VBAParser.ArgumentListContext>();
-                var arguments = argumentList.GetDescendents<VBAParser.PositionalArgumentContext>().ToArray();
+                var arguments = argumentList.children.Where(t => (t is VBAParser.ArgumentContext)).ToArray();
 
                 var parameterIndex = arguments
-                    .Select((arg, index) => arg.GetDescendent<VBAParser.ArgumentExpressionContext>() == argumentExpression ? (arg, index) : (null, -1))
-                    .SingleOrDefault(item => item.arg != null).index;
+                    .Select((arg, index) => (arg: arg as ParserRuleContext, index))
+                    .SingleOrDefault(item => item.arg.ContainsTokenIndex(argumentExpression.Start.TokenIndex)).index;
 
                 parameter = parameters
-                    .OrderBy(p => p.Selection)
                     .Select((param, index) => (param, index))
                     .SingleOrDefault(item => item.index == parameterIndex).param;
             }

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -654,6 +654,11 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             return parameter;
         }
 
+        public ModuleBodyElementDeclaration FindInvokedMemberFromArgumentExpressionContext(VBAParser.ArgumentExpressionContext argumentExpression, QualifiedModuleName module)
+        {
+            return CallingNonDefaultMember(argumentExpression, module);
+        }
+
         private ModuleBodyElementDeclaration CallingNonDefaultMember(VBAParser.ArgumentExpressionContext argumentExpression, QualifiedModuleName module)
         {
             //todo: Make this work for default member calls.

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -602,24 +602,25 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                 : Enumerable.Empty<Declaration>();
         }
 
-        public ParameterDeclaration FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(VBAParser.ArgumentExpressionContext argumentExpression, Declaration enclosingProcedure)
+        public ParameterDeclaration FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(VBAParser.ArgumentContext argument, Declaration enclosingProcedure)
         {
-            return FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argumentExpression, enclosingProcedure.QualifiedModuleName);
+            return FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(argument, enclosingProcedure.QualifiedModuleName);
         }
 
-        public ParameterDeclaration FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(VBAParser.ArgumentExpressionContext argumentExpression, QualifiedModuleName module)
+        public ParameterDeclaration FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(VBAParser.ArgumentContext argument, QualifiedModuleName module)
         {
             //todo: Rename after making it work for more general cases.
-
-            if (argumentExpression  == null 
-                || argumentExpression.GetDescendent<VBAParser.ParenthesizedExprContext>() != null 
-                || argumentExpression.BYVAL() != null)
+            var missingArgument = argument.missingArgument();
+            var argumentExpression = argument.GetDescendent<VBAParser.ArgumentExpressionContext>();
+            if ((missingArgument == null && argumentExpression  == null)
+                || argumentExpression?.GetDescendent<VBAParser.ParenthesizedExprContext>() != null 
+                || argumentExpression?.BYVAL() != null)
             {
                 // not a simple argument, or argument is parenthesized and thus passed ByVal
                 return null;
             }
 
-            var callingNonDefaultMember = CallingNonDefaultMember(argumentExpression, module);
+            var callingNonDefaultMember = CallingNonDefaultMember((ParserRuleContext)argumentExpression ?? missingArgument, module);
             if (callingNonDefaultMember == null)
             {
                 // Either we could not resolve the call or there is a default member call involved. 
@@ -627,6 +628,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             }
 
             var parameters = Parameters(callingNonDefaultMember);
+            var hasNamedArgs = argumentExpression?.GetAncestor<VBAParser.ArgListContext>()?.TryGetChildContext<VBAParser.NamedArgumentContext>(out _) ?? false;
 
             ParameterDeclaration parameter;
             var namedArg = argumentExpression.GetAncestor<VBAParser.NamedArgumentContext>();
@@ -639,35 +641,44 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             else
             {
                 // argument is positional: work out its index
-                var argumentList = argumentExpression.GetAncestor<VBAParser.ArgumentListContext>();
-                var arguments = argumentList.children.Where(t => (t is VBAParser.ArgumentContext)).ToArray();
-
-                var parameterIndex = arguments
-                    .Select((arg, index) => (arg: arg as ParserRuleContext, index))
-                    .SingleOrDefault(item => item.arg.ContainsTokenIndex(argumentExpression.Start.TokenIndex)).index;
-
+                var argumentList = ((ParserRuleContext)argumentExpression ?? missingArgument).GetAncestor<VBAParser.ArgumentListContext>();
+                var arguments = argumentList.children.Where(t => t is VBAParser.ArgumentContext).ToArray();
+                var selection = argumentExpression?.GetSelection() ?? missingArgument.GetSelection();
+                
+                var indexedArgs = arguments.Select((arg, index) => (arg: arg as ParserRuleContext, index))
+                    .Select(e => (arg: e.arg, e.index, selection:e.arg.GetSelection()))
+                    .ToList();
+                var indexedArg = indexedArgs.SingleOrDefault(item => item.selection.Contains(selection));
+                if (indexedArg.arg == null)
+                {
+                    return null;
+                }
                 parameter = parameters
                     .Select((param, index) => (param, index))
-                    .SingleOrDefault(item => item.index == parameterIndex).param;
+                    .Single(item => item.index == indexedArg.index).param;
             }
 
             return parameter;
         }
 
-        public ModuleBodyElementDeclaration FindInvokedMemberFromArgumentExpressionContext(VBAParser.ArgumentExpressionContext argumentExpression, QualifiedModuleName module)
+        public ModuleBodyElementDeclaration FindInvokedMemberFromArgumentContext(VBAParser.ArgumentContext argument, QualifiedModuleName module)
         {
-            return CallingNonDefaultMember(argumentExpression, module);
+            var expression = (ParserRuleContext)argument.GetDescendent<VBAParser.ArgumentExpressionContext>() 
+                ?? argument.GetDescendent<VBAParser.MissingArgumentContext>();
+            return expression != null
+                ? CallingNonDefaultMember(expression, module)
+                : null;
         }
 
-        private ModuleBodyElementDeclaration CallingNonDefaultMember(VBAParser.ArgumentExpressionContext argumentExpression, QualifiedModuleName module)
+        private ModuleBodyElementDeclaration CallingNonDefaultMember(ParserRuleContext argumentExpressionOrMissingArgument, QualifiedModuleName module)
         {
             //todo: Make this work for default member calls.
 
-            var argumentList = argumentExpression.GetAncestor<VBAParser.ArgumentListContext>();
+            var argumentList = argumentExpressionOrMissingArgument.GetAncestor<VBAParser.ArgumentListContext>();
             var cannotHaveDefaultMemberCall = false;
 
             ParserRuleContext callingExpression;
-            switch (argumentList.Parent)
+            switch (argumentList?.Parent)
             {
                 case VBAParser.CallStmtContext callStmt:
                     cannotHaveDefaultMemberCall = true;
@@ -680,7 +691,6 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                     callingExpression = indexExpr.lExpression();
                     break;
                 default:
-                    //This should never happen.
                     return null;
             }
 

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -1591,12 +1591,10 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             }
 
             referenceProject = GetProjectDeclarationForReference(reference);
-
             if (!_referencesByProjectId.TryGetValue(referenceProject.ProjectId, out var directReferences))
             {
                 return output;
             }
-
             output.AddRange(directReferences);
 
             var projectId = referenceProject.ProjectId;

--- a/Rubberduck.Refactorings/Common/CodeBuilder.cs
+++ b/Rubberduck.Refactorings/Common/CodeBuilder.cs
@@ -6,6 +6,7 @@ using Rubberduck.SmartIndenter;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Tokens = Rubberduck.Resources.Tokens;
 
 namespace Rubberduck.Refactorings
 {

--- a/Rubberduck.Refactorings/Common/VBAIdentifierValidator.cs
+++ b/Rubberduck.Refactorings/Common/VBAIdentifierValidator.cs
@@ -12,12 +12,6 @@ namespace Rubberduck.Refactorings.Common
 {
     public static class VBAIdentifierValidator
     {
-        // NOTE: ForbiddenAttribute marks the tokens that don't compile as identifier names. Includes "bad but legal" names.
-        // TODO: Compare with the unfiltered tokens if a client needs to tell "bad but legal" from "bad and illegal" names.
-        private static readonly IEnumerable<string> ReservedIdentifiers =
-            typeof(Tokens).GetFields()
-                .Where(item => item.GetType().GetCustomAttributes<ForbiddenAttribute>().Any())
-                .Select(item => item.GetValue(null).ToString()).ToArray();
 
         /// <summary>
         /// Predicate function determining if an identifier string's content will trigger a result for the UseMeaningfulNames inspection.
@@ -111,7 +105,7 @@ namespace Rubberduck.Refactorings.Common
             //Is a reserved identifier
             if (!declarationType.HasFlag(DeclarationType.UserDefinedTypeMember))
             {
-                if (ReservedIdentifiers.Contains(name, StringComparer.InvariantCultureIgnoreCase))
+                if (Tokens.IllegalIdentifierNames.Contains(name, StringComparer.InvariantCultureIgnoreCase))
                 {
                     criteriaMatchMessage = string.Format(RubberduckUI.InvalidNameCriteria_IsReservedKeywordFormat, name);
                     return true;
@@ -124,7 +118,7 @@ namespace Rubberduck.Refactorings.Common
 
                 //Name is not a reserved identifier, but when used as a UDTMember array declaration
                 //it collides with the 'Name' Statement (Renames a disk file, directory, or folder)
-                var invalidUDTArrayIdentifiers = ReservedIdentifiers.Concat(new List<string>() { "Name" });
+                var invalidUDTArrayIdentifiers = Tokens.IllegalIdentifierNames.Concat(new List<string>() { "Name" });
 
                 if (invalidUDTArrayIdentifiers.Contains(name, StringComparer.InvariantCultureIgnoreCase))
                 {
@@ -182,7 +176,7 @@ namespace Rubberduck.Refactorings.Common
             //Is a reserved identifier
             if (!declarationType.HasFlag(DeclarationType.UserDefinedTypeMember))
             {
-                if (ReservedIdentifiers.Contains(name, StringComparer.InvariantCultureIgnoreCase))
+                if (Tokens.IllegalIdentifierNames.Contains(name, StringComparer.InvariantCultureIgnoreCase))
                 {
                     criteriaMatchMessages.Add(string.Format(RubberduckUI.InvalidNameCriteria_IsReservedKeywordFormat, name));
                 }
@@ -194,7 +188,7 @@ namespace Rubberduck.Refactorings.Common
 
                 //Name is not a reserved identifier, but when used as a UDTMember array declaration
                 //it collides with the 'Name' Statement (Renames a disk file, directory, or folder)
-                var invalidUDTArrayIdentifiers = ReservedIdentifiers.Concat(new List<string>() { "Name" });
+                var invalidUDTArrayIdentifiers = Tokens.IllegalIdentifierNames.Concat(new List<string>() { "Name" });
 
                 if (invalidUDTArrayIdentifiers.Contains(name, StringComparer.InvariantCultureIgnoreCase))
                 {

--- a/Rubberduck.Refactorings/Common/VBAIdentifierValidator.cs
+++ b/Rubberduck.Refactorings/Common/VBAIdentifierValidator.cs
@@ -5,13 +5,19 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
+using Tokens = Rubberduck.Resources.Tokens;
 
 namespace Rubberduck.Refactorings.Common
 {
     public static class VBAIdentifierValidator
     {
-        private static IEnumerable<string> ReservedIdentifiers =
-            typeof(Tokens).GetFields().Select(item => item.GetValue(null).ToString()).ToArray();
+        // NOTE: ForbiddenAttribute marks the tokens that don't compile as identifier names. Includes "bad but legal" names.
+        // TODO: Compare with the unfiltered tokens if a client needs to tell "bad but legal" from "bad and illegal" names.
+        private static readonly IEnumerable<string> ReservedIdentifiers =
+            typeof(Tokens).GetFields()
+                .Where(item => item.GetType().GetCustomAttributes<ForbiddenAttribute>().Any())
+                .Select(item => item.GetValue(null).ToString()).ToArray();
 
         /// <summary>
         /// Predicate function determining if an identifier string's content will trigger a result for the UseMeaningfulNames inspection.

--- a/Rubberduck.Refactorings/ExtractInterface/ExtractInterfaceRefactoringAction.cs
+++ b/Rubberduck.Refactorings/ExtractInterface/ExtractInterfaceRefactoringAction.cs
@@ -15,6 +15,7 @@ using Rubberduck.Resources;
 using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.Utility;
+using Tokens = Rubberduck.Resources.Tokens;
 
 namespace Rubberduck.Refactorings.ExtractInterface
 {

--- a/Rubberduck.Refactorings/ImplementInterface/AddInterfaceImplementations/AddInterfaceImplementationsRefactoringAction.cs
+++ b/Rubberduck.Refactorings/ImplementInterface/AddInterfaceImplementations/AddInterfaceImplementationsRefactoringAction.cs
@@ -5,6 +5,7 @@ using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Rewriter;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Resources;
+using Tokens = Rubberduck.Resources.Tokens;
 
 namespace Rubberduck.Refactorings.AddInterfaceImplementations
 {

--- a/Rubberduck.Resources/Tokens.cs
+++ b/Rubberduck.Resources/Tokens.cs
@@ -1,0 +1,384 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Rubberduck.Resources
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public static class Tokens
+    {
+        [Forbidden]
+        public static readonly string Abs = "Abs";
+        [Forbidden]
+        public static readonly string AddressOf = "AddressOf";
+        [Forbidden]
+        public static readonly string And = "And";
+        [Forbidden]
+        public static readonly string Any = "Any";
+        [Forbidden]
+        public static readonly string As = "As";
+        public static readonly string Asc = "Asc";
+        [Forbidden]
+        public static readonly string Attribute = "Attribute";
+        [Forbidden]
+        public static readonly string Array = "Array";
+        public static readonly string Base = "Base";
+        public static readonly string Beep = "Beep";
+        public static readonly string Binary = "Binary";
+        [Forbidden]
+        public static readonly string Boolean = "Boolean";
+        [Forbidden]
+        public static readonly string ByRef = "ByRef";
+        [Forbidden]
+        public static readonly string Byte = "Byte";
+        [Forbidden]
+        public static readonly string ByVal = "ByVal";
+        [Forbidden]
+        public static readonly string Call = "Call";
+        [Forbidden]
+        public static readonly string Case = "Case";
+        [Forbidden]
+        public static readonly string CBool = "CBool";
+        [Forbidden]
+        public static readonly string CByte = "CByte";
+        [Forbidden]
+        public static readonly string CCur = "CCur";
+        [Forbidden]
+        public static readonly string CDate = "CDate";
+        [Forbidden]
+        public static readonly string CDbl = "CDbl";
+        [Forbidden]
+        public static readonly string CDec = "CDec";
+        public static readonly string ChDir = "ChDir";
+        public static readonly string ChDrive = "ChDrive";
+        public static readonly string Chr = "Chr";
+        public static readonly string ChrB = "ChrB";
+        public static readonly string ChrW = "ChrW";
+        [Forbidden]
+        public static readonly string CInt = "CInt";
+        [Forbidden]
+        public static readonly string CLng = "CLng";
+        public static readonly string CLngLng = "CLngLng";
+        [Forbidden]
+        public static readonly string CLngPtr = "CLngPtr";
+        public static readonly string Close = "Close";
+        public static readonly string Command = "Command";
+        [Forbidden]
+        public static readonly string CommentMarker = "'";
+        public static readonly string Compare = "Compare";
+        [Forbidden]
+        public static readonly string Const = "Const";
+        public static readonly string Cos = "Cos";
+        [Forbidden]
+        public static readonly string CSng = "CSng";
+        [Forbidden]
+        public static readonly string CStr = "CStr";
+        public static readonly string CurDir = "CurDir";
+        [Forbidden]
+        public static readonly string Currency = "Currency";
+        [Forbidden]
+        public static readonly string CVar = "CVar";
+        [Forbidden]
+        public static readonly string CVErr = "CVErr";
+        public static readonly string Data = "Data";
+        [Forbidden]
+        public static readonly string Date = "Date";
+        public static readonly string DateValue = "DateValue";
+        public static readonly string Day = "Day";
+        [Forbidden]
+        public static readonly string Debug = "Debug";
+        [Forbidden]
+        public static readonly string Decimal = "Decimal";
+        [Forbidden]
+        public static readonly string Declare = "Declare";
+        [Forbidden]
+        public static readonly string DefBool = "DefBool";
+        [Forbidden]
+        public static readonly string DefByte = "DefByte";
+        [Forbidden]
+        public static readonly string DefCur = "DefCur";
+        [Forbidden]
+        public static readonly string DefDate = "DefDate";
+        [Forbidden]
+        public static readonly string DefDbl = "DefDbl";
+        [Forbidden]
+        public static readonly string DefInt = "DefInt";
+        [Forbidden]
+        public static readonly string DefLng = "DefLng";
+        public static readonly string DefLngLng = "DefLngLng";
+        [Forbidden]
+        public static readonly string DefLngPtr = "DefLngptr";
+        [Forbidden]
+        public static readonly string DefObj = "DefObj";
+        [Forbidden]
+        public static readonly string DefSng = "DefSng";
+        [Forbidden]
+        public static readonly string DefStr = "DefStr";
+        [Forbidden]
+        public static readonly string DefVar = "DefVar";
+        [Forbidden]
+        public static readonly string Dim = "Dim";
+        public static readonly string Dir = "Dir";
+        [Forbidden]
+        public static readonly string Do = "Do";
+        [Forbidden]
+        public static readonly string DoEvents = "DoEvents";
+        [Forbidden]
+        public static readonly string Double = "Double";
+        [Forbidden]
+        public static readonly string Each = "Each";
+        [Forbidden]
+        public static readonly string Else = "Else";
+        [Forbidden]
+        public static readonly string ElseIf = "ElseIf";
+        [Forbidden]
+        public static readonly string Empty = "Empty";
+        [Forbidden]
+        public static readonly string End = "End";
+        [Forbidden]
+        public static readonly string Enum = "Enum";
+        public static readonly string Environ = "Environ";
+        public static readonly string EOF = "EOF";
+        [Forbidden]
+        public static readonly string Eqv = "Eqv";
+        [Forbidden]
+        public static readonly string Erase = "Erase";
+        public static readonly string Err = "Err";
+        public static readonly string Error = "Error";
+        [Forbidden]
+        public static readonly string Event = "Event";
+        [Forbidden]
+        public static readonly string Exit = "Exit";
+        public static readonly string Exp = "Exp";
+        public static readonly string Explicit = "Explicit";
+        [Forbidden]
+        public static readonly string False = "False";
+        [Forbidden]
+        public static readonly string Fix = "Fix";
+        [Forbidden]
+        public static readonly string For = "For";
+        public static readonly string Format = "Format";
+        public static readonly string FreeFile = "FreeFile";
+        [Forbidden]
+        public static readonly string Friend = "Friend";
+        [Forbidden]
+        public static readonly string Function = "Function";
+        [Forbidden]
+        public static readonly string Get = "Get";
+        [Forbidden]
+        public static readonly string Global = "Global";
+        [Forbidden]
+        public static readonly string GoSub = "GoSub";
+        [Forbidden]
+        public static readonly string GoTo = "GoTo";
+        public static readonly string Hex = "Hex";
+        public static readonly string Hour = "Hour";
+        public static readonly string IDispatch = "IDispatch";
+        [Forbidden]
+        public static readonly string If = "If";
+        [Forbidden]
+        public static readonly string Imp = "Imp";
+        [Forbidden]
+        public static readonly string Implements = "Implements";
+        [Forbidden]
+        public static readonly string In = "In";
+        [Forbidden]
+        public static readonly string Input = "Input";
+        [Forbidden]
+        public static readonly string InputB = "InputB";
+        public static readonly string InputBox = "InputBox";
+        public static readonly string InStr = "InStr";
+        [Forbidden]
+        public static readonly string Int = "Int";
+        [Forbidden]
+        public static readonly string Integer = "Integer";
+        [Forbidden]
+        public static readonly string Is = "Is";
+        public static readonly string IsDate = "IsDate";
+        public static readonly string IsEmpty = "IsEmpty";
+        public static readonly string IsNull = "IsNull";
+        public static readonly string IsNumeric = "IsNumeric";
+        public static readonly string Join = "Join";
+        public static readonly string Kill = "Kill";
+        [Forbidden]
+        public static readonly string LBound = "LBound";
+        public static readonly string LCase = "LCase";
+        public static readonly string Left = "Left";
+        public static readonly string LeftB = "LeftB";
+        [Forbidden]
+        public static readonly string Len = "Len";
+        [Forbidden]
+        public static readonly string LenB = "LenB";
+        [Forbidden]
+        public static readonly string Let = "Let";
+        [Forbidden]
+        public static readonly string Like = "Like";
+        public static readonly string Line = "Line";
+        [Forbidden]
+        public static readonly string LineContinuation = " _";
+        [Forbidden]
+        public static readonly string Lock = "Lock";
+        public static readonly string LOF = "LOF";
+        [Forbidden]
+        public static readonly string Long = "Long";
+        public static readonly string LongLong = "LongLong";
+        [Forbidden]
+        public static readonly string LongPtr = "LongPtr";
+        [Forbidden]
+        public static readonly string Loop = "Loop";
+        [Forbidden]
+        public static readonly string LSet = "LSet";
+        public static readonly string LTrim = "LTrim";
+        [Forbidden]
+        public static readonly string Me = "Me";
+        public static readonly string Mid = "Mid";
+        public static readonly string MidB = "MidB";
+        public static readonly string Minute = "Minute";
+        public static readonly string MkDir = "MkDir";
+        [Forbidden]
+        public static readonly string Mod = "Mod";
+        public static readonly string Month = "Month";
+        public static readonly string MsgBox = "MsgBox";
+        [Forbidden]
+        public static readonly string New = "New";
+        [Forbidden]
+        public static readonly string Next = "Next";
+        [Forbidden]
+        public static readonly string Not = "Not";
+        [Forbidden]
+        public static readonly string Nothing = "Nothing";
+        public static readonly string Now = "Now";
+        [Forbidden]
+        public static readonly string Null = "Null";
+        public static readonly string Object = "Object";
+        public static readonly string Oct = "Oct";
+        [Forbidden]
+        public static readonly string On = "On";
+        [Forbidden]
+        public static readonly string Open = "Open";
+        [Forbidden]
+        public static readonly string Option = "Option";
+        [Forbidden]
+        public static readonly string Optional = "Optional";
+        [Forbidden]
+        public static readonly string Or = "Or";
+        public static readonly string Output = "Output";
+        [Forbidden]
+        public static readonly string ParamArray = "ParamArray";
+        [Forbidden]
+        public static readonly string Preserve = "Preserve";
+        [Forbidden]
+        public static readonly string Print = "Print";
+        [Forbidden]
+        public static readonly string Private = "Private";
+        public static readonly string Property = "Property";
+        [Forbidden]
+        public static readonly string Public = "Public";
+        [Forbidden]
+        public static readonly string Put = "Put";
+        [Forbidden]
+        public static readonly string RaiseEvent = "RaiseEvent";
+        public static readonly string Random = "Random";
+        public static readonly string Randomize = "Randomize";
+        public static readonly string Read = "Read";
+        [Forbidden]
+        public static readonly string ReDim = "ReDim";
+        [Forbidden]
+        public static readonly string Rem = "Rem";
+        [Forbidden]
+        public static readonly string Resume = "Resume";
+        [Forbidden]
+        public static readonly string Return = "Return";
+        [Forbidden]
+        public static readonly string RSet = "RSet";
+        public static readonly string Right = "Right";
+        public static readonly string RightB = "RightB";
+        public static readonly string RmDir = "RmDir";
+        public static readonly string Rnd = "Rnd";
+        public static readonly string RTrim = "RTrim";
+        public static readonly string Second = "Second";
+        [Forbidden]
+        public static readonly string Seek = "Seek";
+        [Forbidden]
+        public static readonly string Select = "Select";
+        [Forbidden]
+        public static readonly string Set = "Set";
+        [Forbidden]
+        public static readonly string Shared = "Shared";
+        public static readonly string Shell = "Shell";
+        public static readonly string Sin = "Sin";
+        [Forbidden]
+        public static readonly string Single = "Single";
+        public static readonly string Sng = "Sng";
+        [Forbidden]
+        public static readonly string Space = "Space";
+        public static readonly string Spc = "Spc";
+        public static readonly string Split = "Split";
+        public static readonly string Sqr = "Sqr";
+        public static readonly string Static = "Static";
+        public static readonly string Step = "Step";
+        [Forbidden]
+        public static readonly string Stop = "Stop";
+        public static readonly string Str = "Str";
+        public static readonly string StrConv = "StrConv";
+        [Forbidden]
+        public static readonly string String = "String";
+        public static readonly string StrPtr = "StrPtr";
+        [Forbidden]
+        public static readonly string Sub = "Sub";
+        [Forbidden]
+        public static readonly string Then = "Then";
+        public static readonly string Time = "Time";
+        [Forbidden]
+        public static readonly string To = "To";
+        public static readonly string Trim = "Trim";
+        [Forbidden]
+        public static readonly string True = "True";
+        [Forbidden]
+        public static readonly string Type = "Type";
+        public static readonly string TypeName = "TypeName";
+        [Forbidden]
+        public static readonly string TypeOf = "TypeOf";
+        [Forbidden]
+        public static readonly string UBound = "UBound";
+        public static readonly string UCase = "UCase";
+        [Forbidden]
+        public static readonly string Unlock = "Unlock";
+        [Forbidden]
+        public static readonly string Until = "Until";
+        public static readonly string Val = "Val";
+        [Forbidden]
+        public static readonly string Variant = "Variant";
+        public static readonly string vbBack = "vbBack";
+        public static readonly string vbCr = "vbCr";
+        public static readonly string vbCrLf = "vbCrLf";
+        public static readonly string vbFormFeed = "vbFormFeed";
+        public static readonly string vbLf = "vbLf";
+        public static readonly string vbNewLine = "vbNewLine";
+        public static readonly string vbNullChar = "vbNullChar";
+        public static readonly string vbNullString = "vbNullString";
+        public static readonly string vbTab = "vbTab";
+        public static readonly string vbVerticalTab = "vbVerticalTab";
+        public static readonly string WeekDay = "WeekDay";
+        [Forbidden]
+        public static readonly string Wend = "Wend";
+        [Forbidden]
+        public static readonly string While = "While";
+        public static readonly string Width = "Width";
+        [Forbidden]
+        public static readonly string With = "With";
+        [Forbidden]
+        public static readonly string WithEvents = "WithEvents";
+        [Forbidden]
+        public static readonly string Write = "Write";
+        [Forbidden]
+        public static readonly string XOr = "Xor";
+        public static readonly string Year = "Year";
+    }
+
+    /// <summary>
+    /// Identifies a static <see cref="Tokens"/> string that isn't a legal identifier name for user code, e.g. keyword or reserved identifier.
+    /// </summary>
+    public class ForbiddenAttribute : Attribute
+    {
+    }
+}

--- a/Rubberduck.Resources/Tokens.cs
+++ b/Rubberduck.Resources/Tokens.cs
@@ -1,11 +1,25 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
 
 namespace Rubberduck.Resources
 {
+    /// <summary>
+    /// Identifies a static <see cref="Tokens"/> string that isn't a legal identifier name for user code, e.g. keyword or reserved identifier.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class ForbiddenAttribute : Attribute { }
+
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static class Tokens
     {
+        public static IEnumerable<string> IllegalIdentifierNames =>
+            typeof(Tokens).GetFields().Where(item => item.GetCustomAttributes<ForbiddenAttribute>().Any())
+                .Select(item => item.GetValue(null)).Cast<string>().Select(item => item);
+
         [Forbidden]
         public static readonly string Abs = "Abs";
         [Forbidden]
@@ -373,12 +387,5 @@ namespace Rubberduck.Resources
         [Forbidden]
         public static readonly string XOr = "Xor";
         public static readonly string Year = "Year";
-    }
-
-    /// <summary>
-    /// Identifies a static <see cref="Tokens"/> string that isn't a legal identifier name for user code, e.g. keyword or reserved identifier.
-    /// </summary>
-    public class ForbiddenAttribute : Attribute
-    {
     }
 }

--- a/Rubberduck.VBEEditor/Selection.cs
+++ b/Rubberduck.VBEEditor/Selection.cs
@@ -46,6 +46,11 @@ namespace Rubberduck.VBEditor
             return Contains(new Selection(selection.StartLine, selection.StartColumn, selection.StartLine, selection.StartColumn));
         }
 
+        public Selection ExtendLeft(int positions = 1)
+        {
+            return new Selection(StartLine, Math.Max(StartColumn - positions, 1), EndLine, EndColumn);
+        }
+
         public bool Contains(Selection selection)
         {
             // single line comparison

--- a/Rubberduck.sln.DotSettings
+++ b/Rubberduck.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rubberduck/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
+++ b/RubberduckTests/CodeExplorer/MockedCodeExplorer.cs
@@ -34,7 +34,6 @@ using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.SourceCodeHandling;
 using Rubberduck.VBEditor.Utility;
 using RubberduckTests.Settings;
-using Rubberduck.Refactorings;
 using System.IO.Abstractions;
 
 namespace RubberduckTests.CodeExplorer

--- a/RubberduckTests/Commands/FindAllReferencesTests.cs
+++ b/RubberduckTests/Commands/FindAllReferencesTests.cs
@@ -525,11 +525,11 @@ End Sub
             return new SearchResultsWindowViewModel();
         }
 
-        private static FindAllReferencesService ArrangeFindAllReferencesService(RubberduckParserState state,
+        private static FindAllReferencesAction ArrangeFindAllReferencesService(RubberduckParserState state,
             ISearchResultsWindowViewModel viewModel, INavigateCommand navigateCommand = null, IMessageBox messageBox = null,
             SearchResultPresenterInstanceManager presenterService = null, IUiDispatcher uiDispatcher = null)
         {
-            return new FindAllReferencesService(
+            return new FindAllReferencesAction(
                 navigateCommand ?? new Mock<INavigateCommand>().Object, 
                 messageBox ?? new Mock<IMessageBox>().Object, 
                 state, 
@@ -547,13 +547,13 @@ End Sub
         }
 
         private static FindAllReferencesCommand ArrangeFindAllReferencesCommand(RubberduckParserState state,
-            Mock<IVBE> vbe, ISearchResultsWindowViewModel viewModel, FindAllReferencesService finder)
+            Mock<IVBE> vbe, ISearchResultsWindowViewModel viewModel, FindAllReferencesAction finder)
         {
             return ArrangeFindAllReferencesCommand(state, vbe, viewModel, finder, MockVbeEvents.CreateMockVbeEvents(vbe));
         }
 
         private static FindAllReferencesCommand ArrangeFindAllReferencesCommand(RubberduckParserState state,
-            Mock<IVBE> vbe, ISearchResultsWindowViewModel viewModel, FindAllReferencesService finder,
+            Mock<IVBE> vbe, ISearchResultsWindowViewModel viewModel, FindAllReferencesAction finder,
             Mock<IVbeEvents> vbeEvents)
         {
             var selectionService = new SelectionService(vbe.Object, state.ProjectsProvider);

--- a/RubberduckTests/Symbols/DeclarationFinderTests.cs
+++ b/RubberduckTests/Symbols/DeclarationFinderTests.cs
@@ -804,7 +804,7 @@ End Sub
                 var expected = declarations.FirstOrDefault(decl => decl.IdentifierName.Equals("expected"));
 
                 var enclosing = declarations.FirstOrDefault(decl => decl.IdentifierName.Equals("Bar"));
-                var context = enclosing?.Context.GetDescendent<VBAParser.ArgumentExpressionContext>();
+                var context = enclosing?.Context.GetDescendent<VBAParser.ArgumentContext>();
                 var actual = state.DeclarationFinder.FindParameterOfNonDefaultMemberFromSimpleArgumentNotPassedByValExplicitly(context, enclosing);
 
                 Assert.AreEqual(expected, actual);


### PR DESCRIPTION
This pull requests makes the `SelectionService` resolve the selected `ParameterDeclaration` given a selection that's inside an `ArgumentContext`; the parameter declaration is used for the "current selection" caption when the argument is an expression that doesn't otherwise resolve to another declaration, like when an argument is a literal:

![literal string argument to MsgBox function shows it's the Prompt parameter and it's a Variant](https://user-images.githubusercontent.com/5751684/115503630-bc909580-a244-11eb-8f4b-af562678ce15.png)

Or when the argument is an expression with late-bound elements selected:

![Sheet1.Cells arguments are late-bound per the implicit default member call](https://user-images.githubusercontent.com/5751684/115504181-869fe100-a245-11eb-87ff-2da66d7a9573.png)

But any early-bound more specific sub-expression that resolves to a declaration remains the caption for other parameters:

![image](https://user-images.githubusercontent.com/5751684/115504298-b64ee900-a245-11eb-8501-044c86ac5d5b.png)

Named arguments in a different order than defined, doesn't break:

![image](https://user-images.githubusercontent.com/5751684/115504645-412fe380-a246-11eb-9c6e-6b96e4bf560b.png)

Missing arguments aren't handled and behave as previously:

![image](https://user-images.githubusercontent.com/5751684/115504761-6cb2ce00-a246-11eb-8b72-691d60df3dfb.png)
