### PR TITLE
Restore FindSymbol search feature

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ParameterNotUsedInspection.cs
@@ -114,7 +114,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
 
         private static bool ParameterAtIndexIsNotUsed(IParameterizedDeclaration declaration, int parameterIndex)
         {
-            var parameter = declaration.Parameters.ElementAtOrDefault(parameterIndex);
+            var parameter = declaration?.Parameters.ElementAtOrDefault(parameterIndex);
             return parameter != null
                    && !parameter.References.Any();
         }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
@@ -98,23 +98,26 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
 
         private UnreachableCaseInspection.CaseInspectionResultType? InvalidRangeExpressionsType(ICollection<IRangeClauseExpression> rangeClauseExpressions)
         {
-            if (rangeClauseExpressions.Any(expr => expr.IsMismatch))
+            if (rangeClauseExpressions.Any(expr => expr?.IsMismatch ?? false))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.MismatchType;
             }
 
-            if (rangeClauseExpressions.Any(expr => expr.IsOverflow))
+            if (rangeClauseExpressions.Any(expr => expr?.IsOverflow ?? false))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.Overflow;
             }
 
-            if (rangeClauseExpressions.All(expr => expr.IsInherentlyUnreachable))
+            if (rangeClauseExpressions.All(expr => expr?.IsInherentlyUnreachable ?? false))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.InherentlyUnreachable;
             }
 
             if (rangeClauseExpressions.All(expr =>
-                expr.IsUnreachable || expr.IsMismatch || expr.IsOverflow || expr.IsInherentlyUnreachable))
+                (expr?.IsUnreachable ?? false) 
+                || (expr?.IsMismatch ?? false)
+                || (expr?.IsOverflow ?? false)
+                || (expr?.IsInherentlyUnreachable ?? false)))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.Unreachable;
             }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
@@ -98,23 +98,24 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
 
         private UnreachableCaseInspection.CaseInspectionResultType? InvalidRangeExpressionsType(ICollection<IRangeClauseExpression> rangeClauseExpressions)
         {
-            if (rangeClauseExpressions.Any(expr => expr?.IsMismatch == true))
+            var usableClauses = rangeClauseExpressions.Where(expr => expr != null).ToList();
+            if (usableClauses.Any(expr => expr.IsMismatch))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.MismatchType;
             }
 
-            if (rangeClauseExpressions.Any(expr => expr?.IsOverflow == true))
+            if (usableClauses.Any(expr => expr.IsOverflow))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.Overflow;
             }
 
-            if (rangeClauseExpressions.All(expr => expr?.IsInherentlyUnreachable == true))
+            if (usableClauses.All(expr => expr.IsInherentlyUnreachable))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.InherentlyUnreachable;
             }
 
-            if (rangeClauseExpressions.All(expr =>
-                expr != null && (expr.IsUnreachable || expr.IsMismatch|| expr.IsOverflow || expr.IsInherentlyUnreachable)))
+            if (usableClauses.All(expr =>
+                expr.IsUnreachable || expr.IsMismatch|| expr.IsOverflow || expr.IsInherentlyUnreachable))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.Unreachable;
             }

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
@@ -98,31 +98,26 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
 
         private UnreachableCaseInspection.CaseInspectionResultType? InvalidRangeExpressionsType(ICollection<IRangeClauseExpression> rangeClauseExpressions)
         {
-            if (rangeClauseExpressions.Any(expr => expr?.IsMismatch ?? false))
+            if (rangeClauseExpressions.Any(expr => expr?.IsMismatch == true))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.MismatchType;
             }
 
-            if (rangeClauseExpressions.Any(expr => expr?.IsOverflow ?? false))
+            if (rangeClauseExpressions.Any(expr => expr?.IsOverflow == true))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.Overflow;
             }
 
-            if (rangeClauseExpressions.All(expr => expr?.IsInherentlyUnreachable ?? false))
+            if (rangeClauseExpressions.All(expr => expr?.IsInherentlyUnreachable == true))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.InherentlyUnreachable;
             }
 
             if (rangeClauseExpressions.All(expr =>
-                (expr?.IsUnreachable ?? false) 
-                || (expr?.IsMismatch ?? false)
-                || (expr?.IsOverflow ?? false)
-                || (expr?.IsInherentlyUnreachable ?? false)))
+                expr != null && (expr.IsUnreachable || expr.IsMismatch|| expr.IsOverflow || expr.IsInherentlyUnreachable))))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.Unreachable;
             }
-
-            return null;
         }
 
         private (UnreachableCaseInspection.CaseInspectionResultType? invalidValueType, VBAParser.CaseClauseContext caseClause) WithInvalidValueType(VBAParser.CaseClauseContext caseClause, IParseTreeVisitorResults parseTreeValues)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnreachableCaseEvaluation/UnreachableCaseInspector.cs
@@ -114,10 +114,12 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete.UnreachableCaseEvaluation
             }
 
             if (rangeClauseExpressions.All(expr =>
-                expr != null && (expr.IsUnreachable || expr.IsMismatch|| expr.IsOverflow || expr.IsInherentlyUnreachable))))
+                expr != null && (expr.IsUnreachable || expr.IsMismatch|| expr.IsOverflow || expr.IsInherentlyUnreachable)))
             {
                 return UnreachableCaseInspection.CaseInspectionResultType.Unreachable;
             }
+
+            return null;
         }
 
         private (UnreachableCaseInspection.CaseInspectionResultType? invalidValueType, VBAParser.CaseClauseContext caseClause) WithInvalidValueType(VBAParser.CaseClauseContext caseClause, IParseTreeVisitorResults parseTreeValues)

--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -58,6 +58,7 @@
             <converters:AnnotationToCodeStringConverter x:Key="AnnotationToCodeString" />
             <converters:AnnotateDeclarationCommandParameterToTupleConverter x:Key="AnnotateDeclarationCommandParameterToTuple" />
             <converters:AnnotateDeclarationCommandCEVisibilityConverter x:Key="AnnotateDeclarationCommandVisibility" />
+            <converters:DeclarationToDeclarationTypeStringConverter x:Key="DeclarationTypeNameConverter" />
 
             <CompositeCollection x:Key="AddModuleCommands" x:Shared="False">
                 <MenuItem Header="{Resx ResxName=Rubberduck.Resources.CodeExplorer.CodeExplorerUI, Key=CodeExplorer_AddExistingFileText}"
@@ -604,7 +605,8 @@
                     </HierarchicalDataTemplate.Resources>
                     <StackPanel Orientation="Horizontal">
                         <Grid>
-                            <Image Style="{StaticResource ToolbarIconStyle}">
+                            <Image Style="{StaticResource ToolbarIconStyle}" 
+                                   ToolTip="{Binding Converter={StaticResource DeclarationTypeNameConverter}}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource NodeToIcon}">
                                         <MultiBinding.Bindings>
@@ -616,7 +618,8 @@
                                     </MultiBinding>
                                 </Image.Source>
                             </Image>
-                            <Image Source="{Binding Declaration, Converter={StaticResource AccessibilityToIcon}}" Style="{StaticResource ToolbarIconStyle}" />
+                            <Image Source="{Binding Declaration, Converter={StaticResource AccessibilityToIcon}}" Style="{StaticResource ToolbarIconStyle}"
+                                   ToolTip="{Binding Converter={StaticResource DeclarationTypeNameConverter}}"/>
                         </Grid>
                         <TextBlock Style="{StaticResource TreeViewItemStyleModified}" />
                     </StackPanel>

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerFindAllReferencesCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerFindAllReferencesCommand.cs
@@ -44,10 +44,16 @@ namespace Rubberduck.UI.CodeExplorer.Commands
 
         protected override void OnExecute(object parameter)
         {
-            if (_state.Status != ParserState.Ready ||
-                !(parameter is ICodeExplorerNode node) ||
-                node.Declaration == null)
+            if (_state.Status != ParserState.Ready 
+                || !(parameter is ICodeExplorerNode node) 
+                || node.Declaration == null)
             {
+                return;
+            }
+
+            if (!(node.Parent.Declaration is ProjectDeclaration projectDeclaration))
+            {
+                Logger.Error($"The specified ICodeExplorerNode expected to be a direct child of a node whose declaration is a ProjectDeclaration.");
                 return;
             }
 
@@ -57,7 +63,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 {
                     return;
                 }
-                _finder.FindAllReferences((ProjectDeclaration)node.Parent.Declaration, model.ToReferenceInfo());
+                _finder.FindAllReferences(projectDeclaration, model.ToReferenceInfo());
                 return;
             }
 

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerFindAllReferencesCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/CodeExplorerFindAllReferencesCommand.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Rubberduck.AddRemoveReferences;
 using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
 using Rubberduck.UI.Controls;
 using Rubberduck.VBEditor.Events;
@@ -56,7 +57,7 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 {
                     return;
                 }
-                _finder.FindAllReferences(node.Parent.Declaration, model.ToReferenceInfo());
+                _finder.FindAllReferences((ProjectDeclaration)node.Parent.Declaration, model.ToReferenceInfo());
                 return;
             }
 

--- a/Rubberduck.Core/UI/Command/ComCommands/FindSymbolCommand.cs
+++ b/Rubberduck.Core/UI/Command/ComCommands/FindSymbolCommand.cs
@@ -15,7 +15,6 @@ namespace Rubberduck.UI.Command.ComCommands
     public class FindSymbolCommand : ComCommandBase
     {
         private readonly RubberduckParserState _state;
-        private readonly DeclarationIconCache _iconCache;
         private readonly NavigateCommand _navigateCommand;
 
         public FindSymbolCommand(
@@ -26,14 +25,12 @@ namespace Rubberduck.UI.Command.ComCommands
             : base(vbeEvents)
         {
             _state = state;
-            _iconCache = iconCache;
-
             _navigateCommand = new NavigateCommand(selectionService);
         }
 
         protected override void OnExecute(object parameter)
         {
-            var viewModel = new FindSymbolViewModel(_state.AllUserDeclarations, _iconCache);
+            var viewModel = new FindSymbolViewModel(_state.AllUserDeclarations);
             var view = new FindSymbolDialog(viewModel);
             {
                 viewModel.Navigate += (sender, e) => { view.Hide(); };

--- a/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/CommandBars/RubberduckCommandBar.cs
@@ -85,8 +85,8 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
                         token.ThrowIfCancellationRequested();
 
                         var argRefCount = e.Declaration is ParameterDeclaration parameter ? parameter.ArgumentReferences.Count() : 0;
-                        var refCount = e.Declaration?.References.Count() ?? 0 + argRefCount;
-                        var description = e.Declaration?.DescriptionString ?? string.Empty;
+                        var refCount = (e.Declaration?.References.Count() ?? 0) + argRefCount;
+                        var description = e.Declaration?.DescriptionString.Trim() ?? string.Empty;
                         token.ThrowIfCancellationRequested();
 
                         //& renders the next character as if it was an accelerator.

--- a/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
+++ b/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
@@ -96,7 +96,8 @@ namespace Rubberduck.UI.Controls
                 .Select(usage =>
                 new SearchResultItem(usage.ParentNonScoping,
                     new NavigateCodeEventArgs(usage.QualifiedModuleName, usage.Selection),
-                    GetModuleLine(usage.QualifiedModuleName, usage.Selection.StartLine)))
+                    GetTrimmedModuleLine(usage.QualifiedModuleName, usage.Selection.StartLine, out var indent),
+                    new Selection(1, usage.Selection.StartColumn - indent, 1, usage.Selection.EndColumn - indent - 1).ToZeroBased()))
                 .ToList();
 
             if (declaration is ParameterDeclaration parameter)
@@ -104,7 +105,8 @@ namespace Rubberduck.UI.Controls
                 usages.AddRange(parameter.ArgumentReferences.Select(usage =>
                 new SearchResultItem(usage.ParentNonScoping,
                     new NavigateCodeEventArgs(usage.QualifiedModuleName, usage.Selection),
-                    GetModuleLine(usage.QualifiedModuleName, usage.Selection.StartLine))));
+                    GetTrimmedModuleLine(usage.QualifiedModuleName, usage.Selection.StartLine, out var indent),
+                    new Selection(1, usage.Selection.StartColumn - indent, 1, usage.Selection.EndColumn - indent - 1).ToZeroBased())));
             }
 
             if (!usages.Any())
@@ -148,12 +150,6 @@ namespace Rubberduck.UI.Controls
 
         private SearchResultsViewModel CreateViewModel(ProjectDeclaration project, ProjectDeclaration reference, IEnumerable<SearchResultItem> results)
         {
-            var results = usages.Select(usage =>
-                new SearchResultItem(usage.ParentNonScoping,
-                    new NavigateCodeEventArgs(usage.QualifiedModuleName, usage.Selection),
-                    GetTrimmedModuleLine(usage.QualifiedModuleName, usage.Selection.StartLine, out var indent),
-                    new Selection(1, reference.Selection.StartColumn - indent, 1, reference.Selection.EndColumn - indent - 1).ToZeroBased()));
-
             var viewModel = new SearchResultsViewModel(_navigateCommand,
                 string.Format(RubberduckUI.SearchResults_AllReferencesTabFormat, reference.IdentifierName), project, results);
 

--- a/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
+++ b/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
@@ -54,7 +54,7 @@ namespace Rubberduck.UI.Controls
         {
             if (_state.Status != ParserState.Ready)
             {
-                _logger.Info($"ParserState is {_state.Status}. This action requires a Ready state.");
+                _logger.Debug($"ParserState is {_state.Status}. This action requires a Ready state.");
                 return;
             }
 
@@ -71,7 +71,7 @@ namespace Rubberduck.UI.Controls
         {
             if (_state.Status != ParserState.Ready)
             {
-                _logger.Info($"ParserState is {_state.Status}. This action requires a Ready state.");
+                _logger.Debug($"ParserState is {_state.Status}. This action requires a Ready state.");
                 return;
             }
 
@@ -153,13 +153,18 @@ namespace Rubberduck.UI.Controls
             foreach (var qualifiedModuleName in modules)
             {
                 var component = _state.ProjectsProvider.Component(qualifiedModuleName);
+                if (component == null)
+                {
+                    _logger.Warn($"Could not retrieve the IVBComponent for module '{qualifiedModuleName}'.");
+                    continue;
+                }
                 var module = component.CodeModule;
 
                 if (nameRefs.TryGetValue(qualifiedModuleName, out var identifierReferences))
                 {
                     foreach (var identifierReference in identifierReferences)
                     {
-                        var (context, selection) = identifierReference.HighligthSelection(module);
+                        var (context, selection) = identifierReference.HighlightSelection(module);
                         var result = new SearchResultItem(
                             identifierReference.ParentNonScoping,
                             new NavigateCodeEventArgs(qualifiedModuleName, identifierReference.Selection),
@@ -172,7 +177,7 @@ namespace Rubberduck.UI.Controls
                 {
                     foreach (var argumentReference in argReferences)
                     {
-                        var (context, selection) = argumentReference.HighligthSelection(module);
+                        var (context, selection) = argumentReference.HighlightSelection(module);
                         var result = new SearchResultItem(
                             argumentReference.ParentNonScoping,
                             new NavigateCodeEventArgs(qualifiedModuleName, argumentReference.Selection),

--- a/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
+++ b/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
@@ -50,31 +50,58 @@ namespace Rubberduck.UI.Controls
             _uiDispatcher.InvokeAsync(UpdateTab);
         }
 
-        public void FindAllReferences(Declaration declaration)
+        public void FindAllReferences(Declaration target)
         {
             if (_state.Status != ParserState.Ready)
             {
+                _logger.Info($"ParserState is {_state.Status}. This action requires a Ready state.");
                 return;
             }
 
-            var viewModel = CreateViewModel(declaration);
-            if (!viewModel.SearchResults.Any())
+            var viewModel = CreateViewModel(target);
+            if (!Confirm(target.IdentifierName, viewModel.SearchResults.Count))
             {
-                _messageBox.NotifyWarn(string.Format(RubberduckUI.AllReferences_NoneFound, declaration.IdentifierName), RubberduckUI.Rubberduck);
                 return;
             }
 
+            ShowResults(viewModel);
+        }
+
+        public void FindAllReferences(ProjectDeclaration project, ReferenceInfo reference)
+        {
+            if (_state.Status != ParserState.Ready)
+            {
+                _logger.Info($"ParserState is {_state.Status}. This action requires a Ready state.");
+                return;
+            }
+
+            var usages = _state.DeclarationFinder.FindAllReferenceUsesInProject(project, reference, out var referenceProject).ToList();
+            if (referenceProject == null)
+            {
+                return;
+            }
+            if (!Confirm(referenceProject.IdentifierName, usages.Count))
+            {
+                return;
+            }
+
+            var viewModel = CreateViewModel(project, referenceProject.IdentifierName, usages);
+            ShowResults(viewModel);
+        }
+
+        private void ShowResults(SearchResultsViewModel viewModel)
+        {
             if (viewModel.SearchResults.Count == 1)
             {
-                _navigateCommand.Execute(viewModel.SearchResults.Single().GetNavigationArgs());
+                viewModel.NavigateCommand.Execute(viewModel.SearchResults[0].GetNavigationArgs());
                 return;
             }
 
-            _viewModel.AddTab(viewModel);
-            _viewModel.SelectedTab = viewModel;
-
             try
             {
+                _viewModel.AddTab(viewModel);
+                _viewModel.SelectedTab = viewModel;
+
                 var presenter = _presenterService.Presenter(_viewModel);
                 presenter.Show();
             }
@@ -84,99 +111,90 @@ namespace Rubberduck.UI.Controls
             }
         }
 
-        public void FindAllReferences(Declaration declaration, ReferenceInfo reference)
+        private bool Confirm(string identifier, int referencesFound)
         {
-            if (_state.Status != ParserState.Ready ||
-                !(declaration is ProjectDeclaration project))
+            const int threshold = 1000;
+            if (referencesFound == 0)
             {
-                return;
+                _messageBox.NotifyWarn(
+                    string.Format(RubberduckUI.AllReferences_NoneFoundReference, identifier), 
+                    RubberduckUI.Rubberduck);
+                return false;
             }
 
-            var usages = _state.DeclarationFinder.FindAllReferenceUsesInProject(project, reference, out var referenceProject)
-                .Select(usage =>
-                new SearchResultItem(usage.ParentNonScoping,
-                    new NavigateCodeEventArgs(usage.QualifiedModuleName, usage.Selection),
-                    GetTrimmedModuleLine(usage.QualifiedModuleName, usage.Selection.StartLine, out var indent),
-                    new Selection(1, usage.Selection.StartColumn - indent, 1, usage.Selection.EndColumn - indent - 1).ToZeroBased()))
-                .ToList();
-
-            if (!usages.Any())
+            if (referencesFound > threshold)
             {
-                _messageBox.NotifyWarn(string.Format(RubberduckUI.AllReferences_NoneFoundReference, referenceProject.IdentifierName), RubberduckUI.Rubberduck);
-                return;
+                return _messageBox.ConfirmYesNo(
+                    string.Format(RubberduckUI.AllReferences_PerformanceWarning, identifier, referencesFound),
+                    RubberduckUI.PerformanceWarningCaption);
             }
 
-            if (usages.Count > 1000 &&
-                !_messageBox.ConfirmYesNo(string.Format(RubberduckUI.AllReferences_PerformanceWarning, referenceProject.IdentifierName, usages.Count),
-                    RubberduckUI.PerformanceWarningCaption))
-            {
-                return;
-            }
-
-            var viewModel = CreateViewModel(project, referenceProject, usages);
-            _viewModel.AddTab(viewModel);
-            _viewModel.SelectedTab = viewModel;
-
-            try
-            {
-                var presenter = _presenterService.Presenter(_viewModel);
-                presenter.Show();
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e);
-            }
+            return true;
         }
 
-        private string GetTrimmedModuleLine(QualifiedModuleName module, int line, out int indent)
-        {
-            var component = _state.ProjectsProvider.Component(module);
-            using (var codeModule = component.CodeModule)
-            {
-                var code = codeModule.GetLines(line, 1);
-                indent = code.TakeWhile(c => c.Equals(' ')).Count();
-                return code.Trim();
-            }
-        }
 
-        private SearchResultsViewModel CreateViewModel(ProjectDeclaration project, ProjectDeclaration reference, IEnumerable<SearchResultItem> results)
+        private SearchResultsViewModel CreateViewModel(Declaration declaration, string identifier = null, IEnumerable<IdentifierReference> references = null)
         {
-            var viewModel = new SearchResultsViewModel(_navigateCommand,
-                string.Format(RubberduckUI.SearchResults_AllReferencesTabFormat, reference.IdentifierName), project, results);
-
-            return viewModel;
-        }
-
-        private SearchResultsViewModel CreateViewModel(Declaration declaration)
-        {
-            var results = declaration.References
+            var nameRefs = (references ?? declaration.References)
                 .Where(reference => !reference.IsArrayAccess)
                 .Distinct()
-                .Select(reference =>
-                    new SearchResultItem(
-                        reference.ParentNonScoping,
-                        new NavigateCodeEventArgs(reference.QualifiedModuleName, reference.Selection),
-                        GetTrimmedModuleLine(reference.QualifiedModuleName, reference.Selection.StartLine, out var indent),
-                        new Selection(1, reference.Selection.StartColumn - indent, 1, reference.Selection.EndColumn - indent - 1).ToZeroBased()))
-                .Concat((declaration is ParameterDeclaration parameter)
-                    ? parameter.ArgumentReferences.Select(argument =>
-                        new SearchResultItem(
-                            argument.ParentNonScoping,
-                            new NavigateCodeEventArgs(argument.QualifiedModuleName, argument.Selection),
-                            GetTrimmedModuleLine(argument.QualifiedModuleName, argument.Selection.StartLine, out var indent),
-                            new Selection(1, argument.Selection.StartColumn - indent, 1, argument.Selection.EndColumn - indent - 1).ToZeroBased()))
-                    : Enumerable.Empty<SearchResultItem>());
+                .GroupBy(reference => reference.QualifiedModuleName)
+                .ToDictionary(group => group.Key);
+
+            var argRefs = (declaration is ParameterDeclaration parameter
+                    ? parameter.ArgumentReferences
+                    : Enumerable.Empty<ArgumentReference>())
+                .Distinct()
+                .GroupBy(argRef => argRef.QualifiedModuleName)
+                .ToDictionary(group => group.Key);
+
+            var results = new List<SearchResultItem>();
+            var modules = nameRefs.Keys.Concat(argRefs.Keys).Distinct();
+            foreach (var qualifiedModuleName in modules)
+            {
+                var component = _state.ProjectsProvider.Component(qualifiedModuleName);
+                var module = component.CodeModule;
+
+                if (nameRefs.TryGetValue(qualifiedModuleName, out var identifierReferences))
+                {
+                    foreach (var identifierReference in identifierReferences)
+                    {
+                        var (context, selection) = identifierReference.HighligthSelection(module);
+                        var result = new SearchResultItem(
+                            identifierReference.ParentNonScoping,
+                            new NavigateCodeEventArgs(qualifiedModuleName, identifierReference.Selection),
+                            context, selection);
+                        results.Add(result);
+                    }
+                }
+
+                if (argRefs.TryGetValue(qualifiedModuleName, out var argReferences))
+                {
+                    foreach (var argumentReference in argReferences)
+                    {
+                        var (context, selection) = argumentReference.HighligthSelection(module);
+                        var result = new SearchResultItem(
+                            argumentReference.ParentNonScoping,
+                            new NavigateCodeEventArgs(qualifiedModuleName, argumentReference.Selection),
+                            context, selection);
+                        results.Add(result);
+                    }
+                }
+            }
 
             var accessor = declaration.DeclarationType.HasFlag(DeclarationType.PropertyGet) ? "(get)"
                 : declaration.DeclarationType.HasFlag(DeclarationType.PropertyLet) ? "(let)"
                 : declaration.DeclarationType.HasFlag(DeclarationType.PropertySet) ? "(set)"
                 : string.Empty;
 
-            var tabCaption = $"{declaration.IdentifierName} {accessor}".Trim();
+            var tabCaption = $"{identifier ?? declaration.IdentifierName} {accessor}".Trim();
 
 
             var viewModel = new SearchResultsViewModel(_navigateCommand,
-                string.Format(RubberduckUI.SearchResults_AllReferencesTabFormat, tabCaption), declaration, results);
+                string.Format(RubberduckUI.SearchResults_AllReferencesTabFormat, tabCaption), declaration, 
+                results.OrderBy(item => item.ParentScope.QualifiedModuleName.ToString())
+                       .ThenBy(item => item.Selection)
+                       .ToList());
 
             return viewModel;
         }

--- a/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
+++ b/Rubberduck.Core/UI/Controls/FindAllReferencesAction.cs
@@ -100,15 +100,6 @@ namespace Rubberduck.UI.Controls
                     new Selection(1, usage.Selection.StartColumn - indent, 1, usage.Selection.EndColumn - indent - 1).ToZeroBased()))
                 .ToList();
 
-            if (declaration is ParameterDeclaration parameter)
-            {
-                usages.AddRange(parameter.ArgumentReferences.Select(usage =>
-                new SearchResultItem(usage.ParentNonScoping,
-                    new NavigateCodeEventArgs(usage.QualifiedModuleName, usage.Selection),
-                    GetTrimmedModuleLine(usage.QualifiedModuleName, usage.Selection.StartLine, out var indent),
-                    new Selection(1, usage.Selection.StartColumn - indent, 1, usage.Selection.EndColumn - indent - 1).ToZeroBased())));
-            }
-
             if (!usages.Any())
             {
                 _messageBox.NotifyWarn(string.Format(RubberduckUI.AllReferences_NoneFoundReference, referenceProject.IdentifierName), RubberduckUI.Rubberduck);
@@ -166,7 +157,15 @@ namespace Rubberduck.UI.Controls
                         reference.ParentNonScoping,
                         new NavigateCodeEventArgs(reference.QualifiedModuleName, reference.Selection),
                         GetTrimmedModuleLine(reference.QualifiedModuleName, reference.Selection.StartLine, out var indent),
-                        new Selection(1, reference.Selection.StartColumn - indent, 1, reference.Selection.EndColumn - indent - 1).ToZeroBased()));
+                        new Selection(1, reference.Selection.StartColumn - indent, 1, reference.Selection.EndColumn - indent - 1).ToZeroBased()))
+                .Concat((declaration is ParameterDeclaration parameter)
+                    ? parameter.ArgumentReferences.Select(argument =>
+                        new SearchResultItem(
+                            argument.ParentNonScoping,
+                            new NavigateCodeEventArgs(argument.QualifiedModuleName, argument.Selection),
+                            GetTrimmedModuleLine(argument.QualifiedModuleName, argument.Selection.StartLine, out var indent),
+                            new Selection(1, argument.Selection.StartColumn - indent, 1, argument.Selection.EndColumn - indent - 1).ToZeroBased()))
+                    : Enumerable.Empty<SearchResultItem>());
 
             var accessor = declaration.DeclarationType.HasFlag(DeclarationType.PropertyGet) ? "(get)"
                 : declaration.DeclarationType.HasFlag(DeclarationType.PropertyLet) ? "(let)"

--- a/Rubberduck.Core/UI/Controls/IdentifierReferenceExtensions.cs
+++ b/Rubberduck.Core/UI/Controls/IdentifierReferenceExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.UI.Controls
+{
+    static class IdentifierReferenceExtensions
+    {
+        public static (string context, Selection highlight) HighlightSelection(this IdentifierReference reference, ICodeModule module)
+        {
+            const int maxLength = 255;
+            var selection = reference.Selection;
+
+            var lines = module.GetLines(selection.StartLine, selection.LineCount).Split('\n');
+
+            var line = lines[0];
+            var indent = line.TakeWhile(c => c.Equals(' ')).Count();
+
+            var highlight = new Selection(
+                    1, Math.Max(selection.StartColumn - indent, 1),
+                    1, Math.Max(selection.EndColumn - indent, 1))
+                .ToZeroBased();
+
+            var trimmed = line.Trim();
+            if (trimmed.Length > maxLength || lines.Length > 1)
+            {
+                trimmed = trimmed.Substring(0, maxLength) + " …";
+            }
+            return (trimmed, highlight);
+        }
+
+        public static (string context, Selection highlight) HighlightSelection(this ArgumentReference reference, ICodeModule module)
+        {
+            const int maxLength = 255;
+            var selection = reference.Selection;
+
+            var lines = module.GetLines(selection.StartLine, selection.LineCount).Split('\n');
+
+            var line = lines[0];
+            var indent = line.TakeWhile(c => c.Equals(' ')).Count();
+
+            var highlight = new Selection(
+                    1, Math.Max(selection.StartColumn - indent, 1),
+                    1, Math.Max(selection.EndColumn - indent, 1))
+                .ToZeroBased();
+
+            var trimmed = line.Trim();
+            if (trimmed.Length > maxLength || lines.Length > 1)
+            {
+                trimmed = trimmed.Substring(0, Math.Min(trimmed.Length, maxLength)) + " …";
+                highlight = new Selection(1, highlight.StartColumn, 1, trimmed.Length);
+            }
+
+            if (highlight.IsSingleCharacter && highlight.StartColumn == 0)
+            {
+                trimmed = " " + trimmed;
+                highlight = new Selection(0, 0, 0, 1);
+            }
+            else if (highlight.IsSingleCharacter)
+            {
+                highlight = new Selection(0, selection.StartColumn - 1 - indent - 1, 0, selection.StartColumn - 1 - indent);
+            }
+            return (trimmed, highlight);
+        }
+    }
+}

--- a/Rubberduck.Core/UI/Controls/SearchResultItem.cs
+++ b/Rubberduck.Core/UI/Controls/SearchResultItem.cs
@@ -9,11 +9,12 @@ namespace Rubberduck.UI.Controls
         private readonly NavigateCodeEventArgs _navigateArgs;
         private string _resultText;
 
-        public SearchResultItem(Declaration parentScopeDeclaration, NavigateCodeEventArgs navigationInfo, string resultText)
+        public SearchResultItem(Declaration parentScopeDeclaration, NavigateCodeEventArgs navigationInfo, string resultText, Selection? highlight = null)
         {
             _navigateArgs = navigationInfo;
             ParentScope = parentScopeDeclaration;
             _resultText = resultText;
+            HighlightIndex = highlight;
         }
 
         public Declaration ParentScope { get; }
@@ -35,6 +36,8 @@ namespace Rubberduck.UI.Controls
             }
         }
         
+        public Selection? HighlightIndex { get; }
+
         public NavigateCodeEventArgs GetNavigationArgs()
         {
             return _navigateArgs;

--- a/Rubberduck.Core/UI/Controls/SearchView.xaml
+++ b/Rubberduck.Core/UI/Controls/SearchView.xaml
@@ -4,12 +4,13 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="clr-namespace:Rubberduck.UI.Controls"
+             xmlns:converters="clr-namespace:Rubberduck.UI.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="550"
              d:DataContext="{d:DesignInstance controls:SearchResultsWindowViewModel}">
-    
     <UserControl.Resources>
         <controls:DeclarationTypeToStringConverter x:Key="DeclarationTypeToString" />
+        <converters:SearchResultToXamlConverter x:Key="SearchResultConverter" />
         <Style x:Key="CloseButton" TargetType="Button">
             <Setter Property="OverridesDefaultStyle" Value="True" />
             <Setter Property="Margin" Value="5,0,0,0" />
@@ -44,7 +45,13 @@
                             <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=SearchResults_MemberName}" Binding="{Binding ParentScope.IdentifierName}" />
                             <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=SearchResults_MemberType}" Binding="{Binding ParentScope.DeclarationType, Converter={StaticResource DeclarationTypeToString}}" />
                             <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=SearchResults_Location}" Binding="{Binding Selection}" />
-                            <DataGridTextColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=SearchResults_Context}" Binding="{Binding ResultText}" Width="*" />
+                            <DataGridTemplateColumn Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=SearchResults_Context}" Width="*">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <ContentControl Content="{Binding Converter={StaticResource SearchResultConverter}}" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
                         </DataGrid.Columns>
                     </controls:GroupingGrid>
                 </DataTemplate>

--- a/Rubberduck.Core/UI/Converters/CodeExplorerNodeToIconConverter.cs
+++ b/Rubberduck.Core/UI/Converters/CodeExplorerNodeToIconConverter.cs
@@ -1,114 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Windows.Data;
 using System.Windows.Media;
 using Rubberduck.Navigation.CodeExplorer;
-using Rubberduck.Parsing.Annotations.Concrete;
-using Rubberduck.Parsing.Symbols;
 using Rubberduck.Resources.CodeExplorer;
 
 namespace Rubberduck.UI.Converters
 {
-    public class DeclarationToIconConverter : ImageSourceConverter
-    {
-        private static readonly ImageSource NullIcon = ToImageSource(CodeExplorerUI.status_offline);
-        private static readonly ImageSource ExceptionIcon = ToImageSource(CodeExplorerUI.exclamation);
-        private static readonly ImageSource InterfaceIcon = ToImageSource(CodeExplorerUI.ObjectInterface);
-        private static readonly ImageSource PredeclaredIcon = ToImageSource(CodeExplorerUI.ObjectClassPredeclared);
-        private static readonly ImageSource TestMethodIcon = ToImageSource(CodeExplorerUI.ObjectTestMethod);
-
-        protected ImageSource NullIconSource => NullIcon;
-        protected ImageSource ExceptionIconSource => ExceptionIcon;
-
-        private static readonly IDictionary<DeclarationType, ImageSource> DeclarationIcons = new Dictionary<DeclarationType, ImageSource>
-        {
-            // Components
-            { DeclarationType.ClassModule, ToImageSource(CodeExplorerUI.ObjectClass) },
-            { DeclarationType.ProceduralModule, ToImageSource(CodeExplorerUI.ObjectModule) },
-            { DeclarationType.UserForm, ToImageSource(CodeExplorerUI.ProjectForm) },
-            { DeclarationType.Document, ToImageSource(CodeExplorerUI.document_office) },
-            { DeclarationType.VbForm, ToImageSource(CodeExplorerUI.ProjectForm)},
-            { DeclarationType.MdiForm, ToImageSource(CodeExplorerUI.MdiForm)},
-            { DeclarationType.UserControl, ToImageSource(CodeExplorerUI.ui_scroll_pane_form)},
-            { DeclarationType.DocObject, ToImageSource(CodeExplorerUI.document_globe)},
-            { DeclarationType.PropPage, ToImageSource(CodeExplorerUI.ui_tab_content)},
-            { DeclarationType.ActiveXDesigner, ToImageSource(CodeExplorerUI.pencil_ruler)},
-            { DeclarationType.ResFile, ToImageSource(CodeExplorerUI.document_block)},
-            { DeclarationType.RelatedDocument, ToImageSource(CodeExplorerUI.document_import)},          
-            // Members
-            { DeclarationType.Constant, ToImageSource(CodeExplorerUI.ObjectConstant)},
-            { DeclarationType.Enumeration, ToImageSource(CodeExplorerUI.ObjectEnum)},
-            { DeclarationType.EnumerationMember, ToImageSource(CodeExplorerUI.ObjectEnumItem)},
-            { DeclarationType.Event, ToImageSource(CodeExplorerUI.ObjectEvent)},
-            { DeclarationType.Function, ToImageSource(CodeExplorerUI.ObjectMethod)},
-            { DeclarationType.LibraryFunction, ToImageSource(CodeExplorerUI.ObjectLibraryFunction)},
-            { DeclarationType.LibraryProcedure, ToImageSource(CodeExplorerUI.ObjectLibraryFunction)},
-            { DeclarationType.Procedure, ToImageSource(CodeExplorerUI.ObjectMethod)},
-            { DeclarationType.PropertyGet, ToImageSource(CodeExplorerUI.ObjectPropertyGet)},
-            { DeclarationType.PropertyLet, ToImageSource(CodeExplorerUI.ObjectPropertyLet)},
-            { DeclarationType.PropertySet, ToImageSource(CodeExplorerUI.ObjectPropertySet)},
-            { DeclarationType.UserDefinedType, ToImageSource(CodeExplorerUI.ObjectValueType)},
-            { DeclarationType.UserDefinedTypeMember, ToImageSource(CodeExplorerUI.ObjectField)},
-            { DeclarationType.Variable, ToImageSource(CodeExplorerUI.ObjectField)},
-            { DeclarationType.Parameter, ToImageSource(CodeExplorerUI.ObjectField)},
-        };
-
-        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value == null)
-            {
-                return NullIcon;
-            }
-
-            if (value is Declaration declaration)
-            {
-                if (declaration is ClassModuleDeclaration classModule)
-                {
-                    if (classModule.QualifiedModuleName.ComponentType ==
-                        VBEditor.SafeComWrappers.ComponentType.Document)
-                    {
-                        return DeclarationIcons[DeclarationType.Document];
-                    }
-                    
-                    if (classModule.QualifiedModuleName.ComponentType == VBEditor.SafeComWrappers.ComponentType.UserForm)
-                    {
-                        // a form has a predeclared ID, but we want it to have a UserForm icon:
-                        return DeclarationIcons[DeclarationType.UserForm];
-                    }
-
-                    if (classModule.IsInterface || classModule.Annotations.Any(annotation => annotation.Annotation is InterfaceAnnotation))
-                    {
-                        return InterfaceIcon;
-                    }
-
-                    if (classModule.HasPredeclaredId)
-                    {
-                        return PredeclaredIcon;
-                    }
-                    
-                    return DeclarationIcons.ContainsKey(classModule.DeclarationType)
-                        ? DeclarationIcons[classModule.DeclarationType]
-                        : NullIcon;
-                }
-
-                if (DeclarationIcons.ContainsKey(declaration.DeclarationType))
-                {
-                    if (declaration.Annotations.Any(a => a.Annotation is TestMethodAnnotation))
-                    {
-                        return TestMethodIcon;
-                    }
-
-                    return DeclarationIcons[declaration.DeclarationType];
-                }
-                return NullIcon;
-            }
-
-            return null;
-        }
-    }
-
     public class CodeExplorerNodeToIconConverter : DeclarationToIconConverter, IMultiValueConverter
     {
         private static readonly ImageSource ProjectIcon = ToImageSource(CodeExplorerUI.ObjectLibrary);

--- a/Rubberduck.Core/UI/Converters/CodeExplorerNodeToIconConverter.cs
+++ b/Rubberduck.Core/UI/Converters/CodeExplorerNodeToIconConverter.cs
@@ -66,48 +66,46 @@ namespace Rubberduck.UI.Converters
             {
                 if (declaration is ClassModuleDeclaration classModule)
                 {
+                    if (classModule.QualifiedModuleName.ComponentType ==
+                        VBEditor.SafeComWrappers.ComponentType.Document)
+                    {
+                        return DeclarationIcons[DeclarationType.Document];
+                    }
+                    
                     if (classModule.QualifiedModuleName.ComponentType == VBEditor.SafeComWrappers.ComponentType.UserForm)
                     {
                         // a form has a predeclared ID, but we want it to have a UserForm icon:
                         return DeclarationIcons[DeclarationType.UserForm];
                     }
-                    else
-                    {
-                        if (classModule.IsInterface || classModule.Annotations.Any(annotation => annotation.Annotation is InterfaceAnnotation))
-                        {
-                            return InterfaceIcon;
-                        }
-                        if (classModule.HasPredeclaredId)
-                        {
-                            return PredeclaredIcon;
-                        }
-                        return DeclarationIcons.ContainsKey(classModule.DeclarationType)
-                            ? DeclarationIcons[classModule.DeclarationType]
-                            : NullIcon;
 
-                    }
-                }
-                else
-                {
-                    if (DeclarationIcons.ContainsKey(declaration.DeclarationType))
+                    if (classModule.IsInterface || classModule.Annotations.Any(annotation => annotation.Annotation is InterfaceAnnotation))
                     {
-                        if (declaration.Annotations.Any(a => a.Annotation is TestMethodAnnotation))
-                        {
-                            return TestMethodIcon;
-                        }
-                        else
-                        {
-                            return DeclarationIcons[declaration.DeclarationType];
-                        }
+                        return InterfaceIcon;
                     }
-                    return NullIcon;
+
+                    if (classModule.HasPredeclaredId)
+                    {
+                        return PredeclaredIcon;
+                    }
+                    
+                    return DeclarationIcons.ContainsKey(classModule.DeclarationType)
+                        ? DeclarationIcons[classModule.DeclarationType]
+                        : NullIcon;
                 }
+
+                if (DeclarationIcons.ContainsKey(declaration.DeclarationType))
+                {
+                    if (declaration.Annotations.Any(a => a.Annotation is TestMethodAnnotation))
+                    {
+                        return TestMethodIcon;
+                    }
+
+                    return DeclarationIcons[declaration.DeclarationType];
+                }
+                return NullIcon;
             }
-            else
-            {
-                return null;
-                //throw new InvalidCastException($"Expected 'Declaration' value, but the type was '{value.GetType().Name}'");
-            }
+
+            return null;
         }
     }
 

--- a/Rubberduck.Core/UI/Converters/DeclarationToDeclarationTypeStringConverter.cs
+++ b/Rubberduck.Core/UI/Converters/DeclarationToDeclarationTypeStringConverter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+using Rubberduck.Navigation.CodeExplorer;
+using Rubberduck.Parsing.Annotations.Concrete;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Resources;
+using Rubberduck.Resources.UnitTesting;
+
+namespace Rubberduck.UI.Converters
+{
+    public class DeclarationToDeclarationTypeStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var declaration = value as Declaration ?? (value as ICodeExplorerNode)?.Declaration;
+            if (declaration == null)
+            {
+                return null;
+            }
+
+            if (value is CodeExplorerCustomFolderViewModel folder)
+            {
+                return folder.Description;
+            }
+
+            if (declaration is ClassModuleDeclaration classModule)
+            {
+                var supertype = classModule.SupertypeNames.FirstOrDefault();
+                if (classModule.QualifiedModuleName.ComponentType ==
+                    VBEditor.SafeComWrappers.ComponentType.Document)
+                {
+                    return $"{RubberduckUI.ResourceManager.GetString($"DeclarationType_{nameof(DeclarationType.Document)}", CultureInfo.CurrentUICulture)} ({classModule.IdentifierName}:{supertype})";
+                }
+
+                if (classModule.QualifiedModuleName.ComponentType == VBEditor.SafeComWrappers.ComponentType.UserForm)
+                {
+                    // a form has a predeclared ID, but we want it to have a UserForm icon:
+                    return $"{RubberduckUI.ResourceManager.GetString($"DeclarationType_{nameof(DeclarationType.UserForm)}", CultureInfo.CurrentUICulture)} ({classModule.IdentifierName}:{supertype})";
+                }
+
+                if (classModule.IsInterface || classModule.Annotations.Any(annotation => annotation.Annotation is InterfaceAnnotation))
+                {
+                    return $"{RubberduckUI.ResourceManager.GetString($"DeclarationType_{nameof(DeclarationType.ClassModule)}", CultureInfo.CurrentUICulture)} (interface)";
+                }
+
+                if (classModule.HasPredeclaredId)
+                {
+                    return $"{RubberduckUI.ResourceManager.GetString($"DeclarationType_{nameof(DeclarationType.ClassModule)}", CultureInfo.CurrentUICulture)} (predeclared)";
+                }
+
+                return $"{RubberduckUI.ResourceManager.GetString($"DeclarationType_{nameof(DeclarationType.ClassModule)}", CultureInfo.CurrentUICulture)}";
+            }
+
+            if (declaration.DeclarationType.HasFlag(DeclarationType.ProceduralModule) && declaration.Annotations.Any(a => a.Annotation is TestModuleAnnotation))
+            {
+                return TestExplorer.TestExplorer_AddTestModule;
+            }
+
+            if (declaration.DeclarationType.HasFlag(DeclarationType.Member) && declaration.Annotations.Any(a => a.Annotation is TestMethodAnnotation))
+            {
+                return TestExplorer.TestExplorer_AddTestMethod;
+            }
+
+            return $"{RubberduckUI.ResourceManager.GetString($"DeclarationType_{declaration.DeclarationType}", CultureInfo.CurrentUICulture)}";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Rubberduck.Core/UI/Converters/DeclarationToIconConverter.cs
+++ b/Rubberduck.Core/UI/Converters/DeclarationToIconConverter.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Media;
+using Rubberduck.Parsing.Annotations.Concrete;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Resources.CodeExplorer;
+
+namespace Rubberduck.UI.Converters
+{
+    public class DeclarationToIconConverter : ImageSourceConverter
+    {
+        private static readonly ImageSource NullIcon = ToImageSource(CodeExplorerUI.status_offline);
+        private static readonly ImageSource ExceptionIcon = ToImageSource(CodeExplorerUI.exclamation);
+        private static readonly ImageSource InterfaceIcon = ToImageSource(CodeExplorerUI.ObjectInterface);
+        private static readonly ImageSource PredeclaredIcon = ToImageSource(CodeExplorerUI.ObjectClassPredeclared);
+        private static readonly ImageSource TestMethodIcon = ToImageSource(CodeExplorerUI.ObjectTestMethod);
+
+        protected ImageSource NullIconSource => NullIcon;
+        protected ImageSource ExceptionIconSource => ExceptionIcon;
+
+        private static readonly IDictionary<DeclarationType, ImageSource> DeclarationIcons = new Dictionary<DeclarationType, ImageSource>
+        {
+            // Components
+            { DeclarationType.ClassModule, ToImageSource(CodeExplorerUI.ObjectClass) },
+            { DeclarationType.ProceduralModule, ToImageSource(CodeExplorerUI.ObjectModule) },
+            { DeclarationType.UserForm, ToImageSource(CodeExplorerUI.ProjectForm) },
+            { DeclarationType.Document, ToImageSource(CodeExplorerUI.document_office) },
+            { DeclarationType.VbForm, ToImageSource(CodeExplorerUI.ProjectForm)},
+            { DeclarationType.MdiForm, ToImageSource(CodeExplorerUI.MdiForm)},
+            { DeclarationType.UserControl, ToImageSource(CodeExplorerUI.ui_scroll_pane_form)},
+            { DeclarationType.DocObject, ToImageSource(CodeExplorerUI.document_globe)},
+            { DeclarationType.PropPage, ToImageSource(CodeExplorerUI.ui_tab_content)},
+            { DeclarationType.ActiveXDesigner, ToImageSource(CodeExplorerUI.pencil_ruler)},
+            { DeclarationType.ResFile, ToImageSource(CodeExplorerUI.document_block)},
+            { DeclarationType.RelatedDocument, ToImageSource(CodeExplorerUI.document_import)},          
+            // Members
+            { DeclarationType.Constant, ToImageSource(CodeExplorerUI.ObjectConstant)},
+            { DeclarationType.Enumeration, ToImageSource(CodeExplorerUI.ObjectEnum)},
+            { DeclarationType.EnumerationMember, ToImageSource(CodeExplorerUI.ObjectEnumItem)},
+            { DeclarationType.Event, ToImageSource(CodeExplorerUI.ObjectEvent)},
+            { DeclarationType.Function, ToImageSource(CodeExplorerUI.ObjectMethod)},
+            { DeclarationType.LibraryFunction, ToImageSource(CodeExplorerUI.ObjectLibraryFunction)},
+            { DeclarationType.LibraryProcedure, ToImageSource(CodeExplorerUI.ObjectLibraryFunction)},
+            { DeclarationType.Procedure, ToImageSource(CodeExplorerUI.ObjectMethod)},
+            { DeclarationType.PropertyGet, ToImageSource(CodeExplorerUI.ObjectPropertyGet)},
+            { DeclarationType.PropertyLet, ToImageSource(CodeExplorerUI.ObjectPropertyLet)},
+            { DeclarationType.PropertySet, ToImageSource(CodeExplorerUI.ObjectPropertySet)},
+            { DeclarationType.UserDefinedType, ToImageSource(CodeExplorerUI.ObjectValueType)},
+            { DeclarationType.UserDefinedTypeMember, ToImageSource(CodeExplorerUI.ObjectField)},
+            { DeclarationType.Variable, ToImageSource(CodeExplorerUI.ObjectField)},
+            { DeclarationType.Parameter, ToImageSource(CodeExplorerUI.ObjectField)},
+        };
+
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return NullIcon;
+            }
+
+            if (value is Declaration declaration)
+            {
+                if (declaration is ClassModuleDeclaration classModule)
+                {
+                    if (classModule.QualifiedModuleName.ComponentType ==
+                        VBEditor.SafeComWrappers.ComponentType.Document)
+                    {
+                        return DeclarationIcons[DeclarationType.Document];
+                    }
+                    
+                    if (classModule.QualifiedModuleName.ComponentType == VBEditor.SafeComWrappers.ComponentType.UserForm)
+                    {
+                        // a form has a predeclared ID, but we want it to have a UserForm icon:
+                        return DeclarationIcons[DeclarationType.UserForm];
+                    }
+
+                    if (classModule.IsInterface || classModule.Annotations.Any(annotation => annotation.Annotation is InterfaceAnnotation))
+                    {
+                        return InterfaceIcon;
+                    }
+
+                    if (classModule.HasPredeclaredId)
+                    {
+                        return PredeclaredIcon;
+                    }
+                    
+                    return DeclarationIcons.ContainsKey(classModule.DeclarationType)
+                        ? DeclarationIcons[classModule.DeclarationType]
+                        : NullIcon;
+                }
+
+                if (DeclarationIcons.ContainsKey(declaration.DeclarationType))
+                {
+                    if (declaration.Annotations.Any(a => a.Annotation is TestMethodAnnotation))
+                    {
+                        return TestMethodIcon;
+                    }
+
+                    return DeclarationIcons[declaration.DeclarationType];
+                }
+                return NullIcon;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
+++ b/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
@@ -45,7 +45,9 @@ namespace Rubberduck.UI.Converters
 
                     var highlightRun = new Run(escapedXml.Substring(highlight.StartColumn, highlight.EndColumn - highlight.StartColumn + 1))
                     {
-                        Background = Brushes.Yellow
+                        Background = Brushes.Yellow,
+                        Foreground = Brushes.Black,
+                        FontWeight = FontWeights.Bold
                     };
                     textBlock.Inlines.Add(highlightRun);
 

--- a/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
+++ b/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
@@ -1,0 +1,75 @@
+﻿using Rubberduck.UI.Controls;
+using Rubberduck.UI.FindSymbol;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace Rubberduck.UI.Converters
+{
+    /// <summary>
+    /// A converter that highlights the search terms in the  a <see cref="SearchResultItem"/>.
+    /// </summary>
+    /// <remarks>
+    /// Based on https://stackoverflow.com/a/22026985/1188513
+    /// </remarks>
+    class SearchResultToXamlConverter : IValueConverter
+    {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is SearchResultItem item)
+            {
+                var textBlock = new TextBlock();
+                textBlock.TextWrapping = TextWrapping.Wrap;
+
+                var input = item.ResultText;
+                string escapedXml = input;// SecurityElement.Escape(input);
+
+                if (item.HighlightIndex.HasValue)
+                {
+                    var highlight = item.HighlightIndex.Value;
+                    if (highlight.StartColumn > 0)
+                    {
+                        var preRun = new Run(escapedXml.Substring(0, highlight.StartColumn));
+                        textBlock.Inlines.Add(preRun);
+                    }
+
+                    var highlightRun = new Run(escapedXml.Substring(highlight.StartColumn, highlight.EndColumn - highlight.StartColumn + 1))
+                    {
+                        Background = Brushes.Yellow
+                    };
+                    textBlock.Inlines.Add(highlightRun);
+
+                    if (highlight.EndColumn < item.ResultText.Length - 1)
+                    {
+                        var postRun = new Run(escapedXml.Substring(highlight.EndColumn + 1));
+                        textBlock.Inlines.Add(postRun);
+                    }
+                }
+                else
+                {
+                    textBlock.Inlines.Add(new Run(escapedXml));
+                }
+
+                return textBlock;
+            }
+
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException("This converter cannot be used in two-way binding.");
+        }
+
+    }
+}

--- a/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
+++ b/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
@@ -47,7 +47,7 @@ namespace Rubberduck.UI.Converters
                     {
                         Background = Brushes.Yellow,
                         Foreground = Brushes.Black,
-                        FontWeight = FontWeights.Bold
+                        FontWeight = FontWeights.SemiBold
                     };
                     textBlock.Inlines.Add(highlightRun);
 

--- a/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
+++ b/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
@@ -26,40 +26,51 @@ namespace Rubberduck.UI.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            const char nonBreakingSpace = '\u00A0';
             if (value is SearchResultItem item)
             {
                 var textBlock = new TextBlock();
                 textBlock.TextWrapping = TextWrapping.Wrap;
 
-                var input = item.ResultText;
-                string escapedXml = input;// SecurityElement.Escape(input);
-
+                var input = item.ResultText.Replace(' ', nonBreakingSpace);
                 if (item.HighlightIndex.HasValue)
                 {
                     var highlight = item.HighlightIndex.Value;
                     if (highlight.StartColumn > 0)
                     {
-                        var preRun = new Run(escapedXml.Substring(0, highlight.StartColumn));
+                        var preRun = new Run(input.Substring(0, highlight.StartColumn))
+                        {
+                            Foreground = Brushes.DimGray,
+                            FontFamily = new FontFamily("Consolas")
+                        };
                         textBlock.Inlines.Add(preRun);
                     }
 
-                    var highlightRun = new Run(escapedXml.Substring(highlight.StartColumn, highlight.EndColumn - highlight.StartColumn + 1))
+                    var highlightRun = new Run(input.Substring(highlight.StartColumn, 
+                        highlight.EndLine == highlight.StartLine 
+                                ? highlight.EndColumn - highlight.StartColumn
+                                : highlight.StartColumn + highlight.EndColumn - 1))
                     {
                         Background = Brushes.Yellow,
-                        Foreground = Brushes.Black,
-                        FontWeight = FontWeights.SemiBold
+                        Foreground = Brushes.DimGray,
+                        FontWeight = FontWeights.Bold,
+                        FontFamily = new FontFamily("Consolas")
                     };
                     textBlock.Inlines.Add(highlightRun);
 
                     if (highlight.EndColumn < item.ResultText.Length - 1)
                     {
-                        var postRun = new Run(escapedXml.Substring(highlight.EndColumn + 1));
+                        var postRun = new Run(input.Substring(highlight.EndColumn))
+                        {
+                            Foreground = Brushes.DimGray,
+                            FontFamily = new FontFamily("Consolas")
+                        };
                         textBlock.Inlines.Add(postRun);
                     }
                 }
                 else
                 {
-                    textBlock.Inlines.Add(new Run(escapedXml));
+                    textBlock.Inlines.Add(new Run(input));
                 }
 
                 return textBlock;

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
@@ -49,14 +49,14 @@
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="24" />
-                            <ColumnDefinition MinWidth="168" />
+                            <ColumnDefinition MinWidth="192" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" Height="16" Width="16" Margin="2" HorizontalAlignment="Center"
                                Source="{Binding Declaration, Converter={StaticResource IconConverter}, Mode=OneTime}" 
                                ToolTip="{Binding Declaration.DeclarationType}" />
                         <TextBlock Grid.Column="1" Text="{Binding IdentifierName}" FontWeight="Bold" MinWidth="160" VerticalAlignment="Center" />
-                        <TextBlock Grid.Column="2" Text="{Binding Location}" Margin="8,0" Foreground="Gray" FontStyle="Italic" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="2" Text="{Binding Location}" Margin="20,0" Foreground="DimGray" FontStyle="Italic" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     </Grid>
                 </DataTemplate>
             </ComboBox.ItemTemplate>

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
@@ -50,13 +50,13 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="24" />
                             <ColumnDefinition MinWidth="168" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Image Grid.Column="0" Height="16" Width="16" Margin="2" HorizontalAlignment="Center"
                                Source="{Binding Declaration, Converter={StaticResource IconConverter}, Mode=OneTime}" 
                                ToolTip="{Binding Declaration.DeclarationType}" />
                         <TextBlock Grid.Column="1" Text="{Binding IdentifierName}" FontWeight="Bold" MinWidth="160" VerticalAlignment="Center" />
-                        <TextBlock Grid.Column="2" Text="{Binding Location}" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="2" Text="{Binding Location}" Margin="8,0" Foreground="Gray" FontStyle="Italic" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     </Grid>
                 </DataTemplate>
             </ComboBox.ItemTemplate>

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
@@ -10,9 +10,17 @@
              d:DataContext="{d:DesignInstance {x:Type local:FindSymbolViewModel}, IsDesignTimeCreatable=False}">
 
     <UserControl.Resources>
-        <BitmapImage x:Key="ArrowImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/arrow.png" />
-        <local:SearchBoxMultiBindingConverter x:Key="SearchBoxTextConverter" />
-        <converters:DeclarationToIconConverter x:Key="IconConverter" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Controls/ToolBar.xaml"/>
+                <ResourceDictionary Source="../Styles/DefaultStyle.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <BitmapImage x:Key="ArrowImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/arrow.png" />
+            <local:SearchBoxMultiBindingConverter x:Key="SearchBoxTextConverter" />
+            <converters:DeclarationToIconConverter x:Key="IconConverter" />
+            <converters:AccessibilityToIconConverter x:Key="AccessibilityToIcon" />
+            <converters:DeclarationToDeclarationTypeStringConverter x:Key="DeclarationTypeConverter" />
+        </ResourceDictionary>
     </UserControl.Resources>
     
     <Grid>
@@ -46,10 +54,13 @@
                             <ColumnDefinition MinWidth="192" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <Image Grid.Column="0" Height="16" Width="16" Margin="2" HorizontalAlignment="Center"
+                        <Image Grid.Column="0" Style="{StaticResource ToolbarIconStyle}" HorizontalAlignment="Center"
                                Source="{Binding Declaration, Converter={StaticResource IconConverter}, Mode=OneTime}" 
-                               ToolTip="{Binding Declaration.DeclarationType}" />
-                        <TextBlock Grid.Column="1" Text="{Binding IdentifierName}" FontWeight="Bold" MinWidth="160" VerticalAlignment="Center" />
+                               ToolTip="{Binding Declaration, Converter={StaticResource DeclarationTypeConverter}, Mode=OneTime}" />
+                        <Image Grid.Column="0" Style="{StaticResource ToolbarIconStyle}" HorizontalAlignment="Center"
+                               Source="{Binding Declaration, Converter={StaticResource AccessibilityToIcon}}"
+                               ToolTip="{Binding Declaration, Converter={StaticResource DeclarationTypeConverter}, Mode=OneTime}" />
+                        <TextBlock Grid.Column="1" Text="{Binding IdentifierName}" FontWeight="Bold" FontFamily="Consolas" MinWidth="160" VerticalAlignment="Center" />
                         <TextBlock Grid.Column="2" Text="{Binding Location}" Margin="20,0" Foreground="DimGray" FontStyle="Italic" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     </Grid>
                 </DataTemplate>

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Rubberduck.UI.FindSymbol"
+             xmlns:converters="clr-namespace:Rubberduck.UI.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="24" d:DesignWidth="270"
              d:DataContext="{d:DesignInstance {x:Type local:FindSymbolViewModel}, IsDesignTimeCreatable=False}">
@@ -17,7 +18,7 @@
     <UserControl.Resources>
         <BitmapImage x:Key="ArrowImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/arrow.png" />
         <local:SearchBoxMultiBindingConverter x:Key="SearchBoxTextConverter" />
-        <KeyBinding x:Key="EnterAndGo" Key="Return" Command="{Binding GoCommand}" />
+        <converters:DeclarationToIconConverter x:Key="IconConverter" />
     </UserControl.Resources>
     
     <Grid>
@@ -30,10 +31,13 @@
         <ComboBox x:Name="searchComboBox"
                   IsEditable="True"
                   ItemsSource="{Binding MatchResults}"
+                  SelectedItem="{Binding SelectedItem}"
                   IsTextSearchCaseSensitive="False"
                   IsTextSearchEnabled="True"
-                  TextSearch.TextPath="IdentifierName"
-                  VirtualizingPanel.IsVirtualizing="True">
+                  TextSearch.TextPath="IdentifierName">
+            <ComboBox.Resources>
+                <KeyBinding x:Key="EnterGo" Key="Return" Command="{Binding GoCommand}" />
+            </ComboBox.Resources>
             <ComboBox.Text>
                 <MultiBinding Converter="{StaticResource SearchBoxTextConverter}">
                     <Binding Path="SearchString" Mode="OneWayToSource" UpdateSourceTrigger="PropertyChanged" />
@@ -44,16 +48,15 @@
                 <DataTemplate DataType="local:SearchResult">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="24" />
+                            <ColumnDefinition MinWidth="168" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="20" />
-                        </Grid.RowDefinitions>
-                        <Image Grid.Column="0" Height="16" Width="16" Margin="2" Source="{Binding Icon, Mode=OneTime}" />
+                        <Image Grid.Column="0" Height="16" Width="16" Margin="2" HorizontalAlignment="Center"
+                               Source="{Binding Declaration, Converter={StaticResource IconConverter}, Mode=OneTime}" 
+                               ToolTip="{Binding Declaration.DeclarationType}" />
                         <TextBlock Grid.Column="1" Text="{Binding IdentifierName}" FontWeight="Bold" MinWidth="160" VerticalAlignment="Center" />
-                        <TextBlock Grid.Column="2" Text="{Binding Location}" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="2" Text="{Binding Location}" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     </Grid>
                 </DataTemplate>
             </ComboBox.ItemTemplate>

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
@@ -16,6 +16,8 @@
 
     <UserControl.Resources>
         <BitmapImage x:Key="ArrowImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/arrow.png" />
+        <local:SearchBoxMultiBindingConverter x:Key="SearchBoxTextConverter" />
+        <KeyBinding x:Key="EnterAndGo" Key="Return" Command="{Binding GoCommand}" />
     </UserControl.Resources>
     
     <Grid>
@@ -28,26 +30,37 @@
         <ComboBox x:Name="searchComboBox"
                   IsEditable="True"
                   ItemsSource="{Binding MatchResults}"
-                  SelectedItem="{Binding SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                   IsTextSearchCaseSensitive="False"
                   IsTextSearchEnabled="True"
-                  Text="{Binding SearchString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                   TextSearch.TextPath="IdentifierName"
-                  PreviewKeyDown="UIElement_OnPreviewKeyDown">
-
+                  VirtualizingPanel.IsVirtualizing="True">
+            <ComboBox.Text>
+                <MultiBinding Converter="{StaticResource SearchBoxTextConverter}">
+                    <Binding Path="SearchString" Mode="OneWayToSource" UpdateSourceTrigger="PropertyChanged" />
+                    <Binding Path="SelectedItem.IdentifierName" Mode="OneWay" UpdateSourceTrigger="PropertyChanged" />
+                </MultiBinding>
+            </ComboBox.Text>
             <ComboBox.ItemTemplate>
                 <DataTemplate DataType="local:SearchResult">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <Image Height="16" Width="16" Margin="2,0,2,0" Source="{Binding Icon}" />
-                        <TextBlock Margin="2,0,2,0" Text="{Binding IdentifierName}" FontWeight="Bold" MinWidth="160" VerticalAlignment="Center" />
-                        <TextBlock Margin="2,0,2,0" Text="{Binding Location}" VerticalAlignment="Center" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="20" />
+                        </Grid.RowDefinitions>
+                        <Image Grid.Column="0" Height="16" Width="16" Margin="2" Source="{Binding Icon, Mode=OneTime}" />
+                        <TextBlock Grid.Column="1" Text="{Binding IdentifierName}" FontWeight="Bold" MinWidth="160" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="2" Text="{Binding Location}" VerticalAlignment="Center" />
+                    </Grid>
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
         
         <Button Grid.Column="1" Command="local:FindSymbolControl.GoCommand">
-            <Image Height="16" Source="{StaticResource ArrowImage}" />
+            <Image Height="16" Width="16" Source="{StaticResource ArrowImage}" />
         </Button>
         
     </Grid>

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml
@@ -9,12 +9,6 @@
              d:DesignHeight="24" d:DesignWidth="270"
              d:DataContext="{d:DesignInstance {x:Type local:FindSymbolViewModel}, IsDesignTimeCreatable=False}">
 
-    <UserControl.CommandBindings>
-        <CommandBinding Command="local:FindSymbolControl.GoCommand" 
-                        Executed="CommandBinding_OnExecuted"
-                        CanExecute="CommandBinding_OnCanExecute"/>
-    </UserControl.CommandBindings>
-
     <UserControl.Resources>
         <BitmapImage x:Key="ArrowImage" UriSource="pack://application:,,,/Rubberduck.Resources;component/Icons/Fugue/arrow.png" />
         <local:SearchBoxMultiBindingConverter x:Key="SearchBoxTextConverter" />
@@ -35,9 +29,9 @@
                   IsTextSearchCaseSensitive="False"
                   IsTextSearchEnabled="True"
                   TextSearch.TextPath="IdentifierName">
-            <ComboBox.Resources>
-                <KeyBinding x:Key="EnterGo" Key="Return" Command="{Binding GoCommand}" />
-            </ComboBox.Resources>
+            <ComboBox.InputBindings>
+                <KeyBinding Command="{Binding GoCommand}" Key="Return" />
+            </ComboBox.InputBindings>
             <ComboBox.Text>
                 <MultiBinding Converter="{StaticResource SearchBoxTextConverter}">
                     <Binding Path="SearchString" Mode="OneWayToSource" UpdateSourceTrigger="PropertyChanged" />
@@ -62,7 +56,7 @@
             </ComboBox.ItemTemplate>
         </ComboBox>
         
-        <Button Grid.Column="1" Command="local:FindSymbolControl.GoCommand">
+        <Button Grid.Column="1" Command="{Binding GoCommand}">
             <Image Height="16" Width="16" Source="{StaticResource ArrowImage}" />
         </Button>
         

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
@@ -20,6 +20,11 @@ namespace Rubberduck.UI.FindSymbol
 
         private void CommandBinding_OnExecuted(object sender, ExecutedRoutedEventArgs e)
         {
+            if (ViewModel == null)
+            {
+                return;
+            }
+            
             ViewModel.Execute();
             e.Handled = true;
         }
@@ -33,15 +38,6 @@ namespace Rubberduck.UI.FindSymbol
 
             e.CanExecute = ViewModel.CanExecute();
             e.Handled = true;
-        }
-
-        private void UIElement_OnPreviewKeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Enter && ViewModel.CanExecute())
-            {
-                ViewModel.Execute();
-                e.Handled = true;
-            }
         }
 
         private void FindSymbolControl_Loaded(object sender, System.Windows.RoutedEventArgs e)

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace Rubberduck.UI.FindSymbol
 {
@@ -16,26 +15,9 @@ namespace Rubberduck.UI.FindSymbol
 
         private FindSymbolViewModel ViewModel => (FindSymbolViewModel)DataContext;
 
-        public static ICommand GoCommand { get; } = new RoutedCommand();
-
-        private void CommandBinding_OnExecuted(object sender, ExecutedRoutedEventArgs e)
-        {
-            ViewModel?.Execute();
-            e.Handled = true;
-        }
-
-        private void CommandBinding_OnCanExecute(object sender, CanExecuteRoutedEventArgs e)
-        {
-            e.CanExecute = ViewModel?.CanExecute() ?? false;
-            e.Handled = true;
-        }
-
         private void FindSymbolControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
         {
             SearchComboBox.Focus();
         }
-
-        // doing this navigates on arrow-up/down, which isn't expected 
-        //private void searchComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e) => ViewModel?.Execute();
     }
 }

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolControl.xaml.cs
@@ -20,23 +20,13 @@ namespace Rubberduck.UI.FindSymbol
 
         private void CommandBinding_OnExecuted(object sender, ExecutedRoutedEventArgs e)
         {
-            if (ViewModel == null)
-            {
-                return;
-            }
-            
-            ViewModel.Execute();
+            ViewModel?.Execute();
             e.Handled = true;
         }
 
         private void CommandBinding_OnCanExecute(object sender, CanExecuteRoutedEventArgs e)
         {
-            if (ViewModel == null)
-            {
-                return;
-            }
-
-            e.CanExecute = ViewModel.CanExecute();
+            e.CanExecute = ViewModel?.CanExecute() ?? false;
             e.Handled = true;
         }
 
@@ -44,5 +34,8 @@ namespace Rubberduck.UI.FindSymbol
         {
             searchComboBox.Focus();
         }
+
+        // doing this navigates on arrow-up/down, which isn't expected 
+        //private void searchComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e) => ViewModel?.Execute();
     }
 }

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolDialog.cs
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolDialog.cs
@@ -14,22 +14,18 @@ namespace Rubberduck.UI.FindSymbol
             viewModel.Navigate += viewModel_Navigate;
         }
 
-        public event EventHandler<NavigateCodeEventArgs> Navigate;
-        private void viewModel_Navigate(object sender, NavigateCodeEventArgs e)
-        {
-            var handler = Navigate;
-            if (handler != null)
-            {
-                handler(this, e);
-                Hide();
-            }
-        }
-
         public FindSymbolDialog()
         {
             InitializeComponent();
-            
-            Text = string.Format("Rubberduck - {0}", RubberduckUI.FindSymbolDialog_Caption);
+            Text = $"Rubberduck - {RubberduckUI.FindSymbolDialog_Caption}";
+        }
+
+
+        public event EventHandler<NavigateCodeEventArgs> Navigate;
+        private void viewModel_Navigate(object sender, NavigateCodeEventArgs e)
+        {
+            Navigate?.Invoke(this, e);
+            Hide();
         }
 
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolViewModel.cs
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolViewModel.cs
@@ -4,10 +4,13 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using NLog;
 using Rubberduck.Common;
 using Rubberduck.Interaction.Navigation;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Properties;
+using Rubberduck.UI.Command;
 
 namespace Rubberduck.UI.FindSymbol
 {
@@ -19,24 +22,23 @@ namespace Rubberduck.UI.FindSymbol
             DeclarationType.Project
         };
 
+        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+
         public FindSymbolViewModel(IEnumerable<Declaration> declarations)
         {
             _declarations = declarations.Where(declaration => !ExcludedTypes.Contains(declaration.DeclarationType)).ToList();
-            
+            GoCommand = new DelegateCommand(Logger, ExecuteGoCommand, CanExecuteGoCommand);
             Search(string.Empty);
         }
 
         public event EventHandler<NavigateCodeEventArgs> Navigate;
 
-        public bool CanExecute()
-        {
-            return _searchString?.Equals(_selectedItem?.IdentifierName, StringComparison.InvariantCultureIgnoreCase) ?? false;
-        }
+        public ICommand GoCommand { get; }
 
-        public void Execute()
-        {
-            OnNavigate();
-        }
+        private bool CanExecuteGoCommand(object param) => _searchString?.Equals(_selectedItem?.IdentifierName, StringComparison.InvariantCultureIgnoreCase) ?? false;
+
+        private void ExecuteGoCommand(object param) => OnNavigate();
+
 
         public void OnNavigate()
         {

--- a/Rubberduck.Core/UI/FindSymbol/FindSymbolViewModel.cs
+++ b/Rubberduck.Core/UI/FindSymbol/FindSymbolViewModel.cs
@@ -19,10 +19,9 @@ namespace Rubberduck.UI.FindSymbol
             DeclarationType.Project
         };
 
-        public FindSymbolViewModel(IEnumerable<Declaration> declarations, DeclarationIconCache cache)
+        public FindSymbolViewModel(IEnumerable<Declaration> declarations)
         {
             _declarations = declarations.Where(declaration => !ExcludedTypes.Contains(declaration.DeclarationType)).ToList();
-            _cache = cache;
             
             Search(string.Empty);
         }
@@ -50,7 +49,6 @@ namespace Rubberduck.UI.FindSymbol
         }
 
         private readonly IEnumerable<Declaration> _declarations;
-        private readonly DeclarationIconCache _cache;
 
         private void Search(string value)
         {
@@ -70,8 +68,8 @@ namespace Rubberduck.UI.FindSymbol
             var results = _declarations
                 .Where(declaration => string.IsNullOrEmpty(value) || declaration.IdentifierName.ToLowerInvariant().Contains(lower))
                 .OrderBy(declaration => declaration.IdentifierName)
-                .Take(80)
-                .Select(declaration => new SearchResult(declaration, _cache[declaration]));
+                .Take(30)
+                .Select(declaration => new SearchResult(declaration));
 
             return results;
         }
@@ -85,6 +83,8 @@ namespace Rubberduck.UI.FindSymbol
                 if (_searchString != value)
                 {
                     _searchString = value;
+                    OnPropertyChanged();
+
                     Search(value);
                 }
             }
@@ -101,10 +101,6 @@ namespace Rubberduck.UI.FindSymbol
                     _selectedItem = value;
                     _searchString = value?.IdentifierName;
                     OnPropertyChanged();
-                }
-                if (_selectedItem != null)
-                {
-                    Execute();
                 }
             }
         }

--- a/Rubberduck.Core/UI/FindSymbol/SearchResult.cs
+++ b/Rubberduck.Core/UI/FindSymbol/SearchResult.cs
@@ -9,10 +9,9 @@ namespace Rubberduck.UI.FindSymbol
 {
     public class SearchResult
     {
-        public SearchResult(Declaration declaration, BitmapImage icon)
+        public SearchResult(Declaration declaration)
         {
             Declaration = declaration;
-            Icon = icon;
         }
 
         public Declaration Declaration { get; }
@@ -20,7 +19,6 @@ namespace Rubberduck.UI.FindSymbol
         public string IdentifierName => Declaration.IdentifierName;
         public string Location => Declaration.Scope;
 
-        public ImageSource Icon { get; }
     }
 
     public class SearchBoxMultiBindingConverter : IMultiValueConverter

--- a/Rubberduck.Core/UI/FindSymbol/SearchResult.cs
+++ b/Rubberduck.Core/UI/FindSymbol/SearchResult.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows.Media.Imaging;
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using Rubberduck.Parsing.Symbols;
 
 namespace Rubberduck.UI.FindSymbol
@@ -16,6 +20,19 @@ namespace Rubberduck.UI.FindSymbol
         public string IdentifierName => Declaration.IdentifierName;
         public string Location => Declaration.Scope;
 
-        public BitmapImage Icon { get; }
+        public ImageSource Icon { get; }
+    }
+
+    public class SearchBoxMultiBindingConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return values[0];
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return value is Declaration declaration ? new[] { declaration.IdentifierName , value } : new[] { value, null };
+        }
     }
 }

--- a/Rubberduck.Parsing/Symbols/ArgumentReference.cs
+++ b/Rubberduck.Parsing/Symbols/ArgumentReference.cs
@@ -49,39 +49,5 @@ namespace Rubberduck.Parsing.Symbols
         public int NumberOfArguments { get; }
         public VBAParser.ArgumentListContext ArgumentListContext { get; }
         public Selection ArgumentListSelection { get; }
-
-        public override (string context, Selection highlight) HighligthSelection(ICodeModule module)
-        {
-            const int maxLength = 255;
-
-            var lines = module.GetLines(Selection.StartLine, Selection.LineCount).Split('\n');
-
-            var line = lines[0];
-            var indent = line.TakeWhile(c => c.Equals(' ')).Count();
-
-            var highlight = new Selection(
-                    1, Math.Max(Selection.StartColumn - indent, 1),
-                    1, Math.Max(Selection.EndColumn - indent, 1))
-                .ToZeroBased();
-
-            var trimmed = line.Trim();
-            if (trimmed.Length > maxLength || lines.Length > 1)
-            {
-                trimmed = trimmed.Substring(0, Math.Min(trimmed.Length, maxLength)) + "...";
-                highlight = new Selection(1, highlight.StartColumn, 1, trimmed.Length);
-            }
-
-            if (highlight.IsSingleCharacter && highlight.StartColumn == 0)
-            {
-                trimmed = " " + trimmed;
-                highlight = new Selection(0, 0, 0, 1);
-            }
-            else if (highlight.IsSingleCharacter)
-            {
-                highlight = new Selection(0, Selection.StartColumn-1 - indent - 1, 0, Selection.StartColumn-1 - indent);
-            }
-            return (trimmed, highlight);
-        }
-
     }
 }

--- a/Rubberduck.Parsing/Symbols/ArgumentReference.cs
+++ b/Rubberduck.Parsing/Symbols/ArgumentReference.cs
@@ -52,11 +52,35 @@ namespace Rubberduck.Parsing.Symbols
 
         public override (string context, Selection highlight) HighligthSelection(ICodeModule module)
         {
+            const int maxLength = 255;
+
             var lines = module.GetLines(Selection.StartLine, Selection.LineCount).Split('\n');
 
-            var line = lines[0]; // TODO think of something that makes sense for multiline
-            var indent = line.TakeWhile((c, i) => c.Equals(' ') && i < Selection.StartColumn).Count();
-            return (line.Trim(), new Selection(1, Math.Max(Selection.StartColumn - indent - 1, 1), 1, Math.Max(Selection.EndColumn - indent,1)).ToZeroBased());
+            var line = lines[0];
+            var indent = line.TakeWhile(c => c.Equals(' ')).Count();
+
+            var highlight = new Selection(
+                    1, Math.Max(Selection.StartColumn - indent, 1),
+                    1, Math.Max(Selection.EndColumn - indent, 1))
+                .ToZeroBased();
+
+            var trimmed = line.Trim();
+            if (trimmed.Length > maxLength || lines.Length > 1)
+            {
+                trimmed = trimmed.Substring(0, Math.Min(trimmed.Length, maxLength)) + "...";
+                highlight = new Selection(1, highlight.StartColumn, 1, trimmed.Length);
+            }
+
+            if (highlight.IsSingleCharacter && highlight.StartColumn == 0)
+            {
+                trimmed = " " + trimmed;
+                highlight = new Selection(0, 0, 0, 1);
+            }
+            else if (highlight.IsSingleCharacter)
+            {
+                highlight = new Selection(0, Selection.StartColumn-1 - indent - 1, 0, Selection.StartColumn-1 - indent);
+            }
+            return (trimmed, highlight);
         }
 
     }

--- a/Rubberduck.Parsing/Symbols/ArgumentReference.cs
+++ b/Rubberduck.Parsing/Symbols/ArgumentReference.cs
@@ -1,9 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Antlr4.Runtime;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Binding;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.VBEditor;
+using Rubberduck.VBEditor.ComManagement;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -45,5 +49,15 @@ namespace Rubberduck.Parsing.Symbols
         public int NumberOfArguments { get; }
         public VBAParser.ArgumentListContext ArgumentListContext { get; }
         public Selection ArgumentListSelection { get; }
+
+        public override (string context, Selection highlight) HighligthSelection(ICodeModule module)
+        {
+            var lines = module.GetLines(Selection.StartLine, Selection.LineCount).Split('\n');
+
+            var line = lines[0]; // TODO think of something that makes sense for multiline
+            var indent = line.TakeWhile((c, i) => c.Equals(' ') && i < Selection.StartColumn).Count();
+            return (line.Trim(), new Selection(1, Math.Max(Selection.StartColumn - indent - 1, 1), 1, Math.Max(Selection.EndColumn - indent,1)).ToZeroBased());
+        }
+
     }
 }

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -135,11 +135,24 @@ namespace Rubberduck.Parsing.Symbols
 
         public virtual (string context, Selection highlight) HighligthSelection(ICodeModule module)
         {
+            const int maxLength = 255;
+
             var lines = module.GetLines(Selection.StartLine, Selection.LineCount).Split('\n');
 
-            var line = lines[0]; // TODO think of something that makes sense for multiline
+            var line = lines[0];
             var indent = line.TakeWhile(c => c.Equals(' ')).Count();
-            return (line.Trim(), new Selection(1, Math.Max(Selection.StartColumn - indent,1), 1, Math.Max(Selection.EndColumn - indent,1)).ToZeroBased());
+
+            var highlight = new Selection(
+                1, Math.Max(Selection.StartColumn - indent, 1), 
+                1, Math.Max(Selection.EndColumn - indent, 1))
+            .ToZeroBased();
+
+            var trimmed = line.Trim();
+            if (trimmed.Length > maxLength || lines.Length > 1)
+            {
+                trimmed = trimmed.Substring(0, maxLength) + "...";
+            }
+            return (trimmed, highlight);
         }
 
         public bool Equals(IdentifierReference other)

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -133,28 +133,6 @@ namespace Rubberduck.Parsing.Symbols
                    Selection.ContainsFirstCharacter(selection.Selection);
         }
 
-        public virtual (string context, Selection highlight) HighligthSelection(ICodeModule module)
-        {
-            const int maxLength = 255;
-
-            var lines = module.GetLines(Selection.StartLine, Selection.LineCount).Split('\n');
-
-            var line = lines[0];
-            var indent = line.TakeWhile(c => c.Equals(' ')).Count();
-
-            var highlight = new Selection(
-                1, Math.Max(Selection.StartColumn - indent, 1), 
-                1, Math.Max(Selection.EndColumn - indent, 1))
-            .ToZeroBased();
-
-            var trimmed = line.Trim();
-            if (trimmed.Length > maxLength || lines.Length > 1)
-            {
-                trimmed = trimmed.Substring(0, maxLength) + "...";
-            }
-            return (trimmed, highlight);
-        }
-
         public bool Equals(IdentifierReference other)
         {
             return other != null

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using System;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 
 namespace Rubberduck.Parsing.Symbols
 {
@@ -130,6 +131,15 @@ namespace Rubberduck.Parsing.Symbols
         {
             return QualifiedModuleName == selection.QualifiedName &&
                    Selection.ContainsFirstCharacter(selection.Selection);
+        }
+
+        public virtual (string context, Selection highlight) HighligthSelection(ICodeModule module)
+        {
+            var lines = module.GetLines(Selection.StartLine, Selection.LineCount).Split('\n');
+
+            var line = lines[0]; // TODO think of something that makes sense for multiline
+            var indent = line.TakeWhile(c => c.Equals(' ')).Count();
+            return (line.Trim(), new Selection(1, Math.Max(Selection.StartColumn - indent,1), 1, Math.Max(Selection.EndColumn - indent,1)).ToZeroBased());
         }
 
         public bool Equals(IdentifierReference other)

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -628,9 +628,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             }
 
             var parameters = Parameters(callingNonDefaultMember);
-            var hasNamedArgs = argumentExpression?.GetAncestor<VBAParser.ArgListContext>()?.TryGetChildContext<VBAParser.NamedArgumentContext>(out _) ?? false;
-
             ParameterDeclaration parameter;
+
             var namedArg = argumentExpression.GetAncestor<VBAParser.NamedArgumentContext>();
             if (namedArg != null)
             {
@@ -1591,6 +1590,11 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             }
 
             referenceProject = GetProjectDeclarationForReference(reference);
+            if (referenceProject == null)
+            {
+                Logger.Warn($"Could not get the project declaration for reference '{reference.Name}'.");
+                return output;
+            }
             if (!_referencesByProjectId.TryGetValue(referenceProject.ProjectId, out var directReferences))
             {
                 return output;

--- a/Rubberduck.VBEEditor/Selection.cs
+++ b/Rubberduck.VBEEditor/Selection.cs
@@ -82,7 +82,8 @@ namespace Rubberduck.VBEditor
             return false;
         }
 
-        public bool IsSingleCharacter => StartLine == EndLine && StartColumn == EndColumn;
+        public bool IsSingleLine => StartLine == EndLine;
+        public bool IsSingleCharacter => IsSingleLine && StartColumn == EndColumn;
 
         public Selection PreviousLine => StartLine == 1 ? Home : new Selection(StartLine - 1, 1);
         public Selection NextLine => new Selection(StartLine + 1, 1);


### PR DESCRIPTION
The feature had been broken for some time; this PR restores its functionality.

![image](https://user-images.githubusercontent.com/5751684/115817971-cc85b200-a3c9-11eb-9624-583fb9fa20c6.png)

The number of items in the dropdown is limited to a hard-set 30 for now.

Also introduces the possibility to highlight (bold, black on yellow) a `Selection` in the search result text of a `SearchResultItem`, and leverages this possibility for _find all references_.

![image](https://user-images.githubusercontent.com/5751684/115817876-a3fdb800-a3c9-11eb-8a71-cde277ad8b69.png)
