### PR TITLE
Introducing workload configs

### DIFF
--- a/Rubberduck.Deployment/InnoSetup/Includes/Czech.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/Czech.CustomMessages.iss
@@ -27,3 +27,4 @@ Czech.UseLegacyWorkloadCaption=Initial Configuration
 Czech.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
 Czech.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
 Czech.UseLegacyWorkloadButtonCaption=Use legacy workload configuration
+Czech.OverwriteWithLegacyWorkloadButtonCaption=Overwrite Rubberduck settings with legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Includes/Czech.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/Czech.CustomMessages.iss
@@ -23,3 +23,7 @@ Czech.UninstallOldVersionPrompt=Vypadá to, že existuje předchozí verze Rubbe
 Czech.UninstallOldVersionFail=Nelze odinstalovat předchozí verzi Rubberducku. Zkuste jej odinstalovat pomocí ovládacího panelu - programy a funkce - a poté spustit instalátor znovu.
 Czech.WarnInstallPerUserOverEveryone=Zdá se, že je nainstalována verze Rubberducku pro všechny uživatele. Pokud budete pokračovat s per-uživatel instalací, bude mít přednost před původní instalací. Přesto pokračovat?
 Czech.ElevationRequestFailMessage=Nelze odinstalovat předchozí verzi Rubberducku. Před instalací nové verze bude nejspíše nutné ji odinstalovat přímo.
+Czech.UseLegacyWorkloadCaption=Initial Configuration
+Czech.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
+Czech.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
+Czech.UseLegacyWorkloadButtonCaption=Use legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Includes/English.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/English.CustomMessages.iss
@@ -28,3 +28,4 @@ English.UseLegacyWorkloadCaption=Initial Configuration
 English.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
 English.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
 English.UseLegacyWorkloadButtonCaption=Use legacy workload configuration
+English.OverwriteWithLegacyWorkloadButtonCaption=Overwrite Rubberduck settings with legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Includes/English.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/English.CustomMessages.iss
@@ -24,3 +24,7 @@ English.UninstallOldVersionFail=Unable to uninstall the previous version of Rubb
 English.UninstallOldVersionNotFound=The uninstaller could not be found. Do you want to proceed and install anyway? This may potentially overwrite existing installation and may result in a duplicate entry in the Add & Remove Programs. Proceed anyway?
 English.WarnInstallPerUserOverEveryone=There seems to be a version of Rubberduck installed for all users. If you proceed with the per-user install, it will take precedence over the original install. Proceed anyway?
 English.ElevationRequestFailMessage=Unable to uninstall the previous version of Rubberduck. You may need to uninstall it directly before you can install the new version.
+English.UseLegacyWorkloadCaption=Initial Configuration
+English.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
+English.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
+English.UseLegacyWorkloadButtonCaption=Use legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Includes/French.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/French.CustomMessages.iss
@@ -27,3 +27,4 @@ French.UseLegacyWorkloadCaption=Configuration Initiale
 French.UseLegacyWorkloadMessage=Vous planifiez utiliser Rubberduck avec un projet existant?
 French.UseLegacyWorkloadDescription=La configuration initiale 'legacy workload' désactive auto-complétion et certaines inspections spécifiques pour réduire la pression sur la mémoire et améliorer la performance. Les fonctionnalités désactivées peuvent être réactivées manuellement à tout moment.
 French.UseLegacyWorkloadButtonCaption=Utiliser la configuration initiale 'legacy workload'
+French.OverwriteWithLegacyWorkloadButtonCaption=écraser la configuration actuelle

--- a/Rubberduck.Deployment/InnoSetup/Includes/French.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/French.CustomMessages.iss
@@ -23,3 +23,7 @@ French.UninstallOldVersionPrompt=Il semble y avoir une version antérieure de Ru
 French.UninstallOldVersionFail=Impossible de désinstaller la version antérieure. Essayez de désinstaller via Ajout/Suppression de Programmes dans le panneau de contrôle, puis recommencer l'installation.
 French.WarnInstallPerUserOverEveryone=Il semble y avoir une version de Rubberduck installée pour tous les utilisateurs. Procéder à une installation utilisateur simple modifiera l'enregistrement, sans affecter les autres utilisateurs. Procéder?
 French.ElevationRequestFailMessage=Impossible de désinstaller la version précédente de Rubberduck. Vous devrez d'abord désinstaller l'ancienne version avant de procéder à la mise à jour.
+French.UseLegacyWorkloadCaption=Configuration Initiale
+French.UseLegacyWorkloadMessage=Vous planifiez utiliser Rubberduck avec un projet existant?
+French.UseLegacyWorkloadDescription=La configuration initiale 'legacy workload' désactive auto-complétion et certaines inspections spécifiques pour réduire la pression sur la mémoire et améliorer la performance. Les fonctionnalités désactivées peuvent être réactivées manuellement à tout moment.
+French.UseLegacyWorkloadButtonCaption=Utiliser la configuration initiale 'legacy workload'

--- a/Rubberduck.Deployment/InnoSetup/Includes/German.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/German.CustomMessages.iss
@@ -27,3 +27,4 @@ German.UseLegacyWorkloadCaption=Initial Configuration
 German.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
 German.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
 German.UseLegacyWorkloadButtonCaption=Use legacy workload configuration
+German.OverwriteWithLegacyWorkloadButtonCaption=Overwrite Rubberduck settings with legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Includes/German.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/German.CustomMessages.iss
@@ -23,3 +23,7 @@ German.UninstallOldVersionPrompt=Es scheint eine vorige Version von Rubberduck, 
 German.UninstallOldVersionFail=Konnte vorige Version nicht deinstallieren. Versuchen Sie, diese über die Systemsteuerung zu deinstallieren und starten Sie den Installer erneut.
 German.WarnInstallPerUserOverEveryone=Es scheint eine für alle Benutzer installierte Version von Rubberduck vorzuliegen. Eine installation nur für diesen Benutzer wird Vorrang vor der originalen Installation haben. Trotzdem fortfahren?
 German.ElevationRequestFailMessage=Konnte vorige Version von Rubberduck nicht deinstallieren. Es kann sein, dass Sie diese manuell deinstallieren müssen, bevor Sie die neue Version installieren können.
+German.UseLegacyWorkloadCaption=Initial Configuration
+German.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
+German.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
+German.UseLegacyWorkloadButtonCaption=Use legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Includes/Spanish.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/Spanish.CustomMessages.iss
@@ -27,3 +27,4 @@ Spanish.UseLegacyWorkloadCaption=Initial Configuration
 Spanish.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
 Spanish.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
 Spanish.UseLegacyWorkloadButtonCaption=Use legacy workload configuration
+Spanish.OverwriteWithLegacyWorkloadButtonCaption=Overwrite Rubberduck settings with legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Includes/Spanish.CustomMessages.iss
+++ b/Rubberduck.Deployment/InnoSetup/Includes/Spanish.CustomMessages.iss
@@ -23,3 +23,7 @@ Spanish.UninstallOldVersionPrompt=Parece que hay una versión anterior de Rubber
 Spanish.UninstallOldVersionFail=No se puede desinstalar la versión anterior de Rubberduck. Inténtelo y desinstálelo a través del panel de control de Programas y vuelva a ejecutar el instalador.
 Spanish.WarnInstallPerUserOverEveryone=Parece que hay una versión de Rubberduck instalada para todos los usuarios. Si continúa con la instalación por usuario, tendrá prioridad sobre la instalación original. ¿Procede de todas maneras?
 Spanish.ElevationRequestFailMessage=No se puede desinstalar la versión anterior de Rubberduck. Es posible que deba desinstalarlo directamente antes de poder instalar la nueva versión.
+Spanish.UseLegacyWorkloadCaption=Initial Configuration
+Spanish.UseLegacyWorkloadMessage=Planning to use Rubberduck with a large existing project?
+Spanish.UseLegacyWorkloadDescription=Using 'legacy workload' default initial configuration disables autocompletion features and a number of specific inspections to help performance and reduce memory pressure. Disabled features can be re-enabled any time from the Settings menu.
+Spanish.UseLegacyWorkloadButtonCaption=Use legacy workload configuration

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -918,9 +918,16 @@ begin
         ExpandConstant('{cm:UseLegacyWorkloadDescription}'),
         false, false);
 
-  WorkloadOptionPage.Add(ExpandConstant('{cm:UseLegacyWorkloadButtonCaption}'))    
+  if IsUpgradeApp() = NoneIsInstalled then
+  begin
+      WorkloadOptionPage.Add(ExpandConstant('{cm:UseLegacyWorkloadButtonCaption}'))    
+  end
+    else
+  begin
+      WorkloadOptionPage.Add(ExpandConstant('{cm:OverwriteWithLegacyWorkloadButtonCaption}'))    
+  end;
+  
   WorkloadOptionPage.Values[0] := false;
-
 
 
 end;

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -105,7 +105,7 @@ Source: "{#IncludesDir}Rubberduck.RegisterAddIn.bat"; DestDir: "{app}"; Flags: i
 Source: "{#IncludesDir}Rubberduck.RegisterAddIn.reg"; DestDir: "{app}"; Flags: ignoreversion replacesameversion;
 
 ; 'LegacyWorkload' initial configuration (disables autocompletion and inspections that could spawn too many results in legacy code)
-Source: "{SourcePath}\WorkloadConfigs\Legacy\rubberduck.config"; DestDir: "{userappdata}\{#AppName}"; Check: UseLegacyWorkloadConfig;
+Source: "{#SourcePath}\WorkloadConfigs\Legacy\rubberduck.config"; DestDir: "{userappdata}\{#AppName}"; Check: UseLegacyWorkloadConfig;
 
 [Registry]
 ; DO NOT attempt to register VBE Add-In with this section. It doesn't work

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -539,7 +539,7 @@ end;
 
 function CheckUseLegacyWorkloadConfig():boolean;
 begin
-  if UseLegacyWorkloadConfig then
+  if WorkloadOptionPage.Values[0] then
     result := true
   else
     result := false;

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -540,7 +540,7 @@ end;
 function CheckUseLegacyWorkloadConfig():boolean;
 begin
   if UseLegacyWorkloadConfig then
-    result := true;
+    result := true
   else
     result := false;
 end;

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -539,7 +539,7 @@ end;
 
 function CheckUseLegacyWorkloadConfig():boolean;
 begin
-  if WorkloadOptionPage.Values[0] then
+  if UseLegacyWorkloadConfig then
     result := true
   else
     result := false;
@@ -1112,12 +1112,14 @@ begin
   end
     else if CurPageID = WorkloadOptionPage.ID then
   begin
-    Log('Legacy workload initial config was requested and will be copied to the destination folder.');
-  end
-    else
-  begin
-    Log('Skipping legacy workload config because the option was left unchecked.');
-  end;
+    if WorkloadOptionPage.Values[0] then
+    begin
+      Log('Legacy workload initial config was requested and will be copied to the destination folder.');
+    end
+      else
+    begin
+      Log('Skipping legacy workload config because the option was left unchecked.');
+    end;
   ;
 
   // Re-enable the button disabled at start of procedure

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -105,7 +105,7 @@ Source: "{#IncludesDir}Rubberduck.RegisterAddIn.bat"; DestDir: "{app}"; Flags: i
 Source: "{#IncludesDir}Rubberduck.RegisterAddIn.reg"; DestDir: "{app}"; Flags: ignoreversion replacesameversion;
 
 ; 'LegacyWorkload' initial configuration (disables autocompletion and inspections that could spawn too many results in legacy code)
-Source: "\WorkloadConfigs\Legacy\rubberduck.config"; DestDir: "{userappdata}\{#AppName}"; Check: UseLegacyWorkloadConfig;
+Source: "{SourcePath}\WorkloadConfigs\Legacy\rubberduck.config"; DestDir: "{userappdata}\{#AppName}"; Check: UseLegacyWorkloadConfig;
 
 [Registry]
 ; DO NOT attempt to register VBE Add-In with this section. It doesn't work

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -105,7 +105,7 @@ Source: "{#IncludesDir}Rubberduck.RegisterAddIn.bat"; DestDir: "{app}"; Flags: i
 Source: "{#IncludesDir}Rubberduck.RegisterAddIn.reg"; DestDir: "{app}"; Flags: ignoreversion replacesameversion;
 
 ; 'LegacyWorkload' initial configuration (disables autocompletion and inspections that could spawn too many results in legacy code)
-Source: "{#SourcePath}\WorkloadConfigs\Legacy\rubberduck.config"; DestDir: "{userappdata}\{#AppName}"; Check: UseLegacyWorkloadConfig;
+Source: "{#SourcePath}\WorkloadConfigs\Legacy\rubberduck.config"; DestDir: "{userappdata}\{#AppName}"; Flags: ignoreversion replacesameversion; Check: CheckUseLegacyWorkloadConfig;
 
 [Registry]
 ; DO NOT attempt to register VBE Add-In with this section. It doesn't work
@@ -535,6 +535,14 @@ begin
     result := IsElevated()
   else
     result := true;
+end;
+
+function CheckUseLegacyWorkloadConfig():boolean;
+begin
+  if UseLegacyWorkloadConfig then
+    result := true;
+  else
+    result := false;
 end;
 
 ///<remarks>

--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -1120,7 +1120,7 @@ begin
     begin
       Log('Skipping legacy workload config because the option was left unchecked.');
     end;
-  ;
+  end;
 
   // Re-enable the button disabled at start of procedure
   Wizardform.NextButton.Enabled := True;

--- a/Rubberduck.Deployment/InnoSetup/WorkloadConfigs/Legacy/rubberduck.config
+++ b/Rubberduck.Deployment/InnoSetup/WorkloadConfigs/Legacy/rubberduck.config
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <GeneralSettings>
+    <Language Code="en-US" />
+    <CanShowSplash>true</CanShowSplash>
+    <CanCheckVersion>true</CanCheckVersion>
+    <IncludePreRelease>false</IncludePreRelease>
+    <CompileBeforeParse>true</CompileBeforeParse>
+    <IsSmartIndenterPrompted>false</IsSmartIndenterPrompted>
+    <IsAutoSaveEnabled>false</IsAutoSaveEnabled>
+    <AutoSavePeriod>10</AutoSavePeriod>
+    <UserEditedLogLevel>false</UserEditedLogLevel>
+    <MinimumLogLevel>0</MinimumLogLevel>
+    <SetDpiUnaware>false</SetDpiUnaware>
+    <EnableFolderDragAndDrop>true</EnableFolderDragAndDrop>
+    <EnableExperimentalFeatures />
+  </GeneralSettings>
+  <HotkeySettings>
+    <Settings>
+      <HotkeySetting>
+        <Key1>M</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>false</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>IndentCurrentModuleCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>R</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>true</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>CodePaneRefactorRenameCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>F</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>true</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>RefactorEncapsulateFieldCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>M</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>true</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>RefactorExtractMethodCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>C</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>true</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>RefactorMoveCloserToUsageCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>R</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>false</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>CodeExplorerCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>E</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>true</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>ExportAllCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>T</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>false</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>FindSymbolCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>P</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>false</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>IndentCurrentProcedureCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>I</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>true</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>InspectionResultsCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>`</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>false</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>ReparseCommand</CommandTypeName>
+      </HotkeySetting>
+      <HotkeySetting>
+        <Key1>T</Key1>
+        <IsEnabled>true</IsEnabled>
+        <HasShiftModifier>true</HasShiftModifier>
+        <HasAltModifier>false</HasAltModifier>
+        <HasCtrlModifier>true</HasCtrlModifier>
+        <CommandTypeName>TestExplorerCommand</CommandTypeName>
+      </HotkeySetting>
+    </Settings>
+  </HotkeySettings>
+  <AutoCompleteSettings IsEnabled="false">
+    <SmartConcat IsEnabled="true">
+      <ConcatVbNewLineModifier>CtrlKey</ConcatVbNewLineModifier>
+      <ConcatMaxLines>25</ConcatMaxLines>
+    </SmartConcat>
+    <SelfClosingPairs IsEnabled="true" />
+    <BlockCompletion IsEnabled="false" CompleteOnEnter="false" CompleteOnTab="false" />
+  </AutoCompleteSettings>
+  <ToDoListSettings>
+    <ToDoMarkers>
+      <ToDoMarker Text="TODO" />
+      <ToDoMarker Text="NOTE" />
+      <ToDoMarker Text="BUG" />
+    </ToDoMarkers>
+    <ColumnHeadersInformation>
+      <ToDoGridViewColumnInfo>
+        <DisplayIndex>0</DisplayIndex>
+        <Width />
+      </ToDoGridViewColumnInfo>
+      <ToDoGridViewColumnInfo>
+        <DisplayIndex>1</DisplayIndex>
+        <Width />
+      </ToDoGridViewColumnInfo>
+      <ToDoGridViewColumnInfo>
+        <DisplayIndex>2</DisplayIndex>
+        <Width />
+      </ToDoGridViewColumnInfo>
+      <ToDoGridViewColumnInfo>
+        <DisplayIndex>3</DisplayIndex>
+        <Width />
+      </ToDoGridViewColumnInfo>
+    </ColumnHeadersInformation>
+  </ToDoListSettings>
+  <CodeInspectionSettings>
+    <CodeInspections>
+      <CodeInspection Name="EmptyStringLiteralInspection" Severity="DoNotShow" InspectionType="LanguageOpportunities" />
+      <CodeInspection Name="ImplicitPublicMemberInspection" Severity="DoNotShow" InspectionType="LanguageOpportunities" />
+      <CodeInspection Name="ObsoleteCallStatementInspection" Severity="DoNotShow" InspectionType="LanguageOpportunities" />
+      <CodeInspection Name="MultipleDeclarationsInspection" Severity="DoNotShow" InspectionType="MaintainabilityAndReadabilityIssues" />
+      <CodeInspection Name="ParameterCanBeByValInspection" Severity="DoNotShow" InspectionType="MaintainabilityAndReadabilityIssues" />
+      <CodeInspection Name="UseMeaningfulNameInspection" Severity="DoNotShow" InspectionType="MaintainabilityAndReadabilityIssues" />
+      <CodeInspection Name="HungarianNotationInspection" Severity="DoNotShow" InspectionType="MaintainabilityAndReadabilityIssues" />
+      <CodeInspection Name="UnreachableCaseInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="ImplicitByRefModifierInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="ImplicitDefaultMemberAccessInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="ImplicitRecursiveDefaultMemberAccessInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="IndexedDefaultMemberAccessInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="RedundantByRefModifierInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="ShadowedDeclarationInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="UseOfBangNotationInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+      <CodeInspection Name="UseOfRecursiveBangNotationInspection" Severity="DoNotShow" InspectionType="CodeQualityIssues" />
+    </CodeInspections>
+    <WhitelistedIdentifiers />
+    <RunInspectionsOnSuccessfulParse>true</RunInspectionsOnSuccessfulParse>
+  </CodeInspectionSettings>
+  <UnitTestSettings>
+    <BindingMode>DualBinding</BindingMode>
+    <AssertMode>StrictAssert</AssertMode>
+    <ModuleInit>false</ModuleInit>
+    <MethodInit>false</MethodInit>
+    <DefaultTestStubInNewModule>false</DefaultTestStubInNewModule>
+  </UnitTestSettings>
+  <IndenterSettings>
+    <IndentEntireProcedureBody>true</IndentEntireProcedureBody>
+    <IndentEnumTypeAsProcedure>false</IndentEnumTypeAsProcedure>
+    <IndentFirstCommentBlock>true</IndentFirstCommentBlock>
+    <IndentFirstDeclarationBlock>true</IndentFirstDeclarationBlock>
+    <IgnoreEmptyLinesInFirstBlocks>false</IgnoreEmptyLinesInFirstBlocks>
+    <AlignCommentsWithCode>true</AlignCommentsWithCode>
+    <AlignContinuations>true</AlignContinuations>
+    <IgnoreOperatorsInContinuations>true</IgnoreOperatorsInContinuations>
+    <IndentCase>false</IndentCase>
+    <ForceDebugStatementsInColumn1>false</ForceDebugStatementsInColumn1>
+    <ForceDebugPrintInColumn1>false</ForceDebugPrintInColumn1>
+    <ForceDebugAssertInColumn1>false</ForceDebugAssertInColumn1>
+    <ForceStopInColumn1>false</ForceStopInColumn1>
+    <ForceCompilerDirectivesInColumn1>false</ForceCompilerDirectivesInColumn1>
+    <IndentCompilerDirectives>true</IndentCompilerDirectives>
+    <AlignDims>false</AlignDims>
+    <AlignDimColumn>15</AlignDimColumn>
+    <EndOfLineCommentStyle>AlignInColumn</EndOfLineCommentStyle>
+    <EmptyLineHandlingMethod>Ignore</EmptyLineHandlingMethod>
+    <EndOfLineCommentColumnSpaceAlignment>50</EndOfLineCommentColumnSpaceAlignment>
+    <IndentSpaces>4</IndentSpaces>
+    <VerticallySpaceProcedures>true</VerticallySpaceProcedures>
+    <LinesBetweenProcedures>1</LinesBetweenProcedures>
+    <GroupRelatedProperties>false</GroupRelatedProperties>
+  </IndenterSettings>
+  <WindowSettings>
+    <CodeExplorerVisibleOnStartup>false</CodeExplorerVisibleOnStartup>
+    <CodeInspectionsVisibleOnStartup>false</CodeInspectionsVisibleOnStartup>
+    <TestExplorerVisibleOnStartup>false</TestExplorerVisibleOnStartup>
+    <TodoExplorerVisibleOnStartup>false</TodoExplorerVisibleOnStartup>
+    <CodeExplorer_SortByName>true</CodeExplorer_SortByName>
+    <CodeExplorer_SortByCodeOrder>false</CodeExplorer_SortByCodeOrder>
+    <CodeExplorer_GroupByType>false</CodeExplorer_GroupByType>
+  </WindowSettings>
+  <IgnoredProjectsSettings>
+    <IgnoredProjectPaths />
+  </IgnoredProjectsSettings>
+</Configuration>

--- a/Rubberduck.Deployment/InnoSetup/WorkloadConfigs/README.md
+++ b/Rubberduck.Deployment/InnoSetup/WorkloadConfigs/README.md
@@ -1,0 +1,34 @@
+﻿## Workload Configurations
+
+Workload configurations copy a `rubberduck.config` file under `%appdata%\Rubberduck` (under the current user's profile) where Rubberduck reads and writes its configuration settings.
+
+If no workload option is specified on install, Rubberduck uses its default configuration and only writes a `rubberduck.config` file if the user changes the settings.
+
+---
+
+### Legacy
+
+This workload aims to improve overall user experience by disabling features that can deteriorate performance in large "legacy" projects that generate lots of inspection results.
+
+**Affected Settings**
+
+- `AutoCompleteSettings` has its `IsEnabled` attribute set to `false`, in order to remove any in-editor interferences.
+- The following inspections have their `Severity` set to `DoNotShow`:
+  - EmptyStringLiteral
+  - ObsoleteCallStatement
+  - MultipleDeclarations
+  - ParameterCanBeByVal
+  - UseMeaningfulName
+  - HungarianNotation
+  - UnreachableCase
+  - ImplicitPublicMember
+  - ImplicitByRefModifier
+  - ImplicitDefaultMemberAccess
+  - ImplicitRecursiveDefaultMemberAccess
+  - IndexedDefaultMemberAccess
+  - RedundantByRefModifier
+  - ShadowedDeclaration
+  - UseOfBangNotation
+  - UseOfRecursiveBangNotation
+
+Disabled inspections can be re-enabled individually from the *Settings* dialog.


### PR DESCRIPTION
Adds a new wizard page to the installer with a checkbox to optionally seed `%appdata%\Rubberduck\rubberduck.config` with a default configuration file that disables a number of features and inspections, documented in a readme.md file.

![new installer wizard page](https://user-images.githubusercontent.com/5751684/115941420-4aea5e80-a473-11eb-8389-7087d1a058b2.png)
