### PR TITLE
Introduce type information iterator + visitor

### DIFF
--- a/Rubberduck.Com/Extensions/ExtensionHelper.cs
+++ b/Rubberduck.Com/Extensions/ExtensionHelper.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Rubberduck.Com.Extensions
+{
+    /// <summary>
+    /// Type API specific extensions for managing memory allocated by calls to Get*** which must be
+    /// followed by a corresponding Release ***. This is used by other extensions classes:
+    /// <see cref="TypeLibExtensions"/>
+    /// <see cref="TypeInfoExtensions"/>
+    /// </summary>
+    internal static class ExtensionHelper
+    {
+        internal static void UsingPtrToStructure<T>(Func<IntPtr, IntPtr> acquireBlock, Action<T> usingBlock, Action<IntPtr> releaseBlock)
+        {
+            var ptr = IntPtr.Zero;
+            try
+            {
+                ptr = acquireBlock.Invoke(ptr);
+                T t = default;
+                if (ptr != IntPtr.Zero)
+                {
+                    t = Marshal.PtrToStructure<T>(ptr);
+                }
+                usingBlock.Invoke(t);
+            }
+            finally
+            {
+                if (ptr != IntPtr.Zero)
+                {
+                    releaseBlock.Invoke(ptr);
+                }
+            }
+        }
+    }
+}

--- a/Rubberduck.Com/Extensions/TypeInfoExtensions.cs
+++ b/Rubberduck.Com/Extensions/TypeInfoExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Rubberduck.Com.Extensions
+{
+    public static class TypeInfoExtensions
+    {
+        public static void UsingTypeAttr(this ITypeInfo typeInfo, Action<TYPEATTR> action)
+        {
+            ExtensionHelper.UsingPtrToStructure(ptr => { typeInfo.GetTypeAttr(out ptr); return ptr; }, action, typeInfo.ReleaseTypeAttr);
+        }
+
+        public static void UsingVarDesc(this ITypeInfo typeInfo, int index, Action<VARDESC> action)
+        {
+            ExtensionHelper.UsingPtrToStructure(ptr => { typeInfo.GetVarDesc(index, out ptr); return ptr; }, action, typeInfo.ReleaseVarDesc);
+        }
+
+        public static void UsingFuncDesc(this ITypeInfo typeInfo, int index, Action<FUNCDESC> action)
+        {
+            ExtensionHelper.UsingPtrToStructure(ptr => { typeInfo.GetFuncDesc(index, out ptr); return ptr; }, action, typeInfo.ReleaseFuncDesc);
+        }
+    }
+}

--- a/Rubberduck.Com/Extensions/TypeLibExtensions.cs
+++ b/Rubberduck.Com/Extensions/TypeLibExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Rubberduck.Com.Extensions
+{
+    public static class TypeLibExtensions
+    {
+        public static void UsingLibAttr(this ITypeLib typeLib, Action<TYPELIBATTR> action)
+        {
+            ExtensionHelper.UsingPtrToStructure(ptr => { typeLib.GetLibAttr(out ptr); return ptr; }, action, typeLib.ReleaseTLibAttr);
+        }
+    }
+}

--- a/Rubberduck.Com/FuncDescData.cs
+++ b/Rubberduck.Com/FuncDescData.cs
@@ -1,0 +1,43 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public readonly struct FuncDescData
+    {
+        public int Index { get; }
+        public string Name { get; }
+        public string DocString { get; }
+        public int HelpContext { get; }
+        public string HelpFile { get; }
+        public FUNCDESC FuncDesc { get; }
+        public IEnumerable<ParamDescData> Parameters { get; }
+
+        public FuncDescData(int index, string name, string docString, int helpContext, string helpFile, FUNCDESC funcDesc, IEnumerable<ParamDescData> parameters)
+        {
+            Index = index;
+            Name = name;
+            DocString = docString;
+            HelpContext = helpContext;
+            HelpFile = helpFile;
+            FuncDesc = funcDesc;
+            Parameters = parameters;
+        }
+    }
+}

--- a/Rubberduck.Com/ITypeInfoVisitor.cs
+++ b/Rubberduck.Com/ITypeInfoVisitor.cs
@@ -1,0 +1,37 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public interface ITypeInfoVisitor
+    {
+        void VisitTypeDocumentation(string typeName, string docString, int helpContext, string helpFile);
+        void VisitTypeDocumentation2(string helpString, int helpStringcontext, string helpStringdll);
+        void VisitTypeAttr(TYPEATTR attr);
+        void VisitTypeCustData(Guid guid, object value);
+        VisitDirectives VisitTypeImplementedTypeInfo(int href, ITypeInfo implementedTypeInfo);
+        void VisitTypeImplTypeCustData(Guid guid, object value);
+        void VisitTypeVarDesc(VarDescData varDescData);
+        void VisitTypeVarCustData(Guid guid, object value);
+        void VisitTypeFuncDesc(FuncDescData funcDescData);
+        VisitDirectives VisitTypeFuncParameter(ParamDescData paramDescData);
+        void VisitTypeFuncCustData(Guid guid, object value);
+        IEnumerable<ITypeLibVisitor> ProvideTypeLibVisitors();
+    }
+}

--- a/Rubberduck.Com/ITypeLibVisitor.cs
+++ b/Rubberduck.Com/ITypeLibVisitor.cs
@@ -1,0 +1,30 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public interface ITypeLibVisitor
+    {
+        void VisitLibDocumentation(string libName, string docString, int helpContext, string helpFile, int typeInfosCount);
+        void VisitLibDocumentation2(string helpString, int helpStringcontext, string helpStringdll);
+        void VisitLibAttr(TYPELIBATTR attr);
+        void VisitLibCustData(Guid guid, object value);
+        IEnumerable<ITypeInfoVisitor> ProvideTypeInfoVisitors();
+    }
+}

--- a/Rubberduck.Com/ParamDescData.cs
+++ b/Rubberduck.Com/ParamDescData.cs
@@ -1,0 +1,53 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public readonly struct ParamDescData
+    {
+        public int Index { get; }
+        public string Name { get; }
+        public ELEMDESC ElemDesc { get; }
+        public bool IsArray { get; }
+        public bool IsReferencedType { get; }
+        public bool IsParamArray { get; }
+        public bool IsOptional { get; }
+        public VarEnum VarEnum { get; }
+        public object DefaultValue { get; }
+        public ITypeInfo ReferencedTypeInfo { get; }
+        public COMException ReferencedTypeInfoException { get; }
+        public IDictionary<Guid, object> CustomData { get; }
+
+        public ParamDescData(int index, string name, ELEMDESC elemDesc, bool isArray, bool isReferencedType, bool isParamArray, bool isOptional, VarEnum varEnum, object defaultValue, ITypeInfo referencedTypeInfo, COMException referencedTypeInfoException, IDictionary<Guid, object> customData)
+        {
+            Index = index;
+            Name = name;
+            ElemDesc = elemDesc;
+            IsArray = isArray;
+            IsReferencedType = isReferencedType;
+            IsParamArray = isParamArray;
+            IsOptional = isOptional;
+            VarEnum = varEnum;
+            DefaultValue = defaultValue;
+            ReferencedTypeInfo = referencedTypeInfo;
+            ReferencedTypeInfoException = referencedTypeInfoException;
+            CustomData = customData;
+        }
+    }
+}

--- a/Rubberduck.Com/Rubberduck.Com.csproj
+++ b/Rubberduck.Com/Rubberduck.Com.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Product>Rubberduck.Com</Product>
+    <Description>This assembly provide reflecting and reasoning about COM types.</Description>
+    <Copyright>Copyright © 2015-2021</Copyright>
+    <AssemblyName>Rubberduck.Com</AssemblyName>
+    <Title>Rubberduck.Com</Title>
+    <RootNamespace>Rubberduck.Com</RootNamespace>
+    <ProjectGuid>{E7521588-0C7A-4627-B6E6-CC431B1DE963}</ProjectGuid>
+    <UnifyOutputPath>true</UnifyOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DocumentationFile>Rubberduck.Com.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <WarningLevel>1</WarningLevel>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
+    <NoWarn>1701;1702;1591;4011;1001;7035;1053</NoWarn>
+  </PropertyGroup>
+  <Import Project="..\RubberduckBaseProject.csproj" />
+  <PropertyGroup>
+    <Antlr4UseCSharpGenerator>True</Antlr4UseCSharpGenerator>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Rubberduck.VBEEditor\Rubberduck.VBEditor.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NLog">
+      <Version>4.5.10</Version>
+    </PackageReference>
+    <PackageReference Include="NLog.Schema">
+      <Version>4.5.10</Version>
+    </PackageReference>
+    <PackageReference Include="Vanara.PInvoke.Ole" Version="3.3.8" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+</Project>

--- a/Rubberduck.Com/Rubberduck.Com.xml
+++ b/Rubberduck.Com/Rubberduck.Com.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Rubberduck.Com</name>
+    </assembly>
+    <members>
+        <member name="T:Rubberduck.Com.Extensions.ExtensionHelper">
+            <summary>
+            Type API specific extensions for managing memory allocated by calls to Get*** which must be
+            followed by a corresponding Release ***. This is used by other extensions classes:
+            <see cref="T:Rubberduck.Com.Extensions.TypeLibExtensions"/>
+            <see cref="T:Rubberduck.Com.Extensions.TypeInfoExtensions"/>
+            </summary>
+        </member>
+        <member name="T:Rubberduck.Com.WellKnown">
+            <summary>
+            There are several constants that are used within the type library APIs; this class helps
+            encapsulates different constants for easy discovery. Each group of related constants should
+            be in a nested class to allow us to use syntax like <see cref="F:Rubberduck.Com.WellKnown.Iids.IID_DISPATCH"/>
+            to make it easier to locate the constant when programming against the API. 
+            </summary>
+        </member>
+        <member name="T:Rubberduck.Com.WellKnown.DispIds">
+            <summary>
+            MS-OAUT Section 2.2.32.1
+            https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oaut/cb9d0131-c6bd-463d-9c40-7264856a10c5
+            Also see:
+            https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/dispid-constants
+            The lower DISPIDs constants are not used by all clients. For example, the <see cref="F:Rubberduck.Com.WellKnown.DispIds.DISPID_CONSTRUCTOR"/> 
+            and <see cref="F:Rubberduck.Com.WellKnown.DispIds.DISPID_DESTRUCTOR"/> are used as part of DCOM but not normally within Automation. 
+            </summary>
+        </member>
+        <member name="T:Rubberduck.Com.WellKnown.MemberIds">
+            <summary>
+            MS-OAUT Section 2.2.35.1
+            https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oaut/5fbb4851-25f6-45ef-9f83-e9dd633e1e00
+            </summary>
+        </member>
+        <member name="T:Rubberduck.Com.WellKnown.ImplIndexes">
+            <summary>
+            Used with <see cref="!:ICreateTypeInfo.AddImplType(uint, uint)"/>'s first parameter, based on the 
+            documentation referred here:
+            https://docs.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-icreatetypeinfo-addimpltype
+            </summary>
+        </member>
+        <member name="F:Rubberduck.Com.WellKnown.ImplIndexes.DualUnknown">
+            <summary>
+            The implementation must be a IUnknown-derived interface for use in a dual implementation
+            </summary>
+        </member>
+        <member name="F:Rubberduck.Com.WellKnown.ImplIndexes.BaseInterface">
+            <summary>
+            The base interface for which the current <see cref="!:ICreateTypeInfo"/> derives from. Normally, 
+            this is either the <code>IUnknown</code> or <code>IDispatch"</code> interface. It may derive
+            from another interface as long the root is one of either. The referenced <see cref="!:ITypeInfo"/>
+            must be of <see cref="!:TYPEKIND.TKIND_INTERFACE"/>.
+            </summary>
+        </member>
+        <member name="F:Rubberduck.Com.WellKnown.ImplIndexes.DispatchInterface">
+            <summary>
+            The IUnknown implementation of the interface for which the dispatch interface must be
+            based on. 
+            </summary>
+        </member>
+    </members>
+</doc>

--- a/Rubberduck.Com/TypeApiWalker.cs
+++ b/Rubberduck.Com/TypeApiWalker.cs
@@ -1,0 +1,60 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public abstract class TypeApiWalker<T>
+    {
+        protected IEnumerable<T> Visitors;
+        
+        protected void ExecuteVisit(Action<T> action)
+        {
+            foreach (var visitor in Visitors)
+            {
+                action.Invoke(visitor);
+            }
+        }
+
+        protected void EnumerateCustomData(Action<IntPtr> getAllCustData, Action<Guid, object> enumerationAction)
+        {
+            var ptrCustData = IntPtr.Zero;
+            getAllCustData.Invoke(ptrCustData);
+
+            if(ptrCustData == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var custData = Marshal.PtrToStructure<CUSTDATA>(ptrCustData);
+            var offset = Marshal.SizeOf(custData.cCustData);
+            var ptrSize = Marshal.SizeOf(typeof(IntPtr));
+
+            for (var i = 0; i < custData.cCustData; i++)
+            {
+                var ptrCustDataItem = ptrCustData + offset + (i * ptrSize);
+                var guid = Marshal.PtrToStructure<Guid>(ptrCustDataItem);
+                var ptrValue = ptrCustDataItem + Marshal.SizeOf(typeof(Guid));
+                var value = Marshal.GetObjectForNativeVariant(ptrValue);
+
+                enumerationAction.Invoke(guid, value);
+            }
+            ClearCustData(ref custData);
+        }
+    }
+}

--- a/Rubberduck.Com/TypeInfoWalker.cs
+++ b/Rubberduck.Com/TypeInfoWalker.cs
@@ -1,0 +1,360 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public class TypeInfoWalker : TypeApiWalker<ITypeInfoVisitor>
+    {
+        private readonly ITypeLib _typeLib;
+        private readonly ITypeLib2 _typeLib2;
+        private readonly ITypeInfo _typeInfo;
+        private readonly ITypeInfo2 _typeInfo2;
+        private readonly int _index;
+
+        private TypeInfoWalker(ITypeLib typeLib, int index, ITypeInfo typeInfo, IEnumerable<ITypeInfoVisitor> visitors)
+        {
+            _typeLib = typeLib;
+            _typeLib2 = typeLib as ITypeLib2;
+            _index = index;
+            _typeInfo = typeInfo;
+            _typeInfo2 = typeInfo as ITypeInfo2;
+            Visitors = visitors;
+        }
+
+        public static void Accept(ITypeLib typeLib, int index, ITypeInfo typeInfo, ITypeInfoVisitor visitor) => Accept(typeLib, index, typeInfo, new[] { visitor });
+
+        public static void Accept(ITypeLib typeLib, int index, ITypeInfo typeInfo, IEnumerable<ITypeInfoVisitor> visitors)
+        {
+            var walker = new TypeInfoWalker(typeLib, index, typeInfo, visitors);
+            walker.WalkTypeInfo();
+        }
+
+        private void WalkTypeInfo()
+        {
+            var cImplTypes = 0;
+            var cVars = 0;
+            var cFuncs = 0;
+
+            _typeLib.GetDocumentation(_index, out var name, out var docString, out var helpContext, out var helpFile);
+            ExecuteVisit(v => v.VisitTypeDocumentation(name, docString, helpContext, helpFile));
+
+            _typeInfo.UsingTypeAttr(attr => {
+                cImplTypes = attr.cImplTypes;
+                cVars = attr.cVars;
+                cFuncs = attr.cFuncs;
+
+                ExecuteVisit(v => v.VisitTypeAttr(attr));
+            });
+
+            if (_typeLib2 != null)
+            {
+                _typeLib2.GetDocumentation2(_index, out var helpString, out var helpStringContext, out var helpStringDll);
+                ExecuteVisit(v => v.VisitTypeDocumentation2(helpString, helpStringContext, helpStringDll));
+            }
+
+            if (_typeInfo2 != null)
+            {
+                EnumerateCustomData(
+                    _typeInfo2.GetAllCustData,
+                    (guid, value) => ExecuteVisit(v => v.VisitTypeCustData(guid, value)));
+            }
+
+            EnumerateImplementedTypes(cImplTypes);
+            EnumerateVariables(cVars);
+            EnumerateFunctions(cFuncs);
+        }
+
+        private void EnumerateImplementedTypes(int cImplTypes)
+        {
+            for (var i = 0; i < cImplTypes; i++)
+            {
+                _typeInfo.GetRefTypeOfImplType(i, out var href);
+                _typeInfo.GetRefTypeInfo(href, out var implementedTypeInfo);
+
+                var implementedLibraryVisitors = new List<ITypeLibVisitor>();
+                var implementedTypeVisitors = new List<ITypeInfoVisitor>();
+                ExecuteVisit(v =>
+                {
+                    var result = v.VisitTypeImplementedTypeInfo(href, implementedTypeInfo);
+                    switch (result)
+                    {
+                        case VisitDirectives.VisitLibrary:
+                            implementedLibraryVisitors.AddRange(v.ProvideTypeLibVisitors().Where(x => !implementedLibraryVisitors.Contains(x)));
+                            break;
+                        case VisitDirectives.VisitType:
+                            implementedTypeVisitors.Add(v);
+                            break;
+                    }
+                });
+                implementedTypeInfo.GetContainingTypeLib(out var implementedTypeLib, out var implementedIndex);
+                if (implementedLibraryVisitors.Any())
+                {
+                    TypeLibWalker.Accept(implementedTypeLib, implementedLibraryVisitors);
+                }
+                if (implementedTypeVisitors.Any())
+                {
+                    Accept(implementedTypeLib, implementedIndex, implementedTypeInfo, implementedTypeVisitors);
+                }
+
+                if (_typeInfo2 != null)
+                {
+                    EnumerateCustomData(
+                        ptr => _typeInfo2.GetAllImplTypeCustData(i, ptr),
+                        (g, o) => ExecuteVisit(
+                            v => v.VisitTypeImplTypeCustData(g, o)));
+                }
+            }
+        }
+
+        private void EnumerateVariables(int cVars)
+        {
+            var names = new string[1];
+            for (var i = 0; i < cVars; i++)
+            {
+                _typeInfo.UsingVarDesc(i, varDesc =>
+                {
+                    _typeInfo.GetNames(varDesc.memid, names, 1, out var count);
+                    object value = null;
+                    if (varDesc.varkind == VARKIND.VAR_CONST && varDesc.desc.lpvarValue != IntPtr.Zero)
+                    {
+                        value = Marshal.GetObjectForNativeVariant(varDesc.desc.lpvarValue);
+                    }
+
+                    var internalType = GetTypeDesc(varDesc.elemdescVar.tdesc, _typeInfo);
+                    var type = new VarDescData(names[0], varDesc, internalType, value);
+                    ExecuteVisit(v => v.VisitTypeVarDesc(type));
+
+                    if (_typeInfo2 != null)
+                    {
+                        EnumerateCustomData(
+                            ptr => _typeInfo2.GetAllVarCustData(i, ptr),
+                            (g, o) => ExecuteVisit(
+                                v => v.VisitTypeVarCustData(g, o)));
+                    }
+                });
+            }
+        }
+
+        private VarDescDataInternal GetTypeDesc(TYPEDESC typeDesc, ITypeInfo typeInfo)
+        {
+            var vt = (VarEnum)typeDesc.vt;
+            TYPEDESC tdesc;
+
+            if (vt == VarEnum.VT_PTR)
+            {
+                tdesc = Marshal.PtrToStructure<TYPEDESC>(typeDesc.lpValue);
+                var result = GetTypeDesc(tdesc, typeInfo);
+                result.IsReferencedType = true;
+                return result;
+            }
+            else if (vt == VarEnum.VT_USERDEFINED)
+            {
+                int href;
+                unchecked
+                {
+                    //The href is a long, but the size of lpValue depends on the platform, so truncate it after the lword.
+                    href = (int)(typeDesc.lpValue.ToInt64() & 0xFFFFFFFF);
+                }
+                typeInfo.GetRefTypeInfo(href, out ITypeInfo refTypeInfo);
+                var varDescType = new VarDescDataInternal();
+                refTypeInfo.UsingTypeAttr(attr =>
+                {
+                    varDescType.IsReferencedType = ReferenceTypeKinds.Contains(attr.typekind);
+                    varDescType.ReferencedTypeInfo = refTypeInfo;
+                });
+                return varDescType;
+            }
+            else if (vt == VarEnum.VT_SAFEARRAY || vt == VarEnum.VT_CARRAY || vt.HasFlag(VarEnum.VT_ARRAY))
+            {
+                tdesc = Marshal.PtrToStructure<TYPEDESC>(typeDesc.lpValue);
+                var result = GetTypeDesc(tdesc, typeInfo);
+                result.IsArray = true;
+                return result;
+            }
+
+            return new VarDescDataInternal { VarEnum = vt };
+        }
+
+        private void EnumerateFunctions(int cFuncs)
+        {
+            for (var i = 0; i < cFuncs; i++)
+            {
+                _typeInfo.UsingFuncDesc(i, funcDesc =>
+                {
+                    var parameters = CollectParameters(i, funcDesc, _typeInfo);
+                    _typeLib.GetDocumentation(funcDesc.memid, out var funcName, out var docString, out var helpContext, out var helpFile);
+                    var data = new FuncDescData
+                    (
+                        i,
+                        funcName,
+                        docString,
+                        helpContext,
+                        helpFile,
+                        funcDesc,
+                        parameters
+                    );
+
+                    ExecuteVisit(v => v.VisitTypeFuncDesc(data));
+
+                    if (_typeInfo2 != null)
+                    {
+                        EnumerateCustomData(
+                            ptr => _typeInfo2.GetAllFuncCustData(i, ptr),
+                            (g, o) => ExecuteVisit(v => v.VisitTypeFuncCustData(g, o)));
+                    }
+                });
+            }
+        }
+
+        private IEnumerable<ParamDescData> CollectParameters(int index, FUNCDESC funcDesc, ITypeInfo typeInfo)
+        {
+            var parameters = new List<ParamDescData>();
+            var names = new string[funcDesc.cParams + 1];
+            typeInfo.GetNames(index, names, names.Length, out _);
+
+            for (var i = 0; i < funcDesc.cParams; i++)
+            {
+                var paramPtr = funcDesc.lprgelemdescParam + (Marshal.SizeOf(typeof(ELEMDESC)) * i);
+                var elemDesc = Marshal.PtrToStructure<ELEMDESC>(paramPtr);
+                var (isByRef, isArray, vt, parameterTypeInfo, exception) = GetParameterType(elemDesc.tdesc, typeInfo);
+                var customData = new Dictionary<Guid, object>();
+                var ptrDefaultValue = elemDesc.desc.paramdesc.lpVarValue + Marshal.SizeOf(typeof(ulong));
+                object defaultValue = GetParameterDefaultValue(ptrDefaultValue);
+
+                if (typeInfo is ITypeInfo2 typeInfo2)
+                {
+                    EnumerateCustomData(
+                        ptr => typeInfo2.GetAllParamCustData(index, i, ptr),
+                        (g, v) => customData.Add(g, v));
+                }
+
+                var data = new ParamDescData(
+                    i,
+                    names[i + 1],
+                    elemDesc,
+                    isArray,
+                    isByRef,
+                    (i == funcDesc.cParams && funcDesc.cParamsOpt == -1),
+                    elemDesc.desc.paramdesc.wParamFlags.HasFlag(PARAMFLAG.PARAMFLAG_FOPT),
+                    vt,
+                    defaultValue,
+                    parameterTypeInfo,
+                    exception,
+                    customData
+                );
+
+                var implementedTypeInfo = parameterTypeInfo;
+                var implementedLibraryVisitors = new List<ITypeLibVisitor>();
+                var implementedTypeVisitors = new List<ITypeInfoVisitor>();
+                ExecuteVisit(v =>
+                {
+                    var result = v.VisitTypeFuncParameter(data);
+                    switch (result)
+                    {
+                        case VisitDirectives.VisitLibrary:
+                            implementedLibraryVisitors.AddRange(v.ProvideTypeLibVisitors().Where(x => !implementedLibraryVisitors.Contains(x)));
+                            break;
+                        case VisitDirectives.VisitType:
+                            implementedTypeVisitors.Add(v);
+                            break;
+                    }
+                });
+                implementedTypeInfo.GetContainingTypeLib(out var implementedTypeLib, out var implementedIndex);
+                if (implementedLibraryVisitors.Any())
+                {
+                    TypeLibWalker.Accept(implementedTypeLib, implementedLibraryVisitors);
+                }
+                if (implementedTypeVisitors.Any())
+                {
+                    Accept(implementedTypeLib, implementedIndex, implementedTypeInfo, implementedTypeVisitors);
+                }
+
+                parameters.Add(data);
+            }
+
+            return parameters;
+        }
+
+        private (VarEnum vt, object value) GetParameterDefaultValue(IntPtr variant)
+        {
+            const ushort VT_TYPEMASK = 0xFFF;
+            var members = Marshal.PtrToStructure<VARIANT>(variant);
+            //AFAICT, this should always pass for automation types supported by VB(A). 
+            Debug.Assert(!Convert.ToBoolean(~VT_TYPEMASK & (int)members.vt), "Non value-type will potentially leak a pointer.");
+
+            var vt = (VarEnum)members.vt;
+            var value = Marshal.GetObjectForNativeVariant(variant);
+
+            if (value == null && vt == VarEnum.VT_BSTR)
+            {
+                value = string.Empty;
+            }
+
+            return (vt, value);
+        }
+
+        private (bool isByRef, bool isArray, VarEnum vt, ITypeInfo parameterTypeInfo, COMException exception) GetParameterType(TYPEDESC desc, ITypeInfo info)
+        {
+            var vt = (VarEnum)desc.vt;
+            TYPEDESC tdesc;
+
+            if (vt == VarEnum.VT_PTR)
+            {
+                tdesc = Marshal.PtrToStructure<TYPEDESC>(desc.lpValue);
+                var (_, isArray, byRefvt, parameterTypeInfo, exception) = GetParameterType(tdesc, info);
+                return (true, isArray, byRefvt, parameterTypeInfo, exception);
+            }
+            else if (vt == VarEnum.VT_USERDEFINED)
+            {
+                int href;
+                unchecked
+                {
+                    href = (int)(desc.lpValue.ToInt64() & 0xFFFFFFFF);
+                }
+
+                try
+                {
+                    info.GetRefTypeInfo(href, out var refTypeInfo);
+                    return (true, false, vt, refTypeInfo, null);
+                }
+                catch(COMException ex)
+                {
+                    return (true, false, vt, null, ex);
+                }
+            }
+            else if (vt == VarEnum.VT_SAFEARRAY || vt == VarEnum.VT_CARRAY || vt.HasFlag(VarEnum.VT_ARRAY))
+            {
+                tdesc = Marshal.PtrToStructure<TYPEDESC>(desc.lpValue);
+                var (isByRef, _, arrayVt, arrayTypeInfo, exception) = GetParameterType(tdesc, info);
+                return (isByRef, true, arrayVt, arrayTypeInfo, exception);
+            }
+            else
+            {
+                return (false, false, vt, null, null);
+            }
+        }
+
+        private static readonly HashSet<TYPEKIND> ReferenceTypeKinds = new HashSet<TYPEKIND>
+        {
+            TYPEKIND.TKIND_DISPATCH,
+            TYPEKIND.TKIND_COCLASS,
+            TYPEKIND.TKIND_INTERFACE
+        };
+    }
+}

--- a/Rubberduck.Com/TypeLibWalker.cs
+++ b/Rubberduck.Com/TypeLibWalker.cs
@@ -1,0 +1,68 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public class TypeLibWalker : TypeApiWalker<ITypeLibVisitor>
+    {
+        private readonly ITypeLib _typeLib;
+        private readonly ITypeLib2 _typeLib2;
+
+        private TypeLibWalker(ITypeLib typeLib, IEnumerable<ITypeLibVisitor> visitors)
+        {
+            _typeLib = typeLib;
+            _typeLib2 = typeLib as ITypeLib2;
+            Visitors = visitors;
+        }
+
+        public static void Accept(ITypeLib typeLib, ITypeLibVisitor visitor)
+        {
+            Accept(typeLib, new[] { visitor });
+        }
+
+        public static void Accept(ITypeLib typeLib, IEnumerable<ITypeLibVisitor> visitors)
+        {
+            var walker = new TypeLibWalker(typeLib, visitors);
+            walker.WalkTypeLib();
+        }
+
+        private void WalkTypeLib()
+        {
+            _typeLib.GetDocumentation(WellKnown.MemberIds.MEMBERID_NIL, out var libName, out var docString, out var helpContext, out var helpFile);
+            ExecuteVisit(v => v.VisitLibDocumentation(libName, docString, helpContext, helpFile, _typeLib.GetTypeInfoCount()));
+
+            _typeLib.UsingLibAttr(attr => ExecuteVisit(v => v.VisitLibAttr(attr)));
+
+            if (_typeLib2 != null)
+            {
+                _typeLib2.GetDocumentation2(WellKnown.MemberIds.MEMBERID_NIL, out var helpString, out var helpStringContext, out var helpStringdll);
+                ExecuteVisit(v => v.VisitLibDocumentation2(helpString, helpStringContext, helpStringdll));
+                EnumerateCustomData(
+                    _typeLib2.GetAllCustData,
+                    (guid, value) => ExecuteVisit(v => v.VisitLibCustData(guid, value)));
+            }
+
+            for (var i = 0; i < _typeLib.GetTypeInfoCount(); i++)
+            {
+                _typeLib.GetTypeInfo(i, out var typeInfo);
+                TypeInfoWalker.Accept(_typeLib, i, typeInfo, Visitors.SelectMany(v => v.ProvideTypeInfoVisitors()));
+            }
+        }
+    }
+}

--- a/Rubberduck.Com/VarDescData.cs
+++ b/Rubberduck.Com/VarDescData.cs
@@ -1,0 +1,51 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    internal struct VarDescDataInternal
+    {
+        public bool IsArray { get; set; }
+        public bool IsReferencedType { get; set; }
+        public VarEnum VarEnum { get; set; }
+        public ITypeInfo ReferencedTypeInfo { get; set; }
+    }
+
+    public readonly struct VarDescData
+    {
+        public string Name { get; }
+        public VARDESC VarDesc { get; }
+        public bool IsArray { get; }
+        public bool IsReferencedType { get; }
+        public VarEnum VarEnum { get; }
+        public ITypeInfo ReferencedTypeInfo { get; }
+        public object Value { get; }
+
+        internal VarDescData(string name, VARDESC varDesc, VarDescDataInternal finalDesc, object value)
+        {
+            Name = name;
+            VarDesc = varDesc;
+            IsArray = finalDesc.IsArray;
+            IsReferencedType = finalDesc.IsReferencedType;
+            VarEnum = finalDesc.VarEnum;
+            ReferencedTypeInfo = finalDesc.ReferencedTypeInfo;
+            Value = value;
+        }
+    }
+}

--- a/Rubberduck.Com/VisitDirectives.cs
+++ b/Rubberduck.Com/VisitDirectives.cs
@@ -1,0 +1,28 @@
+﻿using Rubberduck.Com.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using static Vanara.PInvoke.OleAut32;
+using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
+using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
+using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
+using PARAMDESC = System.Runtime.InteropServices.ComTypes.PARAMDESC;
+using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
+using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
+using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
+using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
+using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
+using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
+
+namespace Rubberduck.Com
+{
+    public enum VisitDirectives
+    {
+        SkipVisit = 0,
+        VisitType,
+        VisitLibrary
+    }
+}

--- a/Rubberduck.Com/WellKnown.cs
+++ b/Rubberduck.Com/WellKnown.cs
@@ -1,0 +1,74 @@
+﻿using System;
+
+namespace Rubberduck.Com
+{
+    /// <summary>
+    /// There are several constants that are used within the type library APIs; this class helps
+    /// encapsulates different constants for easy discovery. Each group of related constants should
+    /// be in a nested class to allow us to use syntax like <see cref="Iids.IID_DISPATCH"/>
+    /// to make it easier to locate the constant when programming against the API. 
+    /// </summary>
+    public static class WellKnown
+    {
+        public static class Iids
+        {
+            public static readonly Guid IID_UNKNOWN = new Guid("00000000-0000-0000-C000-000000000046");
+            public static readonly Guid IID_DISPATCH = new Guid("00020400-0000-0000-C000-000000000046");
+        }
+
+        /// <summary>
+        /// MS-OAUT Section 2.2.32.1
+        /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oaut/cb9d0131-c6bd-463d-9c40-7264856a10c5
+        /// Also see:
+        /// https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/dispid-constants
+        /// The lower DISPIDs constants are not used by all clients. For example, the <see cref="DISPID_CONSTRUCTOR"/> 
+        /// and <see cref="DISPID_DESTRUCTOR"/> are used as part of DCOM but not normally within Automation. 
+        /// </summary>
+        public static class DispIds
+        {
+            public const int DISPID_VALUE = 0;
+            public const int DISPID_UNKNOWN = -1;
+            public const int DISPID_PROPERTYPUT = -3;
+            public const int DISPID_NEWENUM = -4;
+            public const int DISPID_EVALUATE = -5;
+            public const int DISPID_CONSTRUCTOR = -6;
+            public const int DISPID_DESTRUCTOR = -7;
+            public const int DISPID_COLLECT = -8;
+        }
+
+        /// <summary>
+        /// MS-OAUT Section 2.2.35.1
+        /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oaut/5fbb4851-25f6-45ef-9f83-e9dd633e1e00
+        /// </summary>
+        public static class MemberIds
+        {
+            public const int MEMBERID_NIL = -1;
+            public const int MEMBERID_DEFAULTINST = -2;
+        }
+
+        /// <summary>
+        /// Used with <see cref="ICreateTypeInfo.AddImplType(uint, uint)"/>'s first parameter, based on the 
+        /// documentation referred here:
+        /// https://docs.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-icreatetypeinfo-addimpltype
+        /// </summary>
+        public static class ImplIndexes
+        {
+            /// <summary>
+            /// The implementation must be a IUnknown-derived interface for use in a dual implementation
+            /// </summary>
+            public const int DualUnknown = -1;
+            /// <summary>
+            /// The base interface for which the current <see cref="ICreateTypeInfo"/> derives from. Normally, 
+            /// this is either the <code>IUnknown</code> or <code>IDispatch"</code> interface. It may derive
+            /// from another interface as long the root is one of either. The referenced <see cref="ITypeInfo"/>
+            /// must be of <see cref="TYPEKIND.TKIND_INTERFACE"/>.
+            /// </summary>
+            public const int BaseInterface = 0;
+            /// <summary>
+            /// The IUnknown implementation of the interface for which the dispatch interface must be
+            /// based on. 
+            /// </summary>
+            public const int DispatchInterface = 1;
+        }
+    }
+}

--- a/Rubberduck.sln
+++ b/Rubberduck.sln
@@ -88,6 +88,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rubberduck.UnitTesting", "R
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rubberduck.InternalApi", "Rubberduck.InternalApi\Rubberduck.InternalApi.csproj", "{D7A3F7A3-BD90-4845-B098-AC3AFBF0E16F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rubberduck.Com", "Rubberduck.Com\Rubberduck.Com.csproj", "{E7521588-0C7A-4627-B6E6-CC431B1DE963}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -282,6 +284,18 @@ Global
 		{D7A3F7A3-BD90-4845-B098-AC3AFBF0E16F}.Release|x64.Build.0 = Release|Any CPU
 		{D7A3F7A3-BD90-4845-B098-AC3AFBF0E16F}.Release|x86.ActiveCfg = Release|Any CPU
 		{D7A3F7A3-BD90-4845-B098-AC3AFBF0E16F}.Release|x86.Build.0 = Release|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Debug|x64.Build.0 = Debug|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Debug|x86.Build.0 = Debug|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Release|x64.ActiveCfg = Release|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Release|x64.Build.0 = Release|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Release|x86.ActiveCfg = Release|Any CPU
+		{E7521588-0C7A-4627-B6E6-CC431B1DE963}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The goal of the PR is to separate out the mechanics of going through a type library from the operating on the data returned by the type library because we have different needs that requires going through the type library:

* We need it for our `Com***` declarations, which provides a stringified representation and is appropriate for caching. 
* We need it for future object browser to replace VBIDE's object browser and provide more information. 
* We need it for COM mocking. Currently the COM mocking relies on magical `Marshal.GetTypeFromITypeInfo` method which has shown itself to be unreliable. We need to be able to build .NET types from the data. 
* We may replace the dependency on OleWoo in the `Rubberduck.Deployment.Build` for the purpose of generating a valid IDL file. That has the added benefit of removing a dependency that is tied to a specific bitness. 

In order to achieve the goal, we provide iterators in form of both `TypeLibWalker` and `TypeInfoWalker` which handles all the enumerating, converting pointers into a valid data structure or values and returning those data for easier handling. Both types are also visitable, and can `Accept` `ITypeLibVisitor`(s) and `ITypeInfoVisitor`(s), respectively. The implementations are also required to indicate whether they can provide the other visitor to handle the visiting of a referenced type library from a type information or to visit the types within a type library. 

The user is free to visit only a type, or can choose to visit the entire type library. Furthermore, the user is able to direct whether the referenced types ought to be visited or not. It is hoped that offers enough flexibility in allowing different users to operate in their own ways upon the same type library. 

I'm posting this for review by others while developing tests. Feedback appreciated. 