### PR TITLE
Update Czech Translations for v2.5.2

### DIFF
--- a/Rubberduck.Resources/Inspections/InspectionInfo.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.cs.resx
@@ -443,4 +443,22 @@ když by toto mohlo být úmyslné, v mnoha situacích to jen maskuje chybně za
   <data name="ImplicitlyTypedConstInspection" xml:space="preserve">
     <value>Pokud není definována klausule typu 'As' pro deklaraci 'Const', použije se implicitní typ. Explicitně definujte ' As &lt;Type&gt;', kde '&lt;Type&gt;' je korektní data typ hodnoty konstanty.</value>
   </data>
+  <data name="UnrecognizedAnnotationInspection" xml:space="preserve">
+    <value>Komentář byl parsován jako syntakticky platná anotace, ale nebyl rozpoznán jako podporovaný typ anotace.</value>
+  </data>
+  <data name="MisleadingByRefParameterInspection" xml:space="preserve">
+    <value>Poslední parametr (parametr 'Value') mutátorů vlastností (Let/Set) je vždy předán jako ByVal. To platí bez ohledu na přítomnost nebo absenci ByRef/ByVal modifikátorů. Výjimka: UserDefinedType musí být vždy předán jako ByRef, i když se jedná o poslední parametr mutátoru vlastní.</value>
+  </data>
+  <data name="InvalidAnnotationInspection" xml:space="preserve">
+    <value>Anotaci nelze navázat na požadovaný cíl. Má zde anotace být? Anotaci, kterou je třeba specifikovat na úrovni modulu, nelze použít k anotaci členů; naopak, anotaci, kterou jsou specifikovány členy, nelze použít na úrovni modulu.</value>
+  </data>
+  <data name="AnnotationInIncompatibleComponentTypeInspection" xml:space="preserve">
+    <value>V typu modulu, ve kterém není možno specifikovat anotaci, byla specifikována anotace. Některé anotace lze použít pouze u specifických typech modulů. U jiných toto nelze.</value>
+  </data>
+  <data name="ImplicitContainingWorkbookReferenceInspection" xml:space="preserve">
+    <value>Implicitní odkazy na členy sešitu uvnitř modulu dokumentu sešitu lze chybně zaměnit za implicitní odkazy na aktivní sešit, což je normální chování ve všech ostatních modulech. Tím, že explicitně kvalifikujete tato volání členů s 'Me', lze vyřešit tuto dvojznačnost. Pokud byl záměr odkazovat na aktivní sešit, abyste předešli chybám, kvalifikujte volání na 'ActiveWorkbook'.</value>
+  </data>
+  <data name="ImplicitContainingWorksheetReferenceInspection" xml:space="preserve">
+    <value>Implicitní odkazy na členy listu uvnitř modulu dokumentu listu lze chybně zaměnit za implicitní odkazy na aktivní list, což je normální chování ve všech ostatních modulech. Tím, že explicitně kvalifikujete tato volání členů s 'Me', lze vyřešit tuto dvojznačnost. Pokud byl záměr odkazovat na aktivní list, abyste předešli chybám, kvalifikujte volání na 'ActiveSheet'.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.cs.resx
@@ -438,4 +438,22 @@
   <data name="FunctionReturnValueDiscardedInspection" xml:space="preserve">
     <value>Návratová hodnota funkce je zahozena.</value>
   </data>
+  <data name="InvalidAnnotationInspection" xml:space="preserve">
+    <value>Ilegální anotace</value>
+  </data>
+  <data name="AnnotationInIncompatibleComponentTypeInspection" xml:space="preserve">
+    <value>Anotace je nekompatibilní s typem komponenty</value>
+  </data>
+  <data name="MisleadingByRefParameterInspection" xml:space="preserve">
+    <value>Zavádějící modifikátor parametru ByRef</value>
+  </data>
+  <data name="ImplicitContainingWorkbookReferenceInspection" xml:space="preserve">
+    <value>Implicitní odkaz na obsahující modul Sešitu</value>
+  </data>
+  <data name="ImplicitContainingWorksheetReferenceInspection" xml:space="preserve">
+    <value>Implicitní odkaz na obsahující modul Listu</value>
+  </data>
+  <data name="UnrecognizedAnnotationInspection" xml:space="preserve">
+    <value>Nerozpoznaná anotace</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
@@ -465,4 +465,25 @@ In memoriam, 1972-2018</value>
   <data name="ImplicitlyTypedConstInspection" xml:space="preserve">
     <value>Konstanta '{0}' je implicitně typována.</value>
   </data>
+  <data name="InvalidAnnotationInspection" xml:space="preserve">
+    <value>Anotace '{0}' je v tomto kontextu ilegální.</value>
+  </data>
+  <data name="InvalidAnnotationInspection_IncompatibleComponentType" xml:space="preserve">
+    <value>Anotace '{0}' nemůže být použita v '{1}'.</value>
+  </data>
+  <data name="InvalidAnnotationInspection_NotInRequiredComponentType" xml:space="preserve">
+    <value>Anotace '{0}' je použita v '{1}', ale platná je pouze v '{2}'.</value>
+  </data>
+  <data name="ImplicitContainingWorkbookReferenceInspection" xml:space="preserve">
+    <value>Člen '{0}' implicitně odkazuje na modul dokumentu, který obsahuje sešit.</value>
+  </data>
+  <data name="ImplicitContainingWorksheetReferenceInspection" xml:space="preserve">
+    <value>Člen '{0}' implicitně odkazuje na modul dokumentu, který obsahuje list.</value>
+  </data>
+  <data name="UnrecognizedAnnotationInspection" xml:space="preserve">
+    <value>'{0}' není rozpoznán jako Rubberduck anotace (zatím?)</value>
+  </data>
+  <data name="MisleadingByRefParameterInspection" xml:space="preserve">
+    <value>Modifikátor ByRef použitý pro parametr '{0}' členu '{1}' je zavádějící.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.cs.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.cs.resx
@@ -300,4 +300,13 @@
   <data name="IgnoreInModuleQuickFix" xml:space="preserve">
     <value>Ignorovat v modulu</value>
   </data>
+  <data name="AnnotateEntryPointQuickFix" xml:space="preserve">
+    <value>Přidat @EntryPoint anotaci</value>
+  </data>
+  <data name="DeclareAsExplicitTypeQuickFix" xml:space="preserve">
+    <value>Deklarovat jako Explicitní Typ</value>
+  </data>
+  <data name="QualifyWithMeQuickFix" xml:space="preserve">
+    <value>Kvalifikujte 'Me' reference.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Menus/RubberduckMenus.cs.resx
+++ b/Rubberduck.Resources/Menus/RubberduckMenus.cs.resx
@@ -264,4 +264,10 @@
   <data name="AnnotateMenu_SelectedModule" xml:space="preserve">
     <value>Vybraný Modul</value>
   </data>
+  <data name="ProjectExplorer_IgnoreProject" xml:space="preserve">
+    <value>Ignorovat Projekt</value>
+  </data>
+  <data name="ProjectExplorer_UnignoreProject" xml:space="preserve">
+    <value>Odignorovat Projekt</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Rubberduck.Resources.csproj
+++ b/Rubberduck.Resources/Rubberduck.Resources.csproj
@@ -51,7 +51,13 @@
     <Compile Update="RubberduckUI.Designer.cs">
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Update="Settings\AutoCompletesPage.Designer.cs">
+      <DesignTime>True</DesignTime>
+    </Compile>
     <Compile Update="Settings\SettingsUI.Designer.cs">
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Update="Settings\UnitTestingPage.Designer.cs">
       <DesignTime>True</DesignTime>
     </Compile>
     <Compile Update="Templates.Designer.cs">

--- a/Rubberduck.Resources/RubberduckUI.cs.resx
+++ b/Rubberduck.Resources/RubberduckUI.cs.resx
@@ -636,7 +636,7 @@ Jste si jisti, že chcete pokračovat s tímto přejmenováním?</value>
     <value>Zarovnat 'dimy'</value>
   </data>
   <data name="IndenterSettings_AlignmentOptionsLabel" xml:space="preserve">
-    <value>Nastavení Zarovnání</value>
+    <value>Nastavení zarovnání</value>
   </data>
   <data name="IndenterSettings_EnableOptionsLabel" xml:space="preserve">
     <value>Povolit Nastavení</value>
@@ -873,7 +873,7 @@ Jste si jisti, že chcete pokračovat s tímto přejmenováním?</value>
     <value>Specifikujte Název Kopie Lokální Proměnné</value>
   </data>
   <data name="IndenterSettings_CodeSampleHeader" xml:space="preserve">
-    <value>Příklad Odsazeného Kódu</value>
+    <value>Příklad odsazeného kódu</value>
   </data>
   <data name="VersionCheck_NewVersionAvailable" xml:space="preserve">
     <value>Momentálně používáte Rubberduck verzi {0}.
@@ -1640,5 +1640,32 @@ Chcete pokračovat?</value>
   </data>
   <data name="EncapsulateField_WrapFieldsInPrivateType" xml:space="preserve">
     <value>Obalit Pole Privátním Typem</value>
+  </data>
+  <data name="DeclarationType_Document" xml:space="preserve">
+    <value>dokument</value>
+  </data>
+  <data name="TestOutcome_Ignored" xml:space="preserve">
+    <value>Ignorováno</value>
+  </data>
+  <data name="IndenterSettings_GroupRelatedProperties" xml:space="preserve">
+    <value>Odeberte vertikální mezeru mezi souvisejícími property členy</value>
+  </data>
+  <data name="ExtractInterface_OptionReplaceMembersWithInterfaceMembers" xml:space="preserve">
+    <value>Nahradit Členy za Členy Rozhraní</value>
+  </data>
+  <data name="ExtractInterface_ImplementationOptionsGroupBox" xml:space="preserve">
+    <value>Možnosti Implementace:</value>
+  </data>
+  <data name="ExtractInterface_OptionForwardToInterfaceMembers" xml:space="preserve">
+    <value>Přeposlat volání členů objektů na členy rozhraní</value>
+  </data>
+  <data name="ExtractInterface_OptionForwardToObjectMembers" xml:space="preserve">
+    <value>Přeposlat volání členů rozhraní na členy objektů</value>
+  </data>
+  <data name="ExtractInterface_OptionAddEmptyImplementation" xml:space="preserve">
+    <value>Přidat Prázdnou Implementaci</value>
+  </data>
+  <data name="CodeExplorer_IExportable_DeclarationFormat" xml:space="preserve">
+    <value>{0} {1} {2} {3} {4} {5}</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Settings {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class AutoCompletesPage {

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.cs.resx
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.cs.resx
@@ -124,7 +124,7 @@
     <value>Configure which Rubberduck autocompletions are enabled.</value>
   </data>
   <data name="EnableSmartConcat" xml:space="preserve">
-    <value>Enable smart concatenation</value>
+    <value>Povolit chytré odsazování</value>
   </data>
   <data name="CompleteBlockOnTab" xml:space="preserve">
     <value>Automatické doplnění bloku po stisku TAB</value>

--- a/Rubberduck.Resources/Settings/SettingsUI.cs.resx
+++ b/Rubberduck.Resources/Settings/SettingsUI.cs.resx
@@ -231,4 +231,10 @@
   <data name="HotKeys_Exclamation" xml:space="preserve">
     <value>Pozor! Chybí modifikátor!</value>
   </data>
+  <data name="FilesHeader_IgnoredProjectsSettings" xml:space="preserve">
+    <value>Ignorované Soubory</value>
+  </data>
+  <data name="PageHeader_IgnoredProjectsSettings" xml:space="preserve">
+    <value>Ignorované Projekty</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Settings/UnitTestingPage.Designer.cs
+++ b/Rubberduck.Resources/Settings/UnitTestingPage.Designer.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Resources.Settings {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class UnitTestingPage {

--- a/Rubberduck.Resources/Settings/UnitTestingPage.cs.resx
+++ b/Rubberduck.Resources/Settings/UnitTestingPage.cs.resx
@@ -130,7 +130,7 @@
     <value>Režim vazby (binding):</value>
   </data>
   <data name="UnitTestSettings_EarlyBinding" xml:space="preserve">
-    <value>Časná vazba</value>
+    <value>Časná vazba (Early binding)</value>
   </data>
   <data name="UnitTestSettings_IncludeTestMethodInitCleanupPrompt" xml:space="preserve">
     <value>Inicializace/úklid test metody</value>
@@ -142,7 +142,7 @@
     <value>Inicializace/úklid test modulu</value>
   </data>
   <data name="UnitTestSettings_LateBinding" xml:space="preserve">
-    <value>Pozdní vazba</value>
+    <value>Pozdní vazba (Late binding)</value>
   </data>
   <data name="UnitTestSettings_PermissiveAssert" xml:space="preserve">
     <value>Tolerantní assert</value>
@@ -154,6 +154,6 @@
     <value>Šablona Test Modulu</value>
   </data>
   <data name="UnitTestSettings_DualBinding" xml:space="preserve">
-    <value>Dvojitá vazba</value>
+    <value>Dvojí vazba (Dual binding)</value>
   </data>
 </root>

--- a/Rubberduck.Resources/Templates.cs.resx
+++ b/Rubberduck.Resources/Templates.cs.resx
@@ -130,4 +130,10 @@
     <value></value>
     <comment>Do not translate</comment>
   </data>
+  <data name="Menu_Warning_CannotFindTemplate_Caption" xml:space="preserve">
+    <value>Chybějící Soubor Šablony</value>
+  </data>
+  <data name="Menu_Warning_CannotFindTemplate_Message" xml:space="preserve">
+    <value>Nelze najít šablonu pro '{0}'. Soubor mohl být přejmenován nebo odstraněn. Očekávaný název souboru: '{1}'.</value>
+  </data>
 </root>


### PR DESCRIPTION
Czech translations should be updated.

There are 3 items (key names) that were renamed to something else (we talked about that in chat) in ResX manager.

- Neutral language is missing, 
- Czech language is translated. 

Didn't know if I could delete those so I let them there.

```
Key                         #
IllegalAnnotationInspection 113
IllegalAnnotationInspection 113
IllegalAnnotationInspection 121
```
