### PR TITLE
Hotfix for VB6

### DIFF
--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/AddIn.cs
@@ -8,8 +8,12 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
 {
     public class AddIn : SafeComWrapper<VB.AddIn>, IAddIn
     {
-        // this one is an index, not an ID:
+
         private const int MenuBar = 1;
+        private const int CodeWindow = 15;
+        private const int ProjectExplorer = 22;
+        private const int MsForm = 20;
+        private const int MsFormControl = 21;
 
         private const int WindowMenu = 30009;
         private const int ListProperties = 2529;
@@ -18,16 +22,16 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
         private const int ViewCode = 2558;
 
 
-        public AddIn(VB.AddIn target, bool rewrapping = false) 
+        public AddIn(VB.AddIn target, bool rewrapping = false)
             : base(target, rewrapping)
-        {     
+        {
             CommandBarLocations = new ReadOnlyDictionary<CommandBarSite, CommandBarLocation>(new Dictionary<CommandBarSite, CommandBarLocation>
             {
                 {CommandBarSite.MenuBar, new CommandBarLocation(MenuBar, WindowMenu)},
-                {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.CodePaneContext, ListProperties)},
-                {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.ProjectExplorerContext, ProjectProperties)},
-                //{CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.FormDesignerContext, ViewCode)}, // FIXME - see #4280
-                {CommandBarSite.FormDesignerControlContextMenu, new CommandBarLocation(VbeCommandBarMenuNames.FormDesignerControlContext, ViewCode)},
+                {CommandBarSite.CodePaneContextMenu, new CommandBarLocation(CodeWindow, ListProperties)},
+                {CommandBarSite.ProjectExplorerContextMenu, new CommandBarLocation(ProjectExplorer, ProjectProperties)},
+                // {CommandBarSite.MsForm, new CommandBarLocation(MsForm, UpdateUserControls)}, // FIXME - quick hack for #4280
+                {CommandBarSite.FormDesignerContextMenu, new CommandBarLocation(MsFormControl, ViewCode)}
             });
         }
 


### PR DESCRIPTION
Reverts a commit that fixed VBA menu positioning but broke VB6 integration.