### PR TITLE
Consolidate resource Italian translation

### DIFF
--- a/Rubberduck.Core/UI/Inspections/InspectionResultsUI.it.resx
+++ b/Rubberduck.Core/UI/Inspections/InspectionResultsUI.it.resx
@@ -129,4 +129,10 @@
   <data name="FilterByWarning" xml:space="preserve">
     <value>Avvertimento</value>
   </data>
+  <data name="CollapseAll" xml:space="preserve">
+    <value>Raggruppa tutto</value>
+  </data>
+  <data name="ExpandAll" xml:space="preserve">
+    <value>Espandi tutto</value>
+  </data>
 </root>

--- a/Rubberduck.Refactorings/RefactoringsUI.it.resx
+++ b/Rubberduck.Refactorings/RefactoringsUI.it.resx
@@ -556,4 +556,10 @@ Una classe privata riesce ad implementare un'interfaccia pubblica.</value>
   <data name="EncapsulateField_ArrayHasExternalRedimFormat" xml:space="preserve">
     <value>Impossibile incapsulare '{0}'. Istruzione/i ReDim({0}) presente/i in altri moduli.</value>
   </data>
+  <data name="AnnotationArgumentType_Text" xml:space="preserve">
+    <value>Testo</value>
+  </data>
+  <data name="AnnotationArgument_ValidationError_NotANumber" xml:space="preserve">
+    <value>Gli argomenti dell'annotazione di tipo 'Numero' devono essere un numero valido in formato intero o a virgola mobile.</value>
+  </data>
 </root>

--- a/Rubberduck.Refactorings/RefactoringsUI.resx
+++ b/Rubberduck.Refactorings/RefactoringsUI.resx
@@ -610,6 +610,6 @@ Do you want to proceed?</value>
     <value>Optional parameters must be specified at the end of the parameter list.</value>
   </data>
   <data name="AnnotationArgument_ValidationError_NotANumber" xml:space="preserve">
-    <value>Annotation arguments of type 'Number' have to be a valid number in integer of floating point format.</value>
+    <value>Annotation arguments of type 'Number' have to be a valid number in integer or floating point format.</value>
   </data>
 </root>

--- a/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.it.resx
+++ b/Rubberduck.Resources/CodeExplorer/CodeExplorerUI.it.resx
@@ -368,4 +368,7 @@ Importazione annullata.</value>
 
 Importazione annullata.</value>
   </data>
+  <data name="CodeExplorerWindowSettings_AccessKey" xml:space="preserve">
+    <value>_Explorer del Codice</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/RubberduckUI.it.resx
+++ b/Rubberduck.Resources/RubberduckUI.it.resx
@@ -698,4 +698,10 @@ La finestra è stata visualizzata perché è abilitata la verifica di versione. 
   <data name="PeekDefinitionCommandText" xml:space="preserve">
     <value>Guarda la definizione</value>
   </data>
+  <data name="CodeInspectionsWindowSettings_AccessKey" xml:space="preserve">
+    <value>_Ispezioni del codice</value>
+  </data>
+  <data name="PeekDefinition_DefaultDescription" xml:space="preserve">
+    <value>(nessuna annotazione o attributo di descrizione)</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Settings/AutoCompletesPage.it.resx
+++ b/Rubberduck.Resources/Settings/AutoCompletesPage.it.resx
@@ -133,7 +133,7 @@
     <value>Configura quali autocompletamenti di Rubberduck sono abilitati.</value>
   </data>
   <data name="ConcatVbNewLine" xml:space="preserve">
-    <value>Concatena 'vbNewLine' al Ctrl + Invio.</value>
+    <value>Concatena 'vbNewLine' al Ctrl + Invio</value>
   </data>
   <data name="EnableAutocompleteLabel" xml:space="preserve">
     <value>Abilita le funzionalità di completamento automatico</value>

--- a/Rubberduck.Resources/ToDoExplorer/ToDoExplorerUI.it.resx
+++ b/Rubberduck.Resources/ToDoExplorer/ToDoExplorerUI.it.resx
@@ -142,4 +142,7 @@
   <data name="ToDoExplorer_CopyToolTip" xml:space="preserve">
     <value>Copia negli appunti</value>
   </data>
+  <data name="ToDoExplorerWindowSettings_AccessKey" xml:space="preserve">
+    <value>Explorer dei T_odo</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/UnitTesting/TestExplorer.it.resx
+++ b/Rubberduck.Resources/UnitTesting/TestExplorer.it.resx
@@ -373,4 +373,7 @@
   <data name="TestOutcome_Fail" xml:space="preserve">
     <value>Errore</value>
   </data>
+  <data name="TestExplorerWindowSettings_AccessKey" xml:space="preserve">
+    <value>Explorer dei _Test</value>
+  </data>
 </root>


### PR DESCRIPTION
Minor Italian translation missed in IvenBach's ConsolidateResourceCleanup and ancestral typo (I think) in English default RefactoringsUI resource file.