### PR TITLE
Fix optional parameters in Circle special form

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -578,7 +578,7 @@ lineSpecialForm : expression whiteSpace ((STEP whiteSpace?)? tuple)?
 	(COMMA whiteSpace? expression? whiteSpace?)?
 	(COMMA whiteSpace? lineSpecialFormOption)?
 ;
-circleSpecialForm : (expression whiteSpace? DOT whiteSpace?)? CIRCLE whiteSpace (STEP whiteSpace?)? tuple (whiteSpace? COMMA whiteSpace? expression)+;
+circleSpecialForm : (expression whiteSpace? DOT whiteSpace?)? CIRCLE whiteSpace (STEP whiteSpace?)? tuple whiteSpace? COMMA whiteSpace? expression (whiteSpace? COMMA whiteSpace? expression?)*;
 scaleSpecialForm : (expression whiteSpace? DOT whiteSpace?)? SCALE whiteSpace tuple whiteSpace? MINUS whiteSpace? tuple;
 pSetSpecialForm : (expression whiteSpace? DOT whiteSpace?)? PSET (whiteSpace STEP)? whiteSpace? tuple whiteSpace? (COMMA whiteSpace? expression)?;
 tuple : LPAREN whiteSpace? expression whiteSpace? COMMA whiteSpace? expression whiteSpace? RPAREN;

--- a/Rubberduck.Parsing/Symbols/DeclarationLoaders/SpecialFormDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/DeclarationLoaders/SpecialFormDeclarations.cs
@@ -34,7 +34,7 @@ namespace Rubberduck.Parsing.Symbols.DeclarationLoaders
             if (informationModule == null)
             {
                 //This should not happen under normal circumstances.
-                //Most probably, we are in a test that only addded parts of the VBA project.
+                //Most probably, we are in a test that only added parts of the VBA project.
                 return new List<Declaration>();
             }
 

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -7,7 +7,6 @@ using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Binding;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
-using Rubberduck.Parsing.Symbols.DeclarationLoaders;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.VBEditor;
 

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -2715,17 +2715,30 @@ End Sub";
 
         
         [Test]
-        public void TestCircleSpecialForm()
+        [TestCase(", 4, 5, 6, 7")]
+        [TestCase(",,,, 7")]
+        [TestCase(",, 5, 6, 7")]
+        [TestCase(", , , 6, 7")]
+        [TestCase(",,,,")]
+        [TestCase(",, 5,, 7")]
+        [TestCase(", 4, 5,, 7")]
+        [TestCase(", 4, 5, 6,")]
+        [TestCase(", 4,,, 7")]
+        [TestCase("")]
+        [TestCase(", 4,")]
+        [TestCase(", 4, 5")]
+        [TestCase(", 4, 5, 6")]
+        public void TestCircleSpecialForm(string optionalPart)
         {
-            string code = @"
+            var code = $@"
 Sub Test()
-    Me.Circle Step (1, 2), 3, 4, 5, 6, 7
+    Me.Circle Step (1, 2), 3{optionalPart}
 End Sub";
             var parseResult = Parse(code);
             AssertTree(parseResult.Item1, parseResult.Item2, "//circleSpecialForm");
         }
 
-        
+
         [Test]
         public void TestCircleSpecialForm_WithoutStep()
         {


### PR DESCRIPTION
Closes #5775

Previously, missing arguments, i.e. left out optional positional arguments followed by provided arguments, were not supported.
This is a minimal fix honoring that the first two arguments, the coordinate tuple and the radius, are not optional.