### PR TITLE
Fix Add-Remove references caption in CE context menu

### DIFF
--- a/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
+++ b/Rubberduck.Core/UI/CodeExplorer/CodeExplorerControl.xaml
@@ -489,7 +489,7 @@
                         </MenuItem.Icon>
                     </MenuItem>
                     <Separator />
-                    <MenuItem Header="{Resx ResxName=Rubberduck.Resources.RubberduckUI, Key=References_Caption}"
+                    <MenuItem Header="{Resx ResxName=Rubberduck.UI.AddRemoveReferences.AddRemoveReferencesUI, Key=Caption}"
                           Command="{Binding AddRemoveReferencesCommand}"
                           CommandParameter="{Binding SelectedItem, Mode=OneWay}">
                         <MenuItem.Icon>


### PR DESCRIPTION
Closes #5777

It still pointed at the old key in the old location.