### PR TITLE
xmldoc patch

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyStringLiteralInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyStringLiteralInspection.cs
@@ -9,10 +9,15 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
     /// <summary>
     /// Flags uses of an empty string literal ("").
     /// </summary>
+    /// <remarks>
+    /// Treating an empty string literal as equal to the 'vbNullString' constant
+    /// requires using the PermissiveAssertClass. The default AssertClass is more strict about data types, and tells them apart.
+    /// </remarks>
     /// <why>
     /// Standard library constant 'vbNullString' is more explicit about its intent, and should be preferred to a string literal. 
     /// While the memory gain is meaningless, an empty string literal still takes up 2 bytes of memory,
-    /// but 'vbNullString' is a null string pointer, and doesn't.
+    /// but 'vbNullString' is a null string pointer, and doesn't. In VB6 and VBA this makes little to no difference however,
+    /// but in earlier versions each instance of an empty string literal in source code resulted in the allocation of these 2 bytes every time.
     /// </why>
     /// <example hasResult="true">
     /// <module name="MyModule" type="Standard Module">


### PR DESCRIPTION
Adds a remark in the xmldoc (will appear on that inspection's page once xmldoc assets are reprocessed) to mention potential impact on unit testing with a PermissiveAssertClass.