### PR TITLE
Eliminate NRE when tabbing through AddRemoveReferencesWindow

### DIFF
--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml
@@ -188,7 +188,7 @@
                                       ItemsSource="{Binding AvailableReferences}" 
                                       HorizontalContentAlignment="Stretch"
                                       ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                                      GotFocus="ListView_SynchronizeCurrentSelection_OnGotFocus">
+                                      SelectionChanged="ListView_SynchronizeCurrentSelection_OnSelectionChanged">
                                 <ListView.ItemContainerStyle>
                                     <Style TargetType="ListViewItem">
                                         <Setter Property="Height" Value="20" />
@@ -246,8 +246,7 @@
                                       SelectionMode="Single"
                                       ItemsSource="{Binding ProjectReferences, NotifyOnTargetUpdated=True}" 
                                       ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                                      HorizontalContentAlignment="Stretch"
-                                      GotFocus="ListView_SynchronizeCurrentSelection_OnGotFocus">
+                                      HorizontalContentAlignment="Stretch" SelectionChanged="ListView_SynchronizeCurrentSelection_OnSelectionChanged">
                                 <ListView.ItemContainerStyle>
                                     <Style TargetType="ListViewItem">
                                         <Setter Property="Height" Value="20" />

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
@@ -16,12 +16,6 @@ namespace Rubberduck.UI.AddRemoveReferences
 
         private AddRemoveReferencesViewModel ViewModel => DataContext as AddRemoveReferencesViewModel;
 
-        private void UpdateCurrentSelection(Selector sender)
-        {
-            var selectedReferenceModel = (ReferenceModel)sender.SelectedItem;
-            ViewModel.CurrentSelection = selectedReferenceModel;
-        }
-
         private void ListView_SynchronizeCurrentSelection_OnSelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             UpdateCurrentSelection((Selector)sender);
@@ -31,6 +25,12 @@ namespace Rubberduck.UI.AddRemoveReferences
             Version.Text = cs?.Version ?? string.Empty;
             LocaleName.Text = cs?.LocaleName ?? string.Empty;
             FullPath.Text = cs?.FullPath ?? string.Empty;
+        }
+
+        private void UpdateCurrentSelection(Selector sender)
+        {
+            var selectedReferenceModel = (ReferenceModel)sender.SelectedItem;
+            ViewModel.CurrentSelection = selectedReferenceModel;
         }
     }
 }

--- a/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
+++ b/Rubberduck.Core/UI/AddRemoveReferences/AddRemoveReferencesWindow.xaml.cs
@@ -16,7 +16,13 @@ namespace Rubberduck.UI.AddRemoveReferences
 
         private AddRemoveReferencesViewModel ViewModel => DataContext as AddRemoveReferencesViewModel;
 
-        private void ListView_SynchronizeCurrentSelection_OnGotFocus(object sender, RoutedEventArgs e)
+        private void UpdateCurrentSelection(Selector sender)
+        {
+            var selectedReferenceModel = (ReferenceModel)sender.SelectedItem;
+            ViewModel.CurrentSelection = selectedReferenceModel;
+        }
+
+        private void ListView_SynchronizeCurrentSelection_OnSelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             UpdateCurrentSelection((Selector)sender);
 
@@ -25,12 +31,6 @@ namespace Rubberduck.UI.AddRemoveReferences
             Version.Text = cs?.Version ?? string.Empty;
             LocaleName.Text = cs?.LocaleName ?? string.Empty;
             FullPath.Text = cs?.FullPath ?? string.Empty;
-        }
-
-        private void UpdateCurrentSelection(Selector sender)
-        {
-            var selectedReferenceModel = (ReferenceModel)sender.SelectedItem;
-            ViewModel.CurrentSelection = selectedReferenceModel;
         }
     }
 }


### PR DESCRIPTION
Fixes #5553 
Moving the code from the GetFocus handler to the SelectionChanged handler ensures that we're not looking at it when there the selection is Null.

