### PR TITLE
Add beep if hotkey command isn't enabled

### DIFF
--- a/Rubberduck.Core/Common/RubberduckHooks.cs
+++ b/Rubberduck.Core/Common/RubberduckHooks.cs
@@ -121,13 +121,18 @@ namespace Rubberduck.Common
 
         private void hook_MessageReceived(object sender, HookEventArgs e)
         {
-            if (sender is IHotkey hotkey 
-                && hotkey.Command.CanExecute(null))
+            if (sender is IHotkey hotkey)
             {
-                hotkey.Command.Execute(null);
-                return;
+                if (hotkey.Command.CanExecute(null))
+                {
+                    hotkey.Command.Execute(null);
+                    return;
+                }
+                else
+                {
+                    Console.Beep();
+                }
             }
-            
             OnMessageReceived(sender, e);
         }
 

--- a/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
+++ b/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
@@ -527,9 +527,9 @@ End Sub";
                 .AddProjectToVbeBuilder()
                 .Build();
 
-            var (expected, actual) = DeclarationsFromParse(vbe.Object, DeclarationType.Parameter, "Link", "EXCEL.EXE;Excel.Worksheet.Paste");
+            var (expected, actual) = DeclarationsFromParse(vbe.Object, DeclarationType.Parameter, "Link", "EXCEL.EXE;Excel._Worksheet.Paste");
 
-           Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, actual);
         }
 
         [Category("Resolver")]

--- a/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
+++ b/RubberduckTests/Symbols/SelectedDeclarationProviderTests.cs
@@ -527,9 +527,9 @@ End Sub";
                 .AddProjectToVbeBuilder()
                 .Build();
 
-            var (expected, actual) = DeclarationsFromParse(vbe.Object, DeclarationType.Parameter, "Link", "EXCEL.EXE;Excel._Worksheet.Paste");
+            var (expected, actual) = DeclarationsFromParse(vbe.Object, DeclarationType.Parameter, "Link", "EXCEL.EXE;Excel.Worksheet.Paste");
 
-            Assert.AreEqual(expected, actual);
+           Assert.AreEqual(expected, actual);
         }
 
         [Category("Resolver")]


### PR DESCRIPTION
Fixes #4376 

Cause a standard Windows Beep when a user attempts to use a hot-key combo for a RD feature that is not currently executable.