### PR TITLE
Fix #5857 by partially reverting csproj changes

### DIFF
--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -1,19 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Sunburst.NET.Sdk.WPF.Patched/1.0.49">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>Rubberduck</RootNamespace>
     <AssemblyName>Rubberduck.Core</AssemblyName>
     <Title>Rubberduck.Core</Title>
     <Product>Rubberduck.Core</Product>
-    <Copyright>Copyright © 2014-2019</Copyright>
+    <Copyright>Copyright © 2014-2021</Copyright>
     <ProjectGuid>{A1587EAC-7B54-407E-853F-4C7493D0323E}</ProjectGuid>
     <DocumentationFile>bin\Debug\Rubberduck.Core.xml</DocumentationFile>
     <!-- Disable "Missing XML documentation" warning (CS1591) -->
     <DisabledWarnings>$(DisabledWarnings);1591</DisabledWarnings>
     <ApplicationIcon>Ducky.ico</ApplicationIcon>
-    <!-- Give a fixed version to not blow XAML generated code to smithereens -->
-    <!-- This also fixes "Input string was not in the correct format" error message when referring to the current assembly in an XAML-Namespace -->
-    <AssemblyVersion>2.5.1</AssemblyVersion>
+    <UseWpf>true</UseWpf>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <Import Project="..\RubberduckBaseProject.csproj" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugAccess|AnyCPU'">
@@ -45,6 +44,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Rubberduck.CodeAnalysis\Rubberduck.CodeAnalysis.csproj" />
     <ProjectReference Include="..\Rubberduck.Interaction\Rubberduck.Interaction.csproj" />
+    <ProjectReference Include="..\Rubberduck.InternalApi\Rubberduck.InternalApi.csproj" />
     <ProjectReference Include="..\Rubberduck.Parsing\Rubberduck.Parsing.csproj" />
     <ProjectReference Include="..\Rubberduck.Refactorings\Rubberduck.Refactorings.csproj" />
     <ProjectReference Include="..\Rubberduck.RegexAssistant\Rubberduck.RegexAssistant.csproj" />
@@ -83,6 +83,7 @@
     <PackageReference Include="NLog.Schema">
       <Version>4.5.10</Version>
     </PackageReference>
+    <PackageReference Include="System.IO.Abstractions" Version="12.2.1" />
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>
     </PackageReference>
@@ -90,100 +91,4 @@
       <Version>2.0.20525</Version>
     </PackageReference>
   </ItemGroup>
-
-  <!-- BEGIN WINDOWS FORMS WORKAROUND SECTION -->
-  <ItemGroup>
-    <Compile Update="**\*Window.cs" SubType="Form" />
-    <Compile Update="**\*Dialog.cs" SubType="Form" />
-    <Compile Update="**\SettingsForm.cs" SubType="Form" />
-    <Compile Update="**\SimpleListControl.cs" SubType="Form" />
-    <Compile Update="**\Splash.cs" SubType="Form" />
-    <Compile Update="**\*.Designer.cs">
-      <DependentUpon>$([System.String]::Copy('%(Filename)').Replace('.Designer', '')).cs</DependentUpon>
-    </Compile>
-    <!--<EmbeddedResource Update="UI\**\*.resx">
-      <DependentUpon>%(Filename).cs</DependentUpon>
-    </EmbeddedResource>-->
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Update="Properties\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Properties\Settings.Designer.cs">
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <Compile Update="UI\AddRemoveReferences\AddRemoveReferencesUI.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>AddRemoveReferencesUI.resx</DependentUpon>
-    </Compile>
-    <Compile Update="UI\Inspections\InspectionResultsUI.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>InspectionResultsUI.resx</DependentUpon>
-    </Compile>
-    <Compile Update="UI\Refactorings\AnnotateDeclaration\AnnotateDeclarationView.xaml.cs">
-      <DependentUpon>AnnotateDeclarationView.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="UI\Refactorings\MoveFolder\MoveMultipleFoldersView.xaml.cs">
-      <DependentUpon>MoveMultipleFoldersView.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="UI\Refactorings\MoveToFolder\MoveMultipleToFolderView.xaml.cs">
-      <DependentUpon>MoveMultipleToFolderView.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="UI\Refactorings\RenameFolder\RenameFolderView.xaml.cs">
-      <DependentUpon>RenameFolderView.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="UI\Settings\GeneralSettingsUI.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>GeneralSettingsUI.resx</DependentUpon>
-    </Compile>
-    <Compile Update="UI\ToDoItems\ToDoExplorerUI.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ToDoExplorerUI.resx</DependentUpon>
-    </Compile>
-    <Compile Update="UI\Settings\IgnoredProjectsSettingsView.xaml.cs">
-      <DependentUpon>IgnoredProjectsSettingsView.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Update="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="UI\AddRemoveReferences\AddRemoveReferencesUI.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>AddRemoveReferencesUI.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="UI\Inspections\InspectionResultsUI.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>InspectionResultsUI.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="UI\Settings\GeneralSettingsUI.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>GeneralSettingsUI.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="UI\ToDoItems\ToDoExplorerUI.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>ToDoExplorerUI.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="Properties\Settings.settings">
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-      <Generator>SettingsSingleFileGenerator</Generator>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="UI\IgnoredProjects\" />
-  </ItemGroup>
-  <!-- END WINDOWS FORMS WORKAROUND SECTION -->
-
 </Project>


### PR DESCRIPTION
This reverts changes from adecadf and 440992a that incorrectly
reintroduced a specific AssemblyVersion specification in Rubberduck.Core.csproj