### PR TITLE
Fix VariableNotAssigned for Variants used as arrays

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
@@ -51,7 +51,9 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                    && !declaration.IsWithEvents
                    && !declaration.IsSelfAssigned
                    && !HasUdtType(declaration, finder) // UDT variables don't need to be assigned
-                   && !declaration.References.Any(reference => reference.IsAssignment || IsAssignedByRefArgument(reference.ParentScoping, reference, finder));
+                   && !declaration.References.Any(reference => reference.IsAssignment 
+                                                               || reference.IsReDim //Ignores Variants used as arrays without assignment of an existing one.
+                                                               || IsAssignedByRefArgument(reference.ParentScoping, reference, finder));
         }
 
         private static bool HasUdtType(Declaration declaration, DeclarationFinder finder)

--- a/Rubberduck.Parsing/Symbols/Declaration.cs
+++ b/Rubberduck.Parsing/Symbols/Declaration.cs
@@ -382,7 +382,8 @@ namespace Rubberduck.Parsing.Symbols
             bool isArrayAccess = false,
             bool isProcedureCoercion = false,
             bool isInnerRecursiveDefaultMemberAccess = false,
-            IdentifierReference qualifyingReference = null
+            IdentifierReference qualifyingReference = null,
+            bool isReDim = false
             )
         {
             var oldReference = _references.FirstOrDefault(r =>
@@ -416,7 +417,8 @@ namespace Rubberduck.Parsing.Symbols
                 isArrayAccess,
                 isProcedureCoercion,
                 isInnerRecursiveDefaultMemberAccess,
-                qualifyingReference);
+                qualifyingReference,
+                isReDim);
             _references.AddOrUpdate(newReference, 1, (key, value) => 1);
             return newReference;
         }

--- a/Rubberduck.Parsing/Symbols/IdentifierReference.cs
+++ b/Rubberduck.Parsing/Symbols/IdentifierReference.cs
@@ -31,7 +31,8 @@ namespace Rubberduck.Parsing.Symbols
             bool isArrayAccess = false,
             bool isProcedureCoercion = false,
             bool isInnerRecursiveDefaultMemberAccess = false,
-            IdentifierReference qualifyingReference = null)
+            IdentifierReference qualifyingReference = null,
+            bool isReDim = false)
         {
             ParentScoping = parentScopingDeclaration;
             ParentNonScoping = parentNonScopingDeclaration;
@@ -50,6 +51,7 @@ namespace Rubberduck.Parsing.Symbols
             Annotations = annotations ?? new List<IParseTreeAnnotation>();
             IsInnerRecursiveDefaultMemberAccess = isInnerRecursiveDefaultMemberAccess;
             QualifyingReference = qualifyingReference;
+            IsReDim = isReDim;
         }
 
         public QualifiedSelection QualifiedSelection { get; }
@@ -84,6 +86,7 @@ namespace Rubberduck.Parsing.Symbols
         public int DefaultMemberRecursionDepth { get; }
 
         public bool IsArrayAccess { get; }
+        public bool IsReDim { get; }
 
         public ParserRuleContext Context { get; }
 

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/BoundExpressionVisitor.cs
@@ -24,9 +24,10 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             Declaration parent,
             bool isAssignmentTarget = false,
             bool hasExplicitLetStatement = false,
-            bool isSetAssignment = false)
+            bool isSetAssignment = false,
+            bool isReDim = false)
         {
-            Visit(boundExpression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment);
+            Visit(boundExpression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment, isReDim: isReDim);
         }
 
         /// <summary>
@@ -50,12 +51,13 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             bool isAssignmentTarget = false,
             bool hasExplicitLetStatement = false,
             bool isSetAssignment = false,
-            bool hasArrayAccess = false)
+            bool hasArrayAccess = false,
+            bool isReDim = false)
         {
             switch (boundExpression)
             {
                 case SimpleNameExpression simpleNameExpression:
-                    return Visit(simpleNameExpression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment);
+                    return Visit(simpleNameExpression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment, isReDim);
                 case MemberAccessExpression memberAccessExpression:
                     return Visit(memberAccessExpression, module, scope, parent, isAssignmentTarget, hasExplicitLetStatement, isSetAssignment);
                 case IndexExpression indexExpression:
@@ -119,7 +121,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             Declaration parent,
             bool isAssignmentTarget,
             bool hasExplicitLetStatement,
-            bool isSetAssignment)
+            bool isSetAssignment,
+            bool isReDim)
         {
             var callSiteContext = expression.Context;
             var callee = expression.ReferencedDeclaration;
@@ -136,7 +139,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 FindIdentifierAnnotations(module, selection.StartLine),
                 isAssignmentTarget,
                 hasExplicitLetStatement,
-                isSetAssignment);
+                isSetAssignment,
+                isReDim: isReDim);
         }
 
         private IEnumerable<IParseTreeAnnotation> FindIdentifierAnnotations(QualifiedModuleName module, int line)

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -169,7 +169,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             StatementResolutionContext statementContext = StatementResolutionContext.Undefined,
             bool isAssignmentTarget = false,
             bool hasExplicitLetStatement = false,
-            bool isSetAssignment = false)
+            bool isSetAssignment = false,
+            bool isReDim = false)
         {
             var withExpression = GetInnerMostWithExpression();
             var boundExpression = _bindingService.ResolveDefault(
@@ -190,7 +191,8 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 _currentParent,
                 isAssignmentTarget,
                 hasExplicitLetStatement, 
-                isSetAssignment);
+                isSetAssignment,
+                isReDim);
         }
 
         private void ResolveType(ParserRuleContext expression)
@@ -258,7 +260,7 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
                 // The indexedExpression is the array that is being resized.
                 // We can't treat it as a normal index expression because the semantics are different.
                 // It's not actually a function call but a special statement.
-                ResolveDefault(indexedExpression, false);
+                ResolveDefault(indexedExpression, false, isReDim: true);
                 if (argumentList.argument() != null)
                 {
                     foreach (var positionalArgument in argumentList.argument())

--- a/RubberduckTests/Inspections/VariableNotAssignedInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableNotAssignedInspectionTests.cs
@@ -381,6 +381,47 @@ End Sub
 
         [Test]
         [Category("Inspections")]
+        public void VariableNotAssigned_ArrayWithElementAssignment_DoesNotReturnResult()
+        {
+            const string inputCode = @"
+Public Sub Foo()
+    Dim arr(0 To 0) As Variant
+    arr(0) = 42
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VariableNotAssigned_ReDimDeclaredArrayWithElementAssignment_DoesNotReturnResult()
+        {
+            const string inputCode = @"
+Public Sub Foo()
+    ReDim arr(0 To 0) As Variant
+    arr(0) = 42
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //See issue #5845 at https://github.com/rubberduck-vba/Rubberduck/issues/5845
+        public void VariableNotAssigned_VariantUsedAsArrayWithElementAssignment_DoesNotReturnResult()
+        {
+            const string inputCode = @"
+Public Sub Foo()
+    Dim arr As Variant
+    ReDim arr(0 To 0) As Variant
+    arr(0) = 42
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void VariableNotAssigned_Ignored_DoesNotReturnResult()
         {
             const string inputCode =


### PR DESCRIPTION
Closes #5845

This inspection usually ignores arrays because they are technically valid without assignment. Moreover, it is a bit unclear what it means for them not to be assigned. (one index vs. all indices)

In the case of a Variant used as an array without an assignment to it, which is possible using a ReDim statement, we do not know that the variable represents an array. So, an inspection result was issued, although some or all array slots were assigned to.

To deal with this, a new property IsReDim has been introduced on the IdentifierReference that stores whether this reference is the array reference in a ReDim statement; it is set in the resolver.
Whenever we see such a reference on a Variant, we can be sure that it is used as an array at some point. In a sense, the ReDim statement assigns a new array to the Variant.