### PR TITLE
Fix return value discarded inspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueDiscardedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/FunctionReturnValueDiscardedInspection.cs
@@ -77,14 +77,23 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
             }
 
             //Member accesses are parsed right-to-left, e.g. 'foo.Bar' is the parent of 'foo'.
-            //Thus, having a member access parent means that the return value is used somehow.
-            var ownFunctionCallExpression = context.Parent is VBAParser.MemberAccessExprContext methodCall
-                ? methodCall
-                : context;
-            var memberAccessParent = ownFunctionCallExpression.GetAncestor<VBAParser.MemberAccessExprContext>();
+            //Thus, having a member access parent and being contained in its lExpression on the left of the dot
+            //or having a further member access parent means that the return value is used somehow.
+            var memberAccessParent = context.GetAncestor<VBAParser.MemberAccessExprContext>();
             if (memberAccessParent != null)
             {
-                return false;
+                //This case is necessary for member accesses in particular on simple name expressions since the context is the simpleNameExpression there and not the identifier.
+                if (memberAccessParent.lExpression().Contains(context))
+                {
+                    return false;
+                }
+
+                //This case is necessary if the context is itself the unrestricted identifier in a member access. 
+                var furtherMemberAccessParent = memberAccessParent.GetAncestor<VBAParser.MemberAccessExprContext>();
+                if (furtherMemberAccessParent != null)
+                { 
+                    return false;
+                }
             }
 
             //If we are in an output list, the value is used somewhere in defining the argument.

--- a/Rubberduck.Parsing/ParserRuleContextExtensions.cs
+++ b/Rubberduck.Parsing/ParserRuleContextExtensions.cs
@@ -30,10 +30,13 @@ namespace Rubberduck.Parsing
                                  context.Stop.EndColumn() + 1);
         }
 
-        public static bool Contains(this ParserRuleContext context, ParserRuleContext otherContext)
+        /// <summary>
+        ///  Returns whether the other context from the same parse tree is wholly contained in the current context
+        /// </summary>
+        public static bool Contains(this ParserRuleContext context, ParserRuleContext otherContextInSameParseTree)
         {
-            return context.start.TokenIndex <= otherContext.start.TokenIndex
-                   && context.stop.TokenIndex >= otherContext.stop.TokenIndex;
+            return context.start.TokenIndex <= otherContextInSameParseTree.start.TokenIndex
+                   && context.stop.TokenIndex >= otherContextInSameParseTree.stop.TokenIndex;
         }
 
         /// <summary>

--- a/Rubberduck.Parsing/ParserRuleContextExtensions.cs
+++ b/Rubberduck.Parsing/ParserRuleContextExtensions.cs
@@ -30,6 +30,12 @@ namespace Rubberduck.Parsing
                                  context.Stop.EndColumn() + 1);
         }
 
+        public static bool Contains(this ParserRuleContext context, ParserRuleContext otherContext)
+        {
+            return context.start.TokenIndex <= otherContext.start.TokenIndex
+                   && context.stop.TokenIndex >= otherContext.stop.TokenIndex;
+        }
+
         /// <summary>
         ///  Gets the tokens belonging to the context from the token stream.
         /// </summary>

--- a/RubberduckTests/Inspections/FunctionReturnValueDiscardedInspectionTests.cs
+++ b/RubberduckTests/Inspections/FunctionReturnValueDiscardedInspectionTests.cs
@@ -189,6 +189,24 @@ End Sub
         [Test]
         [Category("Inspections")]
         [Category("Unused Value")]
+        public void FunctionReturnValueDiscarded_DoesNotReturnResult_WithStatement()
+        {
+            const string code = @"
+Public Function Foo() As Object
+End Function
+
+Public Sub Baz()
+    With Foo
+        'Do Whatever
+    End With
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(code).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category("Unused Value")]
         public void FunctionReturnValueDiscarded_DoesNotReturnResult_WhileStatement()
         {
             const string code = @"
@@ -374,6 +392,22 @@ End Sub";
             Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
         }
 
+
+        [Test]
+        [Category("Inspections")]
+        [Category("Unused Value")]
+        public void ChainedParameterlessMemberAccess_ReturnsNoResult()
+        {
+            const string inputCode = @"
+Public Function GetIt() As Object
+End Function
+
+Public Sub Baz()
+    GetIt.Select
+End Sub";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
         [Test]
         [Category("Inspections")]
         [Category("Unused Value")]
@@ -453,6 +487,58 @@ End Function
             {
                 ("IFoo", interfaceCode, ComponentType.ClassModule),
                 ("Bar", implementationCode, ComponentType.ClassModule)
+            };
+
+            Assert.AreEqual(0, InspectionResultsForModules(modules).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category("Unused Value")]
+        //See issue #5853 at https://github.com/rubberduck-vba/Rubberduck/issues/5853
+        public void CallToMemberOfFunctionReturnValueInBody_NoResult()
+        {
+            const string returnTypeClassCode = @"
+Public Sub Bar(ByVal arg As String)
+End Sub
+";
+            const string moduleCode =
+                @"
+Public Function Foo() As Class1
+    Set Foo = New Class1
+    Foo.Bar ""SomeArgument""
+End Function
+";
+            var modules = new (string, string, ComponentType)[]
+            {
+                ("Class1", returnTypeClassCode, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule)
+            };
+
+            Assert.AreEqual(0, InspectionResultsForModules(modules).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category("Unused Value")]
+        //See issue #5853 at https://github.com/rubberduck-vba/Rubberduck/issues/5853
+        public void ExplicitCallToMemberOfFunctionReturnValueInBody_NoResult()
+        {
+            const string returnTypeClassCode = @"
+Public Sub Bar(ByVal arg As String)
+End Sub
+";
+            const string moduleCode =
+                @"
+Public Function Foo() As Class1
+    Set Foo = New Class1
+    Call Foo.Bar(""SomeArgument"")
+End Function
+";
+            var modules = new (string, string, ComponentType)[]
+            {
+                ("Class1", returnTypeClassCode, ComponentType.ClassModule),
+                ("Module1", moduleCode, ComponentType.StandardModule)
             };
 
             Assert.AreEqual(0, InspectionResultsForModules(modules).Count());


### PR DESCRIPTION
Closes #5853

Previously, we did not always determine correctly whether there is a member access on the return value of a function. The problem  was that the reference in a member access expression goes to the unrestricted identifier while it goes to the whole simple name expression in case of a simple name expression. This makes it necessary to deal with them in different ways; the first member access parent of a reference to a member access is the member access itself while it is a further member access for all other kinds of references.

This affected both kinds of function return value discarded inspections, since they use the same logic to determine whether a reference is used.