### PR TITLE
Stop bailing out completely on failed supertype resolution

### DIFF
--- a/Rubberduck.Parsing/Binding/Bindings/BindingContextBase.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/BindingContextBase.cs
@@ -1,0 +1,38 @@
+﻿using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using NLog;
+using Rubberduck.Parsing.Symbols;
+
+namespace Rubberduck.Parsing.Binding
+{
+    public abstract class BindingContextBase : IBindingContext
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+
+
+        protected IExpressionBinding HandleUnexpectedExpressionType(ParserRuleContext expression)
+        {
+            Logger.Warn($"Unexpected context type {expression.GetType()}");
+            return new FailedExpressionBinding(expression);
+        }
+
+        public abstract IBoundExpression Resolve(
+            Declaration module, 
+            Declaration parent, 
+            IParseTree expression,
+            IBoundExpression withBlockVariable, 
+            StatementResolutionContext statementContext, 
+            bool requiresLetCoercion = false,
+            bool isLetAssignment = false);
+
+        public abstract IExpressionBinding BuildTree(
+            Declaration module, 
+            Declaration parent, 
+            IParseTree expression,
+            IBoundExpression withBlockVariable, 
+            StatementResolutionContext statementContext, 
+            bool requiresLetCoercion = false,
+            bool isLetAssignment = false);
+    }
+}

--- a/Rubberduck.Parsing/Binding/Bindings/BindingContextBase.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/BindingContextBase.cs
@@ -17,21 +17,19 @@ namespace Rubberduck.Parsing.Binding
             return new FailedExpressionBinding(expression);
         }
 
-        public abstract IBoundExpression Resolve(
-            Declaration module, 
-            Declaration parent, 
-            IParseTree expression,
-            IBoundExpression withBlockVariable, 
-            StatementResolutionContext statementContext, 
+        public abstract IBoundExpression Resolve(Declaration module,
+            Declaration parent,
+            ParserRuleContext expression,
+            IBoundExpression withBlockVariable,
+            StatementResolutionContext statementContext,
             bool requiresLetCoercion = false,
             bool isLetAssignment = false);
 
-        public abstract IExpressionBinding BuildTree(
-            Declaration module, 
-            Declaration parent, 
-            IParseTree expression,
-            IBoundExpression withBlockVariable, 
-            StatementResolutionContext statementContext, 
+        public abstract IExpressionBinding BuildTree(Declaration module,
+            Declaration parent,
+            ParserRuleContext expression,
+            IBoundExpression withBlockVariable,
+            StatementResolutionContext statementContext,
             bool requiresLetCoercion = false,
             bool isLetAssignment = false);
     }

--- a/Rubberduck.Parsing/Binding/Bindings/FailedExpressionBinding.cs
+++ b/Rubberduck.Parsing/Binding/Bindings/FailedExpressionBinding.cs
@@ -1,0 +1,19 @@
+﻿using Antlr4.Runtime;
+
+namespace Rubberduck.Parsing.Binding
+{
+    public sealed class FailedExpressionBinding : IExpressionBinding
+    {
+        private readonly ParserRuleContext _context;
+
+        public FailedExpressionBinding(ParserRuleContext context)
+        {
+            _context = context;
+        }
+
+        public IBoundExpression Resolve()
+        {
+            return new ResolutionFailedExpression(_context);
+        }
+    }
+}

--- a/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/DefaultBindingContext.cs
@@ -3,7 +3,6 @@ using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using System;
 using System.Collections.Generic;
-using Antlr4.Runtime.Tree;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 
 namespace Rubberduck.Parsing.Binding
@@ -24,26 +23,24 @@ namespace Rubberduck.Parsing.Binding
             _procedurePointerBindingContext = procedurePointerBindingContext;
         }
 
-        public override IBoundExpression Resolve(
-            Declaration module, 
-            Declaration parent, 
-            IParseTree expression, 
-            IBoundExpression withBlockVariable, 
-            StatementResolutionContext statementContext, 
-            bool requiresLetCoercion = false, 
+        public override IBoundExpression Resolve(Declaration module,
+            Declaration parent,
+            ParserRuleContext expression,
+            IBoundExpression withBlockVariable,
+            StatementResolutionContext statementContext,
+            bool requiresLetCoercion = false,
             bool isLetAssignment = false)
         {
             var bindingTree = BuildTree(module, parent, expression, withBlockVariable, statementContext, requiresLetCoercion, isLetAssignment);
             return bindingTree?.Resolve();
         }
 
-        public override IExpressionBinding BuildTree(
-            Declaration module, 
-            Declaration parent, 
-            IParseTree expression, 
-            IBoundExpression withBlockVariable, 
+        public override IExpressionBinding BuildTree(Declaration module,
+            Declaration parent,
+            ParserRuleContext expression,
+            IBoundExpression withBlockVariable,
             StatementResolutionContext statementContext,
-            bool requiresLetCoercion = false, 
+            bool requiresLetCoercion = false,
             bool isLetAssignment = false)
         {
             return Visit(
@@ -56,7 +53,7 @@ namespace Rubberduck.Parsing.Binding
                 isLetAssignment);
         }
 
-        public IExpressionBinding Visit(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public IExpressionBinding Visit(Declaration module, Declaration parent, ParserRuleContext expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
         {
             if (requiresLetCoercion && expression is ParserRuleContext context)
             {
@@ -82,10 +79,8 @@ namespace Rubberduck.Parsing.Binding
                     return Visit(module, parent, outputListContext, withBlockVariable);
                 case VBAParser.UnqualifiedObjectPrintStmtContext unqualifiedObjectPrintStmtContext:
                     return Visit(module, parent, unqualifiedObjectPrintStmtContext, withBlockVariable);
-                case ParserRuleContext unexpectedContext:
-                    return HandleUnexpectedExpressionType(unexpectedContext);
                 default:
-                    throw new NotSupportedException($"Unexpected expression parse tree type {expression.GetType()}");
+                    return HandleUnexpectedExpressionType(expression);
             }
         }
 

--- a/Rubberduck.Parsing/Binding/IBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/IBindingContext.cs
@@ -1,11 +1,25 @@
-﻿using Antlr4.Runtime.Tree;
+﻿using Antlr4.Runtime;
 using Rubberduck.Parsing.Symbols;
 
 namespace Rubberduck.Parsing.Binding
 {
     public interface IBindingContext
     {
-        IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false);
-        IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false);
+        IBoundExpression Resolve(
+            Declaration module, 
+            Declaration parent, 
+            ParserRuleContext expression,
+            IBoundExpression withBlockVariable, 
+            StatementResolutionContext statementContext,
+            bool requiresLetCoercion = false, 
+            bool isLetAssignment = false);
+        IExpressionBinding BuildTree(
+            Declaration module, 
+            Declaration parent, 
+            ParserRuleContext expression,
+            IBoundExpression withBlockVariable, 
+            StatementResolutionContext statementContext,
+            bool requiresLetCoercion = false, 
+            bool isLetAssignment = false);
     }
 }

--- a/Rubberduck.Parsing/Binding/ProcedurePointerBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/ProcedurePointerBindingContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Antlr4.Runtime;
-using Antlr4.Runtime.Tree;
+﻿using Antlr4.Runtime;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
@@ -16,7 +14,14 @@ namespace Rubberduck.Parsing.Binding
             _declarationFinder = declarationFinder;
         }
 
-        public override IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public override IBoundExpression Resolve(
+            Declaration module, 
+            Declaration parent, 
+            ParserRuleContext expression,
+            IBoundExpression withBlockVariable, 
+            StatementResolutionContext statementContext,
+            bool requiresLetCoercion = false, 
+            bool isLetAssignment = false)
         {
             IExpressionBinding bindingTree = BuildTree(module, parent, expression, withBlockVariable, statementContext);
             if (bindingTree != null)
@@ -26,7 +31,14 @@ namespace Rubberduck.Parsing.Binding
             return null;
         }
 
-        public override IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public override IExpressionBinding BuildTree(
+            Declaration module, 
+            Declaration parent,
+            ParserRuleContext expression, 
+            IBoundExpression withBlockVariable,
+            StatementResolutionContext statementContext, 
+            bool requiresLetCoercion = false, 
+            bool isLetAssignment = false)
         {
             switch (expression)
             {
@@ -36,10 +48,8 @@ namespace Rubberduck.Parsing.Binding
                     return Visit(module, parent, expressionContext);
                 case VBAParser.AddressOfExpressionContext addressOfExpressionContext:
                     return Visit(module, parent, addressOfExpressionContext);
-                case ParserRuleContext unexpectedContext:
-                    return HandleUnexpectedExpressionType(unexpectedContext);
                 default:
-                    throw new NotSupportedException($"Unexpected expression parse tree type {expression.GetType()}");
+                    return HandleUnexpectedExpressionType(expression);
             }
         }
 

--- a/Rubberduck.Parsing/Binding/TypeBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/TypeBindingContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Antlr4.Runtime;
-using Antlr4.Runtime.Tree;
-using NLog;
+﻿using Antlr4.Runtime;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
@@ -17,13 +14,26 @@ namespace Rubberduck.Parsing.Binding
             _declarationFinder = declarationFinder;
         }
 
-        public override IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public override IBoundExpression Resolve(
+            Declaration module, 
+            Declaration parent, ParserRuleContext expression,
+            IBoundExpression withBlockVariable, 
+            StatementResolutionContext statementContext,
+            bool requiresLetCoercion = false, 
+            bool isLetAssignment = false)
         {
             IExpressionBinding bindingTree = BuildTree(module, parent, expression, withBlockVariable, statementContext);
             return bindingTree?.Resolve();
         }
 
-        public override IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public override IExpressionBinding BuildTree(
+            Declaration module, 
+            Declaration parent,
+            ParserRuleContext expression, 
+            IBoundExpression withBlockVariable,
+            StatementResolutionContext statementContext, 
+            bool requiresLetCoercion = false, 
+            bool isLetAssignment = false)
         {
             switch (expression)
             {
@@ -33,10 +43,8 @@ namespace Rubberduck.Parsing.Binding
                     return Visit(module, parent, ctLExprContext.lExpression());
                 case VBAParser.BuiltInTypeExprContext builtInTypeExprContext:
                     return Visit(builtInTypeExprContext.builtInType());
-                case ParserRuleContext unexpectedContext:
-                    return HandleUnexpectedExpressionType(unexpectedContext);
                 default:
-                    throw new NotSupportedException($"Unexpected expression parse tree type {expression.GetType()}");
+                    return HandleUnexpectedExpressionType(expression);
             }
         }
 

--- a/Rubberduck.Parsing/Binding/TypeBindingContext.cs
+++ b/Rubberduck.Parsing/Binding/TypeBindingContext.cs
@@ -8,10 +8,8 @@ using Rubberduck.Parsing.VBA.DeclarationCaching;
 
 namespace Rubberduck.Parsing.Binding
 {
-    public sealed class TypeBindingContext : IBindingContext
+    public sealed class TypeBindingContext : BindingContextBase
     {
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
         private readonly DeclarationFinder _declarationFinder;
 
         public TypeBindingContext(DeclarationFinder declarationFinder)
@@ -19,13 +17,13 @@ namespace Rubberduck.Parsing.Binding
             _declarationFinder = declarationFinder;
         }
 
-        public IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public override IBoundExpression Resolve(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
         {
             IExpressionBinding bindingTree = BuildTree(module, parent, expression, withBlockVariable, statementContext);
             return bindingTree?.Resolve();
         }
 
-        public IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
+        public override IExpressionBinding BuildTree(Declaration module, Declaration parent, IParseTree expression, IBoundExpression withBlockVariable, StatementResolutionContext statementContext, bool requiresLetCoercion = false, bool isLetAssignment = false)
         {
             switch (expression)
             {
@@ -40,12 +38,6 @@ namespace Rubberduck.Parsing.Binding
                 default:
                     throw new NotSupportedException($"Unexpected expression parse tree type {expression.GetType()}");
             }
-        }
-
-        public IExpressionBinding HandleUnexpectedExpressionType(ParserRuleContext expression)
-        {
-            Logger.Warn($"Unexpected expression context type {expression.GetType()}");
-            return new FailedExpressionBinding(expression);
         }
 
         private IExpressionBinding Visit(VBAParser.BuiltInTypeContext builtInType)


### PR DESCRIPTION
This PR intends to address the issue #5782.

While it does not really fix the root issue while resolving the supertypes of certain controls in Access, it should stop the reolver from bailing out completely.

In general, the implicit contract of the binding contexts has always been to return a failed resolution binding whenever the resolution fails. Unfortunately, that was not actually the case, if unexpected context types were encountered while building the expression tree. To remedy this, a new failed binding expression is introduced, that always resolved to a failed resolution. It is returned whenever unexpected contexts are encountered in any of the binding contexts.

In addition, the binding context interface was changed to require a `ParserRuleContext` instead of a, `IParseTree`. Although the previous parameter type was wider, no implementation could actually deal with anything not deriving from `ParserRuleContext`.  
This change allowed to avoid still throwing for the remaining cases. (The `ResolutionFailedExpression` requires a `ParserRuleContext` and is used in multiple places. Thus changing that to take an `IParseTree` seems to be the wrong way to go.)
