### PR TITLE
Correctly resolve references to declarations named like built-in types

### DIFF
--- a/Rubberduck.Parsing/Symbols/Identifier.cs
+++ b/Rubberduck.Parsing/Symbols/Identifier.cs
@@ -190,6 +190,11 @@ namespace Rubberduck.Parsing.Symbols
             return GetName(context.identifier());
         }
 
+        public static string GetName(VBAParser.BuiltInTypeContext context)
+        {
+            return context.GetText();
+        }
+
         public static string GetName(VBAParser.IdentifierContext context, out Interval tokenInterval)
         {
             tokenInterval = Interval.Of(context.Start.TokenIndex, context.Stop.TokenIndex);

--- a/RubberduckTests/Inspections/ParameterNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/ParameterNotUsedInspectionTests.cs
@@ -50,6 +50,19 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
+        //See issue #5336 at https://github.com/rubberduck-vba/Rubberduck/issues/5336
+        public void ParameterWithBuiltInTypeNameUsed_DoesNotReturnResult()
+        {
+            const string inputCode =
+                @"Public Function Foo(Object As Object) As Object
+Set Foo = Object
+End Function";
+
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ParameterNotUsed_ReturnsResult_SomeParamsUsed()
         {
             const string inputCode =


### PR DESCRIPTION
Closes #5336

The problem is that expressions prefer to resolve built-in type names as built-in types in favor of simple name expressions in order to be able to distinguish them. Unfortunately, VBA allows to name declarations like built-in types.

To fix this, whenever the default expression binding context encounters a built-in type, it first tries to bind it as a simple name. It tries to resolve it and if that is successful, it returns the binding. Otherwise, it falls back to the built-in type binding.