### PR TITLE
Scope annotations to logical lines

### DIFF
--- a/Rubberduck.Parsing/Symbols/IDeclarationFinderFactory.cs
+++ b/Rubberduck.Parsing/Symbols/IDeclarationFinderFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Rubberduck.Parsing.Annotations;
 using System.Collections.Generic;
+using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.Parsing.VBA.ReferenceManagement;
 using Rubberduck.VBEditor;
@@ -9,9 +10,9 @@ namespace Rubberduck.Parsing.Symbols
 {
     public interface IDeclarationFinderFactory
     {
-        DeclarationFinder Create(
-            IReadOnlyList<Declaration> declarations, 
+        DeclarationFinder Create(IReadOnlyList<Declaration> declarations,
             IEnumerable<IParseTreeAnnotation> annotations,
+            IReadOnlyDictionary<QualifiedModuleName, LogicalLineStore> logicalLines,
             IReadOnlyDictionary<QualifiedModuleName, IFailedResolutionStore> failedResolutionStores,
             IHostApplication hostApp);
         void Release(DeclarationFinder declarationFinder);

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinder.cs
@@ -13,12 +13,12 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
     {
         private const int _maxDegreeOfConstructionParallelism = -1;
         
-        public ConcurrentlyConstructedDeclarationFinder(
-            IReadOnlyList<Declaration> declarations, 
-            IEnumerable<IParseTreeAnnotation> annotations, 
+        public ConcurrentlyConstructedDeclarationFinder(IReadOnlyList<Declaration> declarations,
+            IEnumerable<IParseTreeAnnotation> annotations,
+            IReadOnlyDictionary<QualifiedModuleName, LogicalLineStore> logicalLines,
             IReadOnlyDictionary<QualifiedModuleName, IFailedResolutionStore> failedResolutionStores,
             IHostApplication hostApp = null) 
-            :base(declarations, annotations, failedResolutionStores, hostApp)
+            :base(declarations, annotations, logicalLines, failedResolutionStores, hostApp)
         {}
 
         protected override void ExecuteCollectionConstructionActions(List<Action> collectionConstructionActions)

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinderFactory.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/ConcurrentlyConstructedDeclarationFinderFactory.cs
@@ -9,13 +9,13 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
 {
     public class ConcurrentlyConstructedDeclarationFinderFactory : IDeclarationFinderFactory
     {
-        public DeclarationFinder Create(
-            IReadOnlyList<Declaration> declarations, 
+        public DeclarationFinder Create(IReadOnlyList<Declaration> declarations,
             IEnumerable<IParseTreeAnnotation> annotations,
+            IReadOnlyDictionary<QualifiedModuleName, LogicalLineStore> logicalLines,
             IReadOnlyDictionary<QualifiedModuleName, IFailedResolutionStore> failedResolutionStores,
             IHostApplication hostApp)
         {
-            return new ConcurrentlyConstructedDeclarationFinder(declarations, annotations, failedResolutionStores, hostApp);
+            return new ConcurrentlyConstructedDeclarationFinder(declarations, annotations, logicalLines, failedResolutionStores, hostApp);
         }
 
         public void Release(DeclarationFinder declarationFinder)

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -313,6 +313,20 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
             return lineStore.NumberOfLogicalLines();
         }
 
+        public int? StartOfContainingLogicalLine(QualifiedModuleName module, int physicalLine)
+        {
+            return _logicalLines.TryGetValue(module, out var lineStore)
+                ? lineStore.StartOfContainingLogicalLine(physicalLine)
+                : null;
+        }
+
+        public int? EndOfContainingLogicalLine(QualifiedModuleName module, int physicalLine)
+        {
+            return _logicalLines.TryGetValue(module, out var lineStore)
+                ? lineStore.EndOfContainingLogicalLine(physicalLine)
+                : null;
+        }
+
         public IEnumerable<Declaration> Members(Declaration module)
         {
             return Members(module.QualifiedName.QualifiedModuleName);
@@ -565,12 +579,18 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
 
         public IEnumerable<IParseTreeAnnotation> FindAnnotations(QualifiedModuleName module, int annotatedLine)
         {
-            if(!_annotations.TryGetValue(module, out var annotationsByLineInModule))
+            if (!_annotations.TryGetValue(module, out var annotationsByLineInModule))
             {
                 return Enumerable.Empty<IParseTreeAnnotation>();
             }
 
-            return annotationsByLineInModule.TryGetValue(annotatedLine, out var result) 
+            var firstLineOfAnnotatedLogicalLine = StartOfContainingLogicalLine(module, annotatedLine);
+            if (!firstLineOfAnnotatedLogicalLine.HasValue)
+            {
+                return Enumerable.Empty<IParseTreeAnnotation>();
+            }
+
+            return annotationsByLineInModule.TryGetValue(firstLineOfAnnotatedLogicalLine.Value, out var result) 
                 ? result 
                 : Enumerable.Empty<IParseTreeAnnotation>();
         }

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinder.cs
@@ -33,6 +33,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
         private readonly ConcurrentDictionary<(QualifiedMemberName memberName, DeclarationType declarationType), ConcurrentBag<Declaration>> _newUndeclared;
 
         private IDictionary<QualifiedModuleName,IDictionary<int, List<IParseTreeAnnotation>>> _annotations;
+        private readonly IReadOnlyDictionary<QualifiedModuleName, LogicalLineStore> _logicalLines;
         private IDictionary<Declaration, List<ParameterDeclaration>> _parametersByParent;
         private IDictionary<DeclarationType, List<Declaration>> _userDeclarationsByType;
        
@@ -68,14 +69,15 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
                 : declaration.QualifiedSelection;
         }
         
-        public DeclarationFinder(
-            IReadOnlyList<Declaration> declarations, 
-            IEnumerable<IParseTreeAnnotation> annotations, 
+        public DeclarationFinder(IReadOnlyList<Declaration> declarations,
+            IEnumerable<IParseTreeAnnotation> annotations,
+            IReadOnlyDictionary<QualifiedModuleName, LogicalLineStore> logicalLines,
             IReadOnlyDictionary<QualifiedModuleName, IFailedResolutionStore> failedResolutionStores,
             IHostApplication hostApp = null)
         {
             _hostApp = hostApp;
             _failedResolutionStores = failedResolutionStores;
+            _logicalLines = logicalLines;
 
             _newFailedResolutionStores = new ConcurrentDictionary<QualifiedModuleName, IMutableFailedResolutionStore>();
             _newUndeclared = new ConcurrentDictionary<(QualifiedMemberName memberName, DeclarationType declarationType), ConcurrentBag<Declaration>>();
@@ -279,7 +281,37 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
 
         //This does not need a lock because enumerators over a ConcurrentBag uses a snapshot.    
         public IEnumerable<Declaration> FreshUndeclared => _newUndeclared.AllValues();
-        public IReadOnlyDictionary<QualifiedModuleName, IFailedResolutionStore> FreshFailedResolutionStores => _newFailedResolutionStores.ToDictionary(kvp => kvp.Key, kvp => (IFailedResolutionStore)new FailedResolutionStore(kvp.Value));  
+        public IReadOnlyDictionary<QualifiedModuleName, IFailedResolutionStore> FreshFailedResolutionStores => _newFailedResolutionStores.ToDictionary(kvp => kvp.Key, kvp => (IFailedResolutionStore)new FailedResolutionStore(kvp.Value));
+
+        public int? LogicalLine(QualifiedModuleName module, int physicalLine)
+        {
+            return _logicalLines.TryGetValue(module, out var lineStore)
+                ? lineStore.LogicalLineNumber(physicalLine)
+                : null;
+        }
+
+        public int? PhysicalStartLine(QualifiedModuleName module, int logicalLine)
+        {
+            return _logicalLines.TryGetValue(module, out var lineStore)
+                ? lineStore.PhysicalStartLineNumber(logicalLine)
+                : null;
+        }
+
+        public int? PhysicalEndLine(QualifiedModuleName module, int logicalLine)
+        {
+            return _logicalLines.TryGetValue(module, out var lineStore)
+                ? lineStore.PhysicalEndLineNumber(logicalLine)
+                : null;
+        }
+
+        public int? NumberOfLogicalLines(QualifiedModuleName module)
+        {
+            if (!_logicalLines.TryGetValue(module, out var lineStore))
+            {
+                return null;
+            }
+            return lineStore.NumberOfLogicalLines();
+        }
 
         public IEnumerable<Declaration> Members(Declaration module)
         {

--- a/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinderFactory.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationCaching/DeclarationFinderFactory.cs
@@ -9,12 +9,13 @@ namespace Rubberduck.Parsing.VBA.DeclarationCaching
 {
     public class DeclarationFinderFactory : IDeclarationFinderFactory 
     {
-        public DeclarationFinder Create(IReadOnlyList<Declaration> declarations, 
+        public DeclarationFinder Create(IReadOnlyList<Declaration> declarations,
             IEnumerable<IParseTreeAnnotation> annotations,
+            IReadOnlyDictionary<QualifiedModuleName, LogicalLineStore> logicalLines,
             IReadOnlyDictionary<QualifiedModuleName, IFailedResolutionStore> failedResolutionStores,
             IHostApplication hostApp)
         {
-            return new DeclarationFinder(declarations, annotations, failedResolutionStores, hostApp);
+            return new DeclarationFinder(declarations, annotations, logicalLines, failedResolutionStores, hostApp);
         }
 
         public void Release(DeclarationFinder declarationFinder)

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Rubberduck.Parsing.Common;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA.ComReferenceLoading;
+using Rubberduck.Parsing.VBA.Parsing;
 using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.VBA.DeclarationResolving
@@ -46,7 +47,8 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                     module =>
                     {
                         ResolveDeclarations(module,
-                            _state.ParseTrees.Find(s => s.Key == module).Value,
+                            _state.GetParseTree(module),
+                            _state.GetLogicalLines(module),
                             projects,
                             token);
                     }

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationResolveRunnerBase.cs
@@ -128,7 +128,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
 
         protected abstract void ResolveDeclarations(IReadOnlyCollection<QualifiedModuleName> modules, IDictionary<string, ProjectDeclaration> projects, CancellationToken token);
 
-        protected void ResolveDeclarations(QualifiedModuleName module, IParseTree tree, IDictionary<string, ProjectDeclaration> projects, CancellationToken token)
+        protected void ResolveDeclarations(QualifiedModuleName module, IParseTree tree, LogicalLineStore logicalLines, IDictionary<string, ProjectDeclaration> projects, CancellationToken token)
         {
             var stopwatch = Stopwatch.StartNew();
             try
@@ -155,7 +155,7 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                     _state.AddDeclaration(declaration);
                 }
 
-                var declarationsListener = new DeclarationSymbolsListener(moduleDeclaration, annotationsOnWhiteSpaceLines, attributes, membersAllowingAttributes);
+                var declarationsListener = new DeclarationSymbolsListener(moduleDeclaration, annotationsOnWhiteSpaceLines, logicalLines, attributes, membersAllowingAttributes);
                 ParseTreeWalker.Default.Walk(declarationsListener, tree);
                 foreach (var createdDeclaration in declarationsListener.CreatedDeclarations)
                 {

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
@@ -19,23 +19,24 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
         private Declaration _parentDeclaration;
 
         private readonly IDictionary<int, List<IParseTreeAnnotation>> _annotations;
+        private readonly LogicalLineStore _logicalLines;
         private readonly IDictionary<(string scopeIdentifier, DeclarationType scopeType), Attributes> _attributes;
         private readonly IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext> _membersAllowingAttributes;
 
         private readonly List<Declaration> _createdDeclarations = new List<Declaration>();
         public IReadOnlyList<Declaration> CreatedDeclarations => _createdDeclarations;
 
-        public DeclarationSymbolsListener(
-            Declaration moduleDeclaration,
+        public DeclarationSymbolsListener(Declaration moduleDeclaration,
             IDictionary<int, List<IParseTreeAnnotation>> annotations,
-            IDictionary<(string scopeIdentifier, DeclarationType scopeType),
-            Attributes> attributes,
-            IDictionary<(string scopeIdentifier, DeclarationType scopeType),
-                ParserRuleContext> membersAllowingAttributes)
+            LogicalLineStore logicalLines,
+            IDictionary<(string scopeIdentifier, DeclarationType scopeType), Attributes> attributes,
+            IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext>
+                membersAllowingAttributes)
         {
             _moduleDeclaration = moduleDeclaration;
             _qualifiedModuleName = moduleDeclaration.QualifiedModuleName;
             _annotations = annotations;
+            _logicalLines = logicalLines;
             _attributes = attributes;
             _membersAllowingAttributes = membersAllowingAttributes;
 
@@ -54,7 +55,13 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                 return null;
             }
 
-            if (_annotations.TryGetValue(firstLine, out var scopedAnnotations))
+            var firstLineOfLogicalLine = _logicalLines.StartOfContainingLogicalLine(firstLine);
+            if (!firstLineOfLogicalLine.HasValue)
+            {
+                return null;
+            }
+
+            if (_annotations.TryGetValue(firstLineOfLogicalLine.Value, out var scopedAnnotations))
             {
                 return scopedAnnotations.Where(annotation => annotation.Annotation.Target.HasFlag(requiredTarget));
             }

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/SynchronousDeclarationResolveRunner.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/SynchronousDeclarationResolveRunner.cs
@@ -34,7 +34,12 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
             {
                 foreach(var module in modules)
                 {
-                    ResolveDeclarations(module, _state.ParseTrees.Find(s => s.Key == module).Value, projects, token);
+                    ResolveDeclarations(
+                        module, 
+                        _state.GetParseTree(module),
+                        _state.GetLogicalLines(module),
+                        projects,
+                        token);
                     var declaration = _state.DeclarationFinder.ModuleDeclaration(module);
                     if (declaration is DocumentModuleDeclaration document)
                     {

--- a/Rubberduck.Parsing/VBA/IParseTreeProvider.cs
+++ b/Rubberduck.Parsing/VBA/IParseTreeProvider.cs
@@ -10,5 +10,6 @@ namespace Rubberduck.Parsing.VBA
         List<KeyValuePair<QualifiedModuleName, IParseTree>> ParseTrees { get; }
         List<KeyValuePair<QualifiedModuleName, IParseTree>> AttributeParseTrees { get; }
         IParseTree GetParseTree(QualifiedModuleName module, CodeKind codeKind);
+        LogicalLineStore GetLogicalLines(QualifiedModuleName module);
     }
 }

--- a/Rubberduck.Parsing/VBA/LogicalLineStore.cs
+++ b/Rubberduck.Parsing/VBA/LogicalLineStore.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Rubberduck.Parsing.VBA
+{
+    public class LogicalLineStore
+    {
+        private readonly List<int> _logicalLineEnds;
+
+        public LogicalLineStore(IEnumerable<int> logicalLineEnds)
+        {
+            _logicalLineEnds = logicalLineEnds.ToList();
+            if (!IsSorted(_logicalLineEnds))
+            {
+                _logicalLineEnds.Sort();
+            }
+        }
+
+        private static bool IsSorted(List<int> list)
+        {
+            for (var index = 0; index < list.Count - 1; index++)
+            {
+                if (list[index + 1] < list[index])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private int LastPhysicalLine() => _logicalLineEnds[_logicalLineEnds.Count - 1];
+
+        public int? LogicalLineNumber(int physicalLineNumber)
+        {
+            if (physicalLineNumber < 1 || physicalLineNumber > LastPhysicalLine())
+            {
+                return null;
+            }
+
+            var searchResult = _logicalLineEnds.BinarySearch(physicalLineNumber);
+            if (searchResult >= 0)
+            {
+                //VBA line numbers are 1-based.
+                return searchResult + 1;
+            }
+
+            //If the item is not in the sorted list, BinarySearch returns the bitwise complement of the index with the next larger item,
+            //in case there is one, and the binary complement of the length or the list otherwise.
+            var nextLargerIndex = ~searchResult;
+
+            //VBA line numbers are 1-based.
+            return nextLargerIndex + 1;
+        }
+
+        public int? PhysicalEndLineNumber(int logicalLineNumber)
+        {
+            if (logicalLineNumber < 1 || logicalLineNumber > NumberOfLogicalLines())
+            {
+                return null;
+            }
+
+            //VBA line numbers are 1-based.
+            return _logicalLineEnds[logicalLineNumber - 1];
+        }
+
+        public int? PhysicalStartLineNumber(int logicalLineNumber)
+        {
+            if (logicalLineNumber < 1 || logicalLineNumber > NumberOfLogicalLines())
+            {
+                return null;
+            }
+
+            //VBA line numbers are 1-based. So the prior logical line has an index two smaller than the logical line number.
+            return logicalLineNumber == 1 
+                ? 1
+                : _logicalLineEnds[logicalLineNumber - 2] + 1;
+        }
+
+        public int NumberOfLogicalLines()
+        {
+            return _logicalLineEnds.Count;
+        }
+    }
+}

--- a/Rubberduck.Parsing/VBA/LogicalLineStore.cs
+++ b/Rubberduck.Parsing/VBA/LogicalLineStore.cs
@@ -81,5 +81,20 @@ namespace Rubberduck.Parsing.VBA
         {
             return _logicalLineEnds.Count;
         }
+
+        public int? StartOfContainingLogicalLine(int physicalLineNumber)
+        {
+            var logicalLine = LogicalLineNumber(physicalLineNumber);
+            return logicalLine.HasValue
+                ? PhysicalStartLineNumber(logicalLine.Value)
+                : null;
+        }
+        public int? EndOfContainingLogicalLine(int physicalLineNumber)
+        {
+            var logicalLine = LogicalLineNumber(physicalLineNumber);
+            return logicalLine.HasValue
+                ? PhysicalEndLineNumber(logicalLine.Value)
+                : null;
+        }
     }
 }

--- a/Rubberduck.Parsing/VBA/ModuleState.cs
+++ b/Rubberduck.Parsing/VBA/ModuleState.cs
@@ -21,6 +21,7 @@ namespace Rubberduck.Parsing.VBA
         public int ModuleContentHashCode { get; private set; }
         public List<CommentNode> Comments { get; private set; }
         public List<IParseTreeAnnotation> Annotations { get; private set; }
+        public LogicalLineStore LogicalLines { get; private set; }
         public SyntaxErrorException ModuleException { get; private set; }
         public IDictionary<(string scopeIdentifier, DeclarationType scopeType), Attributes> ModuleAttributes { get; private set; }
         public IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext> MembersAllowingAttributes { get; private set; }
@@ -124,6 +125,11 @@ namespace Rubberduck.Parsing.VBA
         public ModuleState SetAnnotations(List<IParseTreeAnnotation> annotations)
         {
             Annotations = annotations;
+            return this;
+        }
+        public ModuleState SetLogicalLines(LogicalLineStore logicalLines)
+        {
+            LogicalLines = logicalLines;
             return this;
         }
 

--- a/Rubberduck.Parsing/VBA/Parsing/IModuleParser.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/IModuleParser.cs
@@ -10,16 +10,16 @@ namespace Rubberduck.Parsing.VBA.Parsing
 {
     public readonly struct ModuleParseResults
     {
-        public ModuleParseResults(
-            IParseTree codePaneParseTree,
+        public ModuleParseResults(IParseTree codePaneParseTree,
             IParseTree attributesParseTree,
             IEnumerable<CommentNode> comments,
             IEnumerable<IParseTreeAnnotation> annotations,
+            LogicalLineStore logicalLines,
             IDictionary<(string scopeIdentifier, DeclarationType scopeType), Attributes> attributes,
-            IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext> membersAllowingAttributes,
+            IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext>
+                membersAllowingAttributes,
             ITokenStream codePaneTokenStream,
-            ITokenStream attributesTokenStream
-        )
+            ITokenStream attributesTokenStream)
         {
             CodePaneParseTree = codePaneParseTree;
             AttributesParseTree = attributesParseTree;
@@ -29,12 +29,14 @@ namespace Rubberduck.Parsing.VBA.Parsing
             MembersAllowingAttributes = membersAllowingAttributes;
             CodePaneTokenStream = codePaneTokenStream;
             AttributesTokenStream = attributesTokenStream;
+            LogicalLines = logicalLines;
         }
 
         public IParseTree CodePaneParseTree { get; }
         public IParseTree AttributesParseTree { get; }
         public IEnumerable<CommentNode> Comments { get; }
         public IEnumerable<IParseTreeAnnotation> Annotations { get; }
+        public LogicalLineStore LogicalLines { get; }
         public IDictionary<(string scopeIdentifier, DeclarationType scopeType), Attributes> Attributes { get; }
         public IDictionary<(string scopeIdentifier, DeclarationType scopeType), ParserRuleContext> MembersAllowingAttributes { get; }
         public ITokenStream CodePaneTokenStream { get; }

--- a/Rubberduck.Parsing/VBA/Parsing/ParseRunnerBase.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/ParseRunnerBase.cs
@@ -96,6 +96,7 @@ namespace Rubberduck.Parsing.VBA.Parsing
             _state.AddParseTree(module, results.AttributesParseTree, CodeKind.AttributesCode);
             _state.SetModuleComments(module, results.Comments);
             _state.SetModuleAnnotations(module, results.Annotations);
+            _state.SetModuleLogicalLines(module, results.LogicalLines);
             _state.SetModuleAttributes(module, results.Attributes);
             _state.SetMembersAllowingAttributes(module, results.MembersAllowingAttributes);
             _state.SetCodePaneTokenStream(module, results.CodePaneTokenStream);

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -870,6 +870,11 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
+        public LogicalLineStore GetLogicalLines(QualifiedModuleName module)
+        {
+            return _moduleStates[module].LogicalLines;
+        }
+
         public List<KeyValuePair<QualifiedModuleName, IParseTree>> AttributeParseTrees
         {
             get

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -141,7 +141,8 @@ namespace Rubberduck.Parsing.VBA
             var oldDeclarationFinder = DeclarationFinder;
             DeclarationFinder = _declarationFinderFactory.Create(
                 AllDeclarationsFromModuleStates, 
-                AllAnnotations,
+                AllAnnotations, 
+                AllLogicalLines,
                 AllFailedResolutionsFromModuleStates,
                 host);
             _declarationFinderFactory.Release(oldDeclarationFinder);
@@ -656,6 +657,19 @@ namespace Rubberduck.Parsing.VBA
                 return annotations;
             }
         }
+        public IReadOnlyDictionary<QualifiedModuleName, LogicalLineStore> AllLogicalLines
+        {
+            get
+            {
+                var logicalLineStored = new Dictionary<QualifiedModuleName, LogicalLineStore>();
+                foreach (var module in _moduleStates.Keys)
+                {
+                    logicalLineStored.Add(module, _moduleStates[module].LogicalLines);
+                }
+
+                return logicalLineStored;
+            }
+        }
 
         public IEnumerable<IParseTreeAnnotation> GetAnnotations(QualifiedModuleName module)
         {
@@ -670,6 +684,10 @@ namespace Rubberduck.Parsing.VBA
         public void SetModuleAnnotations(QualifiedModuleName module, IEnumerable<IParseTreeAnnotation> annotations)
         {
             _moduleStates[module].SetAnnotations(new List<IParseTreeAnnotation>(annotations));
+        }
+        public void SetModuleLogicalLines(QualifiedModuleName module, LogicalLineStore logicalLines)
+        {
+            _moduleStates[module].SetLogicalLines(logicalLines);
         }
 
         /// <summary>

--- a/RubberduckTests/Inspections/InspectionResultTests.cs
+++ b/RubberduckTests/Inspections/InspectionResultTests.cs
@@ -6,6 +6,7 @@ using Rubberduck.CodeAnalysis.Inspections.Results;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Annotations;
 using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
 using Rubberduck.Parsing.VBA.DeclarationCaching;
 using Rubberduck.Parsing.VBA.ReferenceManagement;
 using Rubberduck.VBEditor;
@@ -140,7 +141,8 @@ namespace RubberduckTests.Inspections
 
             var finder = new DeclarationFinder(
                 new List<Declaration>(), 
-                new List<IParseTreeAnnotation>(),
+                new List<IParseTreeAnnotation>(), 
+                new Dictionary<QualifiedModuleName, LogicalLineStore>(),
                 new Dictionary<QualifiedModuleName, IFailedResolutionStore>());
             var inspectionResult = new IdentifierReferenceInspectionResult(inspectionMock.Object, string.Empty, finder, identifierReference);
 
@@ -169,7 +171,8 @@ namespace RubberduckTests.Inspections
 
             var finder = new DeclarationFinder(
                 new List<Declaration>(), 
-                new List<IParseTreeAnnotation>(),
+                new List<IParseTreeAnnotation>(), 
+                new Dictionary<QualifiedModuleName, LogicalLineStore>(),
                 new Dictionary<QualifiedModuleName, IFailedResolutionStore>());
             var inspectionResult = new IdentifierReferenceInspectionResult(inspectionMock.Object, string.Empty, finder, identifierReference);
 

--- a/RubberduckTests/Parsing/LogicalLineStoreTests.cs
+++ b/RubberduckTests/Parsing/LogicalLineStoreTests.cs
@@ -168,5 +168,107 @@ namespace RubberduckTests.Parsing
 
             Assert.AreEqual(expectedPhysicalLine, actualPhysicalLineNumber);
         }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(-42)]
+        [TestCase(0)]
+
+        public void StartOfContainingLogicalLine_ReturnsNullForPhysicalLinesSmallerThanOne(int physicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.StartOfContainingLogicalLine(physicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(28324)]
+        [TestCase(283324)]
+
+        public void StartOfContainingLogicalLine_ReturnsNullForPhysicalLinesLargerThenTheMaxPhysicalEndLine(int physicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.StartOfContainingLogicalLine(physicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(1, 1)]
+        [TestCase(2, 1)]
+        [TestCase(5, 5)]
+        [TestCase(77, 23)]
+        [TestCase(100, 95)]
+        [TestCase(10000, 95)]
+        [TestCase(17, 6)]
+        [TestCase(18, 18)]
+
+        public void StartOfContainingLogicalLine_ReturnsExpectedPhysicalLineForPhysicalLinesBetweenOneAndTheMaxPhysicalEndLine(int physicalLine, int expectedPhysicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.StartOfContainingLogicalLine(physicalLine);
+
+            Assert.AreEqual(expectedPhysicalLine, actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(-42)]
+        [TestCase(0)]
+
+        public void EndOfContainingLogicalLine_ReturnsNullForPhysicalLinesSmallerThanOne(int physicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.EndOfContainingLogicalLine(physicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(28324)]
+        [TestCase(283324)]
+
+        public void EndOfContainingLogicalLine_ReturnsNullForPhysicalLinesLargerThenTheMaxPhysicalEndLine(int physicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.EndOfContainingLogicalLine(physicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(1, 3)]
+        [TestCase(2, 3)]
+        [TestCase(5, 5)]
+        [TestCase(77, 94)]
+        [TestCase(100, 28323)]
+        [TestCase(10000, 28323)]
+        [TestCase(17, 17)]
+        [TestCase(18, 22)]
+
+        public void EndOfContainingLogicalLine_ReturnsExpectedPhysicalLineForPhysicalLinesBetweenOneAndTheMaxPhysicalEndLine(int physicalLine, int expectedPhysicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.EndOfContainingLogicalLine(physicalLine);
+
+            Assert.AreEqual(expectedPhysicalLine, actualPhysicalLineNumber);
+        }
     }
 }

--- a/RubberduckTests/Parsing/LogicalLineStoreTests.cs
+++ b/RubberduckTests/Parsing/LogicalLineStoreTests.cs
@@ -1,0 +1,172 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using Rubberduck.Parsing.VBA;
+
+namespace RubberduckTests.Parsing
+{
+    [TestFixture]
+    public class LogicalLineStoreTests
+    {
+        [Test]
+        [Category("Resolver")]
+        [TestCase(-42)]
+        [TestCase(0)]
+
+        public void LogicalLine_ReturnsNullForPhysicalLinesSmallerThanOne(int physicalLine)
+        {
+            var logicalLineEnds = new List<int>{ 22, 4, 94, 28323, 3, 5, 17};
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualLogicalLineNumber = logicalLineStore.LogicalLineNumber(physicalLine);
+
+            Assert.IsNull(actualLogicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(28324)]
+        [TestCase(283324)]
+
+        public void LogicalLine_ReturnsNullForPhysicalLinesLargerThenTheMaxPhysicalEndLine(int physicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualLogicalLineNumber = logicalLineStore.LogicalLineNumber(physicalLine);
+
+            Assert.IsNull(actualLogicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(1, 1)]
+        [TestCase(2, 1)]
+        [TestCase(5, 3)]
+        [TestCase(77, 6)]
+        [TestCase(100, 7)]
+        [TestCase(10000, 7)]
+        [TestCase(17, 4)]
+        [TestCase(18, 5)]
+
+        public void LogicalLine_ReturnsExpectedLogicalLineForPhysicalLinesBetweenOneAndTheMaxPhysicalEndLine(int physicalLine, int expectedLogicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualLogicalLineNumber = logicalLineStore.LogicalLineNumber(physicalLine);
+
+            Assert.AreEqual(expectedLogicalLine, actualLogicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+
+        public void NumberOfLogicalLines_ReturnsNumberOfLineEnds()
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var expectedNumberOfLines = logicalLineEnds.Count;
+            var actualNumberOfLines = logicalLineStore.NumberOfLogicalLines();
+
+            Assert.AreEqual(expectedNumberOfLines, actualNumberOfLines);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(-42)]
+        [TestCase(0)]
+
+        public void PhysicalStartLine_ReturnsNullForLogicalLinesSmallerThanOne(int logicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.PhysicalStartLineNumber(logicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(8)]
+        [TestCase(9)]
+        [TestCase(33)]
+
+        public void PhysicalStartLine_ReturnsNullForLogicalLinesLargerThenTheNumberOfLogicalLines(int logicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.PhysicalStartLineNumber(logicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(1, 1)]
+        [TestCase(2, 4)]
+        [TestCase(3, 5)]
+        [TestCase(7, 95)]
+
+        public void PhysicalStartLine_ReturnsExpectedPhysicalLineForExistingLogicalLines(int logicalLine, int expectedPhysicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.PhysicalStartLineNumber(logicalLine);
+
+            Assert.AreEqual(expectedPhysicalLine, actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(-42)]
+        [TestCase(0)]
+
+        public void PhysicalEndLine_ReturnsNullForLogicalLinesSmallerThanOne(int logicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.PhysicalEndLineNumber(logicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(8)]
+        [TestCase(9)]
+        [TestCase(33)]
+
+        public void PhysicalEndLine_ReturnsNullForLogicalLinesLargerThenTheNumberOfLogicalLines(int logicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.PhysicalEndLineNumber(logicalLine);
+
+            Assert.IsNull(actualPhysicalLineNumber);
+        }
+
+        [Test]
+        [Category("Resolver")]
+        [TestCase(1, 3)]
+        [TestCase(2, 4)]
+        [TestCase(3, 5)]
+        [TestCase(6, 94)]
+        [TestCase(7, 28323)]
+
+        public void PhysicalEndLine_ReturnsExpectedPhysicalLineForExistingLogicalLines(int logicalLine, int expectedPhysicalLine)
+        {
+            var logicalLineEnds = new List<int> { 22, 4, 94, 28323, 3, 5, 17 };
+            var logicalLineStore = new LogicalLineStore(logicalLineEnds);
+
+            var actualPhysicalLineNumber = logicalLineStore.PhysicalEndLineNumber(logicalLine);
+
+            Assert.AreEqual(expectedPhysicalLine, actualPhysicalLineNumber);
+        }
+    }
+}

--- a/RubberduckTests/PostProcessing/AnnotationUpdaterTests.cs
+++ b/RubberduckTests/PostProcessing/AnnotationUpdaterTests.cs
@@ -390,7 +390,7 @@ End Sub
 
         [Test]
         [Category("AnnotationUpdater")]
-        public void AddAnnotationNotOnFirstPhysicalLineOfALogicalLineDoesNothing()
+        public void AddAnnotationNotOnFirstPhysicalLineOfALogicalLineAddsAnnotationAboveLogicalLine()
         {
             const string inputCode =
                 @"
@@ -406,6 +406,7 @@ baz As Variant
 
             const string expectedCode =
                 @"
+'@Obsolete
 Private fooBar As Long, _
 baz As Variant
 

--- a/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/IgnoreOnceQuickFixTests.cs
@@ -347,7 +347,6 @@ End Sub";
 
         [Test]
         [Category("QuickFixes")]
-        [Ignore("With the current annotation scoping rules, this test makes no sense since the Ignore annotation will not attach to the offending context.")]
         public void MultilineParameter_IgnoreQuickFixWorks()
         {
             const string inputCode =


### PR DESCRIPTION
Closes #5087
Closes #5805

This PR changes the annotation scoping rules, again.
All primary rules, i.e. what is allowed where, stay the same. The difference is that annotations are now scoped to a _logical_ line instead of a _physical_ line. With this change, it is now possible to annotate everything in a module. In particular, the `IgnoreOnceQuickFix` now works for all results relating to some content of a module.

To facilitate the new scoping rules, this PR introduces the `LogicalLineStore`, which holds a sorted list of the physical line numbers of the ends of all logical lines in a module. It features a number of methods providing information regarding the relation of physical and logical lines. The most relevant is `StartOfContainingLogicalLine`, which is used for the annotation scoping.

For each module, a `LogicalLineStore` is generated based on the code pane code as part of the parsing process. This is stored on the corresponding module state and also exposed via the `DeclarationFinder`. It is also available via the `IParseTreeProvider` interface.

The `DeclarationSymbolsListener` and the `DeclarationFinder` use the store in their `FindAnnotations` methods to move the physical line for which they look for annotations from the original line to the start of the logical line. This allows to leave the code that determines the line the annotations refer to as-is; this is much less cumbersome than to switch the meaning of the annotated line to the logical line.

Following the switch in scoping rules, the `AnnotationUpdater` has been updated to add annotations above the current logical line instead of bailing out whenever the target is not on the first physical line of a logical line. 