### PR TITLE
Introducing SuspiciousPredeclaredInstanceAccessInspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/SuspiciousPredeclaredInstanceAccessInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/SuspiciousPredeclaredInstanceAccessInspection.cs
@@ -1,0 +1,70 @@
+﻿using Rubberduck.CodeAnalysis.Inspections.Abstract;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.Resources.Inspections;
+using Tokens = Rubberduck.Resources.Tokens;
+
+namespace Rubberduck.CodeAnalysis.Inspections.Concrete
+{
+    /// <summary>
+    /// This inspection warns about references to the default instance of a class, inside that class.
+    /// </summary>
+    /// <why>
+    /// While a stateful default instance might be intentional, it is a common source of bugs and should be avoided.
+    /// Use the Me qualifier to explicitly refer to the current instance and eliminate any ambiguity.
+    /// </why>
+    /// <example hasResult="true">
+    /// <module name="UserForm1" type="UserForm Module">
+    /// <![CDATA[
+    /// Option Explicit
+    /// Private ClickCount As Long
+    /// 
+    /// Private Sub CommandButton1_Click()
+    ///     ClickCount = ClickCount + 1
+    ///     UserForm1.TextBox1.Text = ClickCount
+    /// End Sub
+    /// ]]>
+    /// </module>
+    /// </example>
+    /// <example hasResult="false">
+    /// <module name="UserForm1" type="UserForm Module">
+    /// <![CDATA[
+    /// Option Explicit
+    /// Private ClickCount As Long
+    /// 
+    /// Private Sub CommandButton1_Click()
+    ///     ClickCount = ClickCount + 1
+    ///     Me.TextBox1.Text = ClickCount
+    /// End Sub
+    /// ]]>
+    /// </module>
+    /// </example>
+    internal sealed class SuspiciousPredeclaredInstanceAccessInspection : IdentifierReferenceInspectionBase
+    {
+        public SuspiciousPredeclaredInstanceAccessInspection(IDeclarationFinderProvider declarationFinderProvider) 
+            : base(declarationFinderProvider)
+        {
+        }
+
+        protected override bool IsResultReference(IdentifierReference reference, DeclarationFinder finder)
+        {
+            if (!(reference.Declaration is ClassModuleDeclaration module) || 
+                !module.HasPredeclaredId ||
+                !reference.ParentScoping.ParentDeclaration.Equals(module))
+            {
+                return false;
+            }
+
+            return reference.IdentifierName != Tokens.Me;
+        }
+
+        protected override string ResultDescription(IdentifierReference reference)
+        {
+            reference.Context.TryGetAncestor<VBAParser.LExpressionContext>(out var expression);
+            return string.Format(InspectionResults.SuspiciousPredeclaredInstanceAccessInspection, reference.IdentifierName, expression.GetText());
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ReplaceQualifierWithMeQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ReplaceQualifierWithMeQuickFix.cs
@@ -1,0 +1,67 @@
+﻿using Rubberduck.CodeAnalysis.Inspections;
+using Rubberduck.CodeAnalysis.Inspections.Concrete;
+using Rubberduck.CodeAnalysis.QuickFixes.Abstract;
+using Rubberduck.Parsing.Rewriter;
+using Rubberduck.Resources;
+
+namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
+{
+    /// <summary>
+    /// Replaces an explicit qualifier with 'Me'.
+    /// </summary>
+    /// <inspections>
+    /// <inspection name="SuspiciousPredeclaredInstanceAccessInspection" />
+    /// </inspections>
+    /// <canfix multiple="true" procedure="true" module="true" project="true" all="true" />
+    /// <example>
+    /// <before>
+    /// <![CDATA[
+    /// Option Explicit
+    /// Private ClickCount As Long
+    /// 
+    /// Private Sub CommandButton1_Click()
+    ///     ClickCount = ClickCount + 1
+    ///     ' works fine as long as the current instance is the default instance
+    ///     UserForm1.TextBox1.Text = ClickCount
+    /// End Sub
+    /// ]]>
+    /// </before>
+    /// <after>
+    /// <![CDATA[
+    /// Option Explicit
+    /// Private ClickCount As Long
+    /// 
+    /// Private Sub CommandButton1_Click()
+    ///     ClickCount = ClickCount + 1
+    ///     ' works fine regardless of which instance we're in
+    ///     Me.TextBox1.Text = ClickCount
+    /// End Sub
+    /// ]]>
+    /// </after>
+    /// </example>
+    internal class ReplaceQualifierWithMeQuickFix : QuickFixBase
+    {
+        public ReplaceQualifierWithMeQuickFix()
+            :base(typeof(SuspiciousPredeclaredInstanceAccessInspection))
+        {}
+
+        public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
+        {
+            var rewriter = rewriteSession.CheckOutModuleRewriter(result.QualifiedSelection.QualifiedName);
+
+            var context = result.Context;
+            rewriter.Replace(context.Start, Tokens.Me);
+        }
+
+        public override string Description(IInspectionResult result)
+        {
+            return Resources.Inspections.QuickFixes.ReplaceQualifierWithMeQuickFix;
+        }
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+        public override bool CanFixAll => true;
+    }
+}

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -934,6 +934,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to While a stateful default instance might be intentional, it is a common source of bugs and should be avoided. Use the &apos;Me&apos; qualifier to explicitly refer to the current instance and eliminate any ambiguity..
+        /// </summary>
+        public static string SuspiciousPredeclaredInstanceAccessInspection {
+            get {
+                return ResourceManager.GetString("SuspiciousPredeclaredInstanceAccessInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This is likely a bug. A variable is being referred to, but is never assigned..
         /// </summary>
         public static string UnassignedVariableUsageInspection {

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -457,4 +457,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="UnrecognizedAnnotationInspection" xml:space="preserve">
     <value>A comment was parsed as a syntactically valid annotation, but not recognized as a supported annotation type.</value>
   </data>
+  <data name="SuspiciousPredeclaredInstanceAccessInspection" xml:space="preserve">
+    <value>While a stateful default instance might be intentional, it is a common source of bugs and should be avoided. Use the 'Me' qualifier to explicitly refer to the current instance and eliminate any ambiguity.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -934,6 +934,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Suspicious access to a predeclared instance.
+        /// </summary>
+        public static string SuspiciousPredeclaredInstanceAccessInspection {
+            get {
+                return ResourceManager.GetString("SuspiciousPredeclaredInstanceAccessInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Variable is used but not assigned..
         /// </summary>
         public static string UnassignedVariableUsageInspection {

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -457,4 +457,7 @@
   <data name="UnrecognizedAnnotationInspection" xml:space="preserve">
     <value>Unrecognized annotation</value>
   </data>
+  <data name="SuspiciousPredeclaredInstanceAccessInspection" xml:space="preserve">
+    <value>Suspicious access to a predeclared instance</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -970,6 +970,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Identifier &apos;{0}&apos; in &apos;{1}&apos; is suspiciously referring to the default instance of that class type..
+        /// </summary>
+        public static string SuspiciousPredeclaredInstanceAccessInspection {
+            get {
+                return ResourceManager.GetString("SuspiciousPredeclaredInstanceAccessInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}
         ///Andrew &quot;ThunderFrame&quot; Jackson would be proud! 
         ///You&apos;re seeing this inspection result because there&apos;s no way that&apos;s real code and you&apos;re just pushing the limits of Rubberduck&apos;s parsing and resolving capabilities, right? ...RIGHT? 

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -536,4 +536,8 @@ In memoriam, 1972-2018</value>
     <value>'{0}' is not a recognized Rubberduck annotation (yet?)</value>
     <comment>{0} Unrecognized annotation name</comment>
   </data>
+  <data name="SuspiciousPredeclaredInstanceAccessInspection" xml:space="preserve">
+    <value>Identifier '{0}' in '{1}' is suspiciously referring to the default instance of that class type.</value>
+    <comment>{0} identifier name; {1} expression/context</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -547,6 +547,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace qualifier with &apos;Me&apos;.
+        /// </summary>
+        public static string ReplaceQualifierWithMeQuickFix {
+            get {
+                return ResourceManager.GetString("ReplaceQualifierWithMeQuickFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Replace &apos;While...Wend&apos; with &apos;Do While...Loop&apos;.
         /// </summary>
         public static string ReplaceWhileWendWithDoWhileLoopQuickFix {

--- a/Rubberduck.Resources/Inspections/QuickFixes.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.resx
@@ -309,4 +309,7 @@
   <data name="AnnotateEntryPointQuickFix" xml:space="preserve">
     <value>Add @EntryPoint annotation</value>
   </data>
+  <data name="ReplaceQualifierWithMeQuickFix" xml:space="preserve">
+    <value>Replace qualifier with 'Me'</value>
+  </data>
 </root>

--- a/RubberduckTests/Inspections/SuspiciousPredeclaredInstanceAccessInspectionTests.cs
+++ b/RubberduckTests/Inspections/SuspiciousPredeclaredInstanceAccessInspectionTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rubberduck.CodeAnalysis.Inspections;
+using Rubberduck.CodeAnalysis.Inspections.Concrete;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers;
+using RubberduckTests.Mocks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    public class SuspiciousPredeclaredInstanceAccessInspectionTests : InspectionTestsBase
+    {
+        [Test]
+        [Category("Inspections")]
+        public void ImplicitQualifier_NoResult()
+        {
+            var className = "UserForm1";
+            var code = @"
+Attribute VB_PredeclaredId = True
+Public AnyField As Long
+Private Sub Test()
+    AnyField = 42
+End Sub
+";
+            var inspectionResults = InspectionResultsForModules((className, code, ComponentType.UserForm));
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExplicitQualifierLHS_HasResult()
+        {
+            var className = "UserForm1";
+            var code = $@"
+Attribute VB_PredeclaredId = True
+Public AnyField As Long
+Private Sub Test()
+    {className}.AnyField = 42
+End Sub
+";
+            var inspectionResults = InspectionResultsForModules((className, code, ComponentType.UserForm));
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExplicitQualifierRHS_HasResult()
+        {
+            var className = "UserForm1";
+            var code = $@"
+Attribute VB_PredeclaredId = True
+Public AnyField As Long
+Private Sub Test()
+    AnyField = {className}.AnyField + 42
+End Sub
+";
+            var inspectionResults = InspectionResultsForModules((className, code, ComponentType.UserForm));
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ExplicitMeQualifier_NoResult()
+        {
+            var className = "UserForm1";
+            var code = $@"
+Attribute VB_PredeclaredId = True
+Public AnyField As Long
+Private Sub Test()
+    Me.AnyField = 42
+End Sub
+";
+            var inspectionResults = InspectionResultsForModules((className, code, ComponentType.UserForm));
+            Assert.AreEqual(0, inspectionResults.Count());
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new SuspiciousPredeclaredInstanceAccessInspection(state);
+        }
+    }
+}


### PR DESCRIPTION
This inspection flags explicit references to a class' default instance, that are made inside that class module.

Introduces a new `ReplaceQualifierWithMeQuickFix` to _replace_ an existing qualifier with the `Me` token - the existing `QualifyWithMeQuickFix` could not have been used for this.