### PR TITLE
Non-disposal decorators for more COM wrapper safety

### DIFF
--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/AddInNonDisposalDecorator.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/AddInNonDisposalDecorator.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    public class AddInNonDisposalDecorator<T> : NonDisposalDecoratorBase<T>, IAddIn
+        where T : IAddIn
+    {
+        public AddInNonDisposalDecorator(T addIn)
+            : base(addIn)
+        { }
+
+        public bool Equals(IAddIn other)
+        {
+            return WrappedItem.Equals(other);
+        }
+
+        public string ProgId => WrappedItem.ProgId;
+
+        public string Guid => WrappedItem.Guid;
+
+        public string Description
+        {
+            get => WrappedItem.Description;
+            set => WrappedItem.Description = value;
+        }
+
+        public bool Connect
+        {
+            get => WrappedItem.Connect;
+            set => WrappedItem.Connect = value;
+        }
+
+        public object Object
+        {
+            get => WrappedItem.Object;
+            set => WrappedItem.Object = value;
+        }
+
+        public IVBE VBE => WrappedItem.VBE;
+
+        public IAddIns Collection => WrappedItem.Collection;
+
+        public IReadOnlyDictionary<CommandBarSite, CommandBarLocation> CommandBarLocations => WrappedItem.CommandBarLocations;
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/CommandBarsNonDisposalDecorator.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/CommandBarsNonDisposalDecorator.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    public class CommandBarsNonDisposalDecorator<T> : NonDisposalDecoratorBase<T>, ICommandBars
+        where T : ICommandBars
+    {
+        public CommandBarsNonDisposalDecorator(T commandBars)
+            : base(commandBars)
+        { }
+
+        public IEnumerator<ICommandBar> GetEnumerator()
+        {
+            return WrappedItem.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) WrappedItem).GetEnumerator();
+        }
+
+        public int Count => WrappedItem.Count;
+
+        public ICommandBar this[object index] => WrappedItem[index];
+
+        public ICommandBar Add(string name)
+        {
+            return WrappedItem.Add(name);
+        }
+
+        public ICommandBar Add(string name, CommandBarPosition position)
+        {
+            return WrappedItem.Add(name, position);
+        }
+
+        public ICommandBarControl FindControl(int id)
+        {
+            return WrappedItem.FindControl(id);
+        }
+
+        public ICommandBarControl FindControl(ControlType type, int id)
+        {
+            return WrappedItem.FindControl(type, id);
+        }
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/NonDisposalDecoratorBase.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/NonDisposalDecoratorBase.cs
@@ -1,0 +1,26 @@
+﻿using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    /// <summary>
+    /// Decorator for SafeComWrappers to safely hand out references that must not be disposed
+    /// </summary>
+    /// <typeparam name="T">Concrete type of the safe com wrapper to decorate</typeparam>
+    public class NonDisposalDecoratorBase<T> : ISafeComWrapper
+        where T :ISafeComWrapper
+    {
+        protected readonly T WrappedItem;
+
+        public NonDisposalDecoratorBase(T wrappedItem)
+        {
+            WrappedItem = wrappedItem;
+        }
+
+        public object Target => WrappedItem.Target;
+        public bool IsWrappingNullReference => WrappedItem.IsWrappingNullReference;
+        public void Dispose()
+        {
+            //Do nothing
+        }
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBComponentNonDisposalDecorator.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBComponentNonDisposalDecorator.cs
@@ -1,0 +1,84 @@
+﻿using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    public class VBComponentNonDisposalDecorator<T> : NonDisposalDecoratorBase<T>, IVBComponent
+        where T : IVBComponent
+    {
+        public VBComponentNonDisposalDecorator(T component)
+            : base(component)
+        { }
+
+        public bool Equals(IVBComponent other)
+        {
+            return WrappedItem.Equals(other);
+        }
+
+        public ComponentType Type => WrappedItem.Type;
+
+        public bool HasCodeModule => WrappedItem.HasCodeModule;
+
+        public ICodeModule CodeModule => WrappedItem.CodeModule;
+
+        public IVBE VBE => WrappedItem.VBE;
+
+        public IVBComponents Collection => WrappedItem.Collection;
+
+        public IProperties Properties => WrappedItem.Properties;
+
+        public IControls Controls => WrappedItem.Controls;
+
+        public IControls SelectedControls => WrappedItem.SelectedControls;
+
+        public bool IsSaved => WrappedItem.IsSaved;
+
+        public bool HasDesigner => WrappedItem.HasDesigner;
+
+        public bool HasOpenDesigner => WrappedItem.HasOpenDesigner;
+
+        public string DesignerId => WrappedItem.DesignerId;
+
+        public string Name
+        {
+            get => WrappedItem.Name;
+            set => WrappedItem.Name = value;
+        }
+
+        public IWindow DesignerWindow()
+        {
+            return WrappedItem.DesignerWindow();
+        }
+
+        public void Activate()
+        {
+            WrappedItem.Activate();
+        }
+
+        public void Export(string path)
+        {
+            WrappedItem.Export(path);
+        }
+
+        public string ExportAsSourceFile(string folder, bool isTempFile = false, bool specialCaseDocumentModules = true)
+        {
+            return WrappedItem.ExportAsSourceFile(folder, isTempFile, specialCaseDocumentModules);
+        }
+
+        public int FileCount => WrappedItem.FileCount;
+
+        public string GetFileName(short index)
+        {
+            return WrappedItem.GetFileName(index);
+        }
+
+        public IVBProject ParentProject => WrappedItem.ParentProject;
+
+        public int ContentHash()
+        {
+            return WrappedItem.ContentHash();
+        }
+
+        public QualifiedModuleName QualifiedModuleName => WrappedItem.QualifiedModuleName;
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBComponentsNonDisposalDecorator.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBComponentsNonDisposalDecorator.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Rubberduck.VBEditor.Events;
+using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    public class VBComponentsNonDisposalDecorator<T> : NonDisposalDecoratorBase<T>, IVBComponents
+        where T : IVBComponents
+    {
+        public VBComponentsNonDisposalDecorator(T components)
+            : base(components)
+        { }
+
+        public void AttachEvents()
+        {
+            WrappedItem.AttachEvents();
+        }
+
+        public void DetachEvents()
+        {
+            WrappedItem.DetachEvents();
+        }
+
+        public IEnumerator<IVBComponent> GetEnumerator()
+        {
+            return WrappedItem.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) WrappedItem).GetEnumerator();
+        }
+
+        public int Count => WrappedItem.Count;
+
+        public event EventHandler<ComponentEventArgs> ComponentAdded
+        {
+            add => WrappedItem.ComponentAdded += value;
+            remove => WrappedItem.ComponentAdded -= value;
+        }
+
+        public event EventHandler<ComponentEventArgs> ComponentRemoved
+        {
+            add => WrappedItem.ComponentRemoved += value;
+            remove => WrappedItem.ComponentRemoved -= value;
+        }
+
+        public event EventHandler<ComponentRenamedEventArgs> ComponentRenamed
+        {
+            add => WrappedItem.ComponentRenamed += value;
+            remove => WrappedItem.ComponentRenamed -= value;
+        }
+
+        public event EventHandler<ComponentEventArgs> ComponentSelected
+        {
+            add => WrappedItem.ComponentSelected += value;
+            remove => WrappedItem.ComponentSelected -= value;
+        }
+
+        public event EventHandler<ComponentEventArgs> ComponentActivated
+        {
+            add => WrappedItem.ComponentActivated += value;
+            remove => WrappedItem.ComponentActivated -= value;
+        }
+
+        public event EventHandler<ComponentEventArgs> ComponentReloaded
+        {
+            add => WrappedItem.ComponentReloaded += value;
+            remove => WrappedItem.ComponentReloaded -= value;
+        }
+
+        public IVBComponent this[object index] => WrappedItem[index];
+
+        public IVBE VBE => WrappedItem.VBE;
+
+        public IVBProject Parent => WrappedItem.Parent;
+
+        public void Remove(IVBComponent item)
+        {
+            WrappedItem.Remove(item);
+        }
+
+        public IVBComponent Add(ComponentType type)
+        {
+            return WrappedItem.Add(type);
+        }
+
+        public IVBComponent Import(string path)
+        {
+            return WrappedItem.Import(path);
+        }
+
+        public IVBComponent AddCustom(string progId)
+        {
+            return WrappedItem.AddCustom(progId);
+        }
+
+        public IVBComponent ImportSourceFile(string path)
+        {
+            return WrappedItem.ImportSourceFile(path);
+        }
+
+        public void RemoveSafely(IVBComponent component)
+        {
+            WrappedItem.RemoveSafely(component);
+        }
+
+        public bool Equals(IVBComponents other)
+        {
+            return WrappedItem.Equals(other);
+        }
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBProjectNonDisposalDecorator.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBProjectNonDisposalDecorator.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    public class VBProjectNonDisposalDecorator<T> : NonDisposalDecoratorBase<T>, IVBProject
+        where T : IVBProject
+    {
+        public VBProjectNonDisposalDecorator(T project)
+            : base(project)
+        { }
+
+        public bool Equals(IVBProject other)
+        {
+            return WrappedItem.Equals(other);
+        }
+
+        public IApplication Application => WrappedItem.Application;
+
+        public IApplication Parent => WrappedItem.Parent;
+
+        public IVBE VBE => WrappedItem.VBE;
+
+        public IVBProjects Collection => WrappedItem.Collection;
+
+        public IReferences References => WrappedItem.References;
+
+        public IVBComponents VBComponents => WrappedItem.VBComponents;
+
+        public string ProjectId => WrappedItem.ProjectId;
+
+        public string Name
+        {
+            get => WrappedItem.Name;
+            set => WrappedItem.Name = value;
+        }
+
+        public string Description
+        {
+            get => WrappedItem.Description;
+            set => WrappedItem.Description = value;
+        }
+
+        public string HelpFile
+        {
+            get => WrappedItem.HelpFile;
+            set => WrappedItem.HelpFile = value;
+        }
+
+        public string FileName => WrappedItem.FileName;
+
+        public string BuildFileName => WrappedItem.BuildFileName;
+
+        public bool IsSaved => WrappedItem.IsSaved;
+
+        public ProjectType Type => WrappedItem.Type;
+
+        public EnvironmentMode Mode => WrappedItem.Mode;
+
+        public ProjectProtection Protection => WrappedItem.Protection;
+
+        public void AssignProjectId()
+        {
+            WrappedItem.AssignProjectId();
+        }
+
+        public void SaveAs(string fileName)
+        {
+            WrappedItem.SaveAs(fileName);
+        }
+
+        public void MakeCompiledFile()
+        {
+            WrappedItem.MakeCompiledFile();
+        }
+
+        public void ExportSourceFiles(string folder)
+        {
+            WrappedItem.ExportSourceFiles(folder);
+        }
+
+        public string ProjectDisplayName => WrappedItem.ProjectDisplayName;
+
+        public IReadOnlyList<string> ComponentNames()
+        {
+            return WrappedItem.ComponentNames();
+        }
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBProjectsNonDisposalDecorator.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VBProjectsNonDisposalDecorator.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Rubberduck.VBEditor.Events;
+using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    public class VBProjectsNonDisposalDecorator<T> : NonDisposalDecoratorBase<T>, IVBProjects
+        where T : IVBProjects
+    {
+        public VBProjectsNonDisposalDecorator(T projects)
+            : base(projects)
+        { }
+
+        public void AttachEvents()
+        {
+            WrappedItem.AttachEvents();
+        }
+
+        public void DetachEvents()
+        {
+            WrappedItem.DetachEvents();
+        }
+
+        public IEnumerator<IVBProject> GetEnumerator()
+        {
+            return WrappedItem.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) WrappedItem).GetEnumerator();
+        }
+
+        public int Count => WrappedItem.Count;
+
+        public IVBProject this[object index] => WrappedItem[index];
+
+        public bool Equals(IVBProjects other)
+        {
+            return WrappedItem.Equals(other);
+        }
+
+        public event EventHandler<ProjectEventArgs> ProjectActivated
+        {
+            add => WrappedItem.ProjectActivated += value;
+            remove => WrappedItem.ProjectActivated -= value;
+        }
+
+        public event EventHandler<ProjectEventArgs> ProjectAdded
+        {
+            add => WrappedItem.ProjectAdded += value;
+            remove => WrappedItem.ProjectAdded -= value;
+        }
+
+        public event EventHandler<ProjectEventArgs> ProjectRemoved
+        {
+            add => WrappedItem.ProjectRemoved += value;
+            remove => WrappedItem.ProjectRemoved -= value;
+        }
+
+        public event EventHandler<ProjectRenamedEventArgs> ProjectRenamed
+        {
+            add => WrappedItem.ProjectRenamed += value;
+            remove => WrappedItem.ProjectRenamed -= value;
+        }
+
+        public IVBE VBE => WrappedItem.VBE;
+
+        public IVBE Parent => WrappedItem.Parent;
+
+        public IVBProject Add(ProjectType type)
+        {
+            return WrappedItem.Add(type);
+        }
+
+        public IVBProject Open(string path)
+        {
+            return WrappedItem.Open(path);
+        }
+
+        public void Remove(IVBProject project)
+        {
+            WrappedItem.Remove(project);
+        }
+
+        public IVBProject StartProject
+        {
+            get => WrappedItem.StartProject;
+            set => WrappedItem.StartProject = value;
+        }
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VbeNonDisposalDecorator.cs
+++ b/Rubberduck.VBEEditor/ComManagement/NonDisposalDecorators/VbeNonDisposalDecorator.cs
@@ -1,0 +1,65 @@
+﻿using Rubberduck.VBEditor.SafeComWrappers;
+using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using Rubberduck.VBEditor.SourceCodeHandling;
+
+namespace Rubberduck.VBEditor.ComManagement.NonDisposalDecorators
+{
+    public class VbeNonDisposalDecorator<T> : NonDisposalDecoratorBase<T>, IVBE
+        where T: IVBE
+    {
+        public VbeNonDisposalDecorator(T vbe)
+            : base(vbe)
+        {}
+
+        public bool Equals(IVBE other)
+        {
+            return WrappedItem.Equals(other);
+        }
+
+        public VBEKind Kind => WrappedItem.Kind;
+        public string Version => WrappedItem.Version;
+        public object HardReference => WrappedItem.HardReference;
+        public IWindow ActiveWindow => WrappedItem.ActiveWindow;
+
+        public ICodePane ActiveCodePane
+        {
+            get => WrappedItem.ActiveCodePane;
+            set => WrappedItem.ActiveCodePane = value;
+        }
+
+        public IVBProject ActiveVBProject
+        {
+            get => WrappedItem.ActiveVBProject;
+            set => WrappedItem.ActiveVBProject = value;
+        }
+
+        public IVBComponent SelectedVBComponent => WrappedItem.SelectedVBComponent;
+        public IWindow MainWindow => WrappedItem.MainWindow;
+        public IAddIns AddIns => WrappedItem.AddIns;
+        public IVBProjects VBProjects => WrappedItem.VBProjects;
+        public ICodePanes CodePanes => WrappedItem.CodePanes;
+        public ICommandBars CommandBars => WrappedItem.CommandBars;
+        public IWindows Windows => WrappedItem.Windows;
+
+        public IHostApplication HostApplication()
+        {
+            return WrappedItem.HostApplication();
+        }
+
+        public IWindow ActiveMDIChild()
+        {
+            return WrappedItem.ActiveMDIChild();
+        }
+
+        public QualifiedSelection? GetActiveSelection()
+        {
+            return WrappedItem.GetActiveSelection();
+        }
+
+        public bool IsInDesignMode => WrappedItem.IsInDesignMode;
+
+        public int ProjectsCount => WrappedItem.ProjectsCount;
+
+        public ITempSourceFileHandler TempSourceFileHandler => WrappedItem.TempSourceFileHandler;
+    }
+}

--- a/Rubberduck.VBEEditor/ComManagement/ProjectsRepository.cs
+++ b/Rubberduck.VBEEditor/ComManagement/ProjectsRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NLog;
+using Rubberduck.VBEditor.ComManagement.NonDisposalDecorators;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
 using Rubberduck.VBEditor.Extensions;
 using Rubberduck.VBEditor.SafeComWrappers;
@@ -200,17 +201,23 @@ namespace Rubberduck.VBEditor.ComManagement
 
         public IVBProjects ProjectsCollection()
         {
-            return _projectsCollection;
+            return new VBProjectsNonDisposalDecorator<IVBProjects>(_projectsCollection);
         }
 
         public IEnumerable<(string ProjectId, IVBProject Project)> Projects()
         {
-            return EvaluateWithinReadLock(() => _projects.Select(kvp => (kvp.Key, kvp.Value)).ToList()) ?? new List<(string, IVBProject)>();
+            return EvaluateWithinReadLock(() => _projects
+                        .Select(kvp => (kvp.Key, new VBProjectNonDisposalDecorator<IVBProject>(kvp.Value) as IVBProject))
+                        .ToList()) 
+                   ?? new List<(string, IVBProject)>();
         }
 
         public IEnumerable<(string ProjectId, IVBProject Project)> LockedProjects()
         {
-            return EvaluateWithinReadLock(() => _lockedProjects.Select(kvp => (kvp.Key, kvp.Value)).ToList()) ?? new List<(string, IVBProject)>();
+            return EvaluateWithinReadLock(() => _lockedProjects
+                        .Select(kvp => (kvp.Key, new VBProjectNonDisposalDecorator<IVBProject>(kvp.Value) as IVBProject))
+                        .ToList()) 
+                   ?? new List<(string, IVBProject)>();
         }
 
         private T EvaluateWithinReadLock<T>(Func<T> function) where T: class
@@ -243,7 +250,9 @@ namespace Rubberduck.VBEditor.ComManagement
                 return null;
             }
 
-            return EvaluateWithinReadLock(() => _projects.TryGetValue(projectId, out var project) ? project : null);
+            return EvaluateWithinReadLock(() => _projects.TryGetValue(projectId, out var project) 
+                ? new VBProjectNonDisposalDecorator<IVBProject>(project)
+                : null);
         }
 
         public IVBComponents ComponentsCollection(string projectId)
@@ -253,25 +262,32 @@ namespace Rubberduck.VBEditor.ComManagement
                 return null;
             }
 
-            return EvaluateWithinReadLock(() => _componentsCollections.TryGetValue(projectId, out var componenstCollection) ? componenstCollection : null);
+            return EvaluateWithinReadLock(() => _componentsCollections.TryGetValue(projectId, out var componentsCollection) 
+                ? new VBComponentsNonDisposalDecorator<IVBComponents>(componentsCollection)
+                : null);
         }
 
         public IEnumerable<(QualifiedModuleName QualifiedModuleName, IVBComponent Component)> Components()
         {
-            return EvaluateWithinReadLock(() => _components.Select(kvp => (kvp.Key, kvp.Value)).ToList()) ?? new List<(QualifiedModuleName, IVBComponent)>();
+            return EvaluateWithinReadLock(() => _components
+                        .Select(kvp => (kvp.Key, new VBComponentNonDisposalDecorator<IVBComponent>(kvp.Value) as IVBComponent))
+                        .ToList()) 
+                   ?? new List<(QualifiedModuleName, IVBComponent)>();
         }
 
         public IEnumerable<(QualifiedModuleName QualifiedModuleName, IVBComponent Component)> Components(string projectId)
         {
             return EvaluateWithinReadLock(() => _components.Where(kvp => kvp.Key.ProjectId.Equals(projectId))
-                       .Select(kvp => (kvp.Key, kvp.Value))
+                       .Select(kvp => (kvp.Key, new VBComponentNonDisposalDecorator<IVBComponent>(kvp.Value) as IVBComponent))
                        .ToList())
                    ?? new List<(QualifiedModuleName, IVBComponent)>();
         }
 
         public IVBComponent Component(QualifiedModuleName qualifiedModuleName)
         {
-            return EvaluateWithinReadLock(() => _components.TryGetValue(qualifiedModuleName, out var component) ? component : null);
+            return EvaluateWithinReadLock(() => _components.TryGetValue(qualifiedModuleName, out var component) 
+                ? new VBComponentNonDisposalDecorator<IVBComponent>(component) as IVBComponent
+                : null);
         }
 
         public void RemoveComponent(QualifiedModuleName qualifiedModuleName)

--- a/Rubberduck.VBEEditor/ComManagement/ProjectsRepository.cs
+++ b/Rubberduck.VBEEditor/ComManagement/ProjectsRepository.cs
@@ -201,7 +201,9 @@ namespace Rubberduck.VBEditor.ComManagement
 
         public IVBProjects ProjectsCollection()
         {
-            return new VBProjectsNonDisposalDecorator<IVBProjects>(_projectsCollection);
+            return _projectsCollection != null 
+                ? new VBProjectsNonDisposalDecorator<IVBProjects>(_projectsCollection) 
+                : null;
         }
 
         public IEnumerable<(string ProjectId, IVBProject Project)> Projects()

--- a/RubberduckTests/Mocks/MockProjectBuilder.cs
+++ b/RubberduckTests/Mocks/MockProjectBuilder.cs
@@ -217,8 +217,8 @@ namespace RubberduckTests.Mocks
 
             result.Setup(m => m.Remove(It.IsAny<IVBComponent>())).Callback((IVBComponent c) =>
             {
-                _componentsMock.Remove(_componentsMock.First(m => m.Object == c));
-                _codeModuleMocks.Remove(_codeModuleMocks.First(m => m.Object.Parent == c));
+                _componentsMock.Remove(_componentsMock.First(m => m.Object.QualifiedModuleName == c.QualifiedModuleName));
+                _codeModuleMocks.Remove(_codeModuleMocks.First(m => m.Object.Parent.QualifiedModuleName == c.QualifiedModuleName));
             });
 
             result.Setup(m => m.Import(It.IsAny<string>())).Callback((string s) =>


### PR DESCRIPTION
This PR adds decorators for several com wrapper types to suppress disposal attempts on them.

This is relevant in two places. First, the wrappers handed out by the `ProjectsRepository` are references to cashed wrappers; only the repository itself should be allowed to dispose the instances when it clears its cache. 
Second, disposal of the com wrappers bound in CW is non-deterministic. In order to avoid running into concurrency issues on shutdown, CW should not be allowed to dispose the wrappers. This will than happen deterministically when disposing the `ComSafe`.