### PR TITLE
Acknowledge that module constants can have attributes

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyModuleInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/EmptyModuleInspection.cs
@@ -84,7 +84,7 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         public override bool VisitModuleDeclarationsElement(VBAParser.ModuleDeclarationsElementContext context)
         {
             return context.moduleVariableStmt() == null
-                   && context.constStmt() == null
+                   && context.moduleConstStmt() == null
                    && context.enumerationStmt() == null
                    && context.udtDeclaration() == null
                    && context.eventStmt() == null

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -102,7 +102,7 @@ moduleDeclarationsElement :
     | defDirective
     | enumerationStmt 
     | eventStmt
-    | constStmt
+    | moduleConstStmt
     | implementsStmt
     | moduleVariableStmt
     | moduleOption
@@ -111,6 +111,11 @@ moduleDeclarationsElement :
 
 moduleVariableStmt :
 	variableStmt
+	(endOfLine attributeStmt)*
+;
+
+moduleConstStmt :
+	constStmt
 	(endOfLine attributeStmt)*
 ;
 

--- a/Rubberduck.Parsing/Rewriter/RewriterInfo/ConstantRewriterInfoFinder.cs
+++ b/Rubberduck.Parsing/Rewriter/RewriterInfo/ConstantRewriterInfoFinder.cs
@@ -24,7 +24,7 @@ namespace Rubberduck.Parsing.Rewriter.RewriterInfo
             var itemIndex = items.ToList().IndexOf(target);
             var count = items.Length;
 
-            var element = context.Parent as VBAParser.ModuleDeclarationsElementContext;
+            var element = context.Parent?.Parent as VBAParser.ModuleDeclarationsElementContext;
             if (element != null)
             {
                 return GetModuleConstantRemovalInfo(target, element, count, itemIndex, items);
@@ -34,8 +34,11 @@ namespace Rubberduck.Parsing.Rewriter.RewriterInfo
         }
 
         private static RewriterInfo GetModuleConstantRemovalInfo(
-            VBAParser.ConstSubStmtContext target, VBAParser.ModuleDeclarationsElementContext element,
-            int count, int itemIndex, IReadOnlyList<VBAParser.ConstSubStmtContext> items)
+            VBAParser.ConstSubStmtContext target, 
+            VBAParser.ModuleDeclarationsElementContext element,
+            int count, 
+            int itemIndex, 
+            IReadOnlyList<VBAParser.ConstSubStmtContext> items)
         {
             if (count == 1)
             {

--- a/Rubberduck.Parsing/Symbols/Identifier.cs
+++ b/Rubberduck.Parsing/Symbols/Identifier.cs
@@ -47,6 +47,12 @@ namespace Rubberduck.Parsing.Symbols
             return GetName(nameContext);
         }
 
+        public static string GetName(VBAParser.ConstSubStmtContext context)
+        {
+            var nameContext = context.identifier();
+            return GetName(nameContext);
+        }
+
         public static string GetName(VBAParser.ConstSubStmtContext context, out Interval tokenInterval)
         {
             var nameContext = context.identifier();

--- a/Rubberduck.Parsing/Symbols/ValuedDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ValuedDeclaration.cs
@@ -23,7 +23,10 @@ namespace Rubberduck.Parsing.Symbols
             string value,
             ParserRuleContext context, 
             Selection selection, 
-            bool isUserDefined = true)
+            bool isUserDefined = true,
+            ParserRuleContext attributesPassContext = null,
+            Attributes attributes = null
+            )
             :base(
                  qualifiedName, 
                  parentDeclaration, 
@@ -35,12 +38,13 @@ namespace Rubberduck.Parsing.Symbols
                  accessibility,
                  declarationType, 
                  context, 
-                 null,
+                 attributesPassContext,
                  selection,
                  false,
                  asTypeContext,
                  isUserDefined,
-                 annotations)
+                 annotations,
+                 attributes: attributes)
         {
             Expression = value;
         }

--- a/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
+++ b/Rubberduck.Parsing/VBA/DeclarationResolving/DeclarationSymbolsListener.cs
@@ -721,6 +721,10 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
             var value = context.expression().GetText();
             var constStmt = (VBAParser.ConstStmtContext)context.Parent;
 
+            var key = (name, DeclarationType.Constant);
+            _attributes.TryGetValue(key, out var attributes);
+            _membersAllowingAttributes.TryGetValue(key, out var attributesPassContext);
+
             var declaration = new ValuedDeclaration(
                 new QualifiedMemberName(_qualifiedModuleName, name),
                 _parentDeclaration,
@@ -733,7 +737,9 @@ namespace Rubberduck.Parsing.VBA.DeclarationResolving
                 DeclarationType.Constant,
                 value,
                 context,
-                identifier.GetSelection());
+                identifier.GetSelection(),
+                attributesPassContext: attributesPassContext,
+                attributes: attributes);
 
             AddDeclaration(declaration);
         }

--- a/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
@@ -42,6 +42,16 @@ namespace Rubberduck.Parsing.VBA.Parsing
             }
         }
 
+        public override void EnterModuleConstStmt(VBAParser.ModuleConstStmtContext context)
+        {
+            var constantDeclarationStatementList = context.constStmt().constSubStmt();
+            foreach (var constContext in constantDeclarationStatementList)
+            {
+                var constantName = Identifier.GetName(constContext);
+                _membersAllowingAttributes[(constantName, DeclarationType.Constant)] = context;
+            }
+        }
+
         public override void EnterDeclareStmt(VBAParser.DeclareStmtContext context)
         {
             var name = Identifier.GetName(context.identifier());

--- a/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
+++ b/RubberduckTests/Inspections/IllegalAnnotationsInspectionTests.cs
@@ -487,6 +487,25 @@ End Sub
 
         [Test]
         [Category("Inspections")]
+        public void VariableAnnotationOnConstant_NoResult()
+        {
+            const string inputCode = @"
+Option Explicit
+Option Private Module
+
+'@VariableDescription ""Test""
+Private Const Test As String = ""TestTestTest""
+
+Public Sub Test2()
+End Sub
+";
+
+            var inspectionResults = InspectionResultsForStandardModule(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void VariableOnOrAboveNonWhitespaceAboveFirstVariable_OneResultEach()
         {
             const string inputCode = @"'@Obsolete 

--- a/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
@@ -287,6 +287,60 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
+        public void VariableDescriptionAnnotationWithoutAttributeReturnsResult_Variable()
+        {
+            const string inputCode =
+                @"'@VariableDescription ""Desc""
+Public Foo As String
+";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void Variable_DescriptionAnnotationWithAttributeReturnsNoResult_Variable()
+        {
+            const string inputCode =
+                @"'@VariableDescription ""Desc""
+Public Foo As String
+Attribute Foo.VB_VarDescription = ""NotDesc""
+";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VariableDescriptionAnnotationWithoutAttributeReturnsResult_Constant()
+        {
+            const string inputCode =
+                @"'@VariableDescription ""Desc""
+Public Const Foo As String = ""Huh""
+";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.AreEqual(1, inspectionResults.Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void Variable_DescriptionAnnotationWithAttributeReturnsNoResult_Constant()
+        {
+            const string inputCode =
+                @"'@VariableDescription ""Desc""
+Public Const Foo As String = ""Huh""
+Attribute Foo.VB_VarDescription = ""NotDesc""
+";
+
+            var inspectionResults = InspectionResults(inputCode);
+            Assert.IsFalse(inspectionResults.Any());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void ModuleDescriptionAnnotationWithoutAttributeReturnsResult()
         {
             const string inputCode =

--- a/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
+++ b/RubberduckTests/QuickFixes/AddMissingAttributeQuickFixTests.cs
@@ -54,6 +54,44 @@ End Sub";
 
         [Test]
         [Category("QuickFixes")]
+        public void MissingVariableAttribute_QuickFixWorks_Variable()
+        {
+            const string inputCode =
+                @"'@VariableDescription ""Desc""
+Public Foo As String
+";
+
+            const string expectedCode =
+                @"'@VariableDescription ""Desc""
+Public Foo As String
+Attribute Foo.VB_VarDescription = ""Desc""
+";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
+        public void MissingVariableAttribute_QuickFixWorks_Constant()
+        {
+            const string inputCode =
+                @"'@VariableDescription ""Desc""
+Public Const Foo As String = ""Huh""
+";
+
+            const string expectedCode =
+                @"'@VariableDescription ""Desc""
+Public Const Foo As String = ""Huh""
+Attribute Foo.VB_VarDescription = ""Desc""
+";
+
+            var actualCode = ApplyQuickFixToFirstInspectionResult(inputCode, state => new MissingAttributeInspection(state), CodeKind.AttributesCode);
+            Assert.AreEqual(expectedCode, actualCode);
+        }
+
+        [Test]
+        [Category("QuickFixes")]
         //See issue #5268 at https://github.com/rubberduck-vba/Rubberduck/issues/5268
         public void MissingMemberAttribute_ExcelHotkey_QuickFixWorks()
         {


### PR DESCRIPTION
Closes #5926 

This PR adds support for attributes on module level constants. 

This required adding the corresponding contexts in the context listener and actually attaching them to the generated `ValuedDeclaration`s. 

Since only module constants can have attributes, a further level has been added in the grammar to reflect the distinction.