### PR TITLE
Fix missing part for VarDesc on constants 

### DIFF
--- a/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
+++ b/Rubberduck.Parsing/VBA/Parsing/AttributeListener.cs
@@ -34,8 +34,8 @@ namespace Rubberduck.Parsing.VBA.Parsing
 
         public override void EnterModuleVariableStmt(VBAParser.ModuleVariableStmtContext context)
         {
-            var variableDeclarationStatemenList = context.variableStmt().variableListStmt().variableSubStmt();
-            foreach (var variableContext in variableDeclarationStatemenList)
+            var variableDeclarationStatementList = context.variableStmt().variableListStmt().variableSubStmt();
+            foreach (var variableContext in variableDeclarationStatementList)
             {
                 var variableName = Identifier.GetName(variableContext);
                 _membersAllowingAttributes[(variableName, DeclarationType.Variable)] = context;
@@ -169,18 +169,28 @@ namespace Rubberduck.Parsing.VBA.Parsing
 
             var scopeName = attributeNameParts[0]; 
 
-            //Might be an attribute for the enclosing procedure, function or poperty.
+            //Might be an attribute for the enclosing procedure, function or property.
             if (_currentScopeAttributes != null && scopeName.Equals(_currentScope.scopeIdentifier, StringComparison.OrdinalIgnoreCase))
             {
                 AddOrUpdateAttribute(_currentScopeAttributes, attributeName, context);
                 return;
             }
 
+            //Member attributes
+            //Due to the VBA naming rules, a name can only refer to either a variable or constant.
+
             //Member variable attributes
             var moduleVariableScope = (scopeName, DeclarationType.Variable);
             if (_membersAllowingAttributes.TryGetValue(moduleVariableScope, out _))
             {
                 AddOrUpdateAttribute(moduleVariableScope, attributeName, context);
+            }
+
+            //Member constant attributes
+            var moduleConstantScope = (scopeName, DeclarationType.Constant);
+            if (_membersAllowingAttributes.TryGetValue(moduleConstantScope, out _))
+            {
+                AddOrUpdateAttribute(moduleConstantScope, attributeName, context);
             }
         }
 

--- a/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
+++ b/RubberduckTests/Inspections/MissingAttributeInspectionTests.cs
@@ -327,7 +327,7 @@ Public Const Foo As String = ""Huh""
 
         [Test]
         [Category("Inspections")]
-        public void Variable_DescriptionAnnotationWithAttributeReturnsResult_Constant()
+        public void Variable_DescriptionAnnotationWithAttributeReturnsNoResult_Constant()
         {
             const string inputCode =
                 @"'@VariableDescription ""Desc""
@@ -336,7 +336,7 @@ Attribute Foo.VB_VarDescription = ""NotDesc""
 ";
 
             var inspectionResults = InspectionResults(inputCode);
-            Assert.AreEqual(1, inspectionResults.Count());
+            Assert.IsFalse(inspectionResults.Any());
         }
 
         [Test]


### PR DESCRIPTION
Fixes #5947

This PR adds the the missing part to actually attach attributes to module constants. Previously, the attributes listener only saved attributes for variables, not constants. 