### PR TITLE
Refine TODO Marker detection

### DIFF
--- a/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
+++ b/Rubberduck.Core/UI/ToDoItems/ToDoExplorerViewModel.cs
@@ -294,7 +294,7 @@ namespace Rubberduck.UI.ToDoItems
         {
             var markers = _configService.Read().UserSettings.ToDoListSettings.ToDoMarkers;
             return markers.Where(marker => !string.IsNullOrEmpty(marker.Text)
-                                         && Regex.IsMatch(comment.CommentText, @"\b" + Regex.Escape(marker.Text) + @"\b", RegexOptions.IgnoreCase))
+                                         && Regex.IsMatch(comment.CommentText, @"^\s*" + Regex.Escape(marker.Text) + @"\b", RegexOptions.IgnoreCase))
                            .Select(marker => new ToDoItem(marker.Text, comment));
         }
 


### PR DESCRIPTION
This change alters the todo marker detection to require the marker be at the start of the comment, optionally preceded by whitespace and ending in a word boundary.
See #5957