### PR TITLE
Fix EmptyLineHandlingMethod user setting initialization

### DIFF
--- a/Rubberduck.Core/UI/Settings/IndenterSettingsViewModel.cs
+++ b/Rubberduck.Core/UI/Settings/IndenterSettingsViewModel.cs
@@ -38,6 +38,7 @@ namespace Rubberduck.UI.Settings
             _spaceProcedures = config.UserSettings.IndenterSettings.VerticallySpaceProcedures;
             _procedureSpacing = config.UserSettings.IndenterSettings.LinesBetweenProcedures;
             _groupRelatedProperties = config.UserSettings.IndenterSettings.GroupRelatedProperties;
+            _emptyLineHandlingMethod = config.UserSettings.IndenterSettings.EmptyLineHandlingMethod;
 
             PropertyChanged += IndenterSettingsViewModel_PropertyChanged;
             ExportButtonCommand = new DelegateCommand(LogManager.GetCurrentClassLogger(), _ => ExportSettings(GetCurrentSettings()));


### PR DESCRIPTION
Fixes #5285 

The `_emptyLineHandlingMethod` field was missing from the set of initializations in the `IndenterSettingsViewModel` constructor. 