### PR TITLE
Improve resource consistency for `XXXNotUsedInspections'

### DIFF
--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -808,7 +808,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter is not referred to..
+        ///   Looks up a localized string similar to Parameter is not used..
         /// </summary>
         public static string ParameterNotUsedInspection {
             get {
@@ -826,7 +826,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Procedure is not referred to..
+        ///   Looks up a localized string similar to Procedure/Function/Property is not used..
         /// </summary>
         public static string ProcedureNotUsedInspection {
             get {
@@ -844,13 +844,6 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Public enumeration declared within worksheet.
-        /// </summary>
-        public static string PublicEnumerationDeclaredInWorksheetInspection {
-            get {
-                return ResourceManager.GetString("PublicEnumerationDeclaredInWorksheetInspection", resourceCulture);
-            }
-        }
         ///   Looks up a localized string similar to Public control field access.
         /// </summary>
         public static string PublicControlFieldAccessInspection {
@@ -859,6 +852,16 @@ namespace Rubberduck.Resources.Inspections {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Public enumeration declared within worksheet.
+        /// </summary>
+        public static string PublicEnumerationDeclaredInWorksheetInspection {
+            get {
+                return ResourceManager.GetString("PublicEnumerationDeclaredInWorksheetInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Read-Only Property assignment.
         /// </summary>
         public static string ReadOnlyPropertyAssignmentInspection {
@@ -1093,7 +1096,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variable is not referred to..
+        ///   Looks up a localized string similar to Variable is not used..
         /// </summary>
         public static string VariableNotUsedInspection {
             get {

--- a/Rubberduck.Resources/Inspections/InspectionNames.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.cs.resx
@@ -120,9 +120,6 @@
   <data name="AssignedByValParameterInspection" xml:space="preserve">
     <value>ByVal parametr je přidělen</value>
   </data>
-  <data name="ConstantNotUsedInspection" xml:space="preserve">
-    <value>Konstanta není použita</value>
-  </data>
   <data name="DefaultProjectNameInspection" xml:space="preserve">
     <value>Název projektu není specifikován</value>
   </data>
@@ -180,12 +177,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Parametr je možné předat jako hodnotu.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Neexistující reference k parametru.</value>
-  </data>
-  <data name="ProcedureNotUsedInspection" xml:space="preserve">
-    <value>Neexistující reference k proceduře.</value>
-  </data>
   <data name="UnassignedVariableUsageInspection" xml:space="preserve">
     <value>Proměnná je použita, avšak není přiřazena.</value>
   </data>
@@ -197,9 +188,6 @@
   </data>
   <data name="VariableNotAssignedInspection" xml:space="preserve">
     <value>Proměnná není přiřazena.</value>
-  </data>
-  <data name="VariableNotUsedInspection" xml:space="preserve">
-    <value>Neexistující reference k proměnné.</value>
   </data>
   <data name="VariableTypeNotDeclaredInspection" xml:space="preserve">
     <value>Implicitně proměnná typu 'Variant'</value>
@@ -254,9 +242,6 @@
   </data>
   <data name="RedundantByRefModifierInspection" xml:space="preserve">
     <value>Nadbytečný 'ByRef' modifikátor</value>
-  </data>
-  <data name="LineLabelNotUsedInspection" xml:space="preserve">
-    <value>Štítek řádku není použit</value>
   </data>
   <data name="EmptyElseBlockInspection" xml:space="preserve">
     <value>Prázdný 'Else' blok</value>

--- a/Rubberduck.Resources/Inspections/InspectionNames.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.de.resx
@@ -120,9 +120,6 @@
   <data name="AssignedByValParameterInspection" xml:space="preserve">
     <value>ByVal Parameter ist zugewiesen</value>
   </data>
-  <data name="ConstantNotUsedInspection" xml:space="preserve">
-    <value>Konstante wird nicht verwendet</value>
-  </data>
   <data name="DefaultProjectNameInspection" xml:space="preserve">
     <value>Das Projekt hat den Standard-Projektnamen</value>
   </data>
@@ -180,12 +177,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Parameter kann als Wert übergeben werden.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Der Parameter wird nicht genutzt.</value>
-  </data>
-  <data name="ProcedureNotUsedInspection" xml:space="preserve">
-    <value>Die Prozedur wird nicht genutzt.</value>
-  </data>
   <data name="UnassignedVariableUsageInspection" xml:space="preserve">
     <value>Variable wird genutzt ohne das ihr ein Wert zugewiesen wurde.</value>
   </data>
@@ -197,9 +188,6 @@
   </data>
   <data name="VariableNotAssignedInspection" xml:space="preserve">
     <value>Der Variable wird kein Wert zugewiesen.</value>
-  </data>
-  <data name="VariableNotUsedInspection" xml:space="preserve">
-    <value>Die Variable wird nicht referenziert.</value>
   </data>
   <data name="VariableTypeNotDeclaredInspection" xml:space="preserve">
     <value>Variable ist implizit 'Variant'</value>
@@ -242,9 +230,6 @@
   </data>
   <data name="OptionBaseZeroInspection" xml:space="preserve">
     <value>'Option Base 0' ist redundant</value>
-  </data>
-  <data name="LineLabelNotUsedInspection" xml:space="preserve">
-    <value>Zeilenbezeichnung wird nicht referenziert</value>
   </data>
   <data name="EmptyIfBlockInspection" xml:space="preserve">
     <value>Leerer 'If'-Block</value>

--- a/Rubberduck.Resources/Inspections/InspectionNames.es.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.es.resx
@@ -120,9 +120,6 @@
   <data name="AssignedByValParameterInspection" xml:space="preserve">
     <value>Se asigna el parámetro ByVal</value>
   </data>
-  <data name="ConstantNotUsedInspection" xml:space="preserve">
-    <value>La constante no se usa</value>
-  </data>
   <data name="DefaultProjectNameInspection" xml:space="preserve">
     <value>No se especifica el nombre del proyecto</value>
   </data>
@@ -183,12 +180,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>El parámetro se puede pasar por valor.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>No se hace referencia al parámetro.</value>
-  </data>
-  <data name="ProcedureNotUsedInspection" xml:space="preserve">
-    <value>No se hace referencia al procedimiento.</value>
-  </data>
   <data name="UnassignedVariableUsageInspection" xml:space="preserve">
     <value>La variable se usa pero no se asigna.</value>
   </data>
@@ -200,9 +191,6 @@
   </data>
   <data name="VariableNotAssignedInspection" xml:space="preserve">
     <value>La variable no esta asignada.</value>
-  </data>
-  <data name="VariableNotUsedInspection" xml:space="preserve">
-    <value>La variable no es referida.</value>
   </data>
   <data name="VariableTypeNotDeclaredInspection" xml:space="preserve">
     <value>Variable 'Variant' implicita</value>
@@ -254,9 +242,6 @@
   </data>
   <data name="RedundantByRefModifierInspection" xml:space="preserve">
     <value>Modificador 'ByRef' redundante</value>
-  </data>
-  <data name="LineLabelNotUsedInspection" xml:space="preserve">
-    <value>No se usa la etiqueta de línea</value>
   </data>
   <data name="EmptyElseBlockInspection" xml:space="preserve">
     <value>Bloque 'Else' vacío</value>

--- a/Rubberduck.Resources/Inspections/InspectionNames.fr.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.fr.resx
@@ -120,9 +120,6 @@
   <data name="AssignedByValParameterInspection" xml:space="preserve">
     <value>Assignation d'un paramètre passé par valeur (ByVal)</value>
   </data>
-  <data name="ConstantNotUsedInspection" xml:space="preserve">
-    <value>Constante non utilisée</value>
-  </data>
   <data name="DefaultProjectNameInspection" xml:space="preserve">
     <value>Le projet porte le nom assigné par défaut</value>
   </data>
@@ -180,12 +177,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Le paramètre peut être passé par valeur.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Le paramètre n'est pas utilisé.</value>
-  </data>
-  <data name="ProcedureNotUsedInspection" xml:space="preserve">
-    <value>La procédure n'est pas appelée.</value>
-  </data>
   <data name="UnassignedVariableUsageInspection" xml:space="preserve">
     <value>La variable est utilisée, mais non assignée.</value>
   </data>
@@ -197,9 +188,6 @@
   </data>
   <data name="VariableNotAssignedInspection" xml:space="preserve">
     <value>Une variable est déclarée, mais pas assignée.</value>
-  </data>
-  <data name="VariableNotUsedInspection" xml:space="preserve">
-    <value>La variable n'est pas utilisée.</value>
   </data>
   <data name="VariableTypeNotDeclaredInspection" xml:space="preserve">
     <value>Variable implicitement de type 'Variant'</value>
@@ -242,9 +230,6 @@
   </data>
   <data name="EmptyCaseBlockInspection" xml:space="preserve">
     <value>Bloc 'Case' vide</value>
-  </data>
-  <data name="LineLabelNotUsedInspection" xml:space="preserve">
-    <value>Étiquette de ligne inutilisée</value>
   </data>
   <data name="EmptyIfBlockInspection" xml:space="preserve">
     <value>Branche conditionelle vide</value>

--- a/Rubberduck.Resources/Inspections/InspectionNames.it.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.it.resx
@@ -132,9 +132,6 @@
   <data name="BooleanAssignedInIfElseInspection" xml:space="preserve">
     <value>Assegnazione letterale booleana in condizionale</value>
   </data>
-  <data name="ConstantNotUsedInspection" xml:space="preserve">
-    <value>La costante non è utilizzata</value>
-  </data>
   <data name="DefaultMemberRequiredInspection" xml:space="preserve">
     <value>Accesso indicizzato al membro predefinito senza un membro predefinito</value>
   </data>
@@ -258,9 +255,6 @@
   <data name="LineContinuationBetweenKeywordsInspection" xml:space="preserve">
     <value>Carattere di continuazione di riga tra parole chiave</value>
   </data>
-  <data name="LineLabelNotUsedInspection" xml:space="preserve">
-    <value>Etichetta di riga non usata</value>
-  </data>
   <data name="MemberNotOnInterfaceInspection" xml:space="preserve">
     <value>Membro non trovato</value>
   </data>
@@ -351,14 +345,8 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Il parametro può essere passato per valore.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Il parametro non ha alcun riferimento.</value>
-  </data>
   <data name="ProcedureCanBeWrittenAsFunctionInspection" xml:space="preserve">
     <value>La procedura può essere scritta come una funzione.</value>
-  </data>
-  <data name="ProcedureNotUsedInspection" xml:space="preserve">
-    <value>Nessun riferimento alla procedura.</value>
   </data>
   <data name="ProcedureRequiredInspection" xml:space="preserve">
     <value>Oggetto senza membro predefinito utilizzato dove è richiesta una procedura</value>
@@ -431,9 +419,6 @@
   </data>
   <data name="VariableNotAssignedInspection" xml:space="preserve">
     <value>La variabile non è assegnata.</value>
-  </data>
-  <data name="VariableNotUsedInspection" xml:space="preserve">
-    <value>La variabile non ha alcun riferimento.</value>
   </data>
   <data name="VariableTypeNotDeclaredInspection" xml:space="preserve">
     <value>Variabile implicitamente 'Variant'</value>

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -184,10 +184,10 @@
     <value>Parameter can be passed by value.</value>
   </data>
   <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Parameter is not referred to.</value>
+    <value>Parameter is not used.</value>
   </data>
   <data name="ProcedureNotUsedInspection" xml:space="preserve">
-    <value>Procedure is not referred to.</value>
+    <value>Procedure/Function/Property is not used.</value>
   </data>
   <data name="UnassignedVariableUsageInspection" xml:space="preserve">
     <value>Variable is used but not assigned.</value>
@@ -202,7 +202,7 @@
     <value>Variable is not assigned.</value>
   </data>
   <data name="VariableNotUsedInspection" xml:space="preserve">
-    <value>Variable is not referred to.</value>
+    <value>Variable is not used.</value>
   </data>
   <data name="VariableTypeNotDeclaredInspection" xml:space="preserve">
     <value>Implicitly 'Variant' variable</value>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -844,7 +844,7 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is never used..
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; is not used..
         /// </summary>
         public static string ParameterNotUsedInspection {
             get {
@@ -880,14 +880,6 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The public enumeration `{0}` should be declared within a Standard or Class module.
-        /// </summary>
-        public static string PublicEnumerationDeclaredInWorksheetInspection {
-            get {
-                return ResourceManager.GetString("PublicEnumerationDeclaredInWorksheetInspection", resourceCulture);
-            }
-        }
-        
         ///   Looks up a localized string similar to Control &apos;{0}.{1}&apos; is being accessed from outside its parent form..
         /// </summary>
         public static string PublicControlFieldAccessInspection {
@@ -896,6 +888,16 @@ namespace Rubberduck.Resources.Inspections {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to The public enumeration `{0}` should be declared within a Standard or Class module.
+        /// </summary>
+        public static string PublicEnumerationDeclaredInWorksheetInspection {
+            get {
+                return ResourceManager.GetString("PublicEnumerationDeclaredInWorksheetInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Attempt to assign Read-Only Property &apos;{0}&apos;.
         /// </summary>
         public static string ReadOnlyPropertyAssignmentInspection {

--- a/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.cs.resx
@@ -123,9 +123,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Parametr '{0}' může být předán jako hodnota.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Parametr '{0}' není nikde použit.</value>
-  </data>
   <data name="ProcedureShouldBeFunctionInspection" xml:space="preserve">
     <value>Procedura '{0}' může být přepsána jako funkce.</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -167,9 +167,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Der Parameter '{0}' kann als Wert übergeben werden.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Der Parameter '{0}' wird nicht verwendet.</value>
-  </data>
   <data name="ProcedureShouldBeFunctionInspection" xml:space="preserve">
     <value>Die Prozedur '{0}' kann als Funktion geschrieben werden.</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionResults.es.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.es.resx
@@ -168,9 +168,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>El parámetro '{0}' se puede pasar por valor.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>El parámetro '{0}' nunca se usa.</value>
-  </data>
   <data name="ProcedureShouldBeFunctionInspection" xml:space="preserve">
     <value>El procedimiento '{0}' se puede escribir como una función.</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionResults.fr.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.fr.resx
@@ -164,9 +164,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Le paramètre '{0}' peut être passé par valeur.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Le paramètre '{0}' n'est pas utilisé.</value>
-  </data>
   <data name="ProcedureShouldBeFunctionInspection" xml:space="preserve">
     <value>La procédure '{0}' pourrait être une fonction.</value>
   </data>

--- a/Rubberduck.Resources/Inspections/InspectionResults.it.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.it.resx
@@ -241,7 +241,6 @@
   </data>
   <data name="ImplicitByRefModifierInspection" xml:space="preserve">
     <value>Il parametro '{0}' viene passato implicitamente per riferimento.</value>
-    
   </data>
   <data name="ImplicitDefaultMemberAccessInspection" xml:space="preserve">
     <value>Nell'espressione '{0}' è presente un accesso implicito al membro predefinito a '{1}'.</value>
@@ -400,9 +399,6 @@
   <data name="ParameterCanBeByValInspection" xml:space="preserve">
     <value>Il parametro '{0}' può essere passato per valore.</value>
   </data>
-  <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Il parametro '{0}' non è mai usato.</value>
-  </data>
   <data name="ProcedureCanBeWrittenAsFunctionInspection" xml:space="preserve">
     <value>La procedura '{0}' può essere scritta come una funzione.</value>
     <comment>{0} Nome procedura</comment>
@@ -423,7 +419,6 @@
   </data>
   <data name="SelfAssignedDeclarationInspection" xml:space="preserve">
     <value>Il riferimento all'oggetto '{0}' è istanziato automaticamente.</value>
-    
   </data>
   <data name="SetAssignmentWithIncompatibleObjectTypeInspection" xml:space="preserve">
     <value>Alla variabile '{0}' di tipo dichiarato '{1}' viene impostato un valore assegnato con il tipo dichiarato incompatibile '{2}'.</value>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -176,7 +176,7 @@
     <value>Parameter '{0}' can be passed by value.</value>
   </data>
   <data name="ParameterNotUsedInspection" xml:space="preserve">
-    <value>Parameter '{0}' is never used.</value>
+    <value>Parameter '{0}' is not used.</value>
   </data>
   <data name="ProcedureShouldBeFunctionInspection" xml:space="preserve">
     <value>Procedure '{0}' can be written as a function.</value>


### PR DESCRIPTION
Issue #5973 surfaced an inconsistency between the content/phrasing of the `Code Inspections` result description and the `ProcedureNotUsedInspection's` `InspectionName` resource used by the `Settings` editor.

Inconsistencies were found for all of the current 'XXXNotUsedInspection' types:

- `ConstantNotUsedInspection`
- `LineLabelNotUsedInspection`
- `ParameterNotUsedInspection`
- `ProcedureNotUsedInspection`
- `VariableNotUsedInspection`

This PR proposes to:

1. Modify the `InspectionName` resource to a phrase of the form "XXX is not used" in preference to "XXX is not referred to".
2. Delete translated "XXXNotUsedInspection" resources for both `InspectionNames` and `InspectionResults`. Re-visiting the translations looks warranted. For example, the German translations contained three forms of the "XXX not used/referred" message across the 5 inspections. Inconsistencies appear to exist in the other translations as well.  Updating the resource translations for these inspections at the same time seems like the most reliable route to getting everything self-consistent.
