### PR TITLE
Save 'Export Project...' Folder

### DIFF
--- a/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
+++ b/Rubberduck.Core/UI/Command/ComCommands/ExportAllCommand.cs
@@ -1,4 +1,5 @@
 using Path = System.IO.Path;
+using Directory = System.IO.Directory;
 using System.Windows.Forms;
 using Rubberduck.Navigation.CodeExplorer;
 using Rubberduck.Resources;
@@ -6,14 +7,19 @@ using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using System.Collections.Generic;
 
 namespace Rubberduck.UI.Command.ComCommands
 {
     public class ExportAllCommand : ComCommandBase 
     {
         private readonly IVBE _vbe;
-        private readonly IFileSystemBrowserFactory _factory;
         private readonly IProjectsProvider _projectsProvider;
+
+        //protected scope to support testing
+        protected IFileSystemBrowserFactory _factory;
+
+        private static Dictionary<string,string> _projectExportFolderpaths;
 
         public ExportAllCommand(
             IVBE vbe, 
@@ -25,6 +31,10 @@ namespace Rubberduck.UI.Command.ComCommands
             _vbe = vbe;
             _factory = folderBrowserFactory;
             _projectsProvider = projectsProvider;
+            if (_projectExportFolderpaths is null)
+            {
+                _projectExportFolderpaths = new Dictionary<string, string>();
+            }
 
             AddToCanExecuteEvaluation(SpecialEvaluateCanExecute);
         }
@@ -103,23 +113,63 @@ namespace Rubberduck.UI.Command.ComCommands
 
         private void Export(IVBProject project)
         {
+            var initialFolderBrowserPath = GetInitialFolderBrowserPath(project);
+
             var desc = string.Format(RubberduckUI.ExportAllCommand_SaveAsDialog_Title, project.Name);
 
-            // If .GetDirectoryName is passed an empty string for a RootFolder, 
-            // it defaults to the Documents library (Win 7+) or equivalent.
-            var path = string.IsNullOrWhiteSpace(project.FileName)
-                ? string.Empty
-                : Path.GetDirectoryName(project.FileName);
-
-            using (var _folderBrowser = _factory.CreateFolderBrowser(desc, true, path))
+            using (var _folderBrowser = _factory.CreateFolderBrowser(desc, true, initialFolderBrowserPath))
             {
                 var result = _folderBrowser.ShowDialog();
 
                 if (result == DialogResult.OK)
                 {
+                    _projectExportFolderpaths[project.FileName] = _folderBrowser.SelectedPath;
                     project.ExportSourceFiles(_folderBrowser.SelectedPath);
                 }
             }
+        }
+
+        //protected scope to support testing
+        protected string GetInitialFolderBrowserPath(IVBProject project)
+        {
+            if (!(string.IsNullOrWhiteSpace(project.FileName))
+                && _projectExportFolderpaths.TryGetValue(project.FileName, out string initialFolderBrowserPath))
+            {
+                if (FolderExists(initialFolderBrowserPath))
+                {
+                    //Return the cached folderpath of the previous ExportAllCommand process
+                    return _projectExportFolderpaths[project.FileName];
+                }
+
+                //The folder used in the previous ExportAllComand process no longer exists, remove the cached folderpath
+                _projectExportFolderpaths.Remove(project.FileName);
+            }
+
+            //The folder of the workbook, or an empty string
+            initialFolderBrowserPath = GetDefaultExportFolder(project.FileName);
+
+            if (!string.IsNullOrEmpty(initialFolderBrowserPath))
+            {
+                _projectExportFolderpaths.Add(project.FileName, initialFolderBrowserPath);
+            }
+
+            return initialFolderBrowserPath;
+        }
+
+        //protected scope to support testing
+        protected string GetDefaultExportFolder(string projectFileName)
+        {
+            // If .GetDirectoryName is passed an empty string for a RootFolder, 
+            // it defaults to the Documents library (Win 7+) or equivalent.
+            return string.IsNullOrWhiteSpace(projectFileName)
+                ? string.Empty
+                : Path.GetDirectoryName(projectFileName);
+        }
+
+        //protected virtual to support testing
+        protected virtual bool FolderExists(string path)
+        {
+            return Directory.Exists(path);
         }
     }
 }

--- a/RubberduckTests/Commands/ExportAllCommandTests.cs
+++ b/RubberduckTests/Commands/ExportAllCommandTests.cs
@@ -25,6 +25,7 @@ namespace RubberduckTests.Commands
         private const string _projectFullPath2 = @"C:\Users\Rubberduck\Documents\Subfolder\Project2.xlsm";
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_CanExecute_PassedNull_ExpectTrue()
         {
@@ -42,6 +43,7 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_CanExecute_PassedNull_NoComponents_ExpectFalse()
         {
@@ -59,6 +61,7 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_CanExecute_PassedIVBProject_ExpectTrue()
         {
@@ -77,6 +80,7 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_CanExecute_PassedIVBProject_NoComponents_ExpectFalse()
         {
@@ -95,32 +99,22 @@ namespace RubberduckTests.Commands
 
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedNull_SingleProject_ExpectExecution()
         {
-            var builder = new MockVbeBuilder();
+            var project = CreateTestProjectMocks("TestProject1").Values.First();
 
-            var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project = projectMock.Build();
             project.SetupGet(m => m.IsSaved).Returns(true);
             project.SetupGet(m => m.FileName).Returns(_projectFullPath);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder.AddProject(project).Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.OK);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand 
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.OK));
 
             exportAllCommand.Execute(null);
 
@@ -128,32 +122,21 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedIVBProject_SingleProject_ExpectExecution()
         {
-            var builder = new MockVbeBuilder();
-
-            var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project = projectMock.Build();
+            var project = CreateTestProjectMocks("TestProject1").Values.First();
             project.SetupGet(m => m.IsSaved).Returns(true);
             project.SetupGet(m => m.FileName).Returns(_projectFullPath);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder.AddProject(project).Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.OK);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand 
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.OK));
 
             exportAllCommand.Execute(project.Object);
 
@@ -162,44 +145,28 @@ namespace RubberduckTests.Commands
 
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedNull_MultipleProjects_ExpectExecution()
         {
-            var builder = new MockVbeBuilder();
-
-            var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project1 = projectMock1.Build();
-            var project2 = projectMock2.Build();
+            var projects = CreateTestProjectMocks("TestProject1", "TestProject2");
+            var project1 = projects["TestProject1"];
+            var project2 = projects["TestProject2"];
             project1.SetupGet(m => m.IsSaved).Returns(true);
             project1.SetupGet(m => m.FileName).Returns(_projectFullPath);
             project2.SetupGet(m => m.IsSaved).Returns(true);
             project2.SetupGet(m => m.FileName).Returns(_projectFullPath2);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder
                 .AddProject(project1)
                 .AddProject(project2)
                 .Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.OK);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project2.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.OK));
 
             exportAllCommand.Execute(null);
 
@@ -209,44 +176,28 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedIVBProject_MultipleProjects_ExpectExecution()
         {
-            var builder = new MockVbeBuilder();
-
-            var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project1 = projectMock1.Build();
-            var project2 = projectMock2.Build();
+            var projects = CreateTestProjectMocks("TestProject1", "TestProject2");
+            var project1 = projects["TestProject1"];
+            var project2 = projects["TestProject2"];
             project1.SetupGet(m => m.IsSaved).Returns(true);
             project1.SetupGet(m => m.FileName).Returns(_projectFullPath);
             project2.SetupGet(m => m.IsSaved).Returns(true);
             project2.SetupGet(m => m.FileName).Returns(_projectFullPath2);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder
                 .AddProject(project1)
                 .AddProject(project2)
                 .Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.OK);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project1.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.OK));
 
             exportAllCommand.Execute(project1.Object);
 
@@ -255,32 +206,21 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedNull_SingleProject_BrowserCanceled_ExpectNoExecution()
         {
-            var builder = new MockVbeBuilder();
-
-            var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project = projectMock.Build();
+            var project = CreateTestProjectMocks("TestProject1").Values.First();
             project.SetupGet(m => m.IsSaved).Returns(true);
             project.SetupGet(m => m.FileName).Returns(_projectFullPath);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder.AddProject(project).Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.Cancel);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.Cancel));
 
             exportAllCommand.Execute(null);
 
@@ -288,32 +228,21 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedIVBProject_SingleProject_BrowserCanceled_ExpectNoExecution()
         {
-            var builder = new MockVbeBuilder();
-
-            var projectMock = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project = projectMock.Build();
+            var project = CreateTestProjectMocks("TestProject1").Values.First();
             project.SetupGet(m => m.IsSaved).Returns(true);
             project.SetupGet(m => m.FileName).Returns(_projectFullPath);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder.AddProject(project).Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.Cancel);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.Cancel));
 
             exportAllCommand.Execute(project.Object);
 
@@ -322,44 +251,28 @@ namespace RubberduckTests.Commands
 
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedNull_MultipleProjects_BrowserCanceled_ExpectNoExecution()
         {
-            var builder = new MockVbeBuilder();
-
-            var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project1 = projectMock1.Build();
-            var project2 = projectMock2.Build();
+            var projects = CreateTestProjectMocks("TestProject1", "TestProject2");
+            var project1 = projects["TestProject1"];
+            var project2 = projects["TestProject2"];
             project1.SetupGet(m => m.IsSaved).Returns(true);
             project1.SetupGet(m => m.FileName).Returns(_projectFullPath);
             project2.SetupGet(m => m.IsSaved).Returns(true);
             project2.SetupGet(m => m.FileName).Returns(_projectFullPath2);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder
                 .AddProject(project1)
                 .AddProject(project2)
                 .Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.Cancel);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project2.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.Cancel));
 
             exportAllCommand.Execute(null);
 
@@ -369,44 +282,28 @@ namespace RubberduckTests.Commands
         }
 
         [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
         [Test]
         public void ExportAllCommand_Execute_PassedIVBProject_MultipleProjects_BrowserCanceled_ExpectNoExecution()
         {
-            var builder = new MockVbeBuilder();
-
-            var projectMock1 = builder.ProjectBuilder("TestProject1", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var projectMock2 = builder.ProjectBuilder("TestProject2", ProjectProtection.Unprotected)
-                .AddComponent("Module1", ComponentType.StandardModule, "")
-                .AddComponent("ClassModule1", ComponentType.ClassModule, "")
-                .AddComponent("Document1", ComponentType.Document, "")
-                .AddComponent("UserForm1", ComponentType.UserForm, "");
-
-            var project1 = projectMock1.Build();
-            var project2 = projectMock2.Build();
+            var projects = CreateTestProjectMocks("TestProject1", "TestProject2");
+            var project1 = projects["TestProject1"];
+            var project2 = projects["TestProject2"];
             project1.SetupGet(m => m.IsSaved).Returns(true);
             project1.SetupGet(m => m.FileName).Returns(_projectFullPath);
             project2.SetupGet(m => m.IsSaved).Returns(true);
             project2.SetupGet(m => m.FileName).Returns(_projectFullPath2);
 
+            var builder = new MockVbeBuilder();
             var vbe = builder
                 .AddProject(project1)
                 .AddProject(project2)
                 .Build();
 
-            var mockFolderBrowser = new Mock<IFolderBrowser>();
-            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(_path);
-            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(DialogResult.Cancel);
-
-            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
-            mockFolderBrowserFactory.Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, _projectPath)).Returns(mockFolderBrowser.Object);
             project1.Setup(m => m.ExportSourceFiles(_path));
 
-            var exportAllCommand = ArrangeExportAllCommand(vbe, mockFolderBrowserFactory);
+            var exportAllCommand
+                = ArrangeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path, DialogResult.Cancel));
 
             exportAllCommand.Execute(project1.Object);
 

--- a/RubberduckTests/Commands/ExportAllCommandTests.cs
+++ b/RubberduckTests/Commands/ExportAllCommandTests.cs
@@ -9,6 +9,10 @@ using System.Windows.Forms;
 using Rubberduck.VBEditor.ComManagement;
 using Rubberduck.VBEditor.Events;
 using Rubberduck.VBEditor.SafeComWrappers.Abstract;
+using System.Collections.Generic;
+using System;
+using Path = System.IO.Path;
+using Directory = System.IO.Directory;
 
 namespace RubberduckTests.Commands
 {
@@ -410,21 +414,294 @@ namespace RubberduckTests.Commands
             project2.Verify(m => m.ExportSourceFiles(_path), Times.Never);
         }
 
+        [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
+        [TestCase(_projectFullPath, _projectPath)]
+        [TestCase("   ", "")]
+        [TestCase(null, "")]
+        public void ExportAllCommand_GetDefaultExportFolder_HandleVariousProjectFileNamePropertyValues(
+            string fileNamePropertyValue, 
+            string expectedParentFolderpath)
+        {
+            var project = CreateTestProjectMocks("TestProject1").Values.First();
+
+            project.SetupGet(m => m.FileName).Returns(fileNamePropertyValue);
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder
+                .AddProject(project)
+                .Build();
+
+            var exportAllCommandStub 
+                = ArrangeFakeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, _path));
+
+            exportAllCommandStub.SetupFolderExists(_projectPath, !string.IsNullOrWhiteSpace(fileNamePropertyValue));
+
+            var actualExportPath = exportAllCommandStub.GetDefaultExportFolder(project.Object.FileName);
+
+            Assert.AreEqual(expectedParentFolderpath, actualExportPath);
+        }
+
+        [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
+        [Test]
+        public void ExportAllCommand_LastFolderpathRetained()
+        {
+            var project = CreateTestProjectMocks("TestProject1").Values.First();
+
+            project.SetupGet(m => m.FileName).Returns(_projectFullPath);
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder
+                .AddProject(project)
+                .Build();
+
+            var selectedPath = _projectPath + "\\ExportPath";
+            var exportAllCommandStub
+                = ArrangeFakeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, selectedPath, DialogResult.OK));
+
+            exportAllCommandStub.SetupFolderExists(selectedPath, true);
+
+            exportAllCommandStub.Execute(project);
+
+            var actualInitialExportPath = exportAllCommandStub.GetInitialFolderBrowserPath(project.Object);
+
+            Assert.AreEqual(selectedPath, actualInitialExportPath);
+        }
+
+        [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
+        [Test]
+        public void ExportAllCommand_HandlesLastFolderpathDeleted_ReturnsWorkbookFolder()
+        {
+            var project = CreateTestProjectMocks("TestProject1").Values.First();
+
+            project.SetupGet(m => m.FileName).Returns(_projectFullPath);
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder
+                .AddProject(project)
+                .Build();
+
+            var selectedPath = _projectPath + "\\ExportPath";
+            var exportAllCommandStub
+                = ArrangeFakeExportAllCommand(vbe, CreateMockFolderBrowserFactory(_projectPath, selectedPath, DialogResult.OK));
+
+            exportAllCommandStub.SetupFolderExists(selectedPath, true);
+
+            exportAllCommandStub.Execute(project);
+
+            //User deletes the folder containing the last export 
+            exportAllCommandStub.SetupFolderExists(selectedPath, false);
+
+            //Initial path provided to the folder browser is now the folder containing the workbook
+            var actual = exportAllCommandStub.GetInitialFolderBrowserPath(project.Object);
+
+            Assert.AreEqual(_projectPath, actual);
+        }
+
+        [Category("Commands")]
+        [Category(nameof(ExportAllCommand))]
+        [Test] //User exports 3 projects.  Tests that all project folderpaths are cached
+        public void ExportAllCommand_MultipleProjectFolders()
+        {
+            //Arrange
+            var projects = CreateTestProjectMocks("TestProject1", "TestProject2", "TestProject3");
+
+            var project1 = projects["TestProject1"];
+            var project2 = projects["TestProject2"];
+            var project3 = projects["TestProject3"];
+
+            var project1FullPath = @"C:\Users\Rubberduck\Documents\Subfolder\Project1.xlsm";
+            var project2FullPath = @"C:\Users\Rubberduck\Documents\Subfolder\Project2.xlsm";
+            var project3FullPath = @"C:\Users\Rubberduck\Documents\Subfolder\Project3.xlsm";
+            var workbookFolderpath = Path.GetDirectoryName(project1FullPath);
+
+            project1.SetupGet(m => m.FileName).Returns(project1FullPath);
+            project2.SetupGet(m => m.FileName).Returns(project2FullPath);
+            project3.SetupGet(m => m.FileName).Returns(project3FullPath);
+
+            var builder = new MockVbeBuilder();
+            var vbe = builder
+                .AddProject(project1)
+                .AddProject(project2)
+                .AddProject(project3)
+                .Build();
+
+            var selected1 = Path.GetDirectoryName(project1.Object.FileName) + "\\Export1";
+            var selected2 = Path.GetDirectoryName(project2.Object.FileName) + "\\Export2";
+            var selected3 = Path.GetDirectoryName(project3.Object.FileName) + "\\Export3";
+
+            var mockBrowserFactory1 = CreateMockFolderBrowserFactory(
+                Path.GetDirectoryName(project1FullPath),
+                selected1,
+                DialogResult.OK);
+
+            var mockBrowserFactory2 = CreateMockFolderBrowserFactory(
+                Path.GetDirectoryName(project2FullPath),
+                selected2,
+                DialogResult.OK);
+
+            var mockBrowserFactory3 = CreateMockFolderBrowserFactory(
+                Path.GetDirectoryName(project3FullPath),
+                selected3,
+                DialogResult.OK);
+
+            var exportAllCommandStub = ArrangeFakeExportAllCommand(vbe, mockBrowserFactory1);
+
+            //Act
+            exportAllCommandStub.SetupFolderExists(selected1, true);
+
+            var initial1BeforeExportAll = exportAllCommandStub.GetInitialFolderBrowserPath(project1.Object);
+            exportAllCommandStub.Execute(project1.Object);
+
+            exportAllCommandStub.InjectFolderBrowserFactory(mockBrowserFactory2.Object);
+            exportAllCommandStub.SetupFolderExists(selected2, true);
+
+            var initial2BeforeExportAll = exportAllCommandStub.GetInitialFolderBrowserPath(project2.Object);
+            exportAllCommandStub.Execute(project2.Object);
+
+            exportAllCommandStub.InjectFolderBrowserFactory(mockBrowserFactory3.Object);
+            exportAllCommandStub.SetupFolderExists(selected3, true);
+
+            var initial3BeforeExportAll = exportAllCommandStub.GetInitialFolderBrowserPath(project3.Object);
+            exportAllCommandStub.Execute(project3.Object);
+
+            //Assert
+            var initial1AfterExportAll = exportAllCommandStub.GetInitialFolderBrowserPath(project1.Object);
+            var initial2AfterExportAll = exportAllCommandStub.GetInitialFolderBrowserPath(project2.Object);
+            var initial3AfterExportAll = exportAllCommandStub.GetInitialFolderBrowserPath(project3.Object);
+
+            Assert.AreEqual(initial1BeforeExportAll, workbookFolderpath);
+            Assert.AreEqual(initial2BeforeExportAll, workbookFolderpath);
+            Assert.AreEqual(initial3BeforeExportAll, workbookFolderpath);
+
+            Assert.AreEqual(selected1, initial1AfterExportAll);
+            Assert.AreEqual(selected2, initial2AfterExportAll);
+            Assert.AreEqual(selected3, initial3AfterExportAll);
+        }
+
+        private Dictionary<string, Mock<IVBProject>> CreateTestProjectMocks(params string[] projectNames)
+        {
+            var results = new Dictionary<string, Mock<IVBProject>>();
+
+            var builder = new MockVbeBuilder();
+
+            for (int i = 0; i < projectNames.Length; i++)
+            {
+                var projectMock = builder.ProjectBuilder(projectNames[i], ProjectProtection.Unprotected)
+                    .AddComponent("Module1", ComponentType.StandardModule, string.Empty)
+                    .AddComponent("ClassModule1", ComponentType.ClassModule, string.Empty)
+                    .AddComponent("Document1", ComponentType.Document, string.Empty)
+                    .AddComponent("UserForm1", ComponentType.UserForm, string.Empty);
+
+                results.Add(projectNames[i], projectMock.Build());
+            }
+
+            return results;
+        }
+
+        private static Mock<IFileSystemBrowserFactory> CreateMockFolderBrowserFactory(string projectPath, 
+            string returnPath, DialogResult dialogResult = DialogResult.Cancel)
+        {
+            var mockFolderBrowser = new Mock<IFolderBrowser>();
+            mockFolderBrowser.Setup(m => m.SelectedPath).Returns(returnPath);
+            mockFolderBrowser.Setup(m => m.ShowDialog()).Returns(dialogResult);
+
+            var mockFolderBrowserFactory = new Mock<IFileSystemBrowserFactory>();
+            mockFolderBrowserFactory
+                .Setup(m => m.CreateFolderBrowser(It.IsAny<string>(), true, projectPath))
+                .Returns(mockFolderBrowser.Object);
+
+            return mockFolderBrowserFactory;
+        }
+
         private static ExportAllCommand ArrangeExportAllCommand(
             Mock<IVBE> vbe,
             Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory,
             IProjectsProvider projectsProvider = null)
         {
-            return ArrangeExportAllCommand(vbe, mockFolderBrowserFactory, MockVbeEvents.CreateMockVbeEvents(vbe), projectsProvider);
+            return ArrangeExportAllCommand(vbe, mockFolderBrowserFactory, 
+                MockVbeEvents.CreateMockVbeEvents(vbe), projectsProvider);
         }
 
         private static ExportAllCommand ArrangeExportAllCommand(
-            Mock<IVBE> vbe, 
-            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory, 
+            Mock<IVBE> vbe,
+            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory,
             Mock<IVbeEvents> vbeEvents,
             IProjectsProvider projectsProvider)
         {
-            return new ExportAllCommand(vbe.Object, mockFolderBrowserFactory.Object, vbeEvents.Object, projectsProvider);
+            return new ExportAllCommand(vbe.Object, mockFolderBrowserFactory.Object, 
+                vbeEvents.Object, projectsProvider);
+        }
+
+        private static ExportAllCommandFake ArrangeFakeExportAllCommand(
+            Mock<IVBE> vbe,
+            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory,
+            Mock<IVbeEvents> vbeEvents,
+            IProjectsProvider projectsProvider)
+        {
+            return new ExportAllCommandFake(vbe.Object, mockFolderBrowserFactory.Object,
+                vbeEvents.Object, projectsProvider);
+        }
+
+        private static ExportAllCommandFake ArrangeFakeExportAllCommand(
+            Mock<IVBE> vbe,
+            Mock<IFileSystemBrowserFactory> mockFolderBrowserFactory,
+            IProjectsProvider projectsProvider = null)
+        {
+            return ArrangeFakeExportAllCommand(vbe, mockFolderBrowserFactory,
+                MockVbeEvents.CreateMockVbeEvents(vbe), projectsProvider);
+        }
+
+        /// <summary>
+        /// ExportAllCommandFake inherits ExportAllCommand in order to access protected functions for testing
+        /// </summary>
+        class ExportAllCommandFake : ExportAllCommand
+        {
+            private Dictionary<string, bool> _projectExportFolderExists;
+
+            public ExportAllCommandFake(IVBE vbe, IFileSystemBrowserFactory browserFactory, 
+                IVbeEvents vbeEvents, IProjectsProvider projectsProvider)
+                   : base(vbe, browserFactory, vbeEvents, projectsProvider)
+            {
+                _projectExportFolderExists = new Dictionary<string, bool>();
+            }
+
+            public new string GetDefaultExportFolder(string projectFileName)
+            {
+                return base.GetDefaultExportFolder(projectFileName);
+            }
+
+            public void InjectFolderBrowserFactory(IFileSystemBrowserFactory factory)
+            {
+                base._factory = factory;
+            }
+
+            public void SetupFolderExists(string exportFolderpath, bool folderExists)
+            {
+                if (!_projectExportFolderExists.ContainsKey(exportFolderpath))
+                {
+                    _projectExportFolderExists.Add(exportFolderpath, folderExists);
+                    return;
+                }
+                _projectExportFolderExists[exportFolderpath] = folderExists;
+            }
+
+            public new string GetInitialFolderBrowserPath(IVBProject project)
+            {
+                return base.GetInitialFolderBrowserPath(project);
+            }
+
+            protected override bool FolderExists(string path)
+            {
+                if (_projectExportFolderExists.ContainsKey(path))
+                {
+                    return _projectExportFolderExists[path];
+                }
+
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #5634 (PR)
Closes #5584

Caches the selected folder by project for the `Export Project...` / `Export Active Project...` commands initiated from the `Rubberduck->Tools` or `Code Explorer` menus respectively.  On subsequent exports of the project, the presented folder target is the previously selected folder.