### PR TITLE
Italian translation 2.5.2.6096-pre (and a typo)

### DIFF
--- a/Rubberduck.Refactorings/RefactoringsUI.it.resx
+++ b/Rubberduck.Refactorings/RefactoringsUI.it.resx
@@ -562,4 +562,11 @@ Una classe privata riesce ad implementare un'interfaccia pubblica.</value>
   <data name="AnnotationArgument_ValidationError_NotANumber" xml:space="preserve">
     <value>Gli argomenti dell'annotazione di tipo 'Numero' devono essere un numero valido in formato intero o a virgola mobile.</value>
   </data>
+  <data name="MoveCloserToUsageDialog_InstructionsLabelText" xml:space="preserve">
+    <value>Selezionare il nuovo Tipo di Istruzione di Dichiarazione per '{0}'.</value>
+    <comment>0: Destinazione selezionata</comment>
+  </data>
+  <data name="MoveCloserToUsageDialog_TitleText" xml:space="preserve">
+    <value>Selezione Istruzione di Dichiarazione</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionInfo.it.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.it.resx
@@ -469,4 +469,7 @@ Se il parametro può essere nullo, ignorare questo risultato dell'ispezione; il 
   <data name="SuspiciousPredeclaredInstanceAccessInspection" xml:space="preserve">
     <value>Sebbene un'istanza predefinita potrebbe essere intenzionale, è una fonte comune di bug e dovrebbe essere evitata. Utilizza il qualificatore 'Me' per fare riferimento esplicitamente all'istanza corrente ed eliminare qualsiasi ambiguità.</value>
   </data>
+  <data name="PublicEnumerationDeclaredInWorksheetInspection" xml:space="preserve">
+    <value>La copia di un foglio di lavoro che contiene una dichiarazione Enum pubblica creerà anche una copia della dichiarazione Enum. La dichiarazione copiata provocherà un errore del compilatore "Nome ambiguo rilevato". La dichiarazione di enumerazioni nei moduli Standard o di Classe evita la duplicazione involontaria di una dichiarazione Enum.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.it.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.it.resx
@@ -450,4 +450,22 @@
   <data name="PublicControlFieldAccessInspection" xml:space="preserve">
     <value>Accesso a campo controllo pubblico</value>
   </data>
+  <data name="VariableNotUsedInspection" xml:space="preserve">
+    <value>La variabile non è usata.</value>
+  </data>
+  <data name="PublicEnumerationDeclaredInWorksheetInspection" xml:space="preserve">
+    <value>Enumerazione pubblica dichiarata all'interno di un foglio di lavoro</value>
+  </data>
+  <data name="ProcedureNotUsedInspection" xml:space="preserve">
+    <value>Procedura/Funzione/Proprietà non usata.</value>
+  </data>
+  <data name="ParameterNotUsedInspection" xml:space="preserve">
+    <value>Il parametro non è usato.</value>
+  </data>
+  <data name="LineLabelNotUsedInspection" xml:space="preserve">
+    <value>Etichetta di riga non usata</value>
+  </data>
+  <data name="ConstantNotUsedInspection" xml:space="preserve">
+    <value>La costante non è usata</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.it.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.it.resx
@@ -549,4 +549,11 @@ In memoriam, 1972-2018</value>
     <value>L'identificatore '{0}' in '{1}' si riferisce in modo sospetto all'istanza predefinita di quel tipo di classe.</value>
     <comment>{0} nome dell'identificatore; {1} espressione/contesto</comment>
   </data>
+  <data name="ParameterNotUsedInspection" xml:space="preserve">
+    <value>Il parametro '{0}' non è usato.</value>
+  </data>
+  <data name="PublicEnumerationDeclaredInWorksheetInspection" xml:space="preserve">
+    <value>L'enumerazione pubblica '{0}' dovrebbe essere dichiarata all'interno di un modulo Standard o di Classe</value>
+    <comment>{0} identificatore</comment>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.resx
@@ -525,7 +525,7 @@ In memoriam, 1972-2018</value>
     <comment>{0} Parameter, {1} Member</comment>
   </data>
   <data name="PublicEnumerationDeclaredInWorksheetInspection" xml:space="preserve">
-    <value>The public enumeration `{0}` should be declared within a Standard or Class module</value>
+    <value>The public enumeration '{0}' should be declared within a Standard or Class module</value>
     <comment>{0} identifier</comment>
   </data>
   <data name="InvalidAnnotationInspection_IncompatibleComponentType" xml:space="preserve">


### PR DESCRIPTION
Italian translation for 2.5.2.6096-pre and fix a typo in InspectionResults.resx