### PR TITLE
Introduce UDTMemberNotUsedInspection

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UDTMemberNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UDTMemberNotUsedInspection.cs
@@ -1,0 +1,83 @@
+﻿using Rubberduck.CodeAnalysis.Inspections.Abstract;
+using Rubberduck.CodeAnalysis.Inspections.Extensions;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using Rubberduck.Parsing.VBA.DeclarationCaching;
+using Rubberduck.Resources.Inspections;
+using System.Linq;
+
+namespace Rubberduck.CodeAnalysis.Inspections.Concrete
+{
+    /// <summary>
+    /// Warns about User Defined Type (UDT) members that are never referenced.
+    /// </summary>
+    /// <why>
+    /// Declarations that are never used should be removed.
+    /// </why>
+    /// <example hasResult="true">
+    /// <module name="MyModule" type="Standard Module">
+    /// <![CDATA[
+    /// Private Type TTestModule
+    ///     FirstVal As Long
+    /// End Type
+    /// 
+    /// Private this As TTestModule
+    /// ]]>
+    /// </module>
+    /// </example>
+    /// <example hasResult="false">
+    /// <module name="MyModule" type="Standard Module">
+    /// <![CDATA[
+    /// Private Type TTestModule
+    ///     FirstVal As Long
+    /// End Type
+    /// 
+    /// Private this As TTestModule
+    /// 
+    /// 'UDT Member is assigned but not used
+    /// Public Sub DoSomething()
+    ///     this.FirstVal = 42
+    /// End Sub
+    /// ]]>
+    /// </module>
+    /// </example>
+    /// <example hasResult="false">
+    /// <module name="MyModule" type="Standard Module">
+    /// <![CDATA[
+    /// Private Type TTestModule
+    ///     FirstVal As Long
+    /// End Type
+    /// 
+    /// Private this As TTestModule
+    /// 
+    /// 'UDT Member is assigned and read
+    /// Public Sub DoSomething()
+    ///     this.FirstVal = 42
+    ///     Debug.Print this.FirstVal
+    /// End Sub
+    /// ]]>
+    /// </module>
+    /// </example>
+    internal sealed class UDTMemberNotUsedInspection : DeclarationInspectionBase
+    {
+        public UDTMemberNotUsedInspection(IDeclarationFinderProvider declarationFinderProvider)
+                : base(declarationFinderProvider, DeclarationType.UserDefinedTypeMember)
+        {}
+
+        protected override bool IsResultDeclaration(Declaration declaration, DeclarationFinder finder)
+        {
+            return declaration.DeclarationType.Equals(DeclarationType.UserDefinedTypeMember)
+                && !declaration.References.Any();
+        }
+
+        protected override string ResultDescription(Declaration declaration)
+        {
+            var declarationType = declaration.DeclarationType.ToLocalizedString();
+            var declarationName = declaration.IdentifierName;
+            return string.Format(
+                InspectionResults.IdentifierNotUsedInspection,
+                declarationType,
+                declarationName);
+        }
+    }
+}

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/RemoveUnusedDeclarationQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/RemoveUnusedDeclarationQuickFix.cs
@@ -50,7 +50,8 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             : base(typeof(ConstantNotUsedInspection), 
                   typeof(ProcedureNotUsedInspection), 
                   typeof(VariableNotUsedInspection), 
-                  typeof(LineLabelNotUsedInspection))
+                  typeof(LineLabelNotUsedInspection),
+                  typeof(UDTMemberNotUsedInspection))
         {
             _refactoring = refactoringAction;
         }

--- a/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.Designer.cs
@@ -844,13 +844,6 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copying a worksheet which contains a public Enum declaration will also create a copy of the Enum declaration.  The copied declaration will result in an &apos;Ambiguous name detected&apos; compiler error.  Declaring Enumerations in Standard or Class modules avoids unintentional duplication of an Enum declaration..
-        /// </summary>
-        public static string PublicEnumerationDeclaredInWorksheetInspection {
-            get {
-                return ResourceManager.GetString("PublicEnumerationDeclaredInWorksheetInspection", resourceCulture);
-            }
-        }
         ///   Looks up a localized string similar to MSForms exposes UserForm controls as public fields; accessing these fields outside the UserForm class breaks encapsulation and needlessly couples code with specific form controls. Consider encapsulating the desired values into their own &apos;model&apos; class, making event handlers in the form manipulate these &apos;model&apos; properties, and then the calling code can query this encapsulated state instead of querying form controls..
         /// </summary>
         public static string PublicControlFieldAccessInspection {
@@ -859,6 +852,16 @@ namespace Rubberduck.Resources.Inspections {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Copying a worksheet which contains a public Enum declaration will also create a copy of the Enum declaration.  The copied declaration will result in an &apos;Ambiguous name detected&apos; compiler error.  Declaring Enumerations in Standard or Class modules avoids unintentional duplication of an Enum declaration..
+        /// </summary>
+        public static string PublicEnumerationDeclaredInWorksheetInspection {
+            get {
+                return ResourceManager.GetString("PublicEnumerationDeclaredInWorksheetInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In general, the VBE editor catches this type of error and will not compile.  However, there are a few scenarios where the error is overlooked by the compiler and an error is generated at runtime.  To avoid a runtime error, implement the missing Property or Subroutine. .
         /// </summary>
         public static string ReadOnlyPropertyAssignmentInspection {
@@ -972,6 +975,15 @@ namespace Rubberduck.Resources.Inspections {
         public static string SuspiciousPredeclaredInstanceAccessInspection {
             get {
                 return ResourceManager.GetString("SuspiciousPredeclaredInstanceAccessInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A User Defined Type (UDT) member is declared but not used.  Consider removing the UDT member declaration..
+        /// </summary>
+        public static string UDTMemberNotUsedInspection {
+            get {
+                return ResourceManager.GetString("UDTMemberNotUsedInspection", resourceCulture);
             }
         }
         

--- a/Rubberduck.Resources/Inspections/InspectionInfo.resx
+++ b/Rubberduck.Resources/Inspections/InspectionInfo.resx
@@ -472,4 +472,7 @@ If the parameter can be null, ignore this inspection result; passing a null valu
   <data name="PublicEnumerationDeclaredInWorksheetInspection" xml:space="preserve">
     <value>Copying a worksheet which contains a public Enum declaration will also create a copy of the Enum declaration.  The copied declaration will result in an 'Ambiguous name detected' compiler error.  Declaring Enumerations in Standard or Class modules avoids unintentional duplication of an Enum declaration.</value>
   </data>
+  <data name="UDTMemberNotUsedInspection" xml:space="preserve">
+    <value>A User Defined Type (UDT) member is declared but not used.  Consider removing the UDT member declaration.</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionNames.Designer.cs
@@ -979,6 +979,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User Defined Type member is not used.
+        /// </summary>
+        public static string UDTMemberNotUsedInspection {
+            get {
+                return ResourceManager.GetString("UDTMemberNotUsedInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Variable is used but not assigned..
         /// </summary>
         public static string UnassignedVariableUsageInspection {

--- a/Rubberduck.Resources/Inspections/InspectionNames.resx
+++ b/Rubberduck.Resources/Inspections/InspectionNames.resx
@@ -472,4 +472,7 @@
   <data name="PublicControlFieldAccessInspection" xml:space="preserve">
     <value>Public control field access</value>
   </data>
+  <data name="UDTMemberNotUsedInspection" xml:space="preserve">
+    <value>User Defined Type member is not used</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
+++ b/Rubberduck.Resources/Inspections/InspectionResults.Designer.cs
@@ -1027,6 +1027,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} &apos;{1}&apos; is not used.
+        /// </summary>
+        public static string UDTMemberNotUsedInspection {
+            get {
+                return ResourceManager.GetString("UDTMemberNotUsedInspection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Variable &apos;{0}&apos; is used but not assigned..
         /// </summary>
         public static string UnassignedVariableUsageInspection {

--- a/RubberduckTests/Inspections/GeneralInspectionTests.cs
+++ b/RubberduckTests/Inspections/GeneralInspectionTests.cs
@@ -84,6 +84,7 @@ namespace RubberduckTests.Inspections
         {
             var inspectionsWithSharedResultFormat = new List<string>
             {
+                typeof(UDTMemberNotUsedInspection).Name,
                 typeof(ConstantNotUsedInspection).Name,
                 typeof(ParameterNotUsedInspection).Name,
                 typeof(ProcedureNotUsedInspection).Name,

--- a/RubberduckTests/Inspections/UDTMemberNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/UDTMemberNotUsedInspectionTests.cs
@@ -1,0 +1,170 @@
+﻿using NUnit.Framework;
+using Rubberduck.CodeAnalysis.Inspections;
+using Rubberduck.CodeAnalysis.Inspections.Concrete;
+using Rubberduck.Parsing.VBA;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RubberduckTests.Inspections
+{
+    [TestFixture]
+    class UDTMemberNotUsedInspectionTests : InspectionTestsBase
+    {
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(UDTMemberNotUsedInspection))]
+        public void ReturnsZeroResult()
+        {
+            const string inputCode =
+@"
+Option Explicit
+
+Private Type TUnitTest
+    FirstVal As Long
+    SecondVal As Long
+End Type
+
+Private this As TUnitTest
+
+Private Sub TestSub(testVal As Long)
+    this.FirstVal = testVal * 2
+    this.SecondVal = testVal
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(UDTMemberNotUsedInspection))]
+        public void ReturnsSingleResult()
+        {
+            const string inputCode =
+@"
+Option Explicit
+
+Private Type TUnitTest
+    FirstVal As Long
+    SecondVal As Long
+End Type
+
+Private this As TUnitTest
+
+Private Sub TestSub(testVal As Long)
+    this.FirstVal = testVal
+End Sub
+";
+            Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(UDTMemberNotUsedInspection))]
+        public void ReturnsManyResults()
+        {
+            const string inputCode =
+@"
+Option Explicit
+
+Private Type TUnitTest
+    FirstVal As Long
+    SecondVal As Long
+    ThirdVal As Long
+End Type
+
+Private this As TUnitTest
+
+Private Sub TestSub(testVal As Long)
+    this.SecondVal = testVal
+End Sub
+";
+            Assert.AreEqual(2, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(UDTMemberNotUsedInspection))]
+        public void ReturnsResultForNestedUDTMember()
+        {
+            const string inputCode =
+@"
+Option Explicit
+
+Private Type TPair
+    IDNumber As Long
+    IDName As String
+End Type
+
+Private Type TUnitTest
+    ID_Name_Pair As TPair
+    SecondVal As Long
+End Type
+
+Private this As TUnitTest
+
+Private Sub TestSub(testVal As Long)
+    this.ID_Name_Pair.IDNumber = testVal
+    this.SecondVal = testVal * 2
+End Sub
+";
+            Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(UDTMemberNotUsedInspection))]
+        public void RespectsIgnoreAnnotation()
+        {
+            const string inputCode =
+@"
+Option Explicit
+
+Private Type TUnitTest
+    FirstVal As Long
+    '@Ignore UDTMemberNotUsed
+    SecondVal As Long
+End Type
+
+Private this As TUnitTest
+
+Private Sub TestSub(testVal As Long)
+    this.FirstVal = testVal
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [TestCase("'@IgnoreModule")]
+        [TestCase("'@IgnoreModule UDTMemberNotUsed")]
+        [Category("Inspections")]
+        [Category(nameof(UDTMemberNotUsedInspection))]
+        public void RespectsIgnoreModuleAnnotation(string annotation)
+        {
+            var inputCode =
+$@"
+{annotation}
+Option Explicit
+
+Private Type TUnitTest
+    FirstVal As Long
+    SecondVal As Long
+End Type
+
+Private this As TUnitTest
+
+Private Sub TestSub(testVal As Long)
+    this.FirstVal = testVal
+End Sub
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        protected override IInspection InspectionUnderTest(RubberduckParserState state)
+        {
+            return new UDTMemberNotUsedInspection(state);
+        }
+    }
+}


### PR DESCRIPTION
Related issue: #5974

Rubberduck provides both tools and encouragement to use `Private User Defined Type` (UDT) members in preference to module-level variables.  However, RD lacks any inspections for UDT members that are similar to those for Fields.  

This PR inspects for UDT Members that are declared but never assigned or used.  The `RemoveUnusedDeclarationQuickFix` supports the removal of the declarations flagged by this inspection.
 