### PR TITLE
Fix inconsistant indentation #5960

### DIFF
--- a/Rubberduck.SmartIndenter/LogicalCodeLine.cs
+++ b/Rubberduck.SmartIndenter/LogicalCodeLine.cs
@@ -220,7 +220,7 @@ namespace Rubberduck.SmartIndenter
                         {
                             var finished = _alignment.Count == stackPos + 1;                            
                             var token =_alignment.Pop();
-                            if (token.Type == AlignmentTokenType.Function && token.NestingDepth == _nestingDepth - 1)
+                            if (token.NestingDepth < _nestingDepth )
                             {
                                 _alignment.Push(token);
                                 finished = true;

--- a/RubberduckTests/SmartIndenter/LineContinuationTests.cs
+++ b/RubberduckTests/SmartIndenter/LineContinuationTests.cs
@@ -342,7 +342,7 @@ namespace RubberduckTests.SmartIndenter
             var indenter = new Indenter(null, () =>
             {
                 var s = IndenterSettingsTests.GetMockIndenterSettings();
-                s.IgnoreOperatorsInContinuations = false;
+                s.IgnoreOperatorsInContinuations = true;
                 return s;
             });
             var actual = indenter.Indent(code);


### PR DESCRIPTION
Fixes Indenter #5960 .
On ')" - Function Call End - the Alignment got resetted, whereby often the LineConttinuiation '_" was taken as Alignment position.

After that I had to adjust one Test that worked not as intended i think.