### PR TITLE
Fix Indent if-then-colon #5929

### DIFF
--- a/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
+++ b/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
@@ -26,6 +26,7 @@ namespace Rubberduck.SmartIndenter
         private static readonly Regex PrecompilerInRegex = new Regex(@"^#(Else)?If\s.+Then$|^#Else$", RegexOptions.IgnoreCase);
         private static readonly Regex PrecompilerOutRegex = new Regex(@"^#ElseIf\s.+Then|^#Else$|#End\sIf$", RegexOptions.IgnoreCase);
         private static readonly Regex SingleLineElseIfRegex = new Regex(@"^ElseIf\s.*\sThen\s.*", RegexOptions.IgnoreCase);
+        private static readonly Regex IfThenWithColonRegex = new Regex(@"If\s.*\sThen:\s", RegexOptions.IgnoreCase);
 
         private readonly IIndenterSettings _settings;
         private int _lineNumber;
@@ -191,6 +192,8 @@ namespace Rubberduck.SmartIndenter
         }
 
         public bool IsEmpty => Original.Trim().Length == 0;
+
+        public bool ContaisIfThenWithColon => IfThenWithColonRegex.IsMatch(_code);
 
         public int NextLineIndents
         {

--- a/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
+++ b/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
@@ -26,7 +26,7 @@ namespace Rubberduck.SmartIndenter
         private static readonly Regex PrecompilerInRegex = new Regex(@"^#(Else)?If\s.+Then$|^#Else$", RegexOptions.IgnoreCase);
         private static readonly Regex PrecompilerOutRegex = new Regex(@"^#ElseIf\s.+Then|^#Else$|#End\sIf$", RegexOptions.IgnoreCase);
         private static readonly Regex SingleLineElseIfRegex = new Regex(@"^ElseIf\s.*\sThen\s.*", RegexOptions.IgnoreCase);
-        private static readonly Regex IfThenWithColonRegex = new Regex(@"If\s.*\sThen:\s", RegexOptions.IgnoreCase);
+        private static readonly Regex IfThenWithColonNoElseRegex = new Regex(@"If\s.*\sThen:\s(?!.*:\sElse(If)?)", RegexOptions.IgnoreCase);
 
         private readonly IIndenterSettings _settings;
         private int _lineNumber;
@@ -193,7 +193,7 @@ namespace Rubberduck.SmartIndenter
 
         public bool IsEmpty => Original.Trim().Length == 0;
 
-        public bool ContaisIfThenWithColon => IfThenWithColonRegex.IsMatch(_code);
+        public bool ContaisIfThenWithColonNoElse => IfThenWithColonNoElseRegex.IsMatch(_code);
 
         public int NextLineIndents
         {

--- a/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
+++ b/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
@@ -193,7 +193,7 @@ namespace Rubberduck.SmartIndenter
 
         public bool IsEmpty => Original.Trim().Length == 0;
 
-        public bool ContaisIfThenWithColonNoElse => IfThenWithColonNoElseRegex.IsMatch(_code);
+        public bool ContainsIfThenWithColonNoElse => IfThenWithColonNoElseRegex.IsMatch(_code);
 
         public int NextLineIndents
         {

--- a/Rubberduck.SmartIndenter/LogicalCodeLine.cs
+++ b/Rubberduck.SmartIndenter/LogicalCodeLine.cs
@@ -55,7 +55,7 @@ namespace Rubberduck.SmartIndenter
                     ? _rebuilt.NextLineIndents
                     : _rebuilt.Segments.Select(s => new AbsoluteCodeLine(s, _settings)).Select(a => a.NextLineIndents).Sum();
 
-                if (_rebuilt.ContaisIfThenWithColonNoElse)
+                if (_rebuilt.ContainsIfThenWithColonNoElse)
                 {
                     indents--;
                 }

--- a/Rubberduck.SmartIndenter/LogicalCodeLine.cs
+++ b/Rubberduck.SmartIndenter/LogicalCodeLine.cs
@@ -51,9 +51,16 @@ namespace Rubberduck.SmartIndenter
                 {
                     return 0;
                 }
-                return _rebuilt.Segments.Count() < 2
+                var indents = _rebuilt.Segments.Count() < 2
                     ? _rebuilt.NextLineIndents
                     : _rebuilt.Segments.Select(s => new AbsoluteCodeLine(s, _settings)).Select(a => a.NextLineIndents).Sum();
+
+                if (_rebuilt.ContaisIfThenWithColon)
+                {
+                    indents--;
+                }
+                return indents;
+
             }
         }
 

--- a/Rubberduck.SmartIndenter/LogicalCodeLine.cs
+++ b/Rubberduck.SmartIndenter/LogicalCodeLine.cs
@@ -55,7 +55,7 @@ namespace Rubberduck.SmartIndenter
                     ? _rebuilt.NextLineIndents
                     : _rebuilt.Segments.Select(s => new AbsoluteCodeLine(s, _settings)).Select(a => a.NextLineIndents).Sum();
 
-                if (_rebuilt.ContaisIfThenWithColon)
+                if (_rebuilt.ContaisIfThenWithColonNoElse)
                 {
                     indents--;
                 }

--- a/RubberduckTests/SmartIndenter/MultiSegmentLineTests.cs
+++ b/RubberduckTests/SmartIndenter/MultiSegmentLineTests.cs
@@ -90,18 +90,16 @@ namespace RubberduckTests.SmartIndenter
             var code = new[]
             {
                 "Public Sub Test()",
-                "If Foo = 42 Then: Bar = Foo: Else",
+                "If Foo = 42 Then: Bar = Foo: Else Baz = Bar",
                 "Baz = Foo",
-                "End If",
                 "End Sub"
             };
 
             var expected = new[]
             {
                 "Public Sub Test()",
-                "    If Foo = 42 Then: Bar = Foo: Else",
-                "        Baz = Foo",
-                "    End If",
+                "    If Foo = 42 Then: Bar = Foo: Else Baz = Bar",
+                "    Baz = Foo",
                 "End Sub"
             };
 

--- a/RubberduckTests/SmartIndenter/MultiSegmentLineTests.cs
+++ b/RubberduckTests/SmartIndenter/MultiSegmentLineTests.cs
@@ -83,6 +83,7 @@ namespace RubberduckTests.SmartIndenter
             Assert.IsTrue(code.SequenceEqual(actual));
         }
 
+        // https://github.com/rubberduck-vba/Rubberduck/issues/5929
         [Test]        // Broken in VB6 SmartIndenter.
         [Category("Indenter")]
         public void IfThenElseOnSameLineWorks()


### PR DESCRIPTION
Fix #5929 .
The 'then'-Statement triggered an Indent even tough the line got continued with ':'.
Edited Test for IfThenElseOnSameLine to contain valid VBA Code and check #5929 