### PR TITLE
Fix Indenter "Declare PtrSafe"

### DIFF
--- a/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
+++ b/Rubberduck.SmartIndenter/AbsoluteCodeLine.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.SmartIndenter
         
         private static readonly Regex PropertyStartRegex = new Regex(@"^(Public\s|Private\s|Friend\s)?(Static\s)?(Property\s(Let|Get|Set))\s", RegexOptions.IgnoreCase);
 
-        private static readonly Regex ProcedureStartIgnoreRegex = new Regex(@"^[LR]?Set\s|^Let\s|^(Public|Private)\sDeclare\s(Function|Sub)", RegexOptions.IgnoreCase);
+        private static readonly Regex ProcedureStartIgnoreRegex = new Regex(@"^[LR]?Set\s|^Let\s|^(Public\s|Private\s)?Declare\s(PtrSafe\s)?(Function|Sub)", RegexOptions.IgnoreCase);
         private static readonly Regex ProcedureEndRegex = new Regex(@"^End\s(Sub|Function|Property)", RegexOptions.IgnoreCase);
         private static readonly Regex TypeEnumStartRegex = new Regex(@"^(Public\s|Private\s)?(Enum\s|Type\s)", RegexOptions.IgnoreCase);
         private static readonly Regex TypeEnumEndRegex = new Regex(@"^End\s(Enum|Type)", RegexOptions.IgnoreCase);

--- a/Rubberduck.SmartIndenter/LogicalCodeLine.cs
+++ b/Rubberduck.SmartIndenter/LogicalCodeLine.cs
@@ -195,7 +195,7 @@ namespace Rubberduck.SmartIndenter
             return _lines.Aggregate(string.Empty, (x, y) => x + y.ToString());
         }
 
-        private static readonly Regex StartIgnoreRegex = new Regex(@"^(\d*\s)?\s*[LR]?Set\s|^(\d*\s)?\s*Let\s|^(\d*\s)?\s*(Public|Private)\sDeclare\s(Function|Sub)|^(\d*\s+)", RegexOptions.IgnoreCase);
+        private static readonly Regex StartIgnoreRegex = new Regex(@"^(\d*\s)?\s*[LR]?Set\s|^(\d*\s)?\s*Let\s|^(\d*\s)?\s*(Public\s|Private\s)?Declare\s(PtrSafe\s)?(Function|Sub)|^(\d*\s+)", RegexOptions.IgnoreCase);
         private readonly Stack<AlignmentToken> _alignment = new Stack<AlignmentToken>();
         private int _nestingDepth;
 

--- a/RubberduckTests/SmartIndenter/LineContinuationTests.cs
+++ b/RubberduckTests/SmartIndenter/LineContinuationTests.cs
@@ -29,6 +29,28 @@ namespace RubberduckTests.SmartIndenter
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
 
+        // https://github.com/rubberduck-vba/Rubberduck/issues/4795
+        [Test]
+        [Category("Indenter")]
+        public void DeclarationPtrSafeLineAlignsCorrectly()
+        {
+            var code = new[]
+            {
+                @"Private Declare PtrSafe Function Foo Lib ""bar.dll"" _",
+                 "(x As Long y As Long) As LongPtr"
+            };
+
+            var expected = new[]
+            {
+                @"Private Declare PtrSafe Function Foo Lib ""bar.dll"" _",
+                 "                                 (x As Long y As Long) As LongPtr"
+            };
+
+            var indenter = new Indenter(null, () => IndenterSettingsTests.GetMockIndenterSettings());
+            var actual = indenter.Indent(code);
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
         [Test]
         [Category("Indenter")]
         public void FunctionParametersAlignCorrectly()


### PR DESCRIPTION
Fix for #4795.
'PtrSafe' was not recognized as a valid part of the declare statement and was therefore not ignored during line continuation alignment
Add Test for Declare PrtSafe.