### PR TITLE
Fix non returning function inspection on UDT return assigned in with statement

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/NonReturningFunctionInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/NonReturningFunctionInspection.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Antlr4.Runtime.Tree;
 using Rubberduck.CodeAnalysis.Inspections.Abstract;
 using Rubberduck.Parsing;
 using Rubberduck.Parsing.Grammar;
@@ -122,48 +123,58 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         private class FunctionReturnValueAssignmentLocator : VBAParserBaseVisitor<bool>
         {
             private readonly string _name;
-            private bool _result;
             private bool _inFunctionReturnWithExpression;
 
             public FunctionReturnValueAssignmentLocator(string name)
             {
                 _name = name;
+                _inFunctionReturnWithExpression = false;
             }
 
-            public override bool VisitBlock(VBAParser.BlockContext context)
+            protected override bool DefaultResult => false;
+
+            protected override bool ShouldVisitNextChild(IRuleNode node, bool currentResult)
             {
-                base.VisitBlock(context);
-                return _result;
+                return !currentResult;
             }
+
+            //This is actually the default implementation, but for explicities sake stated here.
+            protected override bool AggregateResult(bool aggregate, bool nextResult)
+            {
+                return nextResult;
+            }
+
             public override bool VisitWithStmt(VBAParser.WithStmtContext context)
             {
                 var oldInFunctionReturnWithExpression = _inFunctionReturnWithExpression;
                 _inFunctionReturnWithExpression = context.expression().GetText() == _name;
-                base.VisitWithStmt(context);
+                var result = base.VisitWithStmt(context);
                 _inFunctionReturnWithExpression = oldInFunctionReturnWithExpression;
-                return _result;
+                return result;
             }
 
             public override bool VisitLetStmt(VBAParser.LetStmtContext context)
             {
                 var LHS = context.lExpression();
+                if (_inFunctionReturnWithExpression
+                        && LHS is VBAParser.WithMemberAccessExprContext)
+                {
+                    return true;
+                }
                 var leftmost = LHS.GetChild(0).GetText();
-                _result = _result 
-                    || leftmost == _name 
-                    || (_inFunctionReturnWithExpression 
-                        && LHS is VBAParser.WithMemberAccessExprContext);
-                return _result;
+                return leftmost == _name;
             }
 
             public override bool VisitSetStmt(VBAParser.SetStmtContext context)
             {
                 var LHS = context.lExpression();
+                if (_inFunctionReturnWithExpression
+                        && LHS is VBAParser.WithMemberAccessExprContext)
+                {
+                    return true;
+                }
                 var leftmost = LHS.GetChild(0).GetText();
-                _result = _result
-                    || leftmost == _name
-                    || (_inFunctionReturnWithExpression
-                        && LHS is VBAParser.WithMemberAccessExprContext);
-                return _result;
+                return leftmost == _name;
             }
         }
     }

--- a/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
+++ b/RubberduckTests/Inspections/NonReturningFunctionInspectionTests.cs
@@ -194,6 +194,129 @@ End Sub
 
         [Test]
         [Category("Inspections")]
+        //ref issue #5964
+        public void NonReturningFunction_NoResult_AssignmenToUDTMembersInWithBlock()
+        {
+            const string inputCode = @"
+Private Type tipo
+    one As Long
+    two As Long
+End Type
+
+Function assigner() As tipo
+    With assigner
+        .one = 1
+        .two = 2
+    End With
+End Function
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //ref issue #5964
+        public void NonReturningFunction_NoResult_AssignmenToUDTMembersInWithBlock_NestedWith_Inside()
+        {
+            const string inputCode = @"
+Private Type tipo
+    one As Long
+    two As Long
+End Type
+
+Function assigner() As tipo
+    Dim bar As tipo
+    With bar
+        .one = 3
+        .two = 2
+        With assigner
+            .one = 1
+            .two = 2
+        End With
+    End With
+End Function
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //ref issue #5964
+        public void NonReturningFunction_NoResult_AssignmenToUDTMembersInWithBlock_NestedWith_Start()
+        {
+            const string inputCode = @"
+Private Type tipo
+    one As Long
+    two As Long
+End Type
+
+Function assigner() As tipo
+    Dim bar As tipo
+    With assigner
+        .one = 3
+        .two = 2
+        With bar
+            .one = 1
+            .two = 2
+        End With
+    End With
+End Function
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //ref issue #5964
+        public void NonReturningFunction_NoResult_AssignmenToUDTMembersInWithBlock_NestedWith_End()
+        {
+            const string inputCode = @"
+Private Type tipo
+    one As Long
+    two As Long
+End Type
+
+Function assigner() As tipo
+    Dim bar As tipo
+    With assigner
+        With bar
+            .one = 1
+            .two = 2
+        End With
+        .one = 3
+        .two = 2
+    End With
+End Function
+";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        //ref issue #5964
+        public void NonReturningFunction_OneResult_AssignmenToUDTMembersOfOtherVariableInNestedWith()
+        {
+            const string inputCode = @"
+Private Type tipo
+    one As Long
+    two As Long
+End Type
+
+Function assigner() As tipo
+    Dim bar As tipo
+    With assigner
+        With bar
+            .one = 1
+            .two = 2
+        End With
+    End With
+End Function
+";
+            Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
         public void NonReturningFunction_ReturnsResult_InterfaceImplementation()
         {
             //Input


### PR DESCRIPTION
Closes #5991

The inspections handles the case of UDT return types via a parse tree visitor. That did not consider the case of a with assignment, which I fix in this PR. Moreover, the visitor rather worked like a listener before, which I change as well. 