### PR TITLE
Make UnassignedVariableUsageInspection aware of redimmed variant arrays

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/UnassignedVariableUsageInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/UnassignedVariableUsageInspection.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Antlr4.Runtime.Misc;
 using Rubberduck.CodeAnalysis.Inspections.Abstract;
 using Rubberduck.InternalApi.Extensions;
 using Rubberduck.Parsing;
@@ -81,7 +82,8 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                 .ToHashSet();
 
             return base.ObjectionableReferences(finder)
-                .Where(reference => !excludedReferenceSelections.Contains(reference.QualifiedSelection));
+                .Where(reference => !excludedReferenceSelections.Contains(reference.QualifiedSelection)
+                                    && !IsRedimedVariantArrayReference(reference));
         }
 
         private IEnumerable<ModuleBodyElementDeclaration> DeclarationsWithExcludedArgumentUsage(DeclarationFinder finder)
@@ -203,6 +205,86 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
             var reDimVariableStmt = indexExpression.Parent?.Parent;
 
             return reDimVariableStmt is VBAParser.RedimVariableDeclarationContext;
+        }
+
+        // This function works under the assumption that there are no assignments to the referenced variable.
+        private bool IsRedimedVariantArrayReference(IdentifierReference reference)
+        {
+            if (reference.Declaration.AsTypeName != "Variant")
+            {
+                return false;
+            }
+
+            if(!reference.Context.TryGetAncestor<VBAParser.ModuleBodyElementContext>(out var containingMember))
+            {
+                return false;
+            }
+
+            var referenceSelection = reference.Selection;
+            var referencedDeclarationName = reference.Declaration.IdentifierName;
+            var reDimLocator = new PriorReDimLocator(referencedDeclarationName, referenceSelection);
+
+            return reDimLocator.Visit(containingMember);
+        }
+
+        /// <summary>
+        /// A visitor that visits a member's body and returns <c>true</c> if any <c>ReDim</c> statement for the variable called <c>name</c> is present before the <c>selection</c>.
+        /// </summary>
+        private class PriorReDimLocator : VBAParserBaseVisitor<bool>
+        {
+            private readonly string _name;
+            private readonly Selection _selection;
+
+            public PriorReDimLocator(string name, Selection selection)
+            {
+                _name = name;
+                _selection = selection;
+            }
+
+            protected override bool DefaultResult => false;
+
+            protected override bool ShouldVisitNextChild(Antlr4.Runtime.Tree.IRuleNode node, bool currentResult)
+            {
+                return !currentResult;
+            }
+
+            //This is actually the default implementation, but for explicities sake stated here.
+            protected override bool AggregateResult(bool aggregate, bool nextResult)
+            {
+                return nextResult;
+            }
+
+            public override bool VisitRedimVariableDeclaration([NotNull] VBAParser.RedimVariableDeclarationContext context)
+            {
+                var reDimedVariableName = RedimedVariableName(context);
+                if (reDimedVariableName != _name)
+                {
+                    return false;
+                }
+
+                var reDimSelection = context.GetSelection();
+
+                return reDimSelection <= _selection;
+            }
+
+            private string RedimedVariableName([NotNull] VBAParser.RedimVariableDeclarationContext context)
+            {
+                if (!(context.expression() is VBAParser.LExprContext reDimmedVariablelExpr))
+                {
+                    //This is not syntactically correct VBA.
+                    return null;
+                }
+
+                switch (reDimmedVariablelExpr.lExpression())
+                {
+                    case VBAParser.IndexExprContext indexExpr:
+                        return indexExpr.lExpression().GetText();
+                    case VBAParser.WhitespaceIndexExprContext whiteSpaceIndexExpr:
+                        return whiteSpaceIndexExpr.lExpression().GetText();
+                    default:  //This should not be possible in syntactically correct VBA.
+                        return null;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #5990

The problem was that an array declares as a Variant and later assigned via ReDim is not flagged as an array and thus not properly excluded from the inspection.

The approach taken here is to explicitly look for ReDim before the usage inside the same function as the reference. This approach has been taken in favor of enhancing the resolver because whether a Variant declaration is an array depends on the exact location in the code. One can define a Variant then redim it as an array and later assign a non-array value to it. This makes it comparatively complicated to figure out whether a Variant is an array in every spot. Anyway, we store the information whether a variable is an array on the declaration and this does not allow changing values over the code.

Note that that this fix goes in a conservative direction of removing false positives in favor o introducing more obscure false negatives. In particular, the case is no longer covered where the ReDim is conditional, i.e. does not happen in all branches of the code execution.