### PR TITLE
Add null check when assigning null to AsTypeDeclaration

### DIFF
--- a/Rubberduck.Parsing/Symbols/Declaration.cs
+++ b/Rubberduck.Parsing/Symbols/Declaration.cs
@@ -529,7 +529,7 @@ namespace Rubberduck.Parsing.Symbols
             {
                 _asTypeDeclaration = value;
                 IsSelfAssigned = IsSelfAssigned || (DeclarationType == DeclarationType.Variable &&
-                                 AsTypeDeclaration.DeclarationType == DeclarationType.UserDefinedType);
+                                 AsTypeDeclaration?.DeclarationType == DeclarationType.UserDefinedType);
             }
         }
 


### PR DESCRIPTION
Ref #5964

There are uncommon but theoretically valid cases when the `AsTypeDeclaration` of a declaration is set to null. In these cases, a missing null check when setting `IsSelfAssigned` caused an NRE. Adding the null check prevents this and, as a result, makes the `TypeAnnotationPass` in the reference resolver safer.

This PR will remove the failure of the resolution in #5964, but I am still curious how we ended up in this situation in the first place as the only two bindings that seem to be able to provide a `null` are the one for a failed resolution, which we safeguard against, and the one for a built-in type, for which I do not know how that can turn up in a complex type annotation that is not a straight array declaration, which we treat in a special way.
Because of this lack of how we got into this situation, there is no test to verify that everything works now. 