### PR TITLE
Align handling of interfaces in not used inspections

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/ConstantNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/ConstantNotUsedInspection.cs
@@ -45,7 +45,24 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         protected override bool IsResultDeclaration(Declaration declaration, DeclarationFinder finder)
         {
             return declaration?.Context != null 
-                   && !declaration.References.Any();
+                   && !declaration.References.Any()
+                   && !IsPublicInExposedClass(declaration);
+        }
+
+        private static bool IsPublicInExposedClass(Declaration procedure)
+        {
+            if (!(procedure.Accessibility == Accessibility.Public
+                    || procedure.Accessibility == Accessibility.Global))
+            {
+                return false;
+            }
+
+            if (!(Declaration.GetModuleParent(procedure) is ClassModuleDeclaration classParent))
+            {
+                return false;
+            }
+
+            return classParent.IsExposed;
         }
 
         protected override string ResultDescription(Declaration declaration)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotAssignedInspection.cs
@@ -53,7 +53,24 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
                    && !HasUdtType(declaration, finder) // UDT variables don't need to be assigned
                    && !declaration.References.Any(reference => reference.IsAssignment 
                                                                || reference.IsReDim //Ignores Variants used as arrays without assignment of an existing one.
-                                                               || IsAssignedByRefArgument(reference.ParentScoping, reference, finder));
+                                                               || IsAssignedByRefArgument(reference.ParentScoping, reference, finder))
+                   && !IsPublicInExposedClass(declaration);
+        }
+
+        private static bool IsPublicInExposedClass(Declaration procedure)
+        {
+            if (!(procedure.Accessibility == Accessibility.Public
+                    || procedure.Accessibility == Accessibility.Global))
+            {
+                return false;
+            }
+
+            if (!(Declaration.GetModuleParent(procedure) is ClassModuleDeclaration classParent))
+            {
+                return false;
+            }
+
+            return classParent.IsExposed;
         }
 
         private static bool HasUdtType(Declaration declaration, DeclarationFinder finder)

--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotUsedInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/VariableNotUsedInspection.cs
@@ -54,9 +54,27 @@ namespace Rubberduck.CodeAnalysis.Inspections.Concrete
         protected override bool IsResultDeclaration(Declaration declaration, DeclarationFinder finder)
         {
             // exclude undeclared, see #5439
-            return !declaration.IsWithEvents && !declaration.IsUndeclared
+            return !declaration.IsWithEvents 
+                   && !declaration.IsUndeclared
                    && declaration.References.All(reference => reference.IsAssignment)
-                   && !declaration.References.Any(IsForLoopAssignment);
+                   && !declaration.References.Any(IsForLoopAssignment)
+                   && !IsPublicInExposedClass(declaration);
+        }
+
+        private static bool IsPublicInExposedClass(Declaration procedure)
+        {
+            if (!(procedure.Accessibility == Accessibility.Public
+                    || procedure.Accessibility == Accessibility.Global))
+            {
+                return false;
+            }
+
+            if (!(Declaration.GetModuleParent(procedure) is ClassModuleDeclaration classParent))
+            {
+                return false;
+            }
+
+            return classParent.IsExposed;
         }
 
         private bool IsForLoopAssignment(IdentifierReference reference)

--- a/RubberduckTests/Inspections/ConstantNotUsedInspectionTests.cs
+++ b/RubberduckTests/Inspections/ConstantNotUsedInspectionTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Rubberduck.CodeAnalysis.Inspections;
 using Rubberduck.CodeAnalysis.Inspections.Concrete;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.VBEditor.SafeComWrappers;
 
 namespace RubberduckTests.Inspections
 {
@@ -11,13 +12,52 @@ namespace RubberduckTests.Inspections
     {
         [Test]
         [Category("Inspections")]
-        public void ConstantNotUsed_ReturnsResult()
+        public void ConstantNotUsed_ReturnsResult_Local()
         {
             const string inputCode =
                 @"Public Sub Foo()
     Const const1 As Integer = 9
 End Sub";
             Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Public")]
+        [TestCase("Private")]
+        public void ConstantUsed_ReturnsResult_Module(string scopeIdentifier)
+        {
+            var inputCode =
+$@"
+    {scopeIdentifier} Const Bar As Integer = 42
+";
+            Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void ConstantNotUsed_ReturnsResult_Module_Exposed_Private()
+        {
+            var inputCode =
+$@"
+Attribute VB_Exposed = True
+
+    Private Const Bar As Integer = 42
+";
+            Assert.AreEqual(1, InspectionResultsForModules(("Class1", inputCode, ComponentType.ClassModule)).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VariableNotUsed_DoesNotReturnResult_Module_Exposed_Public()
+        {
+            var inputCode =
+$@"
+Attribute VB_Exposed = True
+
+    Public Const Bar As Integer = 42
+";
+            Assert.AreEqual(0, InspectionResultsForModules(("Class1", inputCode, ComponentType.ClassModule)).Count());
         }
 
         [Test]
@@ -51,12 +91,31 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void ConstantNotUsed_DoesNotReturnResult()
+        public void ConstantNotUsed_UsedConstant_DoesNotReturnResult_Local()
         {
             const string inputCode =
                 @"Public Sub Foo()
     Const const1 As Integer = 9
     Goo const1
+End Sub
+
+Public Sub Goo(ByVal arg1 As Integer)
+End Sub";
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Public")]
+        [TestCase("Private")]
+        public void ConstantNotUsed_UsedConstant_DoesNotReturnResult_Module(string scopeIdentifier)
+        {
+            var inputCode =
+                $@"
+{scopeIdentifier} Const Bar As Integer = 42
+
+Public Sub Foo()
+    Goo Bar
 End Sub
 
 Public Sub Goo(ByVal arg1 As Integer)
@@ -89,6 +148,8 @@ End Function";
         {
             const string inputCode =
                 @"'@IgnoreModule
+
+Public Const Bar As Integer = 42
 
 Public Sub Foo()
     Const const1 As Integer = 9

--- a/RubberduckTests/Inspections/VariableNotAssignedInspectionTests.cs
+++ b/RubberduckTests/Inspections/VariableNotAssignedInspectionTests.cs
@@ -12,7 +12,7 @@ namespace RubberduckTests.Inspections
     {
         [Test]
         [Category("Inspections")]
-        public void VariableNotAssigned_ReturnsResult()
+        public void VariableNotAssigned_ReturnsResult_Local()
         {
             const string inputCode =
                 @"Sub Foo()
@@ -20,6 +20,45 @@ namespace RubberduckTests.Inspections
 End Sub";
 
             Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Public")]
+        [TestCase("Private")]
+        public void VariableNotAssigned_ReturnsResult_Module(string scopeIdentifier)
+        {
+            var inputCode =
+$@"
+    {scopeIdentifier} Bar As Variant
+";
+            Assert.AreEqual(1, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VariableNotAssigned_ReturnsResult_Module_Exposed_Private()
+        {
+            var inputCode =
+$@"
+Attribute VB_Exposed = True
+
+    Private Bar As Variant
+";
+            Assert.AreEqual(1, InspectionResultsForModules(("Class1", inputCode, ComponentType.ClassModule)).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        public void VariableNotAssigned_DoesNotReturnResult_Module_Exposed_Public()
+        {
+            var inputCode =
+$@"
+Attribute VB_Exposed = True
+
+    Public Bar As Variant
+";
+            Assert.AreEqual(0, InspectionResultsForModules(("Class1", inputCode, ComponentType.ClassModule)).Count());
         }
 
         [Test]
@@ -37,13 +76,31 @@ End Sub";
 
         [Test]
         [Category("Inspections")]
-        public void UnassignedVariable_DoesNotReturnResult()
+        public void AssignedVariable_DoesNotReturnResult()
         {
             const string inputCode =
                 @"Function Foo() As Boolean
     Dim var1 as String
     var1 = ""test""
 End Function";
+
+            Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [TestCase("Public")]
+        [TestCase("Private")]
+        public void AssignedVariable_DoesNotReturnResult_Module(string scopeIdentifier)
+        {
+            var inputCode =
+$@"
+    {scopeIdentifier} Bar As Variant
+
+Sub Foo()
+    Bar = ""test""
+End Sub
+";
 
             Assert.AreEqual(0, InspectionResultsForStandardModule(inputCode).Count());
         }


### PR DESCRIPTION
Closes #5291
Closes #5908

The two issues are not closed in the sense of the original request. Instead, this PR aligns the handling in accordance with the result of the discussion in #5908.

There are two main changes in which not used/assigned items are reported by the various inspections.

1. Unused interface members are now generally reported. The rational is that these members can be removed from the interface (and the implementations) if nobody uses them.
2. Public members in exposed class modules are never reported as unused or unassigned. The rational is that exposed classes are intended for external use. Accordingly, the uses or assignments are probably intended to be done by another project, which might bot be loaded at the moment. In addition, one has to consciously expose a module since classes default to not being exposed.  