### PR TITLE
Handle inconsistent results from Find All references gracefully

### DIFF
--- a/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
+++ b/Rubberduck.Core/UI/Converters/SearchResultToXamlConverter.cs
@@ -33,10 +33,12 @@ namespace Rubberduck.UI.Converters
                 textBlock.TextWrapping = TextWrapping.Wrap;
 
                 var input = item.ResultText.Replace(' ', nonBreakingSpace);
-                if (item.HighlightIndex.HasValue)
+                if (item.HighlightIndex.HasValue
+                    && item.HighlightIndex.Value.EndColumn < input.Length   // if we do not check this, any inconsistent input will crash the host.
+                    && item.HighlightIndex.Value.StartColumn < input.Length)
                 {
                     var highlight = item.HighlightIndex.Value;
-                    if (highlight.StartColumn > 0)
+                    if (highlight.StartColumn > 0) 
                     {
                         var preRun = new Run(input.Substring(0, highlight.StartColumn))
                         {


### PR DESCRIPTION
Closes #5952

The results of Find All References take the input code from the reference's line in the VBE and the highlight selection based on the reference selection. If this happens in a dirty state, the highlight can be outside the input code on the line that is now on the line the reference was on before. Previously, this caused an `ArgumentOutOfBoundExcetion` in the UI code when applying the highlight, which brought down the host. Now, we check whether the highlight is within the input code and only apply it if this check passes.

The navigation properly navigates to the last known selection of the reference.


I guess displaying the code at and navigating to the last known position is still useful. So, outright deactivating the feature in a dirty state might not be the best option.  