### PR TITLE
Add ConcatOpContext handling to the ImplicitTypeToExplicitRefactoringAction

### DIFF
--- a/Rubberduck.Refactorings/ImplicitTypeToExplicit/ConcatOpContextResolver.cs
+++ b/Rubberduck.Refactorings/ImplicitTypeToExplicit/ConcatOpContextResolver.cs
@@ -1,0 +1,148 @@
+﻿using Antlr4.Runtime;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.Parsing.VBA;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rubberduck.Refactorings.ImplicitTypeToExplicit
+{
+    /// <summary>
+    /// ConcatOpContextResolver resolves the AsTypeName of ConcatOpContext expressions 
+    /// assumed to be on the RHS of a Variable, Constant, or Parameter assignment.  
+    /// </summary>
+    public class ConcatOpContextResolver
+    {
+        private readonly IDeclarationFinderProvider _declarationFinderProvider;
+
+        public ConcatOpContextResolver(IDeclarationFinderProvider declarationFinderProvider)
+        {
+            _declarationFinderProvider = declarationFinderProvider;
+        }
+        /// <summary>
+        /// Returns an AsTypeName result of 'String' or 'Variant' for a List of 
+        /// ConcatOpContext expressions.
+        /// </summary>
+        /// <remarks>
+        /// Until a unified Expression engine is available, the default AsTypeName, 
+        /// 'Variant', is returned for all ConcatOpContexts that contain operand 
+        /// contexts other than LiteralExprContexts and LExprContexts.  
+        /// 
+        /// In general, the '&amp;' operator (and this function) returns 'String' 
+        /// unless a 'Variant' operand is found within the expression.
+        /// </remarks>
+        public List<string> InferAsTypeNames(IEnumerable<VBAParser.ConcatOpContext> tContexts)
+        {
+            if (!tContexts.Any())
+            {
+                return new List<string>();
+            }
+
+            var operandContexts = GetConcatOperandContexts(tContexts).ToList();
+
+            //The logic below will incorrectly interpret a (very unlikely) statement 
+            //like '5 & Null & Null & 5' as a 'Variant' instead of the correct 
+            //AsTypename 'String' ("55").
+            //TODO: The issue above can be resolved once a unified Expression engine 
+            //is available,
+            if (tContexts.Any(ctxt => ctxt.GetText().Contains("Null & Null")))
+            {
+                return new List<string>() { Tokens.Variant };
+            }
+
+            var literals = operandContexts.OfType<VBAParser.LiteralExprContext>();
+            var lexprs = operandContexts.OfType<VBAParser.LExprContext>();
+            if (operandContexts.Count() != (literals.Count() + lexprs.Count()))
+            {
+                //A context type other than VBAParser.LiteralExprContext 
+                //or VBAParser.LExprContext is used - resort to the default AsTypeName
+                return new List<string>() { Tokens.Variant };
+            }
+
+            if (InferAsTypeNamesForLExprContexts(lexprs, _declarationFinderProvider)
+                .Any(tn => tn == Tokens.Variant))
+            {
+                return new List<string>() { Tokens.Variant };
+            }
+
+            return new List<string>() { Tokens.String };
+        }
+
+        private static IEnumerable<ParserRuleContext> GetConcatOperandContexts(
+            IEnumerable<VBAParser.ConcatOpContext> tContexts)
+        {
+            var results = new List<ParserRuleContext>();
+            foreach (var ctxt in tContexts)
+            {
+                results = ExtractOperands(ctxt, results);
+            }
+
+            return results;
+        }
+
+        private static List<ParserRuleContext> ExtractOperands(
+            VBAParser.ConcatOpContext concatOpContext,
+            List<ParserRuleContext> operandContexts)
+        {
+            if (concatOpContext.children.First() is VBAParser.ConcatOpContext concatOpCtxt)
+            {
+                operandContexts = ExtractOperands(concatOpCtxt, operandContexts);
+            }
+
+            var operands = new List<ParserRuleContext>
+                { concatOpContext.children.First() as ParserRuleContext,
+                concatOpContext.children.Last() as ParserRuleContext};
+
+            foreach (var operandContext in operands)
+            {
+                if (!(operandContext is VBAParser.ConcatOpContext))
+                {
+                    operandContexts.Add(operandContext);
+                }
+            }
+
+            return operandContexts;
+        }
+        private static List<string> InferAsTypeNamesForLExprContexts(
+            IEnumerable<VBAParser.LExprContext> lExprCtxts, 
+            IDeclarationFinderProvider declarationFinderProvider)
+        {
+            var results = new List<string>();
+
+            string typeNameResult;
+            foreach (var lExpr in lExprCtxts)
+            {
+                var target = GetLExprDeclaration(lExpr, declarationFinderProvider);
+                typeNameResult = target.IsObject ? Tokens.Variant : target.AsTypeName;
+                results.Add(typeNameResult);
+            }
+            return results;
+        }
+
+        private static Declaration GetLExprDeclaration(
+            VBAParser.LExprContext lExprContext, 
+            IDeclarationFinderProvider declarationFinderProvider)
+        {
+            var simpleNameExpression = 
+                lExprContext.GetDescendent<VBAParser.SimpleNameExprContext>();
+            
+            var candidates = declarationFinderProvider.DeclarationFinder
+                .MatchName(simpleNameExpression.GetText());
+
+            if (candidates.Count() == 1)
+            {
+                return candidates.First();
+            }
+
+            var lExprDeclaration = candidates
+                .Single(c => c.References.Any(rf => rf.Context is ParserRuleContext prc
+                    && simpleNameExpression.Equals(prc)));
+
+            return lExprDeclaration;
+        }
+    }
+}

--- a/Rubberduck.Refactorings/ImplicitTypeToExplicit/ImplicitAsTypeNameResolver.cs
+++ b/Rubberduck.Refactorings/ImplicitTypeToExplicit/ImplicitAsTypeNameResolver.cs
@@ -13,6 +13,7 @@ namespace Rubberduck.Refactorings.ImplicitTypeToExplicit
     {
         private readonly LiteralExprContextToAsTypeNameConverter _literalExprContextEvaluator;
         private readonly IDeclarationFinderProvider _declarationFinderProvider;
+        private readonly ConcatOpContextResolver _concatOpContextResolver;
         private readonly Declaration _target;
 
         public ImplicitAsTypeNameResolver(IDeclarationFinderProvider declarationFinderProvider,
@@ -21,6 +22,8 @@ namespace Rubberduck.Refactorings.ImplicitTypeToExplicit
             _declarationFinderProvider = declarationFinderProvider;
             _literalExprContextEvaluator = new LiteralExprContextToAsTypeNameConverter(parseTreeValueFactory);
             _target = target;
+
+            _concatOpContextResolver = new ConcatOpContextResolver(declarationFinderProvider);
         }
 
         public List<string> InferAsTypeNames(IReadOnlyCollection<VBAParser.LiteralExprContext> tContexts) 
@@ -28,6 +31,11 @@ namespace Rubberduck.Refactorings.ImplicitTypeToExplicit
 
         public List<string> InferAsTypeNames(IReadOnlyCollection<VBAParser.NewExprContext> tContexts) 
             => tContexts.Select(c => c.GetChild<VBAParser.LExprContext>()?.GetText() ?? string.Empty).ToList();
+
+        public List<string> InferAsTypeNames(IReadOnlyCollection<VBAParser.ConcatOpContext> tContexts)
+        {
+            return _concatOpContextResolver.InferAsTypeNames(tContexts);
+        }
 
         public List<string> InferAsTypeNames(IReadOnlyCollection<VBAParser.LetStmtContext> tContexts)
         {

--- a/RubberduckTests/Refactoring/ImplicitTypeToExplicit/ImplicitTypeToExplicitRefactoringActionConstantTests.cs
+++ b/RubberduckTests/Refactoring/ImplicitTypeToExplicit/ImplicitTypeToExplicitRefactoringActionConstantTests.cs
@@ -162,6 +162,24 @@ End {procedureType}
             StringAssert.Contains($"{targetName} As {expectedType}", refactoredCode);
         }
 
+        [TestCase("5 & 5", "String")]
+        [TestCase("Null & Null", "Variant")]
+        [TestCase(@"Null & ""Test""", "String")]
+        [TestCase("5 & Null", "String")]
+        [Category("Refactorings")]
+        [Category(nameof(ImplicitTypeToExplicitRefactoringAction))]
+        public void ConstantTypedByConcatOp(string expression, string expectedType)
+        {
+            var targetName = "MY_CONSTANT";
+            var inputCode =
+$@"
+Public Const MY_CONSTANT = {expression}
+
+";
+            var refactoredCode = RefactoredCode(inputCode, NameAndDeclarationTypeTuple(targetName));
+            StringAssert.Contains($"{targetName} As {expectedType}", refactoredCode);
+        }
+
         private static (string, DeclarationType) NameAndDeclarationTypeTuple(string name)
             => (name, DeclarationType.Constant);
     }

--- a/RubberduckTests/Refactoring/ImplicitTypeToExplicit/ImplicitTypeToExplicitRefactoringActionParameterTests.cs
+++ b/RubberduckTests/Refactoring/ImplicitTypeToExplicit/ImplicitTypeToExplicitRefactoringActionParameterTests.cs
@@ -249,6 +249,41 @@ End Sub";
             StringAssert.Contains(expectedArgList, refactoredCode);
         }
 
+        [TestCase("5 & 5", "String")]
+        [TestCase("Null & Null", "Variant")]
+        [TestCase(@"Null & ""Test""", "String")]
+        [TestCase(@"5 & Null", "String")]
+        [Category("Refactorings")]
+        [Category(nameof(ImplicitTypeToExplicitRefactoringAction))]
+        public void ParameterWithDefaultValue_ConcatExpression(string expression, string expected)
+        {
+            var targetName = "fizz";
+            var inputCode =
+$@"
+Sub Test(Optional ByVal fizz = {expression})
+End Sub";
+
+            var refactoredCode = RefactoredCode(inputCode, NameAndDeclarationTypeTuple(targetName));
+            StringAssert.Contains($"{targetName} As {expected}", refactoredCode);
+        }
+
+        [Test]
+        [Category("Refactorings")]
+        [Category(nameof(ImplicitTypeToExplicitRefactoringAction))]
+        public void ParameterAssignedWithinProcedure_ConcatExpression()
+        {
+            var targetName = "fizz";
+            var expectedType = "String";
+            var inputCode =
+@"
+Sub Test(ByVal countSuffix As Long,  fizz)
+    fizz = ""Test"" & countSuffix
+End Sub";
+
+            var refactoredCode = RefactoredCode(inputCode, NameAndDeclarationTypeTuple(targetName));
+            StringAssert.Contains($"{targetName} As {expectedType}", refactoredCode);
+        }
+
         (string, DeclarationType) NameAndDeclarationTypeTuple(string name)
             => (name, DeclarationType.Parameter);
     }


### PR DESCRIPTION
Closes #5907

Issue #5907 points to the existence of a line continuation as the cause of the incorrect `AsTypeName` outcome.  However, the issue had nothing to do with the line continuation and everything to do with the '&' operator between the string literals.

The goal of the `ImplicitTypeToExplicitRefactoringAction` is to provide an _improved_ result, when possible, relative to the `DeclareAsExplicitVariantQuickFix`.  Absent a unified Expression engine (#3969), the refactoring action is limited to resolving an explicit `AsTypeName` for only a few `ExpressionContexts`.  Otherwise it defaults to `Variant`.  It was possible to add an incomplete but useful `ConcatOpContext` capability since the '&' operator can only result in a 'String' or 'Variant' `AsTypeNames`. 

Adding another `ExpressionContext` handler revealed some opportunities for refactoring the `ImplicitTypeToExplicitRefactoringAction`.  In order to keep this PR focused on introducing `ConcatOpContext` handling, the refactoring opportunities are deferred to a separate PR. 