### PR TITLE
CodeBuilder improvements:  Get <=> Let/Set code block creation

### DIFF
--- a/Rubberduck.Refactorings/Common/DeclarationExtensions.cs
+++ b/Rubberduck.Refactorings/Common/DeclarationExtensions.cs
@@ -41,5 +41,9 @@ namespace Rubberduck.Refactorings.Common
             return declaration.Context.TryGetAncestor<VBAParser.VariableListStmtContext>(out var varList)
                             && varList.ChildCount > 1;
         }
+
+        public static bool IsMutatorProperty(this Declaration declaration)
+            => declaration.DeclarationType.HasFlag(DeclarationType.PropertyLet)
+            || declaration.DeclarationType.HasFlag(DeclarationType.PropertySet);
     }
 }

--- a/Rubberduck.Resources/Refactorings/Refactorings.Designer.cs
+++ b/Rubberduck.Resources/Refactorings/Refactorings.Designer.cs
@@ -61,6 +61,15 @@ namespace Rubberduck.Resources.Refactorings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;TODO implement member.
+        /// </summary>
+        public static string CodeBuilder_DefaultPropertyImplementation {
+            get {
+                return ResourceManager.GetString("CodeBuilder_DefaultPropertyImplementation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to RHS.
         /// </summary>
         public static string CodeBuilder_DefaultPropertyRHSParam {

--- a/Rubberduck.Resources/Refactorings/Refactorings.resx
+++ b/Rubberduck.Resources/Refactorings/Refactorings.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CodeBuilder_DefaultPropertyImplementation" xml:space="preserve">
+    <value>'TODO implement member</value>
+    <comment>VBA code (comment)</comment>
+  </data>
   <data name="CodeBuilder_DefaultPropertyRHSParam" xml:space="preserve">
     <value>RHS</value>
     <comment>VBA identifier; should not be translated</comment>

--- a/RubberduckTests/CodeBuilderTests.cs
+++ b/RubberduckTests/CodeBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using Rubberduck.Common;
+using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Refactorings;
 using Rubberduck.SmartIndenter;
@@ -16,6 +17,8 @@ namespace RubberduckTests
     {
         private static string _rhsIdentifier = Rubberduck.Resources.Refactorings.Refactorings.CodeBuilder_DefaultPropertyRHSParam;
         private static string _defaultUDTIdentifier = "TestUDT";
+        private static string _defaultProcIdentifier = "TestProcedure";
+        private static string _defaultPropertyIdentifier = "TestProperty";
 
         [TestCase("fizz", DeclarationType.Variable, "Integer")]
         [TestCase("FirstValue", DeclarationType.UserDefinedTypeMember, "Long")]
@@ -205,6 +208,154 @@ End {memberEndStatement}
             StringAssert.Contains($"Property Let {testParams.Identifier}(ByVal RHS As {typeName})", result);
         }
 
+        [TestCase("Public", "ByRef arg1 As Long", "String")]
+        [TestCase("Private", "ByRef arg1 As Long", "String")]
+        [TestCase("Public", "ByRef arg1 As Long, ByVal arg2 As Double", "String")]
+        [TestCase("Public", "ByRef arg1 As Long", "Variant")]
+        [Category(nameof(CodeBuilder))]
+        public void PropertyLetFromFromPropertyGetWithParameters(string accessibilityToken,
+            string paramList,
+            string propertyType)
+        {
+            var procType = ProcedureTypeIdentifier(DeclarationType.PropertyGet);
+
+            string inputCode =
+$@"
+{accessibilityToken} {procType.procType} {_defaultPropertyIdentifier}({paramList}) As {propertyType}
+End {procType.endStmt}
+";
+
+            var prototype = GetPrototypeDeclaration<ModuleBodyElementDeclaration>(
+                inputCode, _defaultPropertyIdentifier, DeclarationType.PropertyGet);
+
+            var tryResult = CreateCodeBuilder().TryBuildPropertyLetCodeBlock(
+                prototype, prototype.IdentifierName,
+                out var result, prototype.Accessibility);
+
+            var expected =
+                $"{accessibilityToken} Property Let {_defaultPropertyIdentifier}({paramList}"
+                    + $", ByVal RHS As {propertyType})";
+
+            Assert.IsTrue(tryResult,
+                "TryBuildPropertyLetCodeBlock(...) returned false");
+
+            StringAssert.Contains(expected, result);
+        }
+
+        [TestCase("Public", "ByRef arg1 As Long", "Collection")]
+        [TestCase("Private", "ByRef arg1 As Long", "Collection")]
+        [TestCase("Public", "ByRef arg1 As Long, ByVal arg2 As Double", "Collection")]
+        [TestCase("Public", "ByRef arg1 As Long", "Variant")]
+        [Category(nameof(CodeBuilder))]
+        public void PropertySetFromFromPropertyGetWithParameters(string accessibilityToken,
+            string paramList,
+            string propertyType)
+        {
+            var procType = ProcedureTypeIdentifier(DeclarationType.PropertyGet);
+
+            string inputCode =
+$@"
+{accessibilityToken} {procType.procType} {_defaultPropertyIdentifier}({paramList}) As {propertyType}
+End {procType.endStmt}
+";
+
+            var prototype = GetPrototypeDeclaration<ModuleBodyElementDeclaration>(
+                inputCode, _defaultPropertyIdentifier, DeclarationType.PropertyGet);
+
+            var tryResult = CreateCodeBuilder().TryBuildPropertySetCodeBlock(
+                prototype, prototype.IdentifierName,
+                out var result, prototype.Accessibility);
+
+            var expected =
+                $"{accessibilityToken} Property Set {_defaultPropertyIdentifier}({paramList}"
+                    + $", ByVal RHS As {propertyType})";
+
+            Assert.IsTrue(tryResult,
+                "TryBuildPropertySetCodeBlock(...) returned false");
+
+            StringAssert.Contains(expected, result);
+        }
+
+        [TestCase("Public", 
+            "Public Property Get TestProperty(ByRef arg1 As Long) As String", 
+            "ByRef arg1 As Long", "ByVal RHS As String")]
+        [TestCase("Private", 
+            "Private Property Get TestProperty(ByRef arg1 As Long) As String", 
+            "ByRef arg1 As Long", "ByVal RHS As String")]
+        [TestCase("Public", 
+            "Public Property Get TestProperty(ByRef arg1 As Long) As Variant", 
+            "ByRef arg1 As Long", "ByVal RHS As Variant")]
+        [TestCase("Public", 
+            "Public Property Get TestProperty(ByRef arg1 As Long) As Variant", 
+            "ByRef arg1 As Long", "ByVal RHS")]
+        [TestCase("Public", 
+            "Public Property Get TestProperty(ByRef arg1 As Long, ByRef arg2 As String) As String", 
+            "ByRef arg1 As Long", "ByRef arg2 As String", "ByVal RHS As String")]
+        [Category(nameof(CodeBuilder))]
+        public void PropertyGetFromFromPropertyLetWithParameters(string accessibilityToken, 
+            string expected,
+            params string[] propertLetParamsList)
+        {
+            var procType = ProcedureTypeIdentifier(DeclarationType.PropertyLet);
+
+            string inputCode =
+$@"
+{accessibilityToken} {procType.procType} {_defaultPropertyIdentifier}({string.Join(", ", propertLetParamsList)})
+End {procType.endStmt}
+";
+
+            var prototype = GetPrototypeDeclaration<ModuleBodyElementDeclaration>(
+                inputCode, _defaultPropertyIdentifier, DeclarationType.PropertyLet);
+
+            var tryResult = CreateCodeBuilder().TryBuildPropertyGetCodeBlock(
+                prototype, prototype.IdentifierName,
+                out var result, prototype.Accessibility);
+
+            Assert.IsTrue(tryResult, "TryBuildPropertyGetCodeBlock(...) returned false");
+
+            StringAssert.Contains(expected, result);
+        }
+
+        [TestCase("Public",
+            "Public Property Get TestProperty(ByRef arg1 As Long) As Collection", 
+            "ByRef arg1 As Long", "ByVal RHS As Collection")]
+        [TestCase("Private",
+            "Private Property Get TestProperty(ByRef arg1 As Long) As Collection",
+            "ByRef arg1 As Long", "ByVal RHS As Collection")]
+        [TestCase("Public",
+            "Public Property Get TestProperty(ByRef arg1 As Long) As Variant",
+            "ByRef arg1 As Long", "ByVal RHS As Variant")]
+        [TestCase("Public",
+            "Public Property Get TestProperty(ByRef arg1 As Long) As Variant",
+            "ByRef arg1 As Long", "ByVal RHS")]
+        [TestCase("Public",
+            "Public Property Get TestProperty(ByRef arg1 As Long, ByRef arg2 As String) As Collection",
+            "ByRef arg1 As Long", "ByRef arg2 As String", "ByVal RHS As Collection")]
+        [Category(nameof(CodeBuilder))]
+        public void PropertyGetFromFromPropertySetWithParameters(string accessibilityToken, 
+            string expected,
+            params string[] propertySetParamsList)
+        {
+            var procType = ProcedureTypeIdentifier(DeclarationType.PropertySet);
+
+            string inputCode =
+$@"
+{accessibilityToken} {procType.procType} {_defaultPropertyIdentifier}({string.Join(", ", propertySetParamsList)})
+End {procType.endStmt}
+";
+
+            var prototype = GetPrototypeDeclaration<ModuleBodyElementDeclaration>(
+                inputCode, _defaultPropertyIdentifier, DeclarationType.PropertySet);
+
+            var tryResult = CreateCodeBuilder().TryBuildPropertyGetCodeBlock(
+                prototype, prototype.IdentifierName,
+                out var result, prototype.Accessibility);
+
+            Assert.IsTrue(tryResult, "TryBuildPropertyGetCodeBlock(...) returned false");
+
+            StringAssert.Contains(expected, result);
+        }
+
         [TestCase("fizz", DeclarationType.Variable, "Integer")]
         [TestCase("FirstValue", DeclarationType.UserDefinedTypeMember, "Long")]
         [TestCase("fazz", DeclarationType.Variable, "Long")]
@@ -277,25 +428,23 @@ Private fizz As Variant
         [Category(nameof(CodeBuilder))]
         public void MemberBlockFromPrototype_AppliesByVal(DeclarationType declarationType)
         {
-            var procedureIdentifier = "TestProcedure";
             var procType = ProcedureTypeIdentifier(declarationType);
 
             string inputCode =
 $@"
-Public {procType.procType} {procedureIdentifier}(arg1 As Long, arg2 As String)
+Public {procType.procType} {_defaultProcIdentifier}(arg1 As Long, arg2 As String)
 End {procType.endStmt}
 ";
             var result = ParseAndTest<ModuleBodyElementDeclaration>(inputCode,
-                procedureIdentifier,
+                _defaultProcIdentifier,
                 declarationType,
-                new MemberBlockFromPrototypeTestParams(),
                 MemberBlockFromPrototypeTest);
 
             var expected = declarationType.HasFlag(DeclarationType.Property)
                 ? "(arg1 As Long, ByVal arg2 As String)"
                 : "(arg1 As Long, arg2 As String)";
 
-            StringAssert.Contains($"{procType.procType} {procedureIdentifier}{expected}", result);
+            StringAssert.Contains($"Public {procType.procType} {_defaultProcIdentifier}{expected}", result);
         }
 
         [TestCase(DeclarationType.PropertyLet)]
@@ -304,16 +453,15 @@ End {procType.endStmt}
         [Category(nameof(CodeBuilder))]
         public void ImprovedArgumentList_AppliesByVal(DeclarationType declarationType)
         {
-            var procedureIdentifier = "TestProperty";
             var procType = ProcedureTypeIdentifier(declarationType);
 
             string inputCode =
 $@"
-Public {procType.procType} {procedureIdentifier}(arg1 As Long, arg2 As String)
+Public {procType.procType} {_defaultProcIdentifier}(arg1 As Long, arg2 As String)
 End {procType.endStmt}
 ";
             var result = ParseAndTest<ModuleBodyElementDeclaration>(inputCode,
-                procedureIdentifier,
+                _defaultProcIdentifier,
                 declarationType,
                 ImprovedArgumentListTest);
 
@@ -329,16 +477,15 @@ End {procType.endStmt}
         [Category(nameof(CodeBuilder))]
         public void ImprovedArgumentList_FunctionTypes(DeclarationType declarationType)
         {
-            var procedureIdentifier = "TestProperty";
             var procType = ProcedureTypeIdentifier(declarationType);
 
             string inputCode =
 $@"
-Public {procType.procType} {procedureIdentifier}(arg1 As Long, arg2 As String) As Long
+Public {procType.procType} {_defaultProcIdentifier}(arg1 As Long, arg2 As String) As Long
 End {procType.endStmt}
 ";
             var result = ParseAndTest<ModuleBodyElementDeclaration>(inputCode,
-                procedureIdentifier,
+                _defaultProcIdentifier,
                 declarationType,
                 ImprovedArgumentListTest);
 
@@ -414,25 +561,58 @@ End Type";
             StringAssert.AreEqualIgnoringCase(expected, actual);
         }
 
-        [TestCase("Property Get", "Property", DeclarationType.PropertyGet)]
-        [TestCase("Function", "Function", DeclarationType.Function)]
+        [TestCase(DeclarationType.PropertyGet)]
+        [TestCase(DeclarationType.Function)]
         [Category(nameof(CodeBuilder))]
-        public void UDT_CreateFromFunctionPrototypes(string memberType, string memberEndStatement, DeclarationType declarationType)
+        public void UDT_CreateFromFunctionPrototypes(DeclarationType declarationType)
         {
+            var procStrings = ProcedureTypeIdentifier(declarationType);
             var inputCode =
 $@"
 
 Private mTestValue As Long
 Private mTestValue2 As Variant
 
-Public {memberType} TestValue() As Long
+Public {procStrings.procType} TestValue() As Long
     TestValue = mTestValue
-End {memberEndStatement}
+End {procStrings.endStmt}
 
 
-Public {memberType} TestValue2() As Variant
+Public {procStrings.procType} TestValue2() As Variant
     TestValue2 = mTestValue2
-End {memberEndStatement}
+End {procStrings.endStmt}
+";
+
+            var expected =
+$@"Private Type {_defaultUDTIdentifier}
+    TestValue As Long
+    TestValue2 As Variant
+End Type";
+
+            var actual = CodeBuilderUDTResult(inputCode, declarationType, "TestValue", "TestValue2");
+            StringAssert.AreEqualIgnoringCase(expected, actual);
+        }
+
+        [TestCase(DeclarationType.PropertyLet)]
+        [TestCase(DeclarationType.PropertySet)]
+        [Category(nameof(CodeBuilder))]
+        public void UDT_CreateFromPropertyLetPrototypes(DeclarationType declarationType)
+        {
+            var procStrings = ProcedureTypeIdentifier(declarationType);
+            var inputCode =
+$@"
+
+Private mTestValue As Long
+Private mTestValue2 As Variant
+
+Public {procStrings.procType} TestValue(ByVal RHS As Long)
+    mTestValue = RHS
+End {procStrings.endStmt}
+
+
+Public {procStrings.procType} TestValue2(ByVal RHS As Variant)
+    mTestValue2 = RHS
+End {procStrings.endStmt}
 ";
 
             var expected =
@@ -468,16 +648,16 @@ End Type";
             StringAssert.AreEqualIgnoringCase(expected, actual);
         }
 
-        [TestCase("Property Let", "Property", DeclarationType.PropertyLet)]
-        [TestCase("Property Set", "Property", DeclarationType.PropertySet)]
-        [TestCase("Sub", "Sub", DeclarationType.Procedure)]
+        [TestCase(DeclarationType.Procedure)]
         [Category(nameof(CodeBuilder))]
-        public void UDT_InvalidPrototypes_NoResult(string memberType, string memberEndStatement, DeclarationType declarationType)
+        public void UDT_InvalidPrototypes_NoResult(DeclarationType declarationType)
         {
+            var procStrings = ProcedureTypeIdentifier(declarationType);
+
             var inputCode =
 $@"
-Public {memberType} TestValue(arg As Long)
-End {memberEndStatement}
+Public {procStrings.procType} TestValue(arg As Long)
+End {procStrings.endStmt}
 ";
             var actual = CodeBuilderUDTResult(inputCode, declarationType, "TestValue", "TestValue2");
             Assert.IsTrue(string.IsNullOrEmpty(actual));
@@ -584,7 +764,9 @@ End {memberEndStatement}
             }
         }
 
-        private string ParseAndTest<T>(string inputCode, string targetIdentifier, DeclarationType declarationType, Func<T, string> theTest)
+        private string ParseAndTest<T>(string inputCode, string targetIdentifier, 
+            DeclarationType declarationType, Func<T, string> theTest) where T: Declaration
+
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _).Object;
             var state = MockParser.CreateAndParse(vbe);
@@ -597,7 +779,10 @@ End {memberEndStatement}
             }
         }
 
-        private string ParseAndTest<T>(string inputCode, string targetIdentifier, DeclarationType declarationType, MemberBlockFromPrototypeTestParams testParams, Func<T, MemberBlockFromPrototypeTestParams, string> theTest)
+        private string ParseAndTest<T>(string inputCode, string targetIdentifier, 
+            DeclarationType declarationType, PropertyBlockFromPrototypeParams testParams, 
+            Func<T, PropertyBlockFromPrototypeParams, string> theTest) where T: Declaration
+
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _).Object;
             var state = MockParser.CreateAndParse(vbe);
@@ -610,7 +795,10 @@ End {memberEndStatement}
             }
         }
 
-        private string ParseAndTest<T>(string inputCode, string targetIdentifier, DeclarationType declarationType, PropertyBlockFromPrototypeParams testParams, Func<T, PropertyBlockFromPrototypeParams, string> theTest)
+        private Declaration GetPrototypeDeclaration<T>(
+            string inputCode, 
+            string targetIdentifier, 
+            DeclarationType declarationType) where T:Declaration
         {
             var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _).Object;
             var state = MockParser.CreateAndParse(vbe);
@@ -619,7 +807,7 @@ End {memberEndStatement}
                 var target = state.DeclarationFinder.DeclarationsWithType(declarationType)
                     .Where(d => d.IdentifierName == targetIdentifier).OfType<T>()
                     .Single();
-                return theTest(target, testParams);
+                return target;
             }
         }
 
@@ -644,8 +832,8 @@ End {memberEndStatement}
         private static string ImprovedArgumentListTest(ModuleBodyElementDeclaration mbed)
             => CreateCodeBuilder().ImprovedArgumentList(mbed);
 
-        private static string MemberBlockFromPrototypeTest(ModuleBodyElementDeclaration mbed, MemberBlockFromPrototypeTestParams testParams)
-            => CreateCodeBuilder().BuildMemberBlockFromPrototype(mbed, testParams.Content, testParams.Accessibility, testParams.NewIdentifier);
+        private static string MemberBlockFromPrototypeTest(ModuleBodyElementDeclaration mbed)
+            => CreateCodeBuilder().BuildMemberBlockFromPrototype(mbed, string.Empty, Accessibility.Public, _defaultProcIdentifier);
 
         private static ICodeBuilder CreateCodeBuilder()
             => new CodeBuilder(new Indenter(null, CreateIndenterSettings));
@@ -692,20 +880,6 @@ End {memberEndStatement}
             public Accessibility Accessibility {get; }
             public string Content { get; }
             public string WriteParam { get; }
-        }
-
-        private struct MemberBlockFromPrototypeTestParams
-        {
-            public MemberBlockFromPrototypeTestParams(ModuleBodyElementDeclaration mbed, Accessibility accessibility = Accessibility.Public, string content = null, string newIdentifier = null)
-            {
-                Accessibility = accessibility;
-                Content = content;
-                NewIdentifier = newIdentifier;
-            }
-
-            public Accessibility Accessibility { get; }
-            public string Content { get; }
-            public string NewIdentifier { get; }
         }
     }
 }


### PR DESCRIPTION
Modifications:
1. Fixes a latent Let/Set code block creation bug:  creating a code block from parameterized Get prototypes fail.
2. Adds `DeclarationType.PropertyLet` and `DeclarationType.PropertySet` to the list of valid prototypes for generating code. 

Item 1: Discovered while working with `CodeBuilder` to resolve #5886.  
Item 2: The resolution to #5886 _should_ look a lot like `IntroduceGetAccessorQuickFix`.  However, `IntroduceGetAccessorQuickFix` is not using the `CodeBuilder`.  The `CodeBuilder` was not an option since creating a Get property code block using a Let/Set prototype declaration was not supported.
