### PR TITLE
Fix ParserRuleContextExtensions class NREs due to null arguments

### DIFF
--- a/Rubberduck.Parsing/ParserRuleContextExtensions.cs
+++ b/Rubberduck.Parsing/ParserRuleContextExtensions.cs
@@ -35,6 +35,11 @@ namespace Rubberduck.Parsing
         /// </summary>
         public static bool Contains(this ParserRuleContext context, ParserRuleContext otherContextInSameParseTree)
         {
+            if (context is null || otherContextInSameParseTree is null)
+            {
+                return false;
+            }
+
             return context.start.TokenIndex <= otherContextInSameParseTree.start.TokenIndex
                    && context.stop.TokenIndex >= otherContextInSameParseTree.stop.TokenIndex;
         }
@@ -44,7 +49,7 @@ namespace Rubberduck.Parsing
         /// </summary>
         public static IEnumerable<IToken> GetTokens(this ParserRuleContext context, CommonTokenStream tokenStream)
         {
-            var sourceInterval = context.SourceInterval;
+            var sourceInterval = context?.SourceInterval ?? Interval.Invalid;
             if (sourceInterval.Equals(Interval.Invalid) || sourceInterval.b < sourceInterval.a)
             {
                 return new List<IToken>();
@@ -58,7 +63,7 @@ namespace Rubberduck.Parsing
         public static string GetText(this ParserRuleContext context, ICharStream stream)
         {
             // Can be null if the input is empty it seems.
-            if (context.Stop == null)
+            if (context?.Stop == null)
             {
                 return string.Empty;
             }
@@ -86,7 +91,7 @@ namespace Rubberduck.Parsing
         /// <summary>
         /// Determines if any of the context's ancestors are the generic Type.
         /// </summary>
-        public static bool IsDescendentOf<TContext>(this ParserRuleContext context)
+        public static bool IsDescendentOf<TContext>(this ParserRuleContext context) where TContext: ParserRuleContext
         {
             if (context == null)
             {
@@ -129,7 +134,7 @@ namespace Rubberduck.Parsing
         /// <summary>
         /// Returns the context's first ancestor of the generic Type.
         /// </summary>
-        public static TContext GetAncestor<TContext>(this ParserRuleContext context)
+        public static TContext GetAncestor<TContext>(this ParserRuleContext context) where TContext: ParserRuleContext
         {
             switch (context)
             {
@@ -145,13 +150,13 @@ namespace Rubberduck.Parsing
         /// <summary>
         /// Tries to return the context's first ancestor of the generic Type.
         /// </summary>
-        public static bool TryGetAncestor<TContext>(this ParserRuleContext context, out TContext ancestor)
+        public static bool TryGetAncestor<TContext>(this ParserRuleContext context, out TContext ancestor) where TContext : ParserRuleContext
         {
             ancestor = context.GetAncestor<TContext>();
             return ancestor != null;
         }
 
-        private static TContext GetAncestor_Recursive<TContext>(ParserRuleContext context)
+        private static TContext GetAncestor_Recursive<TContext>(ParserRuleContext context) where TContext: ParserRuleContext
         {
             switch (context)
             {
@@ -258,7 +263,7 @@ namespace Rubberduck.Parsing
         public static VBAParser.EndOfLineContext GetFirstEndOfLine(this VBAParser.EndOfStatementContext endOfStatement)
         {
             //This dedicated method exists for performance reasons on hot-paths.
-            var individualEndOfStatements = endOfStatement.individualNonEOFEndOfStatement();
+            var individualEndOfStatements = endOfStatement?.individualNonEOFEndOfStatement();
 
             if (individualEndOfStatements == null)
             {

--- a/RubberduckTests/Grammar/ParserRuleContextExtensionNullArgumentsTests.cs
+++ b/RubberduckTests/Grammar/ParserRuleContextExtensionNullArgumentsTests.cs
@@ -1,0 +1,431 @@
+﻿using Antlr4.Runtime;
+using Moq;
+using NUnit.Framework;
+using Rubberduck.Parsing;
+using Rubberduck.Parsing.Grammar;
+using Rubberduck.Parsing.Symbols;
+using Rubberduck.VBEditor;
+using RubberduckTests.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RubberduckTests.Grammar
+{
+    [TestFixture]
+    public class ParserRuleContextExtensionNullArgumentsTests
+    {
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetSelection_nullContext_returnsHome()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetSelection();
+
+            //Assert
+            Assert.AreEqual(Selection.Home, actual);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void Contains_nullContainedContext_returnsFalse(bool containingContextIsNull)
+        {
+            //Arrange
+            var inputCode =
+@"
+Public Function Foo(arg1 As Long) As Long
+End Function"
+;
+            var aContext = GetUserDeclaration(inputCode, "Foo").Context;
+            var containingContext = containingContextIsNull ? null : GetUserDeclaration(inputCode, "Foo").Context;
+            var containedContext = containingContextIsNull ? GetUserDeclaration(inputCode, "Foo").Context : null;
+
+            //Act
+            var actual = containingContext.Contains(containedContext);
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetTokens_nullContext_returnsEmptyList()
+        {
+            //Arrange
+            var mockTokenStream = new Mock<ITokenSource>();
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetTokens(new CommonTokenStream(mockTokenStream.Object)).Count();
+
+            //Assert
+            Assert.AreEqual(0, actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetText_nullContext_returnsEmptyString()
+        {
+            //Arrange
+            var mockCharStream = new Mock<ICharStream>();
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetText(mockCharStream.Object);
+
+            //Assert
+            Assert.AreEqual(string.Empty, actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetChild_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetChild<ParserRuleContext>();
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void IsDescendentOf_nullContext_returnsFalse()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.IsDescendentOf<ParserRuleContext>();
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void IsDescendentOf_Ancestor_nullContext_returnsFalse(bool ancestorIsNull)
+        {
+            //Arrange
+            var inputCode =
+@"
+Public Function Foo(arg1 As Long) As Long
+End Function"
+;
+            var aValidContext = GetUserDeclaration(inputCode, "Foo").Context;
+            ParserRuleContext nullContext = ancestorIsNull ? aValidContext : null;
+            ParserRuleContext ancestor = ancestorIsNull ? null : aValidContext;
+
+            //Act
+            var actual = nullContext.IsDescendentOf<ParserRuleContext>(ancestor);
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetAncestor_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetAncestor<ParserRuleContext>();
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void TryGetAncestor_nullContext_returnsFalse()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.TryGetAncestor<ParserRuleContext>(out _);
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetAncestorContainingTokenIndex_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetAncestorContainingTokenIndex(6);
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void ContainsTokenIndex_nullContext_returnsFalse()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.ContainsTokenIndex(6);
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetDescendent_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetDescendent<ParserRuleContext>();
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetDescendents_nullContext_returnsEmptyList()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetDescendents<ParserRuleContext>().Count();
+
+            //Assert
+            Assert.AreEqual(0, actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void TryGetChildContext_nullContext_returnsFalse()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = nullContext.TryGetChildContext<ParserRuleContext>(out _);
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetFirstEndOfLine_nullContext_returnsNull()
+        {
+            //Arrange
+            VBAParser.EndOfStatementContext nullContext = null;
+
+            //Act
+            var actual = nullContext.GetFirstEndOfLine();
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void IsOptionCompareBinary_nullContext_throwsArgumentException()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            //Assert
+            Assert.Throws<ArgumentException>(() => nullContext.IsOptionCompareBinary());
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetWidestDescendentContainingTokenIndex_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = 
+                nullContext.GetWidestDescendentContainingTokenIndex<ParserRuleContext>(6);
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetSmallestDescendentContainingTokenIndex_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = 
+                nullContext.GetSmallestDescendentContainingTokenIndex<ParserRuleContext>(6);
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetDescendentsContainingTokenIndex_nullContext_returnsEmptyList()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = 
+                nullContext.GetDescendentsContainingTokenIndex<ParserRuleContext>(6)
+                .Count();
+
+            //Assert
+            Assert.AreEqual(0, actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetWidestDescendentContainingSelection_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = 
+                nullContext.GetWidestDescendentContainingSelection<ParserRuleContext>(new Selection());
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetSmallestDescendentContainingSelection_nullContext_returnsNull()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual = 
+                nullContext.GetSmallestDescendentContainingSelection<ParserRuleContext>(new Selection());
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void GetDescendentsContainingSelection_nullContext_returnsEmptyList()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual =
+                nullContext.GetDescendentsContainingSelection<ParserRuleContext>(new Selection())
+                .Count();
+
+            //Assert
+            Assert.AreEqual(0, actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void TryGetPrecedingContext_nullContext_returnsFalse()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual =
+                nullContext.TryGetPrecedingContext<ParserRuleContext>(out _);
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void TryGetFollowingContext_nullContext_returnsFalse()
+        {
+            //Arrange
+            ParserRuleContext nullContext = null;
+
+            //Act
+            var actual =
+                nullContext.TryGetFollowingContext<ParserRuleContext>(out _);
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        [Category("Inspections")]
+        [Category(nameof(ParserRuleContextExtensions))]
+        public void ContainsExecutableStatements_nullContext_returnsFalse()
+        {
+            //Arrange
+            VBAParser.BlockContext nullContext = null;
+
+            //Act
+            var actual =
+                nullContext.ContainsExecutableStatements();
+
+            //Assert
+            Assert.IsFalse(actual);
+        }
+
+        private Declaration GetUserDeclaration(string inputCode, string identifier)
+        {
+            var vbe = MockVbeBuilder.BuildFromSingleStandardModule(inputCode, out _);
+            using (var state = MockParser.CreateAndParse(vbe.Object))
+            {
+                return state.DeclarationFinder.MatchName(identifier).FirstOrDefault();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR modifies public `ParserRuleContextExtensions` class functions that were generating NREs as a result of null arguments.