### PR TITLE
Some xmldoc fixes

### DIFF
--- a/Rubberduck.CodeAnalysis/Inspections/Concrete/MultipleDeclarationsInspection.cs
+++ b/Rubberduck.CodeAnalysis/Inspections/Concrete/MultipleDeclarationsInspection.cs
@@ -9,30 +9,32 @@ using Rubberduck.Resources.Inspections;
 namespace Rubberduck.CodeAnalysis.Inspections.Concrete
 {
     /// <summary>
-    /// Flags declaration statements spanning multiple physical lines of code.
+    /// Flags declaration statements declaring multiple variables.
     /// </summary>
     /// <why>
-    /// Declaration statements should generally declare a single variable.
+    /// Declaration statements should generally declare a single variable. 
+    /// Although this inspection does not take variable types into account, it is a common mistake to only declare an explicit type on the last variable in a list.
     /// </why>
     /// <example hasResult="true">
     /// <module name="MyModule" type="Standard Module">
     /// <![CDATA[
-    /// Dim foo As Long, bar As Long
+    /// 'note: RowNumber is untyped / implicitly Variant
+    /// Dim RowNumber, ColumnNumber As Long
     /// ]]>
     /// </module>
     /// </example>
     /// <example hasResult="true">
     /// <module name="MyModule" type="Standard Module">
     /// <![CDATA[
-    /// Dim foo , bar As Long
+    /// Dim RowNumber As Long, ColumnNumber As Long
     /// ]]>
     /// </module>
     /// </example>
     /// <example hasResult="false">
     /// <module name="MyModule" type="Standard Module">
     /// <![CDATA[
-    /// Dim foo As Long 
-    /// Dim bar As Long 
+    /// Dim RowNumber As Long 
+    /// Dim ColumnNumber As Long 
     /// ]]>
     /// </module>
     /// </example>

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ConvertToProcedureQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ConvertToProcedureQuickFix.cs
@@ -17,7 +17,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
     /// </summary>
     /// <inspections>
     /// <inspection name="NonReturningFunctionInspection" />
-    /// <inspection name="FunctionReturnValueNotUsedInspection" />
+    /// <inspection name="FunctionReturnValueAlwaysDiscardedInspection" />
     /// </inspections>
     /// <canfix multiple="true" procedure="false" module="true" project="false" all="false" />
     /// <example>


### PR DESCRIPTION
While reviewing the links between inspections and quickfixes, I stumbled upon a quickfix that was linking to an inspection that was probably renamed, or no longer exists anyway - resulting in a link on the site going to a HTTP 404 error page.

I'll push more commits in this branch if I see others.