### PR TITLE
Fakes fixes

### DIFF
--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakeBase.cs
@@ -75,7 +75,7 @@ namespace Rubberduck.UnitTesting
 
         #region IFake
 
-        private static readonly List<ReturnValueInfo> ReturnValues = new List<ReturnValueInfo>();
+        private readonly List<ReturnValueInfo> ReturnValues = new List<ReturnValueInfo>();
         public virtual void Returns(object value, int invocation = FakesProvider.AllInvocations)
         {
             ReturnValues.Add(new ReturnValueInfo(invocation, string.Empty, string.Empty, value));

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
@@ -24,10 +24,10 @@ namespace Rubberduck.UnitTesting.Fakes
             }
             if (PassThrough)
             {
-                FakesProvider.SuspendFake("Now");
+                FakesProvider.SuspendFake(typeof(Now));
                 var nativeCall = Marshal.GetDelegateForFunctionPointer<DateDelegate>(NativeFunctionAddress);
                 nativeCall(retVal);
-                FakesProvider.ResumeFake("Now");
+                FakesProvider.ResumeFake(typeof(Now));
                 return;
             }
             Marshal.GetNativeVariantForObject(ReturnValue ?? 0, retVal);

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Date.cs
@@ -18,14 +18,16 @@ namespace Rubberduck.UnitTesting.Fakes
         public void DateCallback(IntPtr retVal)
         {
             OnCallBack(true);
-            if (!TrySetReturnValue())                          // specific invocation
+            if (!TrySetReturnValue())
             {
-                TrySetReturnValue(true);                       // any invocation
+                TrySetReturnValue(true);
             }
             if (PassThrough)
             {
+                FakesProvider.SuspendFake("Now");
                 var nativeCall = Marshal.GetDelegateForFunctionPointer<DateDelegate>(NativeFunctionAddress);
                 nativeCall(retVal);
+                FakesProvider.ResumeFake("Now");
                 return;
             }
             Marshal.GetNativeVariantForObject(ReturnValue ?? 0, retVal);

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
@@ -24,10 +24,10 @@ namespace Rubberduck.UnitTesting.Fakes
             }
             if (PassThrough)
             {
-                FakesProvider.SuspendFake("Now");
+                FakesProvider.SuspendFake(typeof(Now));
                 var nativeCall = Marshal.GetDelegateForFunctionPointer<TimeDelegate>(NativeFunctionAddress);
                 nativeCall(retVal);
-                FakesProvider.ResumeFake("Now");
+                FakesProvider.ResumeFake(typeof(Now));
                 return;
             }
             Marshal.GetNativeVariantForObject(ReturnValue ?? 0, retVal);

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/Fakes/Time.cs
@@ -24,8 +24,10 @@ namespace Rubberduck.UnitTesting.Fakes
             }
             if (PassThrough)
             {
+                FakesProvider.SuspendFake("Now");
                 var nativeCall = Marshal.GetDelegateForFunctionPointer<TimeDelegate>(NativeFunctionAddress);
                 nativeCall(retVal);
+                FakesProvider.ResumeFake("Now");
                 return;
             }
             Marshal.GetNativeVariantForObject(ReturnValue ?? 0, retVal);

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
@@ -37,11 +37,11 @@ namespace Rubberduck.UnitTesting
             CodeIsUnderTest = true;
         }
 
-        public static void SuspendFake(String typename)
+        public static void SuspendFake(Type type)
         {
             foreach (var fake in ActiveFakes.Values)
             {
-                if (fake.GetType().Name == typename)
+                if (fake.GetType() == type)
                 {
                     fake.DisableHook();
                     return;
@@ -49,11 +49,11 @@ namespace Rubberduck.UnitTesting
             }
         }
 
-        public static void ResumeFake(String typename)
+        public static void ResumeFake(Type type)
         {
             foreach (var fake in ActiveFakes.Values)
             {
-                if (fake.GetType().Name == typename)
+                if (fake.GetType() == type)
                 {
                     fake.EnableHook();
                     return;

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
@@ -37,6 +37,30 @@ namespace Rubberduck.UnitTesting
             CodeIsUnderTest = true;
         }
 
+        public static void SuspendFake(String typename)
+        {
+            foreach (var fake in ActiveFakes.Values)
+            {
+                if (fake.GetType().Name == typename)
+                {
+                    fake.DisableHook();
+                    return;
+                }
+            }
+        }
+
+        public static void ResumeFake(String typename)
+        {
+            foreach (var fake in ActiveFakes.Values)
+            {
+                if (fake.GetType().Name == typename)
+                {
+                    fake.DisableHook();
+                    return;
+                }
+            }
+        }
+
         public void StopTest()
         {           
             foreach (var fake in ActiveFakes.Values)

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
@@ -55,7 +55,7 @@ namespace Rubberduck.UnitTesting
             {
                 if (fake.GetType().Name == typename)
                 {
-                    fake.DisableHook();
+                    fake.EnableHook();
                     return;
                 }
             }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/StubBase.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/StubBase.cs
@@ -53,6 +53,21 @@ namespace Rubberduck.UnitTesting
             }
         }
 
+        public void DisableHook()
+        {
+            foreach (var hook in _hooks)
+            {
+                hook.ThreadACL.SetExclusiveACL(new[] { 0 });
+            }
+        }
+        public void EnableHook()
+        {
+            foreach (var hook in _hooks)
+            {
+                hook.ThreadACL.SetInclusiveACL(new[] { 0 });
+            }
+        }
+
         public virtual void Dispose()
         {
             foreach (var hook in _hooks)

--- a/RubberduckTests/IntegrationTests/FakeTests.bas
+++ b/RubberduckTests/IntegrationTests/FakeTests.bas
@@ -729,3 +729,48 @@ TestExit:
 TestFail:
     Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
 End Sub
+
+'@TestMethod
+Public Sub TestIssue4476()
+    On Error GoTo TestFail
+    
+    'Arrange:
+    Fakes.Now.PassThrough = True
+    Fakes.Date.PassThrough = True
+    
+    'Act:
+    Debug.Print Now
+    Debug.Print Date '<== KA-BOOOM
+    
+    'Assert:
+    Fakes.Now.Verify.AtLeastOnce
+    Fakes.Date.Verify.AtLeastOnce
+    
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub
+
+'@TestMethod
+Public Sub TestIssue5944()
+    On Error GoTo TestFail
+        
+    Fakes.InputBox.Returns 20
+    Fakes.MsgBox.Returns 20
+    
+    Dim inputBoxReturnValue As String
+    Dim msgBoxReturnValue As Integer
+    
+    inputBoxReturnValue = InputBox("Dummy")
+    msgBoxReturnValue = MsgBox("Dummy")
+    
+    Fakes.MsgBox.Verify.Once
+    Fakes.InputBox.Verify.Once
+    
+TestExit:
+    Exit Sub
+TestFail:
+    Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
+End Sub
+

--- a/RubberduckTests/IntegrationTests/FakeTests.bas
+++ b/RubberduckTests/IntegrationTests/FakeTests.bas
@@ -737,14 +737,16 @@ Public Sub TestIssue4476()
     'Arrange:
     Fakes.Now.PassThrough = True
     Fakes.Date.PassThrough = True
+    Dim retVal As Variant
     
     'Act:
-    Debug.Print Now
-    Debug.Print Date '<== KA-BOOOM
+    retVal = Now
+    retVal = Date '<== KA-BOOOM
+    retVal = Now 'ensure fake reinstated
     
     'Assert:
-    Fakes.Now.Verify.AtLeastOnce
-    Fakes.Date.Verify.AtLeastOnce
+    Fakes.Now.Verify.Exactly 2
+    Fakes.Date.Verify.Once
     
 TestExit:
     Exit Sub


### PR DESCRIPTION
Fixes https://github.com/rubberduck-vba/Rubberduck/issues/4476, fixes https://github.com/rubberduck-vba/Rubberduck/issues/5944

The fix for 4476 is simply to change the list of return values from being static as that meant it was shared across multiple fakes and so a return value intended for one fake could be used by another, causing type conversion errors (as well as unintended values).

The fix for 5944 introduces a way to disable another fake temporarily. This is necessary when one hooked function uses the passthrough feature to call the native function which itself contains a call to another hooked function. We don't want that behaviour anyway as someone hooking the Now function for example would not expect it to change the result of the Date function. I've done this for the Date and Time fakes to avoid issues with the Now fake. I had a quick look through other functions and didn't spot other potential issues but if they do arise the same approach should be useful.

The thing I'm not so keen on in the solution is using a string comparison of the types. I tried to use type comparisons directly but couldn't get it to work. My c# level is pretty basic. Happy to get any pointers to tidy this up.