### PR TITLE
chore: harmonize indention of empty lines in `TestCodeGenerator`

### DIFF
--- a/Rubberduck.UnitTesting/CodeGeneration/TestCodeGeneratorStatics.cs
+++ b/Rubberduck.UnitTesting/CodeGeneration/TestCodeGeneratorStatics.cs
@@ -44,16 +44,16 @@ Private Sub {{0}}() {RenameTestTodoComment}
     On Error GoTo {TestFailLabel}
     
     {ArrangeComment}
-
+    
     {ActComment}
-
+    
     '{AssertLabel}:
     Assert.Succeed
 
 {TestExitLabel}:
 '@Ignore UnhandledOnErrorResumeNext
     On Error Resume Next
-
+    
 Exit Sub
 {TestFailLabel}:
     Assert.Fail ""{TestErrorMessage}"" & Err.Number & "" - "" & Err.Description
@@ -67,9 +67,9 @@ Private Sub {{0}}() {RenameTestTodoComment}
     On Error GoTo {TestFailLabel}
     
     {ArrangeComment}
-
+    
     {ActComment}
-
+    
 {AssertLabel}:
     Assert.Fail ""{ExpectedErrorFailMessage}""
 


### PR DESCRIPTION
(otherwise remove the indention after `On Error GoTo {TestFailLabel}` lines)