### PR TITLE
Adds parameter string names provider to Fakes API

### DIFF
--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IFakesProvider.cs
@@ -135,5 +135,10 @@ namespace Rubberduck.UnitTesting
         [DispId(31)]
         [Description("Configures VBA.FileSystem.FileCopy calls.")]
         IStub FileCopy { get; }
+
+
+        [DispId(255)]
+        [Description("Gets an interface exposing the parameter names for all parameterized fakes.")]
+        IParams Params { get; }
     }
 }

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/IParams.cs
@@ -1,0 +1,107 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.IParamsGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always)
+    ]
+    public interface IParams
+    {
+        [DispId(1)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Interaction.MsgBox' function.")]
+        IMsgBoxParams MsgBox { get; }
+
+        [DispId(2)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Interaction.InputBox' function.")]
+        IInputBoxParams InputBox { get; }
+
+        [DispId(3)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Interaction.Environ' function.")]
+        IEnvironParams Environ { get; }
+
+        [DispId(4)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Interaction.Shell' function.")]
+        IShellParams Shell { get; }
+
+        [DispId(5)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Interaction.SendKeys' function.")]
+        ISendKeysParams SendKeys { get; }
+
+        [DispId(6)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.Kill' function.")]
+        IKillParams Kill { get; }
+
+        [DispId(7)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.FileCopy' statement.")]
+        IFileCopyParams FileCopy { get; }
+
+        [DispId(8)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.FreeFile' function.")]
+        IFreeFileParams FreeFile { get; }
+
+        [DispId(9)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.GetAttr' function.")]
+        IGetAttrParams GetAttr { get; }
+
+        [DispId(10)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.SetAttr' statement.")]
+        ISetAttrParams SetAttr { get; }
+
+        [DispId(11)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.FileLen' function.")]
+        IFileLenParams FileLen { get; }
+
+        [DispId(12)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.FileDateTime' function.")]
+        IFileDateTimeParams FileDateTime { get; }
+
+        [DispId(13)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.Dir' function.")]
+        IDirParams Dir { get; }
+
+        [DispId(14)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.CurDir' function.")]
+        ICurDirParams CurDir { get; }
+
+        [DispId(15)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.ChDir' statement.")]
+        IChDirParams ChDir { get; }
+
+        [DispId(16)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.ChDrive' statement.")]
+        IChDriveParams ChDrive { get; }
+
+        [DispId(17)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.MkDir' statement.")]
+        IMkDirParams MkDir { get; }
+
+        [DispId(18)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.FileSystem.RmDir' statement.")]
+        IRmDirParams RmDir { get; }
+
+        [DispId(19)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Interaction.SaveSetting' statement.")]
+        ISaveSettingParams SaveSetting { get; }
+
+        [DispId(20)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Interaction.DeleteSetting' statement.")]
+        IDeleteSettingParams DeleteSetting { get; }
+
+        [DispId(21)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Math.Randomize' statement.")]
+        IRandomizeParams Randomize { get; }
+
+        [DispId(22)]
+        [Description("Gets an interface exposing the parameter names for the 'VBA.Math.Rnd' function.")]
+        IRndParams Rnd { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IChDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IChDirParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsChDirGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IChDirParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Path' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Path' parameter.")]
+        string Path { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IChDriveParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IChDriveParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsChDriveGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IChDriveParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Drive' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Drive' parameter.")]
+        string Drive { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ICurDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ICurDirParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsCurDirGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface ICurDirParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Drive' optional parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Drive' optional parameter.")]
+        string Drive { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IDeleteSettingParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IDeleteSettingParams.cs
@@ -1,0 +1,40 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsDeleteSettingGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IDeleteSettingParams
+    {
+        /// <summary>
+        /// Gets the name of the 'AppName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'AppName' parameter.")]
+        string AppName { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Section' parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Section' parameter.")]
+        string Section { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Key' parameter.
+        /// </summary>
+        [DispId(3)]
+        [Description("Gets the name of the 'Key' parameter.")]
+        string Key { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IDirParams.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsDirGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IDirParams
+    {
+        /// <summary>
+        /// Gets the name of the 'PathName' optional parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'PathName' optional parameter.")]
+        string PathName { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Attributes' optional parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Attributes' optional parameter.")]
+        string Attributes { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IEnvironParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IEnvironParams.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+    ComVisible(true),
+    Guid(RubberduckGuid.ParamsEnvironGuid),
+    InterfaceType(ComInterfaceType.InterfaceIsDual),
+    EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IEnvironParams
+    {
+        /// <summary>
+        /// Gets the name of the 'EnvString' optional parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'EnvString' optional parameter.")]
+        string EnvString { get; }
+        
+        /// <summary>
+        /// Gets the name of the 'Number' optional parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Number' optional parameter.")]
+        string Number { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFileCopyParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFileCopyParams.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsFileCopyGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IFileCopyParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Source' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Source' parameter.")]
+        string Source { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Destination' parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Destination' parameter.")]
+        string Destination { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFileDateTimeParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFileDateTimeParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsFileDateTimeGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IFileDateTimeParams
+    {
+        /// <summary>
+        /// Gets the name of the 'PathName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'PathName' parameter.")]
+        string PathName { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFileLenParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFileLenParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsFileLenGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IFileLenParams
+    {
+        /// <summary>
+        /// Gets the name of the 'PathName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'PathName' parameter.")]
+        string PathName { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFreeFileParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IFreeFileParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsFreeFileGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IFreeFileParams
+    {
+        /// <summary>
+        /// Gets the name of the 'RangeNumber' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'RangeNumber' parameter.")]
+        string RangeNumber { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IGetAttrParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IGetAttrParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsGetAttrGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IGetAttrParams
+    {
+        /// <summary>
+        /// Gets the name of the 'PathName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'PathName' parameter.")]
+        string PathName { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IInputBoxParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IInputBoxParams.cs
@@ -1,0 +1,68 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+    ComVisible(true),
+    Guid(RubberduckGuid.ParamsInputBoxGuid),
+    InterfaceType(ComInterfaceType.InterfaceIsDual),
+    EditorBrowsable(EditorBrowsableState.Always),   
+    ]
+    public interface IInputBoxParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Prompt' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Prompt' parameter.")]
+        string Prompt { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Title' optional parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Title' optional parameter.")]
+        string Title { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Default' optional parameter.
+        /// </summary>
+        [DispId(3)]
+        [Description("Gets the name of the 'Default' optional parameter.")]
+        string Default { get; }
+
+        /// <summary>
+        /// Gets the name of the 'XPos' optional parameter.
+        /// </summary>
+        [DispId(4)]
+        [Description("Gets the name of the 'XPos' optional parameter.")]
+        string XPos { get; }
+
+        /// <summary>
+        /// Gets the name of the 'YPos' optional parameter.
+        /// </summary>
+        [DispId(5)]
+        [Description("Gets the name of the 'YPos' optional parameter.")]
+        string YPos { get; }
+
+        /// <summary>
+        /// Gets the name of the 'HelpFile' optional parameter.
+        /// </summary>
+        [DispId(6)]
+        [Description("Gets the name of the 'HelpFile' optional parameter.")]
+        string HelpFile { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Context' optional parameter.
+        /// </summary>
+        [DispId(7)]
+        [Description("Gets the name of the 'Context' optional parameter.")]
+        string Context { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IKillParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IKillParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsKillGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IKillParams
+    {
+        /// <summary>
+        /// Gets the name of the 'PathName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'PathName' parameter.")]
+        string PathName { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IMkDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IMkDirParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsMkDirGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IMkDirParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Path' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Path' parameter.")]
+        string Path { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IMsgBoxParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IMsgBoxParams.cs
@@ -1,0 +1,54 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsMsgBoxGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IMsgBoxParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Prompt' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Prompt' parameter.")]
+        string Prompt { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Buttons' optional parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Buttons' parameter.")]
+        string Buttons { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Title' optional parameter.
+        /// </summary>
+        [DispId(3)]
+        [Description("Gets the name of the 'Title' parameter.")]
+        string Title { get; }
+
+        /// <summary>
+        /// Gets the name of the 'HelpFile' optional parameter.
+        /// </summary>
+        [DispId(4)]
+        [Description("Gets the name of the 'HelpFile' parameter.")]
+        string HelpFile { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Context' optional parameter.
+        /// </summary>
+        [DispId(5)]
+        [Description("Gets the name of the 'Context' parameter.")]
+        string Context { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IRandomizeParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IRandomizeParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsRandomizeGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IRandomizeParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Number' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Number' parameter.")]
+        string Number { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IRmDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IRmDirParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsRmDirGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IRmDirParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Path' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Path' parameter.")]
+        string Path { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IRndParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IRndParams.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsRndGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IRndParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Number' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Number' parameter.")]
+        string Number { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ISaveSettingParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ISaveSettingParams.cs
@@ -1,0 +1,47 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsSaveSettingGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface ISaveSettingParams
+    {
+        /// <summary>
+        /// Gets the name of the 'AppName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'AppName' parameter.")]
+        string AppName { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Section' parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Section' parameter.")]
+        string Section { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Key' parameter.
+        /// </summary>
+        [DispId(3)]
+        [Description("Gets the name of the 'Key' parameter.")]
+        string Key { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Setting' parameter.
+        /// </summary>
+        [DispId(4)]
+        [Description("Gets the name of the 'Setting' parameter.")]
+        string Setting { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ISendKeysParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ISendKeysParams.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsSendKeysGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface ISendKeysParams
+    {
+        /// <summary>
+        /// Gets the name of the 'Keys' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'Keys' parameter.")]
+        string Keys { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Wait' parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Wait' parameter.")]
+        string Wait { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ISetAttrParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/ISetAttrParams.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsSetAttrGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface ISetAttrParams
+    {
+        /// <summary>
+        /// Gets the name of the 'PathName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'PathName' parameter.")]
+        string PathName { get; }
+
+        /// <summary>
+        /// Gets the name of the 'Attributes' parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'Attributes' parameter.")]
+        string Attributes { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IShellParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/Abstract/UnitTesting/ParameterInfo/IShellParams.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsShellGuid),
+        InterfaceType(ComInterfaceType.InterfaceIsDual),
+        EditorBrowsable(EditorBrowsableState.Always),
+    ]
+    public interface IShellParams
+    {
+        /// <summary>
+        /// Gets the name of the 'PathName' parameter.
+        /// </summary>
+        [DispId(1)]
+        [Description("Gets the name of the 'PathName' parameter.")]
+        string PathName { get; }
+
+        /// <summary>
+        /// Gets the name of the 'WindowStyle' optional parameter.
+        /// </summary>
+        [DispId(2)]
+        [Description("Gets the name of the 'WindowStyle' parameter.")]
+        string WindowStyle { get; }
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/FakesProvider.cs
@@ -125,5 +125,7 @@ namespace Rubberduck.UnitTesting
         public IFake Dir => RetrieveOrCreateFunction<Dir>();
         public IStub FileCopy => RetrieveOrCreateFunction<FileCopy>();
         #endregion
+
+        public IParams Params { get; } = new Params();
     }
 }

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/ChDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/ChDirParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class ChDirParams : IChDirParams
+    {
+        public string Path { get; } = nameof(Path);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/ChDriveParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/ChDriveParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class ChDriveParams : IChDriveParams
+    {
+        public string Drive { get; } = nameof(Drive);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/CurDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/CurDirParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class CurDirParams : ICurDirParams
+    {
+        public string Drive { get; } = nameof(Drive);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/DeleteSettingParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/DeleteSettingParams.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class DeleteSettingParams : IDeleteSettingParams
+    {
+        public string AppName { get; } = nameof(AppName);
+
+        public string Section { get; } = nameof(Section);
+
+        public string Key { get; } = nameof(Key);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/DirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/DirParams.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class DirParams : IDirParams
+    {
+        public string PathName { get; } = nameof(PathName);
+
+        public string Attributes { get; } = nameof(Attributes);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/EnvironParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/EnvironParams.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class EnvironParams : IEnvironParams
+    {
+        public string EnvString { get; } = nameof(EnvString);
+
+        public string Number { get; } = nameof(Number);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FileCopyParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FileCopyParams.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class FileCopyParams : IFileCopyParams
+    {
+        public string Source { get; } = nameof(Source);
+
+        public string Destination { get; } = nameof(Destination);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FileDateTimeParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FileDateTimeParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class FileDateTimeParams : IFileDateTimeParams
+    {
+        public string PathName { get; } = nameof(PathName);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FileLenParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FileLenParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class FileLenParams : IFileLenParams
+    {
+        public string PathName { get; } = nameof(PathName);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FreeFileParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/FreeFileParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class FreeFileParams : IFreeFileParams
+    {
+        public string RangeNumber { get; } = nameof(RangeNumber);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/GetAttrParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/GetAttrParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class GetAttrParams : IGetAttrParams
+    {
+        public string PathName { get; } = nameof(PathName);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/InputBoxParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/InputBoxParams.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class InputBoxParams : IInputBoxParams
+    {
+        public string Prompt { get; } = nameof(Prompt);
+        public string Title { get; } = nameof(Title);
+        public string Default { get; } = nameof(Default);
+        public string XPos { get; } = nameof(XPos);
+        public string YPos { get; } = nameof(YPos);
+        public string HelpFile { get; } = nameof(HelpFile);
+        public string Context { get; } = nameof(Context);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/KillParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/KillParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class KillParams : IKillParams
+    {
+        public string PathName { get; } = nameof(PathName);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/MkDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/MkDirParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class MkDirParams : IMkDirParams
+    {
+        public string Path { get; } = nameof(Path);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/MsgBoxParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/MsgBoxParams.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class MsgBoxParams : IMsgBoxParams
+    {
+        public string Prompt { get; } = nameof(Prompt);
+        public string Buttons { get; } = nameof(Buttons);
+        public string Title { get; } = nameof(Title);
+        public string HelpFile { get; } = nameof(HelpFile);
+        public string Context { get; } = nameof(Context);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/Params.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/Params.cs
@@ -1,0 +1,46 @@
+﻿using Rubberduck.Resources.Registration;
+using Rubberduck.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rubberduck.UnitTesting
+{
+    [
+        ComVisible(true),
+        Guid(RubberduckGuid.ParamsClassGuid),
+        ProgId(RubberduckProgId.ParamsClassProgId),
+        ClassInterface(ClassInterfaceType.None),
+        ComDefaultInterface(typeof(IParams)),
+        EditorBrowsable(EditorBrowsableState.Always)
+    ]
+    public class Params : IParams
+    {
+        public IMsgBoxParams MsgBox { get; } = new MsgBoxParams();
+        public IInputBoxParams InputBox { get; } = new InputBoxParams();
+        public IEnvironParams Environ { get; } = new EnvironParams();
+        public IShellParams Shell { get; } = new ShellParams();
+        public ISendKeysParams SendKeys { get; } = new SendKeysParams();
+        public IKillParams Kill { get; } = new KillParams();
+        public IFileCopyParams FileCopy { get; } = new FileCopyParams();
+        public IFreeFileParams FreeFile { get; } = new FreeFileParams();
+        public IGetAttrParams GetAttr { get; } = new GetAttrParams();
+        public ISetAttrParams SetAttr { get; } = new SetAttrParams();
+        public IFileLenParams FileLen { get; } = new FileLenParams();
+        public IFileDateTimeParams FileDateTime { get; } = new FileDateTimeParams();
+        public IDirParams Dir { get; } = new DirParams();
+        public ICurDirParams CurDir { get; } = new CurDirParams();
+        public IChDirParams ChDir { get; } = new ChDirParams();
+        public IChDriveParams ChDrive { get; } = new ChDriveParams();
+        public IMkDirParams MkDir { get; } = new MkDirParams();
+        public IRmDirParams RmDir { get; } = new RmDirParams();
+        public IDeleteSettingParams DeleteSetting { get; } = new DeleteSettingParams();
+        public ISaveSettingParams SaveSetting { get; } = new SaveSettingParams();
+        public IRandomizeParams Randomize { get; } = new RandomizeParams();
+        public IRndParams Rnd { get; } = new RndParams();
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/RandomizeParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/RandomizeParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class RandomizeParams : IRandomizeParams
+    {
+        public string Number { get; } = nameof(Number);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/RmDirParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/RmDirParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class RmDirParams : IRmDirParams
+    {
+        public string Path { get; } = nameof(Path);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/RndParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/RndParams.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class RndParams : IRndParams
+    {
+        public string Number { get; } = nameof(Number);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/SaveSettingParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/SaveSettingParams.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class SaveSettingParams : ISaveSettingParams
+    {
+        public string AppName { get; } = nameof(AppName);
+
+        public string Section { get; } = nameof(Section);
+
+        public string Key { get; } = nameof(Key);
+
+        public string Setting { get; } = nameof(Setting);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/SendKeysParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/SendKeysParams.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class SendKeysParams : ISendKeysParams
+    {
+        public string Keys { get; } = nameof(Keys);
+
+        public string Wait { get; } = nameof(Wait);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/SetAttrParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/SetAttrParams.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class SetAttrParams : ISetAttrParams
+    {
+        public string PathName { get; } = nameof(PathName);
+
+        public string Attributes { get; } = nameof(Attributes);
+    }
+}

--- a/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/ShellParams.cs
+++ b/Rubberduck.Main/ComClientLibrary/UnitTesting/ParameterInfo/ShellParams.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Rubberduck.Resources.Registration;
+
+// ReSharper disable InconsistentNaming
+// The parameters on RD's public interfaces are following VBA conventions not C# conventions to stop the
+// obnoxious "Can I haz all identifiers with the same casing" behavior of the VBE.
+
+namespace Rubberduck.UnitTesting
+{
+    internal class ShellParams : IShellParams
+    {
+        public string PathName { get; } = nameof(PathName);
+        public string WindowStyle { get; } = nameof(WindowStyle);
+    }
+}

--- a/Rubberduck.Resources/Registration/RubberduckGuid.cs
+++ b/Rubberduck.Resources/Registration/RubberduckGuid.cs
@@ -26,6 +26,33 @@
         public const string IFakeGuid = UnitTestingGuidspace + "DF" + GuidSuffix;
         public const string IVerifyGuid = UnitTestingGuidspace + "E0" + GuidSuffix;
         public const string IStubGuid = UnitTestingGuidspace + "E1" + GuidSuffix;
+        public const string IParamsGuid = UnitTestingGuidspace + "E2" + GuidSuffix;
+
+        public const string ParamsClassGuid = UnitTestingGuidspace + "40" + GuidSuffix;
+        public const string ParamsMsgBoxGuid = UnitTestingGuidspace + "41" + GuidSuffix;
+        public const string ParamsInputBoxGuid = UnitTestingGuidspace + "42" + GuidSuffix;
+        public const string ParamsEnvironGuid = UnitTestingGuidspace + "44" + GuidSuffix;
+        public const string ParamsShellGuid = UnitTestingGuidspace + "47" + GuidSuffix;
+        public const string ParamsSendKeysGuid = UnitTestingGuidspace + "48" + GuidSuffix;
+        public const string ParamsKillGuid = UnitTestingGuidspace + "49" + GuidSuffix;
+        public const string ParamsMkDirGuid = UnitTestingGuidspace + "4A" + GuidSuffix;
+        public const string ParamsRmDirGuid = UnitTestingGuidspace + "4B" + GuidSuffix;
+        public const string ParamsChDirGuid = UnitTestingGuidspace + "4C" + GuidSuffix;
+        public const string ParamsChDriveGuid = UnitTestingGuidspace + "4D" + GuidSuffix;
+        public const string ParamsCurDirGuid = UnitTestingGuidspace + "4E" + GuidSuffix;
+        public const string ParamsRndGuid = UnitTestingGuidspace + "52" + GuidSuffix;
+        public const string ParamsDeleteSettingGuid = UnitTestingGuidspace + "53" + GuidSuffix;
+        public const string ParamsSaveSettingGuid = UnitTestingGuidspace + "54" + GuidSuffix;
+        public const string ParamsGetSettingGuid = UnitTestingGuidspace + "55" + GuidSuffix;
+        public const string ParamsRandomizeGuid = UnitTestingGuidspace + "56" + GuidSuffix;
+        public const string ParamsGetAllSettingsGuid = UnitTestingGuidspace + "57" + GuidSuffix;
+        public const string ParamsSetAttrGuid = UnitTestingGuidspace + "58" + GuidSuffix;
+        public const string ParamsGetAttrGuid = UnitTestingGuidspace + "59" + GuidSuffix;
+        public const string ParamsFileLenGuid = UnitTestingGuidspace + "5A" + GuidSuffix;
+        public const string ParamsFileDateTimeGuid = UnitTestingGuidspace + "5B" + GuidSuffix;
+        public const string ParamsFreeFileGuid = UnitTestingGuidspace + "5C" + GuidSuffix;
+        public const string ParamsDirGuid = UnitTestingGuidspace + "5E" + GuidSuffix;
+        public const string ParamsFileCopyGuid = UnitTestingGuidspace + "5F" + GuidSuffix;
 
         // Rubberduck API Guids:
         private const string ApiGuidspace = "69E0F7";

--- a/Rubberduck.Resources/Registration/RubberduckProgId.cs
+++ b/Rubberduck.Resources/Registration/RubberduckProgId.cs
@@ -17,6 +17,31 @@
         public const string AssertClassProgId = BaseNamespace + "AssertClass";
         public const string PermissiveAssertClassProgId = BaseNamespace + "PermissiveAssertClass";
         public const string FakesProviderProgId = BaseNamespace + "FakesProvider";
+        public const string ParamsClassProgId = BaseNamespace + "ParamsClass";
+
+        public const string ParamsMsgBoxProgId = BaseNamespace + "MsgBoxParams";
+        public const string ParamsInputBoxProgId = BaseNamespace + "InputBoxParams";
+        public const string ParamsEnvironProgId = BaseNamespace + "EnvironParams";
+        public const string ParamsShellProgId = BaseNamespace + "ShellParams";
+        public const string ParamsSendKeysProgId = BaseNamespace + "SendKeysParams";
+        public const string ParamsKillProgId = BaseNamespace + "KillParams";
+        public const string ParamsMkDirProgId = BaseNamespace + "MkDirParams";
+        public const string ParamsRmDirProgId = BaseNamespace + "RmDirParams";
+        public const string ParamsChDirProgId = BaseNamespace + "ChDirParams";
+        public const string ParamsChDriveProgId = BaseNamespace + "ChDriveParams";
+        public const string ParamsCurDirProgId = BaseNamespace + "CurDirParams";
+        public const string ParamsRandomizeProgId = BaseNamespace + "RandomizeParams";
+        public const string ParamsRndProgId = BaseNamespace + "RndParams";
+        public const string ParamsDeleteSettingProgId = BaseNamespace + "DeleteSettingParams";
+        public const string ParamsSaveSettingProgId = BaseNamespace + "SaveSettingParams";
+        public const string ParamGetSettingProgId = BaseNamespace + "GetSettingParams";
+        public const string ParamsSetAttrProgId = BaseNamespace + "SetAttrParams";
+        public const string ParamsGetAttrProgId = BaseNamespace + "GetAttrParams";
+        public const string ParamsFileLenProgId = BaseNamespace + "FileLenParams";
+        public const string ParamsFileDateTimeProgId = BaseNamespace + "FileDateTimeParams";
+        public const string ParamsFreeFileProgId = BaseNamespace + "FreeFileParams";
+        public const string ParamsDirProgId = BaseNamespace + "DirParams";
+        public const string ParamsFileCopyProgId = BaseNamespace + "FileCopyParams";
 
         public const string DebugAddinObject = BaseNamespace + "VBETypeLibsAPI";
     }


### PR DESCRIPTION
The Fakes API requires working with strings representing parameter names; this PR extends the `IFakesProvider` with a `Params` member that gets an interface exposing the parameter names for all parameterized fakes - so unit test code might access them through `Fakes.Params`:

![image](https://user-images.githubusercontent.com/5751684/204114938-32e7f438-efe1-4097-9df8-8304bbe7b081.png)

It kind of crowds up the COM library and could very likely be cleaned up a bit before merging though:

![image](https://user-images.githubusercontent.com/5751684/204114975-82a0ae17-ef80-458f-a7bc-12b5257569d4.png)
