### PR TITLE
Correcting a typo in Project.Sdk

### DIFF
--- a/RubberduckBaseProject.csproj
+++ b/RubberduckBaseProject.csproj
@@ -1,4 +1,4 @@
-<Project Skd="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <!--
     We're specifying the Sdk here to make sure appveyor correctly recognizes this as a .NET Core project
     Unfortunately this generates the warning MSB4011, because the including projects already define an Sdk


### PR DESCRIPTION
I noticed a simple typo in the base project SDK version.  Quick correction