### PR TITLE
Unified QuickFix classes' layout & added Rename-QuickFix localization

### DIFF
--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AccessSheetUsingCodeNameQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AccessSheetUsingCodeNameQuickFix.cs
@@ -106,10 +106,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             }
         }
 
-        public override string Description(IInspectionResult result)
-        {
-            return Resources.Inspections.QuickFixes.AccessSheetUsingCodeNameQuickFix;
-        }
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AccessSheetUsingCodeNameQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AddMissingAttributeQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AddMissingAttributeQuickFix.cs
@@ -73,10 +73,10 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             _attributesUpdater.AddAttribute(rewriteSession, declaration, attributeName, annotation.AttributeValues(annotationInstance));
         }
 
-        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AddMissingAttributeQuickFix;
-
         public override CodeKind TargetCodeKind => CodeKind.AttributesCode;
 
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AddMissingAttributeQuickFix;
+        
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;
         public override bool CanFixInModule => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AddStepOneQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AddStepOneQuickFix.cs
@@ -42,17 +42,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             : base(typeof(StepIsNotSpecifiedInspection))
         {}
 
-        public override bool CanFixMultiple => true;
-        public override bool CanFixInProcedure => true;
-        public override bool CanFixInModule => true;
-        public override bool CanFixInProject => true;
-        public override bool CanFixAll => true;
-
-        public override string Description(IInspectionResult result)
-        {
-            return Resources.Inspections.QuickFixes.AddStepOneQuickFix;
-        }
-
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
             var rewriter = rewriteSession.CheckOutModuleRewriter(result.QualifiedSelection.QualifiedName);
@@ -76,5 +65,13 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
 
             throw new InvalidOperationException();
         }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AddStepOneQuickFix;
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+        public override bool CanFixAll => true;
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AdjustAttributeValuesQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AdjustAttributeValuesQuickFix.cs
@@ -85,9 +85,9 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             _attributesUpdater.UpdateAttribute(rewriteSession, declaration, attributeName, attributeValuesFromAnnotation, oldValues: attributeValues);
         }
 
-        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AdjustAttributeValuesQuickFix;
-
         public override CodeKind TargetCodeKind => CodeKind.AttributesCode;
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AdjustAttributeValuesQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AnnotateEntryPointQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AnnotateEntryPointQuickFix.cs
@@ -44,12 +44,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             _annotationUpdater = annotationUpdater;
         }
 
-        public override bool CanFixMultiple => true;
-        public override bool CanFixInProcedure => true;
-        public override bool CanFixInModule => true;
-        public override bool CanFixInProject => true;
-        public override bool CanFixAll => true;
-
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
             var module = result.QualifiedSelection.QualifiedName;
@@ -65,5 +59,11 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
         }
 
         public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AnnotateEntryPointQuickFix;
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+        public override bool CanFixAll => true;
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AssignedByValParameterMakeLocalCopyQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/AssignedByValParameterMakeLocalCopyQuickFix.cs
@@ -77,14 +77,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             InsertLocalVariableDeclarationAndAssignment(rewriter, result.Target, localIdentifier);
         }
 
-        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AssignedByValParameterMakeLocalCopyQuickFix;
-
-        public override bool CanFixMultiple => false;
-        public override bool CanFixInProcedure => false;
-        public override bool CanFixInModule => false;
-        public override bool CanFixInProject => false;
-        public override bool CanFixAll => false;
-
         private string PromptForLocalVariableName(Declaration target)
         {
             IAssignedByValParameterQuickFixDialog view = null;
@@ -165,5 +157,14 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             rewriter.Remove(endOfStmtCtxt);
             rewriter.InsertAfter(insertCtxt.Stop.TokenIndex, $"{endOfStmtCtxtComment}{endOfStmtCtxtEndFormat}{localVariableDeclaration}" + $"{endOfStmtCtxtEndFormat}{localVariableAssignment}{endOfStmtCtxtEndFormat}");
         }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.AssignedByValParameterMakeLocalCopyQuickFix;
+
+        public override bool CanFixMultiple => false;
+        public override bool CanFixInProcedure => false;
+        public override bool CanFixInModule => false;
+        public override bool CanFixInProject => false;
+        public override bool CanFixAll => false;
+
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ChangeIntegerToLongQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ChangeIntegerToLongQuickFix.cs
@@ -194,14 +194,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             }
         }
 
-        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.IntegerDataTypeQuickFix;
-
-        public override bool CanFixMultiple => true;
-        public override bool CanFixInProcedure => true;
-        public override bool CanFixInModule => true;
-        public override bool CanFixInProject => true;
-        public override bool CanFixAll => true;
-
         private static int GetParameterIndex(VBAParser.ArgContext context)
         {
             return Array.IndexOf(((VBAParser.ArgListContext)context.Parent).arg().ToArray(), context);
@@ -212,5 +204,13 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             var typeHintContext = ((ParserRuleContext)context).GetDescendent<VBAParser.TypeHintContext>();
             rewriter.Replace(typeHintContext, "&");
         }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.IntegerDataTypeQuickFix;
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+        public override bool CanFixAll => true;
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ChangeProcedureToFunctionQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ChangeProcedureToFunctionQuickFix.cs
@@ -66,8 +66,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             }
         }
 
-        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.ProcedureShouldBeFunctionInspectionQuickFix;
-
         private void UpdateSignature(Declaration target, ParameterDeclaration arg, IRewriteSession rewriteSession)
         {
             var subStmt = (VBAParser.SubStmtContext) target.Context;
@@ -106,6 +104,8 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             rewriter.Replace(callStmtContext.whiteSpace(), "(");
             rewriter.InsertAfter(argListContext.Stop.TokenIndex, ")");
         }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.ProcedureShouldBeFunctionInspectionQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => false;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ConvertToProcedureQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ConvertToProcedureQuickFix.cs
@@ -180,14 +180,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             }
         }
 
-        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.ConvertFunctionToProcedureQuickFix;
-
-        public override bool CanFixMultiple => true;
-        public override bool CanFixInProcedure => false;
-        public override bool CanFixInModule => true;
-        public override bool CanFixInProject => false;
-        public override bool CanFixAll => false;
-
         private IEnumerable<ParserRuleContext> GetReturnStatements(Declaration declaration)
         {
             return declaration.References
@@ -200,5 +192,13 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
         {
             return assignment.ParentScoping.Equals(declaration) && assignment.Declaration.Equals(declaration);
         }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.ConvertFunctionToProcedureQuickFix;
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => false;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => false;
+        public override bool CanFixAll => false;
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/DeclareAsExplicitTypeQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/DeclareAsExplicitTypeQuickFix.cs
@@ -84,18 +84,17 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             _refactoring = refactoringAction;
         }
 
-        public override bool CanFixMultiple => true;
-        public override bool CanFixInProcedure => false;
-        public override bool CanFixInModule => true;
-        public override bool CanFixInProject => true;
-        public override bool CanFixAll => true;
-
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
             _refactoring.Refactor(new ImplicitTypeToExplicitModel(result.Target), rewriteSession);
         }
 
-        public override string Description(IInspectionResult result)
-            => Resources.Inspections.QuickFixes.DeclareAsExplicitTypeQuickFix;
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.DeclareAsExplicitTypeQuickFix;
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => false;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+        public override bool CanFixAll => true;
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ExpandBangNotationQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ExpandBangNotationQuickFix.cs
@@ -47,6 +47,14 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
     /// </example>
     internal class ExpandBangNotationQuickFix : QuickFixBase
     {
+        private readonly string NonIdentifierCharacters = "[](){}\r\n\t.,'\"\\ |!@#$%^&*-+:=; ";
+        private readonly string AdditionalNonFirstIdentifierCharacters = "0123456789_";
+
+        private static readonly Dictionary<string, string> DefaultMemberOverrides = new Dictionary<string, string>
+        {
+            ["Excel.Range._Default"] = "Item"
+        };
+
         private readonly IDeclarationFinderProvider _declarationFinderProvider; 
 
         public ExpandBangNotationQuickFix(IDeclarationFinderProvider declarationFinderProvider)
@@ -121,24 +129,12 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
                 || AdditionalNonFirstIdentifierCharacters.Contains(declarationName[0]); ;
         }
 
-        public override string Description(IInspectionResult result)
-        {
-            return Resources.Inspections.QuickFixes.ExpandBangNotationQuickFix;
-        }
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.ExpandBangNotationQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;
         public override bool CanFixInModule => true;
         public override bool CanFixInProject => true;
         public override bool CanFixAll => true;
-
-        private readonly string NonIdentifierCharacters = "[](){}\r\n\t.,'\"\\ |!@#$%^&*-+:=; ";
-        private readonly string AdditionalNonFirstIdentifierCharacters = "0123456789_";
-
-        private static readonly Dictionary<string, string> DefaultMemberOverrides = new Dictionary<string, string>
-        {
-            ["Excel.Range._Default"] = "Item"
-        };
-
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ExpandDefaultMemberQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ExpandDefaultMemberQuickFix.cs
@@ -51,6 +51,19 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
     /// </example>
     internal class ExpandDefaultMemberQuickFix : QuickFixBase
     {
+        private string NonIdentifierCharacters = "[](){}\r\n\t.,'\"\\ |!@#$%^&*-+:=; ";
+        private string AdditionalNonFirstIdentifierCharacters = "0123456789_";
+
+        private static readonly Dictionary<string, string> DefaultMemberBaseOverrides = new Dictionary<string, string>
+        {
+            ["Excel.Range._Default"] = "Item"
+        };
+
+        private static readonly Dictionary<string, Dictionary<int, string>> DefaultMemberArgumentNumberOverrides = new Dictionary<string, Dictionary<int, string>>
+        {
+            ["Excel.Range._Default"] = new Dictionary<int, string> { [0] = "Value" }
+        };
+
         private readonly IDeclarationFinderProvider _declarationFinderProvider;
 
         public ExpandDefaultMemberQuickFix(IDeclarationFinderProvider declarationFinderProvider)
@@ -165,28 +178,12 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             }
         }
 
-        public override string Description(IInspectionResult result)
-        {
-            return Resources.Inspections.QuickFixes.ExpandDefaultMemberQuickFix;
-        }
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.ExpandDefaultMemberQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;
         public override bool CanFixInModule => true;
         public override bool CanFixInProject => true;
         public override bool CanFixAll => true;
-
-        private string NonIdentifierCharacters = "[](){}\r\n\t.,'\"\\ |!@#$%^&*-+:=; ";
-        private string AdditionalNonFirstIdentifierCharacters = "0123456789_";
-
-        private static readonly Dictionary<string, string> DefaultMemberBaseOverrides = new Dictionary<string, string>
-        {
-            ["Excel.Range._Default"] = "Item"
-        };
-
-        private static readonly Dictionary<string, Dictionary<int, string>> DefaultMemberArgumentNumberOverrides = new Dictionary<string, Dictionary<int, string>>
-        {
-            ["Excel.Range._Default"] = new Dictionary<int, string>{[0] = "Value"}
-        };
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/IgnoreInModuleQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/IgnoreInModuleQuickFix.cs
@@ -52,12 +52,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             _annotationUpdater = annotationUpdater;
         }
 
-        public override bool CanFixMultiple => true;
-        public override bool CanFixInProcedure => false;
-        public override bool CanFixInModule => true;
-        public override bool CanFixInProject => true;
-        public override bool CanFixAll => true;
-
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
             var module = result.QualifiedSelection.QualifiedName;
@@ -101,5 +95,11 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
         }
 
         public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.IgnoreInModuleQuickFix;
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => false;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+        public override bool CanFixAll => true;
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/IgnoreOnceQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/IgnoreOnceQuickFix.cs
@@ -48,12 +48,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             _annotationUpdater = annotationUpdater;
         }
 
-        public override bool CanFixMultiple => true;
-        public override bool CanFixInProcedure => true;
-        public override bool CanFixInModule => true;
-        public override bool CanFixInProject => true;
-        public override bool CanFixAll => true;
-
         public override void Fix(IInspectionResult result, IRewriteSession rewriteSession)
         {
             if (result.Target?.DeclarationType.HasFlag(DeclarationType.Module) ?? false)
@@ -109,5 +103,11 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
         }
 
         public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.IgnoreOnce;
+
+        public override bool CanFixMultiple => true;
+        public override bool CanFixInProcedure => true;
+        public override bool CanFixInModule => true;
+        public override bool CanFixInProject => true;
+        public override bool CanFixAll => true;
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/PassParameterByValueQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/PassParameterByValueQuickFix.cs
@@ -56,8 +56,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             }
         }
 
-        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.PassParameterByValueQuickFix;
-
         private void FixMethods(Declaration target, IRewriteSession rewriteSession)
         {
             var declarationParameters =
@@ -110,6 +108,8 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
                 rewriter.InsertBefore(context.unrestrictedIdentifier().Start.TokenIndex, "ByVal ");
             }
         }
+
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.PassParameterByValueQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/QualifyWithMeQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/QualifyWithMeQuickFix.cs
@@ -47,10 +47,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             rewriter.InsertBefore(context.Start.TokenIndex, $"{Tokens.Me}.");
         }
 
-        public override string Description(IInspectionResult result)
-        {
-            return Resources.Inspections.QuickFixes.QualifyWithMeQuickFix;
-        }
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.QualifyWithMeQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/Refactoring/MoveFieldCloserToUsageQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/Refactoring/MoveFieldCloserToUsageQuickFix.cs
@@ -50,7 +50,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete.Refactoring
 
         public override string Description(IInspectionResult result)
         {
-            return string.Format(InspectionResults.MoveFieldCloserToUsageInspection, result.Target.IdentifierName);
+            return string.Format(Resources.Inspections.InspectionResults.MoveFieldCloserToUsageInspection, result.Target.IdentifierName);
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/Refactoring/RenameDeclarationQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/Refactoring/RenameDeclarationQuickFix.cs
@@ -65,9 +65,8 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete.Refactoring
 
         public override string Description(IInspectionResult result)
         {
-            return string.Format(RefactoringsUI.Rename_DeclarationType,
-                       RubberduckUI.ResourceManager.GetString("DeclarationType_" + result.Target.DeclarationType,
-                           CultureInfo.CurrentUICulture));
+            return string.Format(Resources.Inspections.QuickFixes.RenameDeclarationQuickFix,
+                RubberduckUI.ResourceManager.GetString("DeclarationType_" + result.Target.DeclarationType, CultureInfo.CurrentUICulture));
         }
     }
 }

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/RemoveDuplicatedAnnotationQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/RemoveDuplicatedAnnotationQuickFix.cs
@@ -63,8 +63,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             _annotationUpdater.RemoveAnnotations(rewriteSession, duplicateAnnotations);
         }
 
-        public override string Description(IInspectionResult result) =>
-            Resources.Inspections.QuickFixes.RemoveDuplicatedAnnotationQuickFix;
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.RemoveDuplicatedAnnotationQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/RemoveRedundantOptionStatementQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/RemoveRedundantOptionStatementQuickFix.cs
@@ -49,9 +49,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
 
         public override string Description(IInspectionResult result)
         {
-            return string.Format(
-                Resources.Inspections.QuickFixes.RemoveRedundantOptionStatementQuickFix,
-                result.Context.GetText());
+            return string.Format(Resources.Inspections.QuickFixes.RemoveRedundantOptionStatementQuickFix, result.Context.GetText());
         }
 
         public override bool CanFixMultiple => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ReplaceQualifierWithMeQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/ReplaceQualifierWithMeQuickFix.cs
@@ -53,10 +53,7 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             rewriter.Replace(context.Start, Tokens.Me);
         }
 
-        public override string Description(IInspectionResult result)
-        {
-            return Resources.Inspections.QuickFixes.ReplaceQualifierWithMeQuickFix;
-        }
+        public override string Description(IInspectionResult result) => Resources.Inspections.QuickFixes.ReplaceQualifierWithMeQuickFix;
 
         public override bool CanFixMultiple => true;
         public override bool CanFixInProcedure => true;

--- a/Rubberduck.CodeAnalysis/QuickFixes/Concrete/UntypedFunctionUsageQuickFix.cs
+++ b/Rubberduck.CodeAnalysis/QuickFixes/Concrete/UntypedFunctionUsageQuickFix.cs
@@ -48,11 +48,6 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
             rewriter.InsertAfter(result.Context.Stop.TokenIndex, "$");
         }
 
-        public override string Description(IInspectionResult result)
-        {
-            return string.Format(Resources.Inspections.QuickFixes.UseTypedFunctionQuickFix, result.Context.GetText(), GetNewSignature(result.Context));
-        }
-
         private static string GetNewSignature(ParserRuleContext context)
         {
             Debug.Assert(context != null);
@@ -62,6 +57,11 @@ namespace Rubberduck.CodeAnalysis.QuickFixes.Concrete
                 var isIdentifierNode = member is VBAParser.IdentifierContext;
                 return current + member.GetText() + (isIdentifierNode ? "$" : string.Empty);
             });
+        }
+
+        public override string Description(IInspectionResult result)
+        {
+            return string.Format(Resources.Inspections.QuickFixes.UseTypedFunctionQuickFix, result.Context.GetText(), GetNewSignature(result.Context));
         }
 
         public override bool CanFixMultiple => true;

--- a/Rubberduck.Resources/Inspections/InspectionResults.de.resx
+++ b/Rubberduck.Resources/Inspections/InspectionResults.de.resx
@@ -128,7 +128,7 @@
     <comment>{0} Procedure name</comment>
   </data>
   <data name="IdentifierNameInspection" xml:space="preserve">
-    <value>Überlegen Sie '{1}' ({0}) umzubenennen.</value>
+    <value>Ziehen Sie in Erwägung, {0} '{1}' umzubenennen.</value>
   </data>
   <data name="WriteOnlyPropertyInspection" xml:space="preserve">
     <value>Eigenschaft '{0}' hat keinen Getter.</value>

--- a/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
+++ b/Rubberduck.Resources/Inspections/QuickFixes.Designer.cs
@@ -529,6 +529,15 @@ namespace Rubberduck.Resources.Inspections {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Rename {0} ähnelt.
+        /// </summary>
+        public static string RenameDeclarationQuickFix {
+            get {
+                return ResourceManager.GetString("RenameDeclarationQuickFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Replace &apos;Rem&apos; usage with a single-quote comment marker ähnelt.
         /// </summary>
         public static string ReplaceCommentMarkerQuickFix {

--- a/Rubberduck.Resources/Inspections/QuickFixes.cs.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.cs.resx
@@ -312,4 +312,7 @@
   <data name="RemoveRedundantOptionStatementQuickFix" xml:space="preserve">
     <value>Odstraň prohlášení '{0}'</value>
   </data>
+  <data name="RenameDeclarationQuickFix" xml:space="preserve">
+    <value>Přejmenovat {0}</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.de.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.de.resx
@@ -312,4 +312,7 @@
   <data name="RemoveRedundantOptionStatementQuickFix" xml:space="preserve">
     <value>'{0}'-Anweisung entfernen</value>
   </data>
+  <data name="RenameDeclarationQuickFix" xml:space="preserve">
+    <value>Benenne {0} um</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.es.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.es.resx
@@ -303,4 +303,7 @@
   <data name="RemoveRedundantOptionStatementQuickFix" xml:space="preserve">
     <value>Eliminar la declaración '{0}'</value>
   </data>
+  <data name="RenameDeclarationQuickFix" xml:space="preserve">
+    <value>Renombrar {0}</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.fr.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.fr.resx
@@ -312,4 +312,7 @@
   <data name="RemoveRedundantOptionStatementQuickFix" xml:space="preserve">
     <value>Supprimer l'instruction '{0}'</value>
   </data>
+  <data name="RenameDeclarationQuickFix" xml:space="preserve">
+    <value>Renommer {0}</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.it.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.it.resx
@@ -315,4 +315,7 @@
   <data name="ReplaceQualifierWithMeQuickFix" xml:space="preserve">
     <value>Sostituire il qualificatore con 'Me'</value>
   </data>
+  <data name="RenameDeclarationQuickFix" xml:space="preserve">
+    <value>Rinomina {0}</value>
+  </data>
 </root>

--- a/Rubberduck.Resources/Inspections/QuickFixes.resx
+++ b/Rubberduck.Resources/Inspections/QuickFixes.resx
@@ -316,4 +316,7 @@
     <value>Remove '{0}' statement</value>
     <comment>'{0}' the whole Option-Statement-Context</comment>
   </data>
+  <data name="RenameDeclarationQuickFix" xml:space="preserve">
+    <value>Rename {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
- (Maybe hopefully) fixed #6095
- Unified layout of QuickFix classes:
  - Put override bools always at bottom
  - Put description override always above them
  - Changed to => for Description wherever possible
  - Where not, unified indentation
- Added RenameDeclarationQuickFix string to QuickFix*.resx files
- Changed RenameDeclarationQuickFix.cs to use QuickFix*.resx