### PR TITLE
Fix version check crash

### DIFF
--- a/Rubberduck.Core/Properties/Settings.Designer.cs
+++ b/Rubberduck.Core/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Rubberduck.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Rubberduck.Core/Rubberduck.Core.csproj
+++ b/Rubberduck.Core/Rubberduck.Core.csproj
@@ -93,4 +93,17 @@
       <Version>2.0.20525</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Rubberduck.Core/Settings/GeneralSettings.cs
+++ b/Rubberduck.Core/Settings/GeneralSettings.cs
@@ -13,6 +13,7 @@ namespace Rubberduck.Settings
         DisplayLanguageSetting Language { get; set; }
         bool CanShowSplash { get; set; }
         bool CanCheckVersion { get; set; }
+        string ApiBaseUrl { get; set; }
         bool IncludePreRelease { get; set; }
         bool CompileBeforeParse { get; set; }
         bool IsSmartIndenterPrompted { get; set; }
@@ -45,6 +46,7 @@ namespace Rubberduck.Settings
 
         public bool CanShowSplash { get; set; }
         public bool CanCheckVersion { get; set; }
+        public string ApiBaseUrl { get; set; }
         public bool IncludePreRelease { get; set; }
         public bool CompileBeforeParse { get; set; }
         public bool IsSmartIndenterPrompted { get; set; }
@@ -103,7 +105,8 @@ namespace Rubberduck.Settings
                    EnableExperimentalFeatures.Count == other.EnableExperimentalFeatures.Count &&
                    EnableExperimentalFeatures.All(other.EnableExperimentalFeatures.Contains) &&
                    SetDpiUnaware == other.SetDpiUnaware &&
-                   EnableFolderDragAndDrop == other.EnableFolderDragAndDrop;
+                   EnableFolderDragAndDrop == other.EnableFolderDragAndDrop &&
+                   ApiBaseUrl == other.ApiBaseUrl;
         }
     }
 }

--- a/Rubberduck.Core/UI/Command/VersionCheckCommand.cs
+++ b/Rubberduck.Core/UI/Command/VersionCheckCommand.cs
@@ -53,40 +53,40 @@ namespace Rubberduck.UI.Command
             Logger.Info("Executing version check...");
 
             var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            await _versionCheck
-                .GetLatestVersionAsync(settings, tokenSource.Token)
-                .ContinueWith(t =>
+            Version latest = default;
+
+            try
+            {
+                latest = await _versionCheck.GetLatestVersionAsync(settings, tokenSource.Token);
+            }
+            catch(Exception e)
+            {
+                Logger.Warn(e, "Version check failed.");
+            }
+
+            if (_versionCheck.CurrentVersion < latest)
+            {
+                var proceed = true;
+                if (_versionCheck.IsDebugBuild || !settings.IncludePreRelease)
                 {
-                    if (t.IsFaulted)
-                    {
-                        Logger.Warn(t.Exception);
-                        return;
-                    }
+                    // if the latest version has a revision number and isn't a pre-release build,
+                    // avoid prompting since we can't know if the build already includes the latest version.
+                    proceed = latest.Revision == 0;
+                }
 
-                    if (_versionCheck.CurrentVersion < t.Result)
-                    {
-                        var proceed = true;
-                        if (_versionCheck.IsDebugBuild || !settings.IncludePreRelease)
-                        {
-                            // if the latest version has a revision number and isn't a pre-release build,
-                            // avoid prompting since we can't know if the build already includes the latest version.
-                            proceed = t.Result.Revision == 0;
-                        }
-
-                        if (proceed)
-                        {
-                            PromptAndBrowse(t.Result, settings.IncludePreRelease);
-                        }
-                        else
-                        {
-                            Logger.Info("Version check skips notification of an existing newer version available.");
-                        }
-                    }
-                    else
-                    {
-                        Logger.Info("Version check completed: running current latest.");
-                    }
-                });
+                if (proceed)
+                {
+                    PromptAndBrowse(latest, settings.IncludePreRelease);
+                }
+                else
+                {
+                    Logger.Info("Version check skips notification of an existing newer version available.");
+                }
+            }
+            else if (latest != default)
+            {
+                Logger.Info("Version check completed: running current latest.");
+            }
         }
 
         private void PromptAndBrowse(Version latestVersion, bool includePreRelease)

--- a/Rubberduck.Core/UI/Command/VersionCheckCommand.cs
+++ b/Rubberduck.Core/UI/Command/VersionCheckCommand.cs
@@ -53,16 +53,7 @@ namespace Rubberduck.UI.Command
             Logger.Info("Executing version check...");
 
             var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            Version latest = default;
-
-            try
-            {
-                latest = await _versionCheck.GetLatestVersionAsync(settings, tokenSource.Token);
-            }
-            catch(Exception e)
-            {
-                Logger.Warn(e, "Version check failed.");
-            }
+            var latest = await _versionCheck.GetLatestVersionAsync(settings, tokenSource.Token);
 
             if (_versionCheck.CurrentVersion < latest)
             {

--- a/Rubberduck.Core/UI/Splash2021.cs
+++ b/Rubberduck.Core/UI/Splash2021.cs
@@ -1,6 +1,5 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
-using Rubberduck.VersionCheck;
 
 namespace Rubberduck.UI
 {
@@ -11,9 +10,9 @@ namespace Rubberduck.UI
             InitializeComponent();
         }
 
-        public Splash2021(IVersionCheckService versionCheck) : this()
+        public Splash2021(string versionString) : this()
         {
-            VersionLabel.Text = string.Format(Resources.RubberduckUI.Rubberduck_AboutBuild, versionCheck.VersionString);
+            VersionLabel.Text = string.Format(Resources.RubberduckUI.Rubberduck_AboutBuild, versionString);
             VersionLabel.Parent = pictureBox1;
             VersionLabel.BackColor = Color.Transparent;
         }

--- a/Rubberduck.Core/VersionCheck/ApiClientBase.cs
+++ b/Rubberduck.Core/VersionCheck/ApiClientBase.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Rubberduck.Settings;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -9,40 +10,69 @@ using System.Threading.Tasks;
 
 namespace Rubberduck.Client.Abstract
 {
-    public abstract class ApiClientBase : IDisposable
+    public interface IHttpClientProvider
+    {
+        HttpClient GetClient();
+    }
+
+    public sealed class ApiHttpClientProvider : IHttpClientProvider, IDisposable
+    {
+        private readonly Lazy<HttpClient> _client;
+
+        public ApiHttpClientProvider(Func<HttpClient> getClient)
+        {
+            _client = new Lazy<HttpClient>(getClient);
+        }
+
+        public HttpClient GetClient()
+        {
+            return _client.Value;
+        }
+
+        public void Dispose()
+        {
+            if (_client.IsValueCreated)
+            {
+                _client.Value.Dispose();
+            }
+        }
+    }
+
+    public abstract class ApiClientBase
     {
         protected static readonly string UserAgentName = "Rubberduck";
-        protected static readonly string BaseUrl = "https://api.rubberduckvba.com/api/v1/";
         protected static readonly string ContentTypeApplicationJson = "application/json";
         protected static readonly int MaxAttempts = 3;
         protected static readonly TimeSpan RetryCooldownDelay = TimeSpan.FromSeconds(1);
 
-        protected readonly Lazy<HttpClient> _client;
+        protected readonly IHttpClientProvider _clientProvider;
+        protected readonly string _baseUrl;
 
-        protected ApiClientBase()
+        protected ApiClientBase(IGeneralSettings settings, IHttpClientProvider clientProvider)
         {
-            _client = new Lazy<HttpClient>(() => GetClient());
+            _clientProvider = clientProvider;
+            _baseUrl = string.IsNullOrWhiteSpace(settings.ApiBaseUrl) ? "https://api.rubberduckvba.com" : settings.ApiBaseUrl;
         }
 
         protected HttpClient GetClient()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new HttpClient();
-            return ConfigureClient(client);
+            var client = _clientProvider.GetClient();
+            ConfigureClient(client);
+            return client;
         }
 
-        protected virtual HttpClient ConfigureClient(HttpClient client)
+        protected virtual void ConfigureClient(HttpClient client)
         {
             var userAgentVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
             var userAgentHeader = new ProductInfoHeaderValue(UserAgentName, userAgentVersion);
 
             client.DefaultRequestHeaders.UserAgent.Add(userAgentHeader);
-            return client;
         }
 
         protected virtual async Task<TResult> GetResponse<TResult>(string route, CancellationToken? cancellationToken = null)
         {
-            var uri = new Uri($"{BaseUrl}{route}");
+            var uri = new Uri($"{_baseUrl}{route}");
 
             var attempt = 0;
             var token = cancellationToken ?? CancellationToken.None;
@@ -102,7 +132,7 @@ namespace Rubberduck.Client.Abstract
 
         protected virtual async Task<TResult> Post<TArgs, TResult>(string route, TArgs args, CancellationToken? cancellationToken = null)
         {
-            var uri = new Uri($"{BaseUrl}{route}");
+            var uri = new Uri($"{_baseUrl}{route}");
             string json;
             try
             {
@@ -165,14 +195,6 @@ namespace Rubberduck.Client.Abstract
             catch
             {
                 return default;
-            }
-        }
-
-        public void Dispose()
-        {
-            if (_client.IsValueCreated)
-            {
-                _client.Value.Dispose();
             }
         }
     }

--- a/Rubberduck.Core/VersionCheck/ApiClientBase.cs
+++ b/Rubberduck.Core/VersionCheck/ApiClientBase.cs
@@ -15,11 +15,11 @@ namespace Rubberduck.Client.Abstract
         HttpClient GetClient();
     }
 
-    public sealed class ApiHttpClientProvider : IHttpClientProvider, IDisposable
+    public sealed class HttpClientProvider : IHttpClientProvider, IDisposable
     {
         private readonly Lazy<HttpClient> _client;
 
-        public ApiHttpClientProvider(Func<HttpClient> getClient)
+        public HttpClientProvider(Func<HttpClient> getClient)
         {
             _client = new Lazy<HttpClient>(getClient);
         }

--- a/Rubberduck.Core/VersionCheck/ApiClientBase.cs
+++ b/Rubberduck.Core/VersionCheck/ApiClientBase.cs
@@ -51,7 +51,7 @@ namespace Rubberduck.Client.Abstract
         protected ApiClientBase(IGeneralSettings settings, IHttpClientProvider clientProvider)
         {
             _clientProvider = clientProvider;
-            _baseUrl = string.IsNullOrWhiteSpace(settings.ApiBaseUrl) ? "https://api.rubberduckvba.com" : settings.ApiBaseUrl;
+            _baseUrl = string.IsNullOrWhiteSpace(settings.ApiBaseUrl) ? "https://api.rubberduckvba.com/api/v1/" : settings.ApiBaseUrl;
         }
 
         protected HttpClient GetClient()

--- a/Rubberduck.Core/VersionCheck/PublicApiClient.cs
+++ b/Rubberduck.Core/VersionCheck/PublicApiClient.cs
@@ -1,15 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Rubberduck.Client.Abstract;
+using Rubberduck.Settings;
 
 namespace Rubberduck.VersionCheck
 {
-    public class PublicApiClient : ApiClientBase
+    public interface IPublicApiClient
+    {
+        Task<IEnumerable<Tag>> GetLatestTagsAsync(CancellationToken token);
+    }
+
+    public class PublicApiClient : ApiClientBase, IPublicApiClient
     {
         private static readonly string PublicTagsEndPoint = "public/tags";
+
+        public PublicApiClient(IGeneralSettings settings, IHttpClientProvider clientProvider) 
+            : base(settings, clientProvider)
+        {
+        }
 
         public async Task<IEnumerable<Tag>> GetLatestTagsAsync(CancellationToken token)
         {

--- a/Rubberduck.Core/VersionCheck/VersionCheckService.cs
+++ b/Rubberduck.Core/VersionCheck/VersionCheckService.cs
@@ -36,15 +36,22 @@ namespace Rubberduck.VersionCheck
                 return _latestVersion; 
             }
 
-            var tags = await _client.GetLatestTagsAsync(token);
+            try
+            {
+                var tags = await _client.GetLatestTagsAsync(token);
 
-            var next = tags.Single(e => e.IsPreRelease);
-            var main = tags.Single(e => !e.IsPreRelease);
-            _logger.Info($"Main: v{main.Version.ToString(3)}; Next: v{next.Version.ToString(4)}");
+                var next = tags.Single(e => e.IsPreRelease);
+                var main = tags.Single(e => !e.IsPreRelease);
+                _logger.Info($"Main: v{main.Version.ToString(3)}; Next: v{next.Version.ToString(4)}");
 
-            _latestVersion = settings.IncludePreRelease ? next.Version : main.Version;
-            _logger.Info($"Check prerelease: {settings.IncludePreRelease}; latest: v{_latestVersion.ToString(4)}");
+                _latestVersion = settings.IncludePreRelease ? next.Version : main.Version;
+                _logger.Info($"Check prerelease: {settings.IncludePreRelease}; latest: v{_latestVersion.ToString(4)}");
+            }
+            catch ( Exception ex )
+            {
+                _logger.Warn(ex, "Version check failed.");
 
+            }
             return _latestVersion;
         }
 

--- a/Rubberduck.Core/app.config
+++ b/Rubberduck.Core/app.config
@@ -221,6 +221,7 @@
             <MinimumLogLevel>0</MinimumLogLevel>
             <SetDpiUnaware>false</SetDpiUnaware>
             <EnableExperimentalFeatures />
+            <ApiBaseUrl>https://api.rubberduckvba.com/api/v1/</ApiBaseUrl>
           </GeneralSettings>
         </value>
       </setting>

--- a/Rubberduck.Main/Extension.cs
+++ b/Rubberduck.Main/Extension.cs
@@ -194,7 +194,7 @@ namespace Rubberduck
 
                 if (_initialSettings?.CanShowSplash ?? false)
                 {
-                    splash = new Splash2021(new VersionCheckService(typeof(Splash2021).Assembly.GetName().Version));
+                    splash = new Splash2021(string.Format(RubberduckUI.Rubberduck_AboutBuild, Assembly.GetExecutingAssembly().GetName().Version.ToString(3)));
                     splash.Show();
                     splash.Refresh();
                 }

--- a/RubberduckTests/VersionCheckTests.cs
+++ b/RubberduckTests/VersionCheckTests.cs
@@ -24,9 +24,9 @@ namespace RubberduckTests
             
             var sut = new VersionCheckService(appVersion, apiClient.Object);
             
-            await sut.GetLatestVersionAsync(new GeneralSettings(), CancellationToken.None);
+            var result = await sut.GetLatestVersionAsync(new GeneralSettings(), CancellationToken.None);
 
-            Assert.IsTrue(true); // if we make it here, service isn't throwing.
+            Assert.IsNull(result);
         }
     }
 

--- a/RubberduckTests/VersionCheckTests.cs
+++ b/RubberduckTests/VersionCheckTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
 using Moq;
 using NUnit.Framework;
 using Rubberduck.Interaction;
@@ -10,6 +12,24 @@ using Rubberduck.VersionCheck;
 
 namespace RubberduckTests
 {
+    [TestFixture]
+    public class VersionCheckServiceTests
+    {
+        [Test]
+        public async Task GetLatestVersionThrowsHttpException_IsHandled()
+        {
+            var appVersion = new Version();
+            var apiClient = new Mock<IPublicApiClient>();
+            apiClient.Setup(m => m.GetLatestTagsAsync(It.IsAny<CancellationToken>())).Throws<HttpException>();
+            
+            var sut = new VersionCheckService(appVersion, apiClient.Object);
+            
+            await sut.GetLatestVersionAsync(new GeneralSettings(), CancellationToken.None);
+
+            Assert.IsTrue(true); // if we make it here, service isn't throwing.
+        }
+    }
+
     [TestFixture]
     public class VersionCheckTests
     {
@@ -34,12 +54,12 @@ namespace RubberduckTests
             mockConfig.Setup(m => m.Read()).Returns(() => config);
 
             mockService = new Mock<IVersionCheckService>();
-            
+
             mockService.Setup(m => m.CurrentVersion)
                        .Returns(() => currentVersion);
 
             mockService.Setup(m => m.GetLatestVersionAsync(It.IsAny<GeneralSettings>(), It.IsAny<CancellationToken>()))
-                       .ReturnsAsync(() => latestVersion);
+                        .ReturnsAsync(() => latestVersion);
 
             return new VersionCheckCommand(mockService.Object, mockPrompt.Object, mockProcess.Object, mockConfig.Object);
         }


### PR DESCRIPTION
DockableWindowHost in RD2.x is still consistently throwing on my machine (interestingly, not RD3's), so I couldn't fully test the initialization sequence - but the version check command is should no longer throw.

Bonus, made the API base url configurable via a hidden `<ApiBaseUrl>` setting in the `<GeneralSettings>` section; value must end with a slash, and the reason it's there is because the Azure-hosted API URL contains the deployment timestamp, which means it's going to change whenever a new build is deployed, so whether it's GoDaddy returning 503 or Azure returning 404 the version check is going to end up failing no matter what - hence making it catch and log (at warn level) any exceptions thrown.

Having the ability to set the base URL without needing to re-install RD felt like a good idea.

Closes #6157 
Closes #6156
Closes #6153 
Closes #6152 