### PR TITLE
Make parser understand multiple line continuations inside lExpressions

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -687,13 +687,13 @@ variantLiteralIdentifier : EMPTY | NULL;
 
 lExpression :
     lExpression LPAREN whiteSpace? argumentList? whiteSpace? RPAREN                                                 # indexExpr
-    | lExpression mandatoryLineContinuation? DOT mandatoryLineContinuation? printMethod (whiteSpace outputList)?    # objectPrintExpr
-    | lExpression mandatoryLineContinuation? DOT mandatoryLineContinuation? unrestrictedIdentifier                  # memberAccessExpr
-    | lExpression mandatoryLineContinuation? dictionaryAccess mandatoryLineContinuation? unrestrictedIdentifier     # dictionaryAccessExpr
+    | lExpression mandatoryLineContinuation* DOT mandatoryLineContinuation* printMethod (whiteSpace outputList)?                                  # objectPrintExpr
+    | lExpression mandatoryLineContinuation* DOT mandatoryLineContinuation* unrestrictedIdentifier                                                # memberAccessExpr
+    | lExpression mandatoryLineContinuation* dictionaryAccess mandatoryLineContinuation* unrestrictedIdentifier                                   # dictionaryAccessExpr
     | ME                                                                                                            # instanceExpr
     | identifier                                                                                                    # simpleNameExpr
-    | DOT mandatoryLineContinuation? unrestrictedIdentifier                                                         # withMemberAccessExpr
-    | dictionaryAccess mandatoryLineContinuation? unrestrictedIdentifier                                            # withDictionaryAccessExpr
+    | DOT whiteSpace? unrestrictedIdentifier                                                                        # withMemberAccessExpr
+    | dictionaryAccess whiteSpace? unrestrictedIdentifier                                                           # withDictionaryAccessExpr
     | lExpression mandatoryLineContinuation whiteSpace? LPAREN whiteSpace? argumentList? whiteSpace? RPAREN         # whitespaceIndexExpr
 ;
 

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -3989,6 +3989,29 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//unrestrictedIdentifier", matches => matches.Count == 1);
         }
 
+
+        // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/6164
+        [Test]
+        [TestCase(@"b _
+  _
+     . _
+     c")]
+        [TestCase(@"b _
+      . _
+  _
+     c")]
+        [TestCase(@"b _
+  _
+      . _
+  _
+     c")]
+        public void ParserCanDealWithMultiplyLineContinuedMemberAccess(string lineContinuedMemberAccess)
+        {
+            string code = $"Sub Test()\r\n     a = {lineContinuedMemberAccess}\r\nEnd Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression", matches => matches.Count == 3);
+        }
+
         // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/4875
         [Test]
         [TestCase("form.Line (0, 0)-(12, 12), RGB(255, 255, 0), B")]


### PR DESCRIPTION
Closes #6164

This was just a matter of allowing multiple line continuations in the grammar instead of just one.