### PR TITLE
Make the parser understand completely empty single line if statements

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -421,7 +421,7 @@ elseBlock :
 // 5.4.2.9 Single-line If Statement
 singleLineIfStmt : ifWithNonEmptyThen | ifWithEmptyThen;
 ifWithNonEmptyThen : IF whiteSpace? booleanExpression whiteSpace? THEN whiteSpace? listOrLabel (whiteSpace singleLineElseClause)?;
-ifWithEmptyThen : IF whiteSpace? booleanExpression whiteSpace? THEN whiteSpace? emptyThenStatement? singleLineElseClause;
+ifWithEmptyThen : IF whiteSpace? booleanExpression whiteSpace? THEN whiteSpace? emptyThenStatement? singleLineElseClause?;
 singleLineElseClause : ELSE whiteSpace? listOrLabel?;
 
 // lineNumberLabel should actually be "statement-label" according to MS VBAL but they only allow lineNumberLabels:

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -4012,6 +4012,27 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//lExpression", matches => matches.Count == 3);
         }
 
+
+        // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/6163
+        [Test]
+        [TestCase(@"If True Then:")]
+        [TestCase(@"If True Then: ")]
+        [TestCase(@"If True Then: 
+")]
+        [TestCase(@"         If True Then::::::::::::: _
+             :::::::::::::::: _
+             :::")]
+        [TestCase(@"         If True Then::::::::::::: _
+             :::::::::::::::: _
+             :::Else")]
+        public void ParserCanDealWithStatementSeparateorsInOneLineIfStatements(string oneLineIfStatement)
+        {
+            string code = $"Sub Test()\r\n {oneLineIfStatement}\r\nEnd Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt", matches => matches.Count == 1);
+        }
+
+
         // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/4875
         [Test]
         [TestCase("form.Line (0, 0)-(12, 12), RGB(255, 255, 0), B")]


### PR DESCRIPTION
Closes #6163

Yes, the Else part in a single line if statement is optional even if the Then part is empty. 
It makes no sense to include this in your code, but technically it is legal.
This PR makes it possible that RD does not choke on it anymore. 