### PR TITLE
Try to avoid RCW exception on CommandBarButtons at shutdown

### DIFF
--- a/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
+++ b/Rubberduck.Core/UI/Command/MenuItems/ParentMenus/ParentMenuItemBase.cs
@@ -154,8 +154,8 @@ namespace Rubberduck.UI.Command.MenuItems.ParentMenus
                             }
                             catch (Exception exception)
                             {
-                                value.IsEnabled = false;
                                 Logger.Error(exception, "Could not evaluate availability of commmand menu item {0}.", value.Tag ?? "{Unknown}");
+                                value.IsEnabled = false;
                             }
                         });
                         break;

--- a/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
+++ b/Rubberduck.VBEEditor/SafeComWrappers/SafeComWrapper.cs
@@ -92,7 +92,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers
             }
         }
 
-        private bool HasBeenReleased => _rcwReferenceCount <= 0;
+        protected bool HasBeenReleased => _rcwReferenceCount <= 0;
 
         public bool IsWrappingNullReference => Target == null;
         object INullObjectWrapper.Target => Target;

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/Office/CommandBarButton.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/Office/CommandBarButton.cs
@@ -15,14 +15,14 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
 
         public const bool AddCommandBarControlsTemporarily = false;
 
-        public CommandBarButton(MSO.CommandBarButton target, bool rewrapping = false) 
+        public CommandBarButton(MSO.CommandBarButton target, bool rewrapping = false)
             : base(target, rewrapping)
         {
             _control = new CommandBarControl(target, true);
         }
-        
+
         private MSO.CommandBarButton Button => Target;
-        
+
         public bool IsBuiltInFace
         {
             get => !IsWrappingNullReference && Button.BuiltInFace;
@@ -35,7 +35,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
             }
         }
 
-        public int FaceId 
+        public int FaceId
         {
             get => IsWrappingNullReference ? 0 : Button.FaceId;
             set
@@ -183,13 +183,31 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
         public string DescriptionText
         {
             get => _control.DescriptionText;
-            set => _control.DescriptionText=value;
+            set => _control.DescriptionText = value;
         }
 
         public bool IsEnabled
         {
-            get => _control.IsEnabled;
-            set=> _control.IsEnabled = value;
+            get
+            {
+                if (HasBeenReleased)
+                {
+                    _logger.Warn($"Getting IsEnabled of already release CommandBarButton.");
+                    return false;
+                }
+                else
+                {
+                    return _control.IsEnabled;
+                }
+            }
+            set 
+            {
+                if (!HasBeenReleased) {
+                    _control.IsEnabled = value;
+                } else {
+                    _logger.Warn($"Setting IsEnabled on already release CommandBarButton.");
+                }
+            }
         }
 
         public int Height
@@ -226,8 +244,28 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
 
         public string Tag
         {
-            get => _control.Tag;
-            set => _control.Tag = value;
+            get 
+            {
+                if (HasBeenReleased)
+                {
+                    _logger.Warn($"Getting Tag of already release CommandBarButton.");
+                    return null;
+                } else
+                {
+                    return _control.Tag;
+                }
+            }
+            set
+            {
+                if (!HasBeenReleased)
+                {
+                    _control.Tag = value;
+                }
+                else
+                {
+                    _logger.Warn($"Setting Tag on already release CommandBarButton.");
+                }
+            }
         }
 
         public string TooltipText
@@ -242,8 +280,29 @@ namespace Rubberduck.VBEditor.SafeComWrappers.Office12
 
         public bool IsVisible
         {
-            get => _control.IsVisible;
-            set => _control.IsVisible = value;
+            get
+            {
+                if (HasBeenReleased)
+                {
+                    _logger.Warn($"Getting IsVisible of already release CommandBarButton.");
+                    return false;
+                }
+                else
+                {
+                    return _control.IsVisible;
+                }
+            }
+            set
+            {
+                if (!HasBeenReleased)
+                {
+                    _control.IsVisible = value;
+                }
+                else
+                {
+                    _logger.Warn($"Setting IsVisible on already release CommandBarButton.");
+                }
+            }
         }
 
         public int Width


### PR DESCRIPTION
This PR tries to address our notorious shutdown issue based on the stack traces from #6150 and #6146.

It wraps the calls to set and get the enabled state, the visibility and the tag of a `CommandBarButton` in a check whether it has already been released an logs any attempt to access these methods after the release as a warning.

This should lead to a clean exit. However, it only fixes the symptoms of apparently too late `CanExecute` checks. Identifying these is made difficult by the fact that setting the enabled state is dispatched to the UI thread, which cuts off the stack trace.

I cannot guarantee that this works since I currently cannot reproduce the shutdown issue, which seems to partially be a race condition.