### PR TITLE
Fix unsafe conversion from Char to int

### DIFF
--- a/Rubberduck.Parsing/VBA/Extensions/StringExtensions.cs
+++ b/Rubberduck.Parsing/VBA/Extensions/StringExtensions.cs
@@ -148,7 +148,7 @@ namespace Rubberduck.Parsing.VBA.Extensions
             var literal = string.Empty;
             foreach (var character in managed.ToCharArray())
             {
-                var unicode = Convert.ToInt16(character) > byte.MaxValue;
+                var unicode = Convert.ToInt32(character) > byte.MaxValue;
                 var specialCased = VbCharacterConstants.ContainsKey(character);
                 if (specialCased || char.IsControl(character) && !unicode)
                 {


### PR DESCRIPTION
It is not safe to convert from Char to int16, since the unicode code points are unsigned 16-bit integers. The safe conversion it to int32, as also indicated in the docs.

This should eliminate the cause of #6017. 