### PR TITLE
Fix selection end column if pruning an empty last column

### DIFF
--- a/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CodePane.cs
+++ b/Rubberduck.VBEditor.VB6/SafeComWrappers/VB/CodePane.cs
@@ -46,7 +46,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VB6
                 endLine -= 1;
                 using (var codeModule = CodeModule)
                 {
-                    endColumn = codeModule.GetLines(endLine, 1).Length;
+                    endColumn = codeModule.GetLines(endLine, 1).Length + 1;
                 }
             }
 

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/CodePane.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/CodePane.cs
@@ -46,7 +46,7 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
                 endLine -= 1;
                 using (var codeModule = CodeModule)
                 {
-                    endColumn = codeModule.GetLines(endLine, 1).Length;
+                    endColumn = codeModule.GetLines(endLine, 1).Length + 1;
                 }
             }
 


### PR DESCRIPTION
Fixes #6181 

When a selection of code includes a trailing blank line, the GetSelection method cuts this line and sets the end column to the length of the previous line. However, selections are supposed to be one-based, so we want the length plus 1. E.g. if selecting a line which is just `End`, we should see start column = 1, end column = 4 which we do if that is the only line selected but if changing the selection to include an extra blank line, the selection gets modified to have end column = 3.

I'm not sure exactly why the last blank line if being pruned but it's not relevant to this issue. Note that only one blank line would be pruned even if there are multiple.