### PR TITLE
Recent Grammar issues

### DIFF
--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -543,6 +543,7 @@ subroutineName : identifier;
 
 // 5.2.3.3 User Defined Type Declarations
 // member list includes trailing endOfStatement
+// To support actual VBA behaviour, had to change optionalArrayClause to allow a standalone arrayDim without the asTypeClause - see issue #6194
 udtDeclaration : (visibility whiteSpace)? TYPE whiteSpace untypedIdentifier endOfStatement udtMemberList END_TYPE;  
 udtMemberList : (udtMember endOfStatement)+; 
 udtMember : reservedNameMemberDeclaration | untypedNameMemberDeclaration;

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -421,7 +421,7 @@ elseBlock :
 // 5.4.2.9 Single-line If Statement
 singleLineIfStmt : ifWithNonEmptyThen | ifWithEmptyThen;
 ifWithNonEmptyThen : IF whiteSpace? booleanExpression whiteSpace? THEN whiteSpace? listOrLabel (whiteSpace singleLineElseClause)?;
-ifWithEmptyThen : IF whiteSpace? booleanExpression whiteSpace? THEN whiteSpace? emptyThenStatement? singleLineElseClause?;
+ifWithEmptyThen : IF whiteSpace? booleanExpression whiteSpace? THEN whiteSpace? (emptyThenStatement singleLineElseClause? | singleLineElseClause);
 singleLineElseClause : ELSE whiteSpace? listOrLabel?;
 
 // lineNumberLabel should actually be "statement-label" according to MS VBAL but they only allow lineNumberLabels:

--- a/Rubberduck.Parsing/Grammar/VBAParser.g4
+++ b/Rubberduck.Parsing/Grammar/VBAParser.g4
@@ -548,7 +548,7 @@ udtMemberList : (udtMember endOfStatement)+;
 udtMember : reservedNameMemberDeclaration | untypedNameMemberDeclaration;
 untypedNameMemberDeclaration : untypedIdentifier whiteSpace? optionalArrayClause;
 reservedNameMemberDeclaration : unrestrictedIdentifier whiteSpace asTypeClause;
-optionalArrayClause : (arrayDim whiteSpace)? asTypeClause;
+optionalArrayClause : ((arrayDim whiteSpace)? asTypeClause | arrayDim);
 
 // 5.2.3.1.3 Array Dimensions and Bounds
 arrayDim : LPAREN whiteSpace? boundsList? whiteSpace? RPAREN;

--- a/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
+++ b/Rubberduck.Parsing/VBA/ReferenceManagement/IdentifierReferenceResolver.cs
@@ -321,7 +321,10 @@ namespace Rubberduck.Parsing.VBA.ReferenceManagement
             if (context.ifWithEmptyThen() != null)
             {
                 ResolveDefault(context.ifWithEmptyThen().booleanExpression());
-                ResolveListOrLabel(context.ifWithEmptyThen().singleLineElseClause().listOrLabel());
+                if (context.ifWithEmptyThen().singleLineElseClause() != null)
+                {
+                    ResolveListOrLabel(context.ifWithEmptyThen().singleLineElseClause().listOrLabel());
+                }
             }
             else
             {

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -4032,6 +4032,20 @@ End Type
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt", matches => matches.Count == 1);
         }
 
+        // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/6187
+        [Test]
+        public void OneLineIfStatementNotMistakenForIfStatement()
+        {
+            string code = @"
+Sub Test()
+    If True Then: A = 1
+    If False Then
+        A = 5
+    End If
+End Sub";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt", matches => matches.Count == 1);
+        }
 
         // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/4875
         [Test]

--- a/RubberduckTests/Grammar/VBAParserTests.cs
+++ b/RubberduckTests/Grammar/VBAParserTests.cs
@@ -4047,6 +4047,18 @@ End Sub";
             AssertTree(parseResult.Item1, parseResult.Item2, "//singleLineIfStmt", matches => matches.Count == 1);
         }
 
+        // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/6194
+        [Test]
+        public void UDTMemberCanHaveArrayWithoutType()
+        {
+            string code = @"
+Type Test
+    A(0 To 2)
+End Type";
+            var parseResult = Parse(code);
+            AssertTree(parseResult.Item1, parseResult.Item2, "//untypedNameMemberDeclaration", matches => matches.Count == 1);
+        }
+
         // Adapted from opened issue https://github.com/rubberduck-vba/Rubberduck/issues/4875
         [Test]
         [TestCase("form.Line (0, 0)-(12, 12), RGB(255, 255, 0), B")]


### PR DESCRIPTION
Fixes for #6187, #6194

Single line if statements had been made too flexible, in particular the rule ifWithEmptyThen where all the elements following the THEN were optional, letting the singleLineIfStmt match what is really an ifStmt:

`ifWithEmptyThen : IF whiteSpace? booleanExpression whiteSpace? THEN whiteSpace? emptyThenStatement? singleLineElseClause?;`

Now the rule requires at least one of emptyThenStatement or singleLineElseClause.

The user defined type member rule has been modified to allow the asTypeClause to be omitted but only if the member is an array. This ensures valid (though not defined in the language specification) examples through as in #6187 

`optionalArrayClause : ((arrayDim whiteSpace)? asTypeClause | arrayDim);`