### PR TITLE
Change xaml property from Color to Brush to prevent crash with @Obsolete annotation

### DIFF
--- a/Rubberduck.Core/UI/Controls/ToolBar.xaml
+++ b/Rubberduck.Core/UI/Controls/ToolBar.xaml
@@ -458,7 +458,7 @@
         <Setter Property="Foreground" Value="{Binding IsDimmed, Mode=OneWay, Converter={StaticResource BooleanToDimmed}}" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding IsObsolete}" Value="True">
-                <Setter Property="Foreground" Value="{StaticResource CaptionDisabledColor}" />
+                <Setter Property="Foreground" Value="{StaticResource CaptionDisabledBrush}" />
                 <Setter Property="TextDecorations" Value="Strikethrough" />
             </DataTrigger>
         </Style.Triggers>


### PR DESCRIPTION
Fixes #6197, fixes #6141 
Code explorer style for @Obsolete annotation needed a brush instead of a color. Example of being able to expand the class details shared in #6141 (see strikethrough of function GetCultureInfoByIetfLanguageTag near the bottom):
<img width="496" alt="Screenshot 2024-01-29 at 21 20 32" src="https://github.com/rubberduck-vba/Rubberduck/assets/4892984/58c069b9-aef8-4a89-81e9-c7bfd42aa38c">
