### PR TITLE
Test explorer UI speed ups

### DIFF
--- a/Rubberduck.Core/UI/UnitTesting/LazyBindingExtension.cs
+++ b/Rubberduck.Core/UI/UnitTesting/LazyBindingExtension.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+using System.Windows;
+
+namespace Rubberduck.UI.UnitTesting
+{
+    [MarkupExtensionReturnType(typeof(object))]
+    public class LazyBindingExtension : MarkupExtension
+    {
+        private Binding binding;
+        private UIElement bindingTarget;
+        private DependencyProperty bindingTargetProperty;
+
+        public LazyBindingExtension()
+        {
+        }
+
+        public LazyBindingExtension(PropertyPath path) : this()
+        {
+            Path = path;
+        }
+
+        public IValueConverter Converter { get; set; }
+        [TypeConverter(typeof(CultureInfoIetfLanguageTagConverter))]
+        public CultureInfo ConverterCulture { get; set; }
+        public object ConverterParameter { get; set; }
+        public string ElementName { get; set; }
+        [ConstructorArgument("path")]
+        public PropertyPath Path { get; set; }
+        public RelativeSource RelativeSource { get; set; }
+        public object Source { get; set; }
+        public UpdateSourceTrigger UpdateSourceTrigger { get; set; }
+        public bool ValidatesOnDataErrors { get; set; }
+        public bool ValidatesOnExceptions { get; set; }
+        public bool ValidatesOnNotifyDataErrors { get; set; }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            var valueProvider = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+            if (valueProvider == null)
+                return null;
+
+            bindingTarget = valueProvider.TargetObject as UIElement;
+            if (bindingTarget == null)
+                throw new NotSupportedException($"The target must be a UIElement, '{valueProvider.TargetObject}' is not valid.");
+
+            bindingTargetProperty = valueProvider.TargetProperty as DependencyProperty;
+            if (bindingTargetProperty == null)
+                throw new NotSupportedException($"The target property must be a DependencyProperty, '{valueProvider.TargetProperty}' is not valid.");
+
+            InitializeBinding();
+            SetVisibilityHandler();
+
+            return this;
+        }
+
+        private void InitializeBinding()
+        {
+            binding = new Binding
+            {
+                Path = Path,
+                Converter = Converter,
+                ConverterCulture = ConverterCulture,
+                ConverterParameter = ConverterParameter
+            };
+
+            if (!string.IsNullOrEmpty(ElementName))
+                binding.ElementName = ElementName;
+
+            if (RelativeSource != null)
+                binding.RelativeSource = RelativeSource;
+
+            if (Source != null)
+                binding.Source = Source;
+
+            binding.UpdateSourceTrigger = UpdateSourceTrigger;
+            binding.ValidatesOnDataErrors = ValidatesOnDataErrors;
+            binding.ValidatesOnExceptions = ValidatesOnExceptions;
+            binding.ValidatesOnNotifyDataErrors = ValidatesOnNotifyDataErrors;
+        }
+
+        private void SetVisibilityHandler()
+        {
+            bindingTarget.IsVisibleChanged += OnIsVisibleChanged;
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            UpdateBinding();
+        }
+
+        private void UpdateBinding()
+        {
+            if (bindingTarget.IsVisible && !IsBindingActive())
+                ApplyBinding();
+            else if (!bindingTarget.IsVisible)
+                ClearBinding();
+        }
+
+        private bool IsBindingActive()
+        {
+            return BindingOperations.GetBinding(bindingTarget, bindingTargetProperty) != null;
+        }
+
+        private void ApplyBinding()
+        {
+            if (!IsBindingActive())
+                BindingOperations.SetBinding(bindingTarget, bindingTargetProperty, binding);
+        }
+
+        private void ClearBinding()
+        {
+            if (IsBindingActive())
+                BindingOperations.ClearBinding(bindingTarget, bindingTargetProperty);
+        }
+    }
+}

--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerControl.xaml
@@ -8,6 +8,7 @@
              xmlns:controls="clr-namespace:Rubberduck.UI.Controls"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:converters="clr-namespace:Rubberduck.UI.Converters"
+             xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              Language="{UICulture}"
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="800"
@@ -334,17 +335,18 @@
         <Border Grid.Row="3" Padding="2">
             <Grid>
                 <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
-		            <controls:GroupingGrid x:Name="TestGrid"
-	                                       ItemsSource="{Binding Tests}"
+                    <controls:GroupingGrid x:Name="TestGrid"
+	                                       ItemsSource="{local:LazyBinding Tests}"
 	                                       SelectionMode="Extended"
 	                                       ShowGroupingItemCount="True"
 	                                       InitialExpandedState="True"
 	                                       VirtualizingPanel.IsVirtualizingWhenGrouping="True"
                                            RequestBringIntoView="TestGrid_RequestBringIntoView"
-	                                       ScrollViewer.CanContentScroll="False" 
+	                                       ScrollViewer.CanContentScroll="True" 
+                                           Visibility="{Binding Model.IsBusyOrRefreshing, Converter={StaticResource BoolToHiddenVisibility}}"
 	                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
 	                                       ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-	                    <DataGrid.Columns>
+                        <DataGrid.Columns>
 	                        <DataGridTemplateColumn Header="{Resx ResxName=Rubberduck.Resources.UnitTesting.TestExplorer, Key=TestExplorer_Outcome}">
 	                            <DataGridTemplateColumn.CellTemplate>
 	                                <DataTemplate DataType="vm:TestMethodViewModel">
@@ -480,6 +482,6 @@
 				</ScrollViewer>
 			</Grid>
         </Border>
-        <controls:BusyIndicator Grid.Row="3" Width="120" Height="120" Visibility="{Binding Model.IsRefreshing, Converter={StaticResource BoolToVisibility}}" />
+        <controls:BusyIndicator Grid.Row="3" Width="120" Height="120" Visibility="{Binding Model.IsBusyOrRefreshing, Converter={StaticResource BoolToVisibility}}" />
     </Grid>
 </UserControl>

--- a/Rubberduck.Core/UI/UnitTesting/TestExplorerModel.cs
+++ b/Rubberduck.Core/UI/UnitTesting/TestExplorerModel.cs
@@ -83,6 +83,7 @@ namespace Rubberduck.UI.UnitTesting
             {
                 _isBusy = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(IsBusyOrRefreshing));
             }
         }
 
@@ -94,8 +95,11 @@ namespace Rubberduck.UI.UnitTesting
             {
                 _isRefreshing = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(IsBusyOrRefreshing));
             }
         }
+
+        public bool IsBusyOrRefreshing => IsBusy || IsRefreshing;
 
         public string LastTestRunSummary =>
             string.Format(Resources.UnitTesting.TestExplorer.TestOutcome_RunSummaryFormat, CurrentRunTestCount, Tests.Count, TimeSpan.FromMilliseconds(TotalDuration));


### PR DESCRIPTION
Unbinds and hides the grid of tests while tests are running to avoid excessive run times due to layout updates. The spinning ducks are shown instead. Thanks to [@sihlfall](https://github.com/sihlfall) for finding the method for lazy binding from https://stackoverflow.com/a/48202247 which is lightly modified for this purpose. Also improves UI responsiveness when interacting with the Test Explorer window when there are lots of tests due to setting CanContentScroll to True.

Checked with two test workbooks which were taking minutes before but now run in a second or two.