### PR TITLE
Enable arm64 in Inno Setup

### DIFF
--- a/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
+++ b/Rubberduck.Deployment/InnoSetup/Rubberduck.Installer.Build.iss
@@ -62,8 +62,8 @@ OutputBaseFilename=Rubberduck.Setup
 Compression=lzma
 SolidCompression=yes
 
-ArchitecturesAllowed=x86 x64
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x86 x64 arm64
+ArchitecturesInstallIn64BitMode=x64 arm64
 
 SetupLogging=yes
 PrivilegesRequired=lowest


### PR DESCRIPTION
Just changes the allowable architectures in the installer to include `arm64`.

To test this I've compiled locally and then also built the installer by executing this line from the appveyor script:
`"C:\Program Files (x86)\Inno Setup 6\iscc.exe" /O "Rubberduck.Deployment\InnoSetup\Rubberduck.Installer.Build.iss"` 
with paths changed to suit my local system. Then I copied the installer to my ARM machine to install there (because building on ARM is harder).

Everything I've tested works, even the new mocking framework.

The caveat with this is that the UI is not very responsive if the Rubberduck command bar is visible. Hiding this and it works very smoothly. With the command bar showing, it sometimes gets very slow when moving around the code. In particular, it seems to struggle when moving the cursor with the arrow keys in code that would display something in the greyed out section (ContextDescriptionLabelMenuItem?):
<img width="731" alt="image" src="https://github.com/user-attachments/assets/a1907a18-b350-4475-a34c-f381e2a5ecae" />

It would make sense to have a note somewhere about hiding the command bar on ARM machines but I'm not sure where to put this. Could be with a new issue to help people find this or maybe something else?



