### PR TITLE
Issue5397 display tooltip immediately to inform error reason

### DIFF
--- a/Rubberduck.Core/UI/Refactorings/Rename/RenameView.xaml
+++ b/Rubberduck.Core/UI/Refactorings/Rename/RenameView.xaml
@@ -38,6 +38,7 @@
                      Height="22"
                      VerticalAlignment="Top"
                      VerticalContentAlignment="Center"
+                     ToolTipService.InitialShowDelay="0"
                      HorizontalAlignment="Stretch" />
         </Grid>
         <Grid Grid.Row="2" Background="{x:Static SystemColors.ControlDarkBrush}" Grid.IsSharedSizeScope="True">

--- a/Rubberduck.Core/UI/Refactorings/Rename/RenameView.xaml
+++ b/Rubberduck.Core/UI/Refactorings/Rename/RenameView.xaml
@@ -38,7 +38,6 @@
                      Height="22"
                      VerticalAlignment="Top"
                      VerticalContentAlignment="Center"
-                     ToolTipService.InitialShowDelay="0"
                      HorizontalAlignment="Stretch" />
         </Grid>
         <Grid Grid.Row="2" Background="{x:Static SystemColors.ControlDarkBrush}" Grid.IsSharedSizeScope="True">

--- a/Rubberduck.Core/UI/Styles/DefaultStyle.xaml
+++ b/Rubberduck.Core/UI/Styles/DefaultStyle.xaml
@@ -135,6 +135,9 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Setter Property="ToolTipService.InitialShowDelay">
+            <Setter.Value>0</Setter.Value>
+        </Setter>
         <Style.Triggers>
             <Trigger Property="Validation.HasError"
                      Value="True">


### PR DESCRIPTION
close #5397

git-blame indicates this feature was added a couple months after I opened the issue. It surprised me a bit when I let the mouse hover over the TextBox and it gave me the reason for a worksheet rename prohibition in the tooltip.

Reduced the timer to immediately show the tooltip for all TextBoxes using TextBoxErrorStyle. The faster the user can see the reason for the error the faster they ~~can~~ will correct it. TextBoxes that currently use the style reside in AnnotateDeclarationView.xaml, MoveMultipleFoldersView.xaml, MoveMultipleToFolderView.xaml, RenameView.xaml, RenameFolderView.xaml.