### PR TITLE
Export function now allows to choose a file name

### DIFF
--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
@@ -101,7 +101,6 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 var component = ProjectsProvider.Component(qualifiedModule);
                 try
                 {
-                    //var path = Path.GetDirectoryName(dialog.FileName);
                     var path = dialog.FileName; // This makes it that the file is named not as the module name, but as the file name the user provided in the explorer.
                     component.ExportAsSourceFile(path, false, true); // skipped optional parameters interfere with mock setup
                 }

--- a/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
+++ b/Rubberduck.Core/UI/CodeExplorer/Commands/ExportCommand.cs
@@ -101,7 +101,8 @@ namespace Rubberduck.UI.CodeExplorer.Commands
                 var component = ProjectsProvider.Component(qualifiedModule);
                 try
                 {
-                    var path = Path.GetDirectoryName(dialog.FileName);
+                    //var path = Path.GetDirectoryName(dialog.FileName);
+                    var path = dialog.FileName; // This makes it that the file is named not as the module name, but as the file name the user provided in the explorer.
                     component.ExportAsSourceFile(path, false, true); // skipped optional parameters interfere with mock setup
                 }
                 catch (Exception ex)

--- a/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBComponent.cs
+++ b/Rubberduck.VBEditor.VBA/SafeComWrappers/VB/VBComponent.cs
@@ -107,18 +107,27 @@ namespace Rubberduck.VBEditor.SafeComWrappers.VBA
         /// <param name="folder">Destination folder for the resulting source file.</param>
         /// <param name="isTempFile">True if a unique temp file name should be generated. WARNING: filenames generated with this flag are not persisted.</param>
         /// <param name="specialCaseDocumentModules">If reimport of a document file is required later, it has to receive special treatment.</param>
-        public string ExportAsSourceFile(string folder, bool isTempFile = false, bool specialCaseDocumentModules = true)
+        public string ExportAsSourceFile(string folderOrPath, bool isTempFile = false, bool specialCaseDocumentModules = true)
         {
             //TODO: this entire thign needs to be reworked. IO is not the class' concern.
             //We probably need to leverage IPersistancePathProvider? ITempSourceFileHandler? 
             //Just not here.
-            var fullPath = isTempFile
-                ? _fileSystem.Path.Combine(folder, _fileSystem.Path.GetRandomFileName())
-                : _fileSystem.Path.Combine(folder, SafeName + Type.FileExtension());
-
-            if (!_fileSystem.Directory.Exists(folder))
+            string fullPath;
+            if (_fileSystem.Path.HasExtension(folderOrPath))
             {
-                _fileSystem.Directory.CreateDirectory(folder);
+                fullPath = folderOrPath;
+            }
+            else
+            {
+                fullPath = isTempFile
+                    ? _fileSystem.Path.Combine(folderOrPath, _fileSystem.Path.GetRandomFileName())
+                    : _fileSystem.Path.Combine(folderOrPath, SafeName + Type.FileExtension());
+            }
+
+            var dir = _fileSystem.Path.GetDirectoryName(fullPath);
+            if (!_fileSystem.Directory.Exists(dir))
+            {
+                _fileSystem.Directory.CreateDirectory(dir);
             }
 
             switch (Type)

--- a/RubberduckTests/CodeExplorer/CodeExplorerViewModelTests.cs
+++ b/RubberduckTests/CodeExplorer/CodeExplorerViewModelTests.cs
@@ -1858,7 +1858,8 @@ namespace RubberduckTests.CodeExplorer
             {
                 explorer.VbComponent.Setup(c => c.ExportAsSourceFile(folder, It.IsAny<bool>(), It.IsAny<bool>()));
                 explorer.ExecuteExportCommand();
-                explorer.VbComponent.Verify(c => c.ExportAsSourceFile(folder, false, true), Times.Once);
+                // Expected: ExportAsSourceFile will now be called with the full path, because the default filename was appended.
+                explorer.VbComponent.Verify(c => c.ExportAsSourceFile(path, false, true), Times.Once);
             }
         }
 


### PR DESCRIPTION
PR to fix issue [export function should allow to change the file name #6135 ](https://github.com/rubberduck-vba/Rubberduck/issues/6135)

New behavior: The file now saves with the name and extension given in the "Save as" file explorer window instead of the module name inside the code explorer. If no file name is given, it defaults to the module name just as it used to work before.

Explanation of the changes: 
`ExportAsSourceFile` now has a conditional check where it sees whether a custom file name was provided. 
`PromptFileNameAndExport` now passes the full path (including the file name), instead of only the directory path.

NOTE: Due to these changes, the unit test `ExportModule_ExpectExecution` in `RubberduckTests\CodeExplorer\CodeExplorerViewModelTests.cs` was updated. The test now expects that when a custom file name is provided, ExportAsSourceFile is called with the full file path (folder plus filename) instead of just the folder. 
