### PR TITLE
Fix Code Inspections: Do not collapse tree view #5954

### DIFF
--- a/Rubberduck.Core/UI/Controls/PersistGroupExpandedStateBehavior.cs
+++ b/Rubberduck.Core/UI/Controls/PersistGroupExpandedStateBehavior.cs
@@ -45,8 +45,7 @@ namespace Rubberduck.UI.Controls
             base.OnAttached();
 
             // Ensure the visual tree is fully loaded before trying to access parents
-            AssociatedObject.Dispatcher.BeginInvoke(new System.Action(() =>
-            {
+            AssociatedObject.Dispatcher.InvokeAsync(() => {
                 var states = GetExpandedStateStore();
                 var expanded = !states.ContainsKey(GroupName ?? string.Empty) ? (bool?)null : states[GroupName ?? string.Empty];
 
@@ -54,7 +53,7 @@ namespace Rubberduck.UI.Controls
 
                 AssociatedObject.Expanded += OnExpanded;
                 AssociatedObject.Collapsed += OnCollapsed;
-            }));
+            });
         }
 
 

--- a/Rubberduck.Core/UI/Controls/PersistGroupExpandedStateBehavior.cs
+++ b/Rubberduck.Core/UI/Controls/PersistGroupExpandedStateBehavior.cs
@@ -44,14 +44,19 @@ namespace Rubberduck.UI.Controls
         {
             base.OnAttached();
 
-            var states = GetExpandedStateStore();
-            var expanded = !states.ContainsKey(GroupName ?? string.Empty) ? (bool?)null : states[GroupName ?? string.Empty];
+            // Ensure the visual tree is fully loaded before trying to access parents
+            AssociatedObject.Dispatcher.BeginInvoke(new System.Action(() =>
+            {
+                var states = GetExpandedStateStore();
+                var expanded = !states.ContainsKey(GroupName ?? string.Empty) ? (bool?)null : states[GroupName ?? string.Empty];
 
-            AssociatedObject.IsExpanded = expanded ?? InitialExpandedState;
+                AssociatedObject.IsExpanded = expanded ?? InitialExpandedState;
 
-            AssociatedObject.Expanded += OnExpanded;
-            AssociatedObject.Collapsed += OnCollapsed;
+                AssociatedObject.Expanded += OnExpanded;
+                AssociatedObject.Collapsed += OnCollapsed;
+            }));
         }
+
 
         protected override void OnDetaching()
         {


### PR DESCRIPTION
## Fix Issue #5954: Do not collapse tree view 
Refreshing causes the tree view to collapse. The existing Rubberduck.Core\UI\Controls\PersistGroupExpandedStateBehavior.cs should handle this, but it does not appear to be working as expected.
## Description
The ``PersistGroupExpandedStateBehavior`` is designed to preserve expanded states, but it is currently failing to do so. The issue occurs because ``OnAttached()`` is called as soon as the behavior is applied to the ``Expander``. At this point, however, the visual tree may not be fully built, causing the behavior to malfunction.
## Solution
We wrapped the content inside ``OnAttached()`` with ``AssociatedObject.Dispatcher.BeginInvoke``, ensuring that access to the parent elements is deferred until after the tree has fully loaded.



