### PR TITLE
Unicode default value

### DIFF
--- a/Rubberduck.Parsing/VBA/Extensions/StringExtensions.cs
+++ b/Rubberduck.Parsing/VBA/Extensions/StringExtensions.cs
@@ -170,7 +170,7 @@ namespace Rubberduck.Parsing.VBA.Extensions
                         tokens.Add($"\"{literal}\"");
                         literal = string.Empty;
                     }
-                    tokens.Add($"ChrW$(&H{Convert.ToInt16(character):X})");
+                    tokens.Add($"ChrW$(&H{Convert.ToInt32(character):X})");
                 }
 
             }

--- a/RubberduckTests/Symbols/ToVbExpressionTests.cs
+++ b/RubberduckTests/Symbols/ToVbExpressionTests.cs
@@ -130,6 +130,17 @@ namespace RubberduckTests.Symbols
 
         [Test]
         [Category("String Extensions")]
+        public void UnicodeOverMaxInt16UsesChrWCallWithHexNotation()
+        {
+            var managed = "耀";
+            var expected = "ChrW$(&H8000)";
+            var actual = managed.ToVbExpression();
+
+            Assert.AreEqual(expected, actual, "Expected {0}, actual was {1}", expected, actual);
+        }
+        
+        [Test]
+        [Category("String Extensions")]
         public void MixedAsciiAndUnicodeUsesChrAndChrWConstFlagOff()
         {
             var managed = "•\tBullet\x00";


### PR DESCRIPTION
Closes #6274 

Was able to create a minimal failing example as follows...

1. Switched locale to Japanese in Control Panel -> Clock and Region -> Region -> Administrative to Japanese
2. Create new xlam file with a function with signature `Public Function a(Optional b As String = "擐") As String`
3. Password protect the xlam VBA project
4. Create new file and add a reference to the xlam file
5. Add code using the new function e.g. `Debug.Print AnAddin.a("f")`
6. Refresh Rubberduck and get "Unexpected Error" as the status

Note, if trying this, make sure to change the locale back or Visual Studio wants to change some characters within the Rubberduck project. 

The code was failing with an overflow error in the line `tokens.Add($"ChrW$(&H{Convert.ToInt16(character):X})");`

Have changed this to `ToInt32`, similar to a previous fix https://github.com/rubberduck-vba/Rubberduck/pull/6178 

Tested that Rubberduck parses successfully after this change.
